### PR TITLE
Enable TypedDict input types for the Python SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Chart v4 should handle an array of assets (https://github.com/pulumi/pulumi-kubernetes/pull/3061)
 
+- Generate TypedDict input types for the Python SDK (https://github.com/pulumi/pulumi-kubernetes/pull/3070)
+
 ## 4.13.0 (June 4, 2024)
 
 ### Added

--- a/provider/pkg/gen/schema.go
+++ b/provider/pkg/gen/schema.go
@@ -545,6 +545,7 @@ Use the navigation below to see detailed documentation for each of the supported
 		"moduleNameOverrides": modToPkg,
 		"compatibility":       kubernetes20,
 		"usesIOClasses":       true,
+		"inputTypes":          "classes-and-dicts",
 		"readme": `The Kubernetes provider package offers support for all Kubernetes resources and their properties.
 Resources are exposed as types from modules based on Kubernetes API groups such as 'apps', 'core',
 'rbac', and 'storage', among many others. Additionally, support for deploying Helm charts ('helm')

--- a/sdk/dotnet/Pulumi.Kubernetes.csproj
+++ b/sdk/dotnet/Pulumi.Kubernetes.csproj
@@ -9,7 +9,7 @@
     <PackageProjectUrl>https://pulumi.com</PackageProjectUrl>
     <RepositoryUrl>https://github.com/pulumi/pulumi-kubernetes</RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
-    <Version>4.14.0-alpha.1718665781</Version>
+    <Version>4.0.0-alpha.0+dev</Version>
 
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>

--- a/sdk/dotnet/pulumi-plugin.json
+++ b/sdk/dotnet/pulumi-plugin.json
@@ -1,5 +1,5 @@
 {
   "resource": true,
   "name": "kubernetes",
-  "version": "4.14.0-alpha.1718665781"
+  "version": "4.0.0-alpha.0+dev"
 }

--- a/sdk/go/kubernetes/pulumi-plugin.json
+++ b/sdk/go/kubernetes/pulumi-plugin.json
@@ -1,5 +1,5 @@
 {
   "resource": true,
   "name": "kubernetes",
-  "version": "4.14.0-alpha.1718665781"
+  "version": "4.0.0-alpha.0+dev"
 }

--- a/sdk/go/kubernetes/utilities/pulumiUtilities.go
+++ b/sdk/go/kubernetes/utilities/pulumiUtilities.go
@@ -165,7 +165,7 @@ func callPlainInner(
 func PkgResourceDefaultOpts(opts []pulumi.ResourceOption) []pulumi.ResourceOption {
 	defaults := []pulumi.ResourceOption{}
 
-	version := semver.MustParse("4.14.0-alpha.1718665781")
+	version := semver.MustParse("4.0.0-alpha.0+dev")
 	if !version.Equals(semver.Version{}) {
 		defaults = append(defaults, pulumi.Version(version.String()))
 	}
@@ -176,7 +176,7 @@ func PkgResourceDefaultOpts(opts []pulumi.ResourceOption) []pulumi.ResourceOptio
 func PkgInvokeDefaultOpts(opts []pulumi.InvokeOption) []pulumi.InvokeOption {
 	defaults := []pulumi.InvokeOption{}
 
-	version := semver.MustParse("4.14.0-alpha.1718665781")
+	version := semver.MustParse("4.0.0-alpha.0+dev")
 	if !version.Equals(semver.Version{}) {
 		defaults = append(defaults, pulumi.Version(version.String()))
 	}

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pulumi/kubernetes",
-    "version": "4.14.0-alpha.1718665781",
+    "version": "4.0.0-alpha.0+dev",
     "keywords": [
         "pulumi",
         "kubernetes",
@@ -32,6 +32,6 @@
     "pulumi": {
         "resource": true,
         "name": "kubernetes",
-        "version": "4.14.0-alpha.1718665781"
+        "version": "4.0.0-alpha.0+dev"
     }
 }

--- a/sdk/python/pulumi_kubernetes/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/_inputs.py
@@ -4,15 +4,52 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from . import _utilities
 
 __all__ = [
     'HelmReleaseSettingsArgs',
+    'HelmReleaseSettingsArgsDict',
     'KubeClientSettingsArgs',
+    'KubeClientSettingsArgsDict',
 ]
+
+MYPY = False
+
+if not MYPY:
+    class HelmReleaseSettingsArgsDict(TypedDict):
+        """
+        Options to configure the Helm Release resource.
+        """
+        driver: NotRequired[pulumi.Input[str]]
+        """
+        The backend storage driver for Helm. Values are: configmap, secret, memory, sql.
+        """
+        plugins_path: NotRequired[pulumi.Input[str]]
+        """
+        The path to the helm plugins directory.
+        """
+        registry_config_path: NotRequired[pulumi.Input[str]]
+        """
+        The path to the registry config file.
+        """
+        repository_cache: NotRequired[pulumi.Input[str]]
+        """
+        The path to the directory containing cached repository indexes.
+        """
+        repository_config_path: NotRequired[pulumi.Input[str]]
+        """
+        The path to the file containing repository names and URLs.
+        """
+elif False:
+    HelmReleaseSettingsArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class HelmReleaseSettingsArgs:
@@ -111,6 +148,26 @@ class HelmReleaseSettingsArgs:
     def repository_config_path(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "repository_config_path", value)
 
+
+if not MYPY:
+    class KubeClientSettingsArgsDict(TypedDict):
+        """
+        Options for tuning the Kubernetes client used by a Provider.
+        """
+        burst: NotRequired[pulumi.Input[int]]
+        """
+        Maximum burst for throttle. Default value is 120.
+        """
+        qps: NotRequired[pulumi.Input[float]]
+        """
+        Maximum queries per second (QPS) to the API server from this client. Default value is 50.
+        """
+        timeout: NotRequired[pulumi.Input[int]]
+        """
+        Maximum time in seconds to wait before cancelling a HTTP request to the Kubernetes server. Default value is 32.
+        """
+elif False:
+    KubeClientSettingsArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class KubeClientSettingsArgs:

--- a/sdk/python/pulumi_kubernetes/admissionregistration/v1/MutatingWebhookConfiguration.py
+++ b/sdk/python/pulumi_kubernetes/admissionregistration/v1/MutatingWebhookConfiguration.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class MutatingWebhookConfiguration(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 webhooks: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['MutatingWebhookArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 webhooks: Optional[pulumi.Input[Sequence[pulumi.Input[Union['MutatingWebhookArgs', 'MutatingWebhookArgsDict']]]]] = None,
                  __props__=None):
         """
         MutatingWebhookConfiguration describes the configuration of and admission webhook that accept or reject and may change the object.
@@ -103,8 +108,8 @@ class MutatingWebhookConfiguration(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['MutatingWebhookArgs']]]] webhooks: Webhooks is a list of webhooks and the affected resources and operations.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['MutatingWebhookArgs', 'MutatingWebhookArgsDict']]]] webhooks: Webhooks is a list of webhooks and the affected resources and operations.
         """
         ...
     @overload
@@ -132,8 +137,8 @@ class MutatingWebhookConfiguration(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 webhooks: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['MutatingWebhookArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 webhooks: Optional[pulumi.Input[Sequence[pulumi.Input[Union['MutatingWebhookArgs', 'MutatingWebhookArgsDict']]]]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/admissionregistration/v1/MutatingWebhookConfigurationList.py
+++ b/sdk/python/pulumi_kubernetes/admissionregistration/v1/MutatingWebhookConfigurationList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class MutatingWebhookConfigurationList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['MutatingWebhookConfigurationArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['MutatingWebhookConfigurationArgs', 'MutatingWebhookConfigurationArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         MutatingWebhookConfigurationList is a list of MutatingWebhookConfiguration.
@@ -101,9 +106,9 @@ class MutatingWebhookConfigurationList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['MutatingWebhookConfigurationArgs']]]] items: List of MutatingWebhookConfiguration.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['MutatingWebhookConfigurationArgs', 'MutatingWebhookConfigurationArgsDict']]]] items: List of MutatingWebhookConfiguration.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class MutatingWebhookConfigurationList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['MutatingWebhookConfigurationArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['MutatingWebhookConfigurationArgs', 'MutatingWebhookConfigurationArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/admissionregistration/v1/MutatingWebhookConfigurationPatch.py
+++ b/sdk/python/pulumi_kubernetes/admissionregistration/v1/MutatingWebhookConfigurationPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class MutatingWebhookConfigurationPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 webhooks: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['MutatingWebhookPatchArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 webhooks: Optional[pulumi.Input[Sequence[pulumi.Input[Union['MutatingWebhookPatchArgs', 'MutatingWebhookPatchArgsDict']]]]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -109,8 +114,8 @@ class MutatingWebhookConfigurationPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['MutatingWebhookPatchArgs']]]] webhooks: Webhooks is a list of webhooks and the affected resources and operations.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['MutatingWebhookPatchArgs', 'MutatingWebhookPatchArgsDict']]]] webhooks: Webhooks is a list of webhooks and the affected resources and operations.
         """
         ...
     @overload
@@ -144,8 +149,8 @@ class MutatingWebhookConfigurationPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 webhooks: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['MutatingWebhookPatchArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 webhooks: Optional[pulumi.Input[Sequence[pulumi.Input[Union['MutatingWebhookPatchArgs', 'MutatingWebhookPatchArgsDict']]]]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/admissionregistration/v1/ValidatingAdmissionPolicy.py
+++ b/sdk/python/pulumi_kubernetes/admissionregistration/v1/ValidatingAdmissionPolicy.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class ValidatingAdmissionPolicy(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ValidatingAdmissionPolicySpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ValidatingAdmissionPolicySpecArgs', 'ValidatingAdmissionPolicySpecArgsDict']]] = None,
                  __props__=None):
         """
         ValidatingAdmissionPolicy describes the definition of an admission validation policy that accepts or rejects an object without changing it.
@@ -103,8 +108,8 @@ class ValidatingAdmissionPolicy(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
-        :param pulumi.Input[pulumi.InputType['ValidatingAdmissionPolicySpecArgs']] spec: Specification of the desired behavior of the ValidatingAdmissionPolicy.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
+        :param pulumi.Input[Union['ValidatingAdmissionPolicySpecArgs', 'ValidatingAdmissionPolicySpecArgsDict']] spec: Specification of the desired behavior of the ValidatingAdmissionPolicy.
         """
         ...
     @overload
@@ -132,8 +137,8 @@ class ValidatingAdmissionPolicy(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ValidatingAdmissionPolicySpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ValidatingAdmissionPolicySpecArgs', 'ValidatingAdmissionPolicySpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/admissionregistration/v1/ValidatingAdmissionPolicyBinding.py
+++ b/sdk/python/pulumi_kubernetes/admissionregistration/v1/ValidatingAdmissionPolicyBinding.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class ValidatingAdmissionPolicyBinding(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ValidatingAdmissionPolicyBindingSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ValidatingAdmissionPolicyBindingSpecArgs', 'ValidatingAdmissionPolicyBindingSpecArgsDict']]] = None,
                  __props__=None):
         """
         ValidatingAdmissionPolicyBinding binds the ValidatingAdmissionPolicy with paramerized resources. ValidatingAdmissionPolicyBinding and parameter CRDs together define how cluster administrators configure policies for clusters.
@@ -107,8 +112,8 @@ class ValidatingAdmissionPolicyBinding(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
-        :param pulumi.Input[pulumi.InputType['ValidatingAdmissionPolicyBindingSpecArgs']] spec: Specification of the desired behavior of the ValidatingAdmissionPolicyBinding.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
+        :param pulumi.Input[Union['ValidatingAdmissionPolicyBindingSpecArgs', 'ValidatingAdmissionPolicyBindingSpecArgsDict']] spec: Specification of the desired behavior of the ValidatingAdmissionPolicyBinding.
         """
         ...
     @overload
@@ -140,8 +145,8 @@ class ValidatingAdmissionPolicyBinding(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ValidatingAdmissionPolicyBindingSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ValidatingAdmissionPolicyBindingSpecArgs', 'ValidatingAdmissionPolicyBindingSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/admissionregistration/v1/ValidatingAdmissionPolicyBindingList.py
+++ b/sdk/python/pulumi_kubernetes/admissionregistration/v1/ValidatingAdmissionPolicyBindingList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -92,9 +97,9 @@ class ValidatingAdmissionPolicyBindingList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ValidatingAdmissionPolicyBindingArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ValidatingAdmissionPolicyBindingArgs', 'ValidatingAdmissionPolicyBindingArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         ValidatingAdmissionPolicyBindingList is a list of ValidatingAdmissionPolicyBinding.
@@ -102,9 +107,9 @@ class ValidatingAdmissionPolicyBindingList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ValidatingAdmissionPolicyBindingArgs']]]] items: List of PolicyBinding.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['ValidatingAdmissionPolicyBindingArgs', 'ValidatingAdmissionPolicyBindingArgsDict']]]] items: List of PolicyBinding.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
         """
         ...
     @overload
@@ -131,9 +136,9 @@ class ValidatingAdmissionPolicyBindingList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ValidatingAdmissionPolicyBindingArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ValidatingAdmissionPolicyBindingArgs', 'ValidatingAdmissionPolicyBindingArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/admissionregistration/v1/ValidatingAdmissionPolicyBindingPatch.py
+++ b/sdk/python/pulumi_kubernetes/admissionregistration/v1/ValidatingAdmissionPolicyBindingPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class ValidatingAdmissionPolicyBindingPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ValidatingAdmissionPolicyBindingSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ValidatingAdmissionPolicyBindingSpecPatchArgs', 'ValidatingAdmissionPolicyBindingSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -113,8 +118,8 @@ class ValidatingAdmissionPolicyBindingPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
-        :param pulumi.Input[pulumi.InputType['ValidatingAdmissionPolicyBindingSpecPatchArgs']] spec: Specification of the desired behavior of the ValidatingAdmissionPolicyBinding.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
+        :param pulumi.Input[Union['ValidatingAdmissionPolicyBindingSpecPatchArgs', 'ValidatingAdmissionPolicyBindingSpecPatchArgsDict']] spec: Specification of the desired behavior of the ValidatingAdmissionPolicyBinding.
         """
         ...
     @overload
@@ -152,8 +157,8 @@ class ValidatingAdmissionPolicyBindingPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ValidatingAdmissionPolicyBindingSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ValidatingAdmissionPolicyBindingSpecPatchArgs', 'ValidatingAdmissionPolicyBindingSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/admissionregistration/v1/ValidatingAdmissionPolicyList.py
+++ b/sdk/python/pulumi_kubernetes/admissionregistration/v1/ValidatingAdmissionPolicyList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -92,9 +97,9 @@ class ValidatingAdmissionPolicyList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ValidatingAdmissionPolicyArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ValidatingAdmissionPolicyArgs', 'ValidatingAdmissionPolicyArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         ValidatingAdmissionPolicyList is a list of ValidatingAdmissionPolicy.
@@ -102,9 +107,9 @@ class ValidatingAdmissionPolicyList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ValidatingAdmissionPolicyArgs']]]] items: List of ValidatingAdmissionPolicy.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['ValidatingAdmissionPolicyArgs', 'ValidatingAdmissionPolicyArgsDict']]]] items: List of ValidatingAdmissionPolicy.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
         """
         ...
     @overload
@@ -131,9 +136,9 @@ class ValidatingAdmissionPolicyList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ValidatingAdmissionPolicyArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ValidatingAdmissionPolicyArgs', 'ValidatingAdmissionPolicyArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/admissionregistration/v1/ValidatingAdmissionPolicyPatch.py
+++ b/sdk/python/pulumi_kubernetes/admissionregistration/v1/ValidatingAdmissionPolicyPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class ValidatingAdmissionPolicyPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ValidatingAdmissionPolicySpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ValidatingAdmissionPolicySpecPatchArgs', 'ValidatingAdmissionPolicySpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -109,8 +114,8 @@ class ValidatingAdmissionPolicyPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
-        :param pulumi.Input[pulumi.InputType['ValidatingAdmissionPolicySpecPatchArgs']] spec: Specification of the desired behavior of the ValidatingAdmissionPolicy.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
+        :param pulumi.Input[Union['ValidatingAdmissionPolicySpecPatchArgs', 'ValidatingAdmissionPolicySpecPatchArgsDict']] spec: Specification of the desired behavior of the ValidatingAdmissionPolicy.
         """
         ...
     @overload
@@ -144,8 +149,8 @@ class ValidatingAdmissionPolicyPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ValidatingAdmissionPolicySpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ValidatingAdmissionPolicySpecPatchArgs', 'ValidatingAdmissionPolicySpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/admissionregistration/v1/ValidatingWebhookConfiguration.py
+++ b/sdk/python/pulumi_kubernetes/admissionregistration/v1/ValidatingWebhookConfiguration.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class ValidatingWebhookConfiguration(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 webhooks: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ValidatingWebhookArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 webhooks: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ValidatingWebhookArgs', 'ValidatingWebhookArgsDict']]]]] = None,
                  __props__=None):
         """
         ValidatingWebhookConfiguration describes the configuration of and admission webhook that accept or reject and object without changing it.
@@ -103,8 +108,8 @@ class ValidatingWebhookConfiguration(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ValidatingWebhookArgs']]]] webhooks: Webhooks is a list of webhooks and the affected resources and operations.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['ValidatingWebhookArgs', 'ValidatingWebhookArgsDict']]]] webhooks: Webhooks is a list of webhooks and the affected resources and operations.
         """
         ...
     @overload
@@ -132,8 +137,8 @@ class ValidatingWebhookConfiguration(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 webhooks: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ValidatingWebhookArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 webhooks: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ValidatingWebhookArgs', 'ValidatingWebhookArgsDict']]]]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/admissionregistration/v1/ValidatingWebhookConfigurationList.py
+++ b/sdk/python/pulumi_kubernetes/admissionregistration/v1/ValidatingWebhookConfigurationList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class ValidatingWebhookConfigurationList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ValidatingWebhookConfigurationArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ValidatingWebhookConfigurationArgs', 'ValidatingWebhookConfigurationArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         ValidatingWebhookConfigurationList is a list of ValidatingWebhookConfiguration.
@@ -101,9 +106,9 @@ class ValidatingWebhookConfigurationList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ValidatingWebhookConfigurationArgs']]]] items: List of ValidatingWebhookConfiguration.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['ValidatingWebhookConfigurationArgs', 'ValidatingWebhookConfigurationArgsDict']]]] items: List of ValidatingWebhookConfiguration.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class ValidatingWebhookConfigurationList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ValidatingWebhookConfigurationArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ValidatingWebhookConfigurationArgs', 'ValidatingWebhookConfigurationArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/admissionregistration/v1/ValidatingWebhookConfigurationPatch.py
+++ b/sdk/python/pulumi_kubernetes/admissionregistration/v1/ValidatingWebhookConfigurationPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class ValidatingWebhookConfigurationPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 webhooks: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ValidatingWebhookPatchArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 webhooks: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ValidatingWebhookPatchArgs', 'ValidatingWebhookPatchArgsDict']]]]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -109,8 +114,8 @@ class ValidatingWebhookConfigurationPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ValidatingWebhookPatchArgs']]]] webhooks: Webhooks is a list of webhooks and the affected resources and operations.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['ValidatingWebhookPatchArgs', 'ValidatingWebhookPatchArgsDict']]]] webhooks: Webhooks is a list of webhooks and the affected resources and operations.
         """
         ...
     @overload
@@ -144,8 +149,8 @@ class ValidatingWebhookConfigurationPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 webhooks: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ValidatingWebhookPatchArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 webhooks: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ValidatingWebhookPatchArgs', 'ValidatingWebhookPatchArgsDict']]]]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/admissionregistration/v1/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/admissionregistration/v1/_inputs.py
@@ -4,51 +4,121 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import meta as _meta
 
 __all__ = [
     'AuditAnnotationPatchArgs',
+    'AuditAnnotationPatchArgsDict',
     'AuditAnnotationArgs',
+    'AuditAnnotationArgsDict',
     'ExpressionWarningArgs',
+    'ExpressionWarningArgsDict',
     'MatchConditionPatchArgs',
+    'MatchConditionPatchArgsDict',
     'MatchConditionArgs',
+    'MatchConditionArgsDict',
     'MatchResourcesPatchArgs',
+    'MatchResourcesPatchArgsDict',
     'MatchResourcesArgs',
+    'MatchResourcesArgsDict',
     'MutatingWebhookConfigurationArgs',
+    'MutatingWebhookConfigurationArgsDict',
     'MutatingWebhookPatchArgs',
+    'MutatingWebhookPatchArgsDict',
     'MutatingWebhookArgs',
+    'MutatingWebhookArgsDict',
     'NamedRuleWithOperationsPatchArgs',
+    'NamedRuleWithOperationsPatchArgsDict',
     'NamedRuleWithOperationsArgs',
+    'NamedRuleWithOperationsArgsDict',
     'ParamKindPatchArgs',
+    'ParamKindPatchArgsDict',
     'ParamKindArgs',
+    'ParamKindArgsDict',
     'ParamRefPatchArgs',
+    'ParamRefPatchArgsDict',
     'ParamRefArgs',
+    'ParamRefArgsDict',
     'RuleWithOperationsPatchArgs',
+    'RuleWithOperationsPatchArgsDict',
     'RuleWithOperationsArgs',
+    'RuleWithOperationsArgsDict',
     'ServiceReferencePatchArgs',
+    'ServiceReferencePatchArgsDict',
     'ServiceReferenceArgs',
+    'ServiceReferenceArgsDict',
     'TypeCheckingArgs',
+    'TypeCheckingArgsDict',
     'ValidatingAdmissionPolicyBindingSpecPatchArgs',
+    'ValidatingAdmissionPolicyBindingSpecPatchArgsDict',
     'ValidatingAdmissionPolicyBindingSpecArgs',
+    'ValidatingAdmissionPolicyBindingSpecArgsDict',
     'ValidatingAdmissionPolicyBindingArgs',
+    'ValidatingAdmissionPolicyBindingArgsDict',
     'ValidatingAdmissionPolicySpecPatchArgs',
+    'ValidatingAdmissionPolicySpecPatchArgsDict',
     'ValidatingAdmissionPolicySpecArgs',
+    'ValidatingAdmissionPolicySpecArgsDict',
     'ValidatingAdmissionPolicyStatusArgs',
+    'ValidatingAdmissionPolicyStatusArgsDict',
     'ValidatingAdmissionPolicyArgs',
+    'ValidatingAdmissionPolicyArgsDict',
     'ValidatingWebhookConfigurationArgs',
+    'ValidatingWebhookConfigurationArgsDict',
     'ValidatingWebhookPatchArgs',
+    'ValidatingWebhookPatchArgsDict',
     'ValidatingWebhookArgs',
+    'ValidatingWebhookArgsDict',
     'ValidationPatchArgs',
+    'ValidationPatchArgsDict',
     'ValidationArgs',
+    'ValidationArgsDict',
     'VariablePatchArgs',
+    'VariablePatchArgsDict',
     'VariableArgs',
+    'VariableArgsDict',
     'WebhookClientConfigPatchArgs',
+    'WebhookClientConfigPatchArgsDict',
     'WebhookClientConfigArgs',
+    'WebhookClientConfigArgsDict',
 ]
+
+MYPY = False
+
+if not MYPY:
+    class AuditAnnotationPatchArgsDict(TypedDict):
+        """
+        AuditAnnotation describes how to produce an audit annotation for an API request.
+        """
+        key: NotRequired[pulumi.Input[str]]
+        """
+        key specifies the audit annotation key. The audit annotation keys of a ValidatingAdmissionPolicy must be unique. The key must be a qualified name ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.
+
+        The key is combined with the resource name of the ValidatingAdmissionPolicy to construct an audit annotation key: "{ValidatingAdmissionPolicy name}/{key}".
+
+        If an admission webhook uses the same resource name as this ValidatingAdmissionPolicy and the same audit annotation key, the annotation key will be identical. In this case, the first annotation written with the key will be included in the audit event and all subsequent annotations with the same key will be discarded.
+
+        Required.
+        """
+        value_expression: NotRequired[pulumi.Input[str]]
+        """
+        valueExpression represents the expression which is evaluated by CEL to produce an audit annotation value. The expression must evaluate to either a string or null value. If the expression evaluates to a string, the audit annotation is included with the string value. If the expression evaluates to null or empty string the audit annotation will be omitted. The valueExpression may be no longer than 5kb in length. If the result of the valueExpression is more than 10kb in length, it will be truncated to 10kb.
+
+        If multiple ValidatingAdmissionPolicyBinding resources match an API request, then the valueExpression will be evaluated for each binding. All unique values produced by the valueExpressions will be joined together in a comma-separated list.
+
+        Required.
+        """
+elif False:
+    AuditAnnotationPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class AuditAnnotationPatchArgs:
@@ -110,6 +180,32 @@ class AuditAnnotationPatchArgs:
         pulumi.set(self, "value_expression", value)
 
 
+if not MYPY:
+    class AuditAnnotationArgsDict(TypedDict):
+        """
+        AuditAnnotation describes how to produce an audit annotation for an API request.
+        """
+        key: pulumi.Input[str]
+        """
+        key specifies the audit annotation key. The audit annotation keys of a ValidatingAdmissionPolicy must be unique. The key must be a qualified name ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.
+
+        The key is combined with the resource name of the ValidatingAdmissionPolicy to construct an audit annotation key: "{ValidatingAdmissionPolicy name}/{key}".
+
+        If an admission webhook uses the same resource name as this ValidatingAdmissionPolicy and the same audit annotation key, the annotation key will be identical. In this case, the first annotation written with the key will be included in the audit event and all subsequent annotations with the same key will be discarded.
+
+        Required.
+        """
+        value_expression: pulumi.Input[str]
+        """
+        valueExpression represents the expression which is evaluated by CEL to produce an audit annotation value. The expression must evaluate to either a string or null value. If the expression evaluates to a string, the audit annotation is included with the string value. If the expression evaluates to null or empty string the audit annotation will be omitted. The valueExpression may be no longer than 5kb in length. If the result of the valueExpression is more than 10kb in length, it will be truncated to 10kb.
+
+        If multiple ValidatingAdmissionPolicyBinding resources match an API request, then the valueExpression will be evaluated for each binding. All unique values produced by the valueExpressions will be joined together in a comma-separated list.
+
+        Required.
+        """
+elif False:
+    AuditAnnotationArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class AuditAnnotationArgs:
     def __init__(__self__, *,
@@ -168,6 +264,22 @@ class AuditAnnotationArgs:
         pulumi.set(self, "value_expression", value)
 
 
+if not MYPY:
+    class ExpressionWarningArgsDict(TypedDict):
+        """
+        ExpressionWarning is a warning information that targets a specific expression.
+        """
+        field_ref: pulumi.Input[str]
+        """
+        The path to the field that refers the expression. For example, the reference to the expression of the first item of validations is "spec.validations[0].expression"
+        """
+        warning: pulumi.Input[str]
+        """
+        The content of type checking information in a human-readable form. Each line of the warning contains the type that the expression is checked against, followed by the type check error from the compiler.
+        """
+elif False:
+    ExpressionWarningArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ExpressionWarningArgs:
     def __init__(__self__, *,
@@ -205,6 +317,32 @@ class ExpressionWarningArgs:
     def warning(self, value: pulumi.Input[str]):
         pulumi.set(self, "warning", value)
 
+
+if not MYPY:
+    class MatchConditionPatchArgsDict(TypedDict):
+        """
+        MatchCondition represents a condition which must by fulfilled for a request to be sent to a webhook.
+        """
+        expression: NotRequired[pulumi.Input[str]]
+        """
+        Expression represents the expression which will be evaluated by CEL. Must evaluate to bool. CEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:
+
+        'object' - The object from the incoming request. The value is null for DELETE requests. 'oldObject' - The existing object. The value is null for CREATE requests. 'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest). 'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.
+          See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz
+        'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the
+          request resource.
+        Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/
+
+        Required.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name is an identifier for this match condition, used for strategic merging of MatchConditions, as well as providing an identifier for logging purposes. A good name should be descriptive of the associated expression. Name must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')
+
+        Required.
+        """
+elif False:
+    MatchConditionPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class MatchConditionPatchArgs:
@@ -266,6 +404,32 @@ class MatchConditionPatchArgs:
         pulumi.set(self, "name", value)
 
 
+if not MYPY:
+    class MatchConditionArgsDict(TypedDict):
+        """
+        MatchCondition represents a condition which must by fulfilled for a request to be sent to a webhook.
+        """
+        expression: pulumi.Input[str]
+        """
+        Expression represents the expression which will be evaluated by CEL. Must evaluate to bool. CEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:
+
+        'object' - The object from the incoming request. The value is null for DELETE requests. 'oldObject' - The existing object. The value is null for CREATE requests. 'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest). 'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.
+          See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz
+        'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the
+          request resource.
+        Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/
+
+        Required.
+        """
+        name: pulumi.Input[str]
+        """
+        Name is an identifier for this match condition, used for strategic merging of MatchConditions, as well as providing an identifier for logging purposes. A good name should be descriptive of the associated expression. Name must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')
+
+        Required.
+        """
+elif False:
+    MatchConditionArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class MatchConditionArgs:
     def __init__(__self__, *,
@@ -323,6 +487,70 @@ class MatchConditionArgs:
     def name(self, value: pulumi.Input[str]):
         pulumi.set(self, "name", value)
 
+
+if not MYPY:
+    class MatchResourcesPatchArgsDict(TypedDict):
+        """
+        MatchResources decides whether to run the admission control policy on an object based on whether it meets the match criteria. The exclude rules take precedence over include rules (if a resource matches both, it is excluded)
+        """
+        exclude_resource_rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['NamedRuleWithOperationsPatchArgsDict']]]]
+        """
+        ExcludeResourceRules describes what operations on what resources/subresources the ValidatingAdmissionPolicy should not care about. The exclude rules take precedence over include rules (if a resource matches both, it is excluded)
+        """
+        match_policy: NotRequired[pulumi.Input[str]]
+        """
+        matchPolicy defines how the "MatchResources" list is used to match incoming requests. Allowed values are "Exact" or "Equivalent".
+
+        - Exact: match a request only if it exactly matches a specified rule. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, but "rules" only included `apiGroups:["apps"], apiVersions:["v1"], resources: ["deployments"]`, a request to apps/v1beta1 or extensions/v1beta1 would not be sent to the ValidatingAdmissionPolicy.
+
+        - Equivalent: match a request if modifies a resource listed in rules, even via another API group or version. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, and "rules" only included `apiGroups:["apps"], apiVersions:["v1"], resources: ["deployments"]`, a request to apps/v1beta1 or extensions/v1beta1 would be converted to apps/v1 and sent to the ValidatingAdmissionPolicy.
+
+        Defaults to "Equivalent"
+        """
+        namespace_selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorPatchArgsDict']]
+        """
+        NamespaceSelector decides whether to run the admission control policy on an object based on whether the namespace for that object matches the selector. If the object itself is a namespace, the matching is performed on object.metadata.labels. If the object is another cluster scoped resource, it never skips the policy.
+
+        For example, to run the webhook on any objects whose namespace is not associated with "runlevel" of "0" or "1";  you will set the selector as follows: "namespaceSelector": {
+          "matchExpressions": [
+            {
+              "key": "runlevel",
+              "operator": "NotIn",
+              "values": [
+                "0",
+                "1"
+              ]
+            }
+          ]
+        }
+
+        If instead you want to only run the policy on any objects whose namespace is associated with the "environment" of "prod" or "staging"; you will set the selector as follows: "namespaceSelector": {
+          "matchExpressions": [
+            {
+              "key": "environment",
+              "operator": "In",
+              "values": [
+                "prod",
+                "staging"
+              ]
+            }
+          ]
+        }
+
+        See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/ for more examples of label selectors.
+
+        Default to the empty LabelSelector, which matches everything.
+        """
+        object_selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorPatchArgsDict']]
+        """
+        ObjectSelector decides whether to run the validation based on if the object has matching labels. objectSelector is evaluated against both the oldObject and newObject that would be sent to the cel validation, and is considered to match if either object matches the selector. A null object (oldObject in the case of create, or newObject in the case of delete) or an object that cannot have labels (like a DeploymentRollback or a PodProxyOptions object) is not considered to match. Use the object selector only if the webhook is opt-in, because end users may skip the admission webhook by setting the labels. Default to the empty LabelSelector, which matches everything.
+        """
+        resource_rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['NamedRuleWithOperationsPatchArgsDict']]]]
+        """
+        ResourceRules describes what operations on what resources/subresources the ValidatingAdmissionPolicy matches. The policy cares about an operation if it matches _any_ Rule.
+        """
+elif False:
+    MatchResourcesPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class MatchResourcesPatchArgs:
@@ -484,6 +712,70 @@ class MatchResourcesPatchArgs:
         pulumi.set(self, "resource_rules", value)
 
 
+if not MYPY:
+    class MatchResourcesArgsDict(TypedDict):
+        """
+        MatchResources decides whether to run the admission control policy on an object based on whether it meets the match criteria. The exclude rules take precedence over include rules (if a resource matches both, it is excluded)
+        """
+        exclude_resource_rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['NamedRuleWithOperationsArgsDict']]]]
+        """
+        ExcludeResourceRules describes what operations on what resources/subresources the ValidatingAdmissionPolicy should not care about. The exclude rules take precedence over include rules (if a resource matches both, it is excluded)
+        """
+        match_policy: NotRequired[pulumi.Input[str]]
+        """
+        matchPolicy defines how the "MatchResources" list is used to match incoming requests. Allowed values are "Exact" or "Equivalent".
+
+        - Exact: match a request only if it exactly matches a specified rule. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, but "rules" only included `apiGroups:["apps"], apiVersions:["v1"], resources: ["deployments"]`, a request to apps/v1beta1 or extensions/v1beta1 would not be sent to the ValidatingAdmissionPolicy.
+
+        - Equivalent: match a request if modifies a resource listed in rules, even via another API group or version. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, and "rules" only included `apiGroups:["apps"], apiVersions:["v1"], resources: ["deployments"]`, a request to apps/v1beta1 or extensions/v1beta1 would be converted to apps/v1 and sent to the ValidatingAdmissionPolicy.
+
+        Defaults to "Equivalent"
+        """
+        namespace_selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorArgsDict']]
+        """
+        NamespaceSelector decides whether to run the admission control policy on an object based on whether the namespace for that object matches the selector. If the object itself is a namespace, the matching is performed on object.metadata.labels. If the object is another cluster scoped resource, it never skips the policy.
+
+        For example, to run the webhook on any objects whose namespace is not associated with "runlevel" of "0" or "1";  you will set the selector as follows: "namespaceSelector": {
+          "matchExpressions": [
+            {
+              "key": "runlevel",
+              "operator": "NotIn",
+              "values": [
+                "0",
+                "1"
+              ]
+            }
+          ]
+        }
+
+        If instead you want to only run the policy on any objects whose namespace is associated with the "environment" of "prod" or "staging"; you will set the selector as follows: "namespaceSelector": {
+          "matchExpressions": [
+            {
+              "key": "environment",
+              "operator": "In",
+              "values": [
+                "prod",
+                "staging"
+              ]
+            }
+          ]
+        }
+
+        See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/ for more examples of label selectors.
+
+        Default to the empty LabelSelector, which matches everything.
+        """
+        object_selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorArgsDict']]
+        """
+        ObjectSelector decides whether to run the validation based on if the object has matching labels. objectSelector is evaluated against both the oldObject and newObject that would be sent to the cel validation, and is considered to match if either object matches the selector. A null object (oldObject in the case of create, or newObject in the case of delete) or an object that cannot have labels (like a DeploymentRollback or a PodProxyOptions object) is not considered to match. Use the object selector only if the webhook is opt-in, because end users may skip the admission webhook by setting the labels. Default to the empty LabelSelector, which matches everything.
+        """
+        resource_rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['NamedRuleWithOperationsArgsDict']]]]
+        """
+        ResourceRules describes what operations on what resources/subresources the ValidatingAdmissionPolicy matches. The policy cares about an operation if it matches _any_ Rule.
+        """
+elif False:
+    MatchResourcesArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class MatchResourcesArgs:
     def __init__(__self__, *,
@@ -644,6 +936,30 @@ class MatchResourcesArgs:
         pulumi.set(self, "resource_rules", value)
 
 
+if not MYPY:
+    class MutatingWebhookConfigurationArgsDict(TypedDict):
+        """
+        MutatingWebhookConfiguration describes the configuration of and admission webhook that accept or reject and may change the object.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
+        """
+        webhooks: NotRequired[pulumi.Input[Sequence[pulumi.Input['MutatingWebhookArgsDict']]]]
+        """
+        Webhooks is a list of webhooks and the affected resources and operations.
+        """
+elif False:
+    MutatingWebhookConfigurationArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class MutatingWebhookConfigurationArgs:
     def __init__(__self__, *,
@@ -715,6 +1031,111 @@ class MutatingWebhookConfigurationArgs:
     def webhooks(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['MutatingWebhookArgs']]]]):
         pulumi.set(self, "webhooks", value)
 
+
+if not MYPY:
+    class MutatingWebhookPatchArgsDict(TypedDict):
+        """
+        MutatingWebhook describes an admission webhook and the resources and operations it applies to.
+        """
+        admission_review_versions: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        AdmissionReviewVersions is an ordered list of preferred `AdmissionReview` versions the Webhook expects. API server will try to use first version in the list which it supports. If none of the versions specified in this list supported by API server, validation will fail for this object. If a persisted webhook configuration specifies allowed versions and does not include any versions known to the API Server, calls to the webhook will fail and be subject to the failure policy.
+        """
+        client_config: NotRequired[pulumi.Input['WebhookClientConfigPatchArgsDict']]
+        """
+        ClientConfig defines how to communicate with the hook. Required
+        """
+        failure_policy: NotRequired[pulumi.Input[str]]
+        """
+        FailurePolicy defines how unrecognized errors from the admission endpoint are handled - allowed values are Ignore or Fail. Defaults to Fail.
+        """
+        match_conditions: NotRequired[pulumi.Input[Sequence[pulumi.Input['MatchConditionPatchArgsDict']]]]
+        """
+        MatchConditions is a list of conditions that must be met for a request to be sent to this webhook. Match conditions filter requests that have already been matched by the rules, namespaceSelector, and objectSelector. An empty list of matchConditions matches all requests. There are a maximum of 64 match conditions allowed.
+
+        The exact matching logic is (in order):
+          1. If ANY matchCondition evaluates to FALSE, the webhook is skipped.
+          2. If ALL matchConditions evaluate to TRUE, the webhook is called.
+          3. If any matchCondition evaluates to an error (but none are FALSE):
+             - If failurePolicy=Fail, reject the request
+             - If failurePolicy=Ignore, the error is ignored and the webhook is skipped
+        """
+        match_policy: NotRequired[pulumi.Input[str]]
+        """
+        matchPolicy defines how the "rules" list is used to match incoming requests. Allowed values are "Exact" or "Equivalent".
+
+        - Exact: match a request only if it exactly matches a specified rule. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, but "rules" only included `apiGroups:["apps"], apiVersions:["v1"], resources: ["deployments"]`, a request to apps/v1beta1 or extensions/v1beta1 would not be sent to the webhook.
+
+        - Equivalent: match a request if modifies a resource listed in rules, even via another API group or version. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, and "rules" only included `apiGroups:["apps"], apiVersions:["v1"], resources: ["deployments"]`, a request to apps/v1beta1 or extensions/v1beta1 would be converted to apps/v1 and sent to the webhook.
+
+        Defaults to "Equivalent"
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        The name of the admission webhook. Name should be fully qualified, e.g., imagepolicy.kubernetes.io, where "imagepolicy" is the name of the webhook, and kubernetes.io is the name of the organization. Required.
+        """
+        namespace_selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorPatchArgsDict']]
+        """
+        NamespaceSelector decides whether to run the webhook on an object based on whether the namespace for that object matches the selector. If the object itself is a namespace, the matching is performed on object.metadata.labels. If the object is another cluster scoped resource, it never skips the webhook.
+
+        For example, to run the webhook on any objects whose namespace is not associated with "runlevel" of "0" or "1";  you will set the selector as follows: "namespaceSelector": {
+          "matchExpressions": [
+            {
+              "key": "runlevel",
+              "operator": "NotIn",
+              "values": [
+                "0",
+                "1"
+              ]
+            }
+          ]
+        }
+
+        If instead you want to only run the webhook on any objects whose namespace is associated with the "environment" of "prod" or "staging"; you will set the selector as follows: "namespaceSelector": {
+          "matchExpressions": [
+            {
+              "key": "environment",
+              "operator": "In",
+              "values": [
+                "prod",
+                "staging"
+              ]
+            }
+          ]
+        }
+
+        See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/ for more examples of label selectors.
+
+        Default to the empty LabelSelector, which matches everything.
+        """
+        object_selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorPatchArgsDict']]
+        """
+        ObjectSelector decides whether to run the webhook based on if the object has matching labels. objectSelector is evaluated against both the oldObject and newObject that would be sent to the webhook, and is considered to match if either object matches the selector. A null object (oldObject in the case of create, or newObject in the case of delete) or an object that cannot have labels (like a DeploymentRollback or a PodProxyOptions object) is not considered to match. Use the object selector only if the webhook is opt-in, because end users may skip the admission webhook by setting the labels. Default to the empty LabelSelector, which matches everything.
+        """
+        reinvocation_policy: NotRequired[pulumi.Input[str]]
+        """
+        reinvocationPolicy indicates whether this webhook should be called multiple times as part of a single admission evaluation. Allowed values are "Never" and "IfNeeded".
+
+        Never: the webhook will not be called more than once in a single admission evaluation.
+
+        IfNeeded: the webhook will be called at least one additional time as part of the admission evaluation if the object being admitted is modified by other admission plugins after the initial webhook call. Webhooks that specify this option *must* be idempotent, able to process objects they previously admitted. Note: * the number of additional invocations is not guaranteed to be exactly one. * if additional invocations result in further modifications to the object, webhooks are not guaranteed to be invoked again. * webhooks that use this option may be reordered to minimize the number of additional invocations. * to validate an object after all mutations are guaranteed complete, use a validating admission webhook instead.
+
+        Defaults to "Never".
+        """
+        rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['RuleWithOperationsPatchArgsDict']]]]
+        """
+        Rules describes what operations on what resources/subresources the webhook cares about. The webhook cares about an operation if it matches _any_ Rule. However, in order to prevent ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks from putting the cluster in a state which cannot be recovered from without completely disabling the plugin, ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks are never called on admission requests for ValidatingWebhookConfiguration and MutatingWebhookConfiguration objects.
+        """
+        side_effects: NotRequired[pulumi.Input[str]]
+        """
+        SideEffects states whether this webhook has side effects. Acceptable values are: None, NoneOnDryRun (webhooks created via v1beta1 may also specify Some or Unknown). Webhooks with side effects MUST implement a reconciliation system, since a request may be rejected by a future step in the admission chain and the side effects therefore need to be undone. Requests with the dryRun attribute will be auto-rejected if they match a webhook with sideEffects == Unknown or Some.
+        """
+        timeout_seconds: NotRequired[pulumi.Input[int]]
+        """
+        TimeoutSeconds specifies the timeout for this webhook. After the timeout passes, the webhook call will be ignored or the API call will fail based on the failure policy. The timeout value must be between 1 and 30 seconds. Default to 10 seconds.
+        """
+elif False:
+    MutatingWebhookPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class MutatingWebhookPatchArgs:
@@ -1014,6 +1435,111 @@ class MutatingWebhookPatchArgs:
         pulumi.set(self, "timeout_seconds", value)
 
 
+if not MYPY:
+    class MutatingWebhookArgsDict(TypedDict):
+        """
+        MutatingWebhook describes an admission webhook and the resources and operations it applies to.
+        """
+        admission_review_versions: pulumi.Input[Sequence[pulumi.Input[str]]]
+        """
+        AdmissionReviewVersions is an ordered list of preferred `AdmissionReview` versions the Webhook expects. API server will try to use first version in the list which it supports. If none of the versions specified in this list supported by API server, validation will fail for this object. If a persisted webhook configuration specifies allowed versions and does not include any versions known to the API Server, calls to the webhook will fail and be subject to the failure policy.
+        """
+        client_config: pulumi.Input['WebhookClientConfigArgsDict']
+        """
+        ClientConfig defines how to communicate with the hook. Required
+        """
+        name: pulumi.Input[str]
+        """
+        The name of the admission webhook. Name should be fully qualified, e.g., imagepolicy.kubernetes.io, where "imagepolicy" is the name of the webhook, and kubernetes.io is the name of the organization. Required.
+        """
+        side_effects: pulumi.Input[str]
+        """
+        SideEffects states whether this webhook has side effects. Acceptable values are: None, NoneOnDryRun (webhooks created via v1beta1 may also specify Some or Unknown). Webhooks with side effects MUST implement a reconciliation system, since a request may be rejected by a future step in the admission chain and the side effects therefore need to be undone. Requests with the dryRun attribute will be auto-rejected if they match a webhook with sideEffects == Unknown or Some.
+        """
+        failure_policy: NotRequired[pulumi.Input[str]]
+        """
+        FailurePolicy defines how unrecognized errors from the admission endpoint are handled - allowed values are Ignore or Fail. Defaults to Fail.
+        """
+        match_conditions: NotRequired[pulumi.Input[Sequence[pulumi.Input['MatchConditionArgsDict']]]]
+        """
+        MatchConditions is a list of conditions that must be met for a request to be sent to this webhook. Match conditions filter requests that have already been matched by the rules, namespaceSelector, and objectSelector. An empty list of matchConditions matches all requests. There are a maximum of 64 match conditions allowed.
+
+        The exact matching logic is (in order):
+          1. If ANY matchCondition evaluates to FALSE, the webhook is skipped.
+          2. If ALL matchConditions evaluate to TRUE, the webhook is called.
+          3. If any matchCondition evaluates to an error (but none are FALSE):
+             - If failurePolicy=Fail, reject the request
+             - If failurePolicy=Ignore, the error is ignored and the webhook is skipped
+        """
+        match_policy: NotRequired[pulumi.Input[str]]
+        """
+        matchPolicy defines how the "rules" list is used to match incoming requests. Allowed values are "Exact" or "Equivalent".
+
+        - Exact: match a request only if it exactly matches a specified rule. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, but "rules" only included `apiGroups:["apps"], apiVersions:["v1"], resources: ["deployments"]`, a request to apps/v1beta1 or extensions/v1beta1 would not be sent to the webhook.
+
+        - Equivalent: match a request if modifies a resource listed in rules, even via another API group or version. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, and "rules" only included `apiGroups:["apps"], apiVersions:["v1"], resources: ["deployments"]`, a request to apps/v1beta1 or extensions/v1beta1 would be converted to apps/v1 and sent to the webhook.
+
+        Defaults to "Equivalent"
+        """
+        namespace_selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorArgsDict']]
+        """
+        NamespaceSelector decides whether to run the webhook on an object based on whether the namespace for that object matches the selector. If the object itself is a namespace, the matching is performed on object.metadata.labels. If the object is another cluster scoped resource, it never skips the webhook.
+
+        For example, to run the webhook on any objects whose namespace is not associated with "runlevel" of "0" or "1";  you will set the selector as follows: "namespaceSelector": {
+          "matchExpressions": [
+            {
+              "key": "runlevel",
+              "operator": "NotIn",
+              "values": [
+                "0",
+                "1"
+              ]
+            }
+          ]
+        }
+
+        If instead you want to only run the webhook on any objects whose namespace is associated with the "environment" of "prod" or "staging"; you will set the selector as follows: "namespaceSelector": {
+          "matchExpressions": [
+            {
+              "key": "environment",
+              "operator": "In",
+              "values": [
+                "prod",
+                "staging"
+              ]
+            }
+          ]
+        }
+
+        See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/ for more examples of label selectors.
+
+        Default to the empty LabelSelector, which matches everything.
+        """
+        object_selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorArgsDict']]
+        """
+        ObjectSelector decides whether to run the webhook based on if the object has matching labels. objectSelector is evaluated against both the oldObject and newObject that would be sent to the webhook, and is considered to match if either object matches the selector. A null object (oldObject in the case of create, or newObject in the case of delete) or an object that cannot have labels (like a DeploymentRollback or a PodProxyOptions object) is not considered to match. Use the object selector only if the webhook is opt-in, because end users may skip the admission webhook by setting the labels. Default to the empty LabelSelector, which matches everything.
+        """
+        reinvocation_policy: NotRequired[pulumi.Input[str]]
+        """
+        reinvocationPolicy indicates whether this webhook should be called multiple times as part of a single admission evaluation. Allowed values are "Never" and "IfNeeded".
+
+        Never: the webhook will not be called more than once in a single admission evaluation.
+
+        IfNeeded: the webhook will be called at least one additional time as part of the admission evaluation if the object being admitted is modified by other admission plugins after the initial webhook call. Webhooks that specify this option *must* be idempotent, able to process objects they previously admitted. Note: * the number of additional invocations is not guaranteed to be exactly one. * if additional invocations result in further modifications to the object, webhooks are not guaranteed to be invoked again. * webhooks that use this option may be reordered to minimize the number of additional invocations. * to validate an object after all mutations are guaranteed complete, use a validating admission webhook instead.
+
+        Defaults to "Never".
+        """
+        rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['RuleWithOperationsArgsDict']]]]
+        """
+        Rules describes what operations on what resources/subresources the webhook cares about. The webhook cares about an operation if it matches _any_ Rule. However, in order to prevent ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks from putting the cluster in a state which cannot be recovered from without completely disabling the plugin, ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks are never called on admission requests for ValidatingWebhookConfiguration and MutatingWebhookConfiguration objects.
+        """
+        timeout_seconds: NotRequired[pulumi.Input[int]]
+        """
+        TimeoutSeconds specifies the timeout for this webhook. After the timeout passes, the webhook call will be ignored or the API call will fail based on the failure policy. The timeout value must be between 1 and 30 seconds. Default to 10 seconds.
+        """
+elif False:
+    MutatingWebhookArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class MutatingWebhookArgs:
     def __init__(__self__, *,
@@ -1308,6 +1834,44 @@ class MutatingWebhookArgs:
         pulumi.set(self, "timeout_seconds", value)
 
 
+if not MYPY:
+    class NamedRuleWithOperationsPatchArgsDict(TypedDict):
+        """
+        NamedRuleWithOperations is a tuple of Operations and Resources with ResourceNames.
+        """
+        api_groups: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        APIGroups is the API groups the resources belong to. '*' is all groups. If '*' is present, the length of the slice must be one. Required.
+        """
+        api_versions: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        APIVersions is the API versions the resources belong to. '*' is all versions. If '*' is present, the length of the slice must be one. Required.
+        """
+        operations: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Operations is the operations the admission hook cares about - CREATE, UPDATE, DELETE, CONNECT or * for all of those operations and any future admission operations that are added. If '*' is present, the length of the slice must be one. Required.
+        """
+        resource_names: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
+        """
+        resources: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Resources is a list of resources this rule applies to.
+
+        For example: 'pods' means pods. 'pods/log' means the log subresource of pods. '*' means all resources, but not subresources. 'pods/*' means all subresources of pods. '*/scale' means all scale subresources. '*/*' means all resources and their subresources.
+
+        If wildcard is present, the validation rule will ensure resources do not overlap with each other.
+
+        Depending on the enclosing object, subresources might not be allowed. Required.
+        """
+        scope: NotRequired[pulumi.Input[str]]
+        """
+        scope specifies the scope of this rule. Valid values are "Cluster", "Namespaced", and "*" "Cluster" means that only cluster-scoped resources will match this rule. Namespace API objects are cluster-scoped. "Namespaced" means that only namespaced resources will match this rule. "*" means that there are no scope restrictions. Subresources match the scope of their parent resource. Default is "*".
+        """
+elif False:
+    NamedRuleWithOperationsPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class NamedRuleWithOperationsPatchArgs:
     def __init__(__self__, *,
@@ -1423,6 +1987,44 @@ class NamedRuleWithOperationsPatchArgs:
     def scope(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "scope", value)
 
+
+if not MYPY:
+    class NamedRuleWithOperationsArgsDict(TypedDict):
+        """
+        NamedRuleWithOperations is a tuple of Operations and Resources with ResourceNames.
+        """
+        api_groups: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        APIGroups is the API groups the resources belong to. '*' is all groups. If '*' is present, the length of the slice must be one. Required.
+        """
+        api_versions: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        APIVersions is the API versions the resources belong to. '*' is all versions. If '*' is present, the length of the slice must be one. Required.
+        """
+        operations: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Operations is the operations the admission hook cares about - CREATE, UPDATE, DELETE, CONNECT or * for all of those operations and any future admission operations that are added. If '*' is present, the length of the slice must be one. Required.
+        """
+        resource_names: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
+        """
+        resources: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Resources is a list of resources this rule applies to.
+
+        For example: 'pods' means pods. 'pods/log' means the log subresource of pods. '*' means all resources, but not subresources. 'pods/*' means all subresources of pods. '*/scale' means all scale subresources. '*/*' means all resources and their subresources.
+
+        If wildcard is present, the validation rule will ensure resources do not overlap with each other.
+
+        Depending on the enclosing object, subresources might not be allowed. Required.
+        """
+        scope: NotRequired[pulumi.Input[str]]
+        """
+        scope specifies the scope of this rule. Valid values are "Cluster", "Namespaced", and "*" "Cluster" means that only cluster-scoped resources will match this rule. Namespace API objects are cluster-scoped. "Namespaced" means that only namespaced resources will match this rule. "*" means that there are no scope restrictions. Subresources match the scope of their parent resource. Default is "*".
+        """
+elif False:
+    NamedRuleWithOperationsArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class NamedRuleWithOperationsArgs:
@@ -1540,6 +2142,22 @@ class NamedRuleWithOperationsArgs:
         pulumi.set(self, "scope", value)
 
 
+if not MYPY:
+    class ParamKindPatchArgsDict(TypedDict):
+        """
+        ParamKind is a tuple of Group Kind and Version.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion is the API group version the resources belong to. In format of "group/version". Required.
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is the API kind the resources belong to. Required.
+        """
+elif False:
+    ParamKindPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ParamKindPatchArgs:
     def __init__(__self__, *,
@@ -1580,6 +2198,22 @@ class ParamKindPatchArgs:
         pulumi.set(self, "kind", value)
 
 
+if not MYPY:
+    class ParamKindArgsDict(TypedDict):
+        """
+        ParamKind is a tuple of Group Kind and Version.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion is the API group version the resources belong to. In format of "group/version". Required.
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is the API kind the resources belong to. Required.
+        """
+elif False:
+    ParamKindArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ParamKindArgs:
     def __init__(__self__, *,
@@ -1619,6 +2253,48 @@ class ParamKindArgs:
     def kind(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "kind", value)
 
+
+if not MYPY:
+    class ParamRefPatchArgsDict(TypedDict):
+        """
+        ParamRef describes how to locate the params to be used as input to expressions of rules applied by a policy binding.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        name is the name of the resource being referenced.
+
+        One of `name` or `selector` must be set, but `name` and `selector` are mutually exclusive properties. If one is set, the other must be unset.
+
+        A single parameter used for all admission requests can be configured by setting the `name` field, leaving `selector` blank, and setting namespace if `paramKind` is namespace-scoped.
+        """
+        namespace: NotRequired[pulumi.Input[str]]
+        """
+        namespace is the namespace of the referenced resource. Allows limiting the search for params to a specific namespace. Applies to both `name` and `selector` fields.
+
+        A per-namespace parameter may be used by specifying a namespace-scoped `paramKind` in the policy and leaving this field empty.
+
+        - If `paramKind` is cluster-scoped, this field MUST be unset. Setting this field results in a configuration error.
+
+        - If `paramKind` is namespace-scoped, the namespace of the object being evaluated for admission will be used when this field is left unset. Take care that if this is left empty the binding must not match any cluster-scoped resources, which will result in an error.
+        """
+        parameter_not_found_action: NotRequired[pulumi.Input[str]]
+        """
+        `parameterNotFoundAction` controls the behavior of the binding when the resource exists, and name or selector is valid, but there are no parameters matched by the binding. If the value is set to `Allow`, then no matched parameters will be treated as successful validation by the binding. If set to `Deny`, then no matched parameters will be subject to the `failurePolicy` of the policy.
+
+        Allowed values are `Allow` or `Deny`
+
+        Required
+        """
+        selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorPatchArgsDict']]
+        """
+        selector can be used to match multiple param objects based on their labels. Supply selector: {} to match all resources of the ParamKind.
+
+        If multiple params are found, they are all evaluated with the policy expressions and the results are ANDed together.
+
+        One of `name` or `selector` must be set, but `name` and `selector` are mutually exclusive properties. If one is set, the other must be unset.
+        """
+elif False:
+    ParamRefPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ParamRefPatchArgs:
@@ -1728,6 +2404,48 @@ class ParamRefPatchArgs:
         pulumi.set(self, "selector", value)
 
 
+if not MYPY:
+    class ParamRefArgsDict(TypedDict):
+        """
+        ParamRef describes how to locate the params to be used as input to expressions of rules applied by a policy binding.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        name is the name of the resource being referenced.
+
+        One of `name` or `selector` must be set, but `name` and `selector` are mutually exclusive properties. If one is set, the other must be unset.
+
+        A single parameter used for all admission requests can be configured by setting the `name` field, leaving `selector` blank, and setting namespace if `paramKind` is namespace-scoped.
+        """
+        namespace: NotRequired[pulumi.Input[str]]
+        """
+        namespace is the namespace of the referenced resource. Allows limiting the search for params to a specific namespace. Applies to both `name` and `selector` fields.
+
+        A per-namespace parameter may be used by specifying a namespace-scoped `paramKind` in the policy and leaving this field empty.
+
+        - If `paramKind` is cluster-scoped, this field MUST be unset. Setting this field results in a configuration error.
+
+        - If `paramKind` is namespace-scoped, the namespace of the object being evaluated for admission will be used when this field is left unset. Take care that if this is left empty the binding must not match any cluster-scoped resources, which will result in an error.
+        """
+        parameter_not_found_action: NotRequired[pulumi.Input[str]]
+        """
+        `parameterNotFoundAction` controls the behavior of the binding when the resource exists, and name or selector is valid, but there are no parameters matched by the binding. If the value is set to `Allow`, then no matched parameters will be treated as successful validation by the binding. If set to `Deny`, then no matched parameters will be subject to the `failurePolicy` of the policy.
+
+        Allowed values are `Allow` or `Deny`
+
+        Required
+        """
+        selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorArgsDict']]
+        """
+        selector can be used to match multiple param objects based on their labels. Supply selector: {} to match all resources of the ParamKind.
+
+        If multiple params are found, they are all evaluated with the policy expressions and the results are ANDed together.
+
+        One of `name` or `selector` must be set, but `name` and `selector` are mutually exclusive properties. If one is set, the other must be unset.
+        """
+elif False:
+    ParamRefArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ParamRefArgs:
     def __init__(__self__, *,
@@ -1836,6 +2554,40 @@ class ParamRefArgs:
         pulumi.set(self, "selector", value)
 
 
+if not MYPY:
+    class RuleWithOperationsPatchArgsDict(TypedDict):
+        """
+        RuleWithOperations is a tuple of Operations and Resources. It is recommended to make sure that all the tuple expansions are valid.
+        """
+        api_groups: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        APIGroups is the API groups the resources belong to. '*' is all groups. If '*' is present, the length of the slice must be one. Required.
+        """
+        api_versions: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        APIVersions is the API versions the resources belong to. '*' is all versions. If '*' is present, the length of the slice must be one. Required.
+        """
+        operations: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Operations is the operations the admission hook cares about - CREATE, UPDATE, DELETE, CONNECT or * for all of those operations and any future admission operations that are added. If '*' is present, the length of the slice must be one. Required.
+        """
+        resources: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Resources is a list of resources this rule applies to.
+
+        For example: 'pods' means pods. 'pods/log' means the log subresource of pods. '*' means all resources, but not subresources. 'pods/*' means all subresources of pods. '*/scale' means all scale subresources. '*/*' means all resources and their subresources.
+
+        If wildcard is present, the validation rule will ensure resources do not overlap with each other.
+
+        Depending on the enclosing object, subresources might not be allowed. Required.
+        """
+        scope: NotRequired[pulumi.Input[str]]
+        """
+        scope specifies the scope of this rule. Valid values are "Cluster", "Namespaced", and "*" "Cluster" means that only cluster-scoped resources will match this rule. Namespace API objects are cluster-scoped. "Namespaced" means that only namespaced resources will match this rule. "*" means that there are no scope restrictions. Subresources match the scope of their parent resource. Default is "*".
+        """
+elif False:
+    RuleWithOperationsPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class RuleWithOperationsPatchArgs:
     def __init__(__self__, *,
@@ -1935,6 +2687,40 @@ class RuleWithOperationsPatchArgs:
     def scope(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "scope", value)
 
+
+if not MYPY:
+    class RuleWithOperationsArgsDict(TypedDict):
+        """
+        RuleWithOperations is a tuple of Operations and Resources. It is recommended to make sure that all the tuple expansions are valid.
+        """
+        api_groups: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        APIGroups is the API groups the resources belong to. '*' is all groups. If '*' is present, the length of the slice must be one. Required.
+        """
+        api_versions: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        APIVersions is the API versions the resources belong to. '*' is all versions. If '*' is present, the length of the slice must be one. Required.
+        """
+        operations: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Operations is the operations the admission hook cares about - CREATE, UPDATE, DELETE, CONNECT or * for all of those operations and any future admission operations that are added. If '*' is present, the length of the slice must be one. Required.
+        """
+        resources: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Resources is a list of resources this rule applies to.
+
+        For example: 'pods' means pods. 'pods/log' means the log subresource of pods. '*' means all resources, but not subresources. 'pods/*' means all subresources of pods. '*/scale' means all scale subresources. '*/*' means all resources and their subresources.
+
+        If wildcard is present, the validation rule will ensure resources do not overlap with each other.
+
+        Depending on the enclosing object, subresources might not be allowed. Required.
+        """
+        scope: NotRequired[pulumi.Input[str]]
+        """
+        scope specifies the scope of this rule. Valid values are "Cluster", "Namespaced", and "*" "Cluster" means that only cluster-scoped resources will match this rule. Namespace API objects are cluster-scoped. "Namespaced" means that only namespaced resources will match this rule. "*" means that there are no scope restrictions. Subresources match the scope of their parent resource. Default is "*".
+        """
+elif False:
+    RuleWithOperationsArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class RuleWithOperationsArgs:
@@ -2036,6 +2822,30 @@ class RuleWithOperationsArgs:
         pulumi.set(self, "scope", value)
 
 
+if not MYPY:
+    class ServiceReferencePatchArgsDict(TypedDict):
+        """
+        ServiceReference holds a reference to Service.legacy.k8s.io
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        `name` is the name of the service. Required
+        """
+        namespace: NotRequired[pulumi.Input[str]]
+        """
+        `namespace` is the namespace of the service. Required
+        """
+        path: NotRequired[pulumi.Input[str]]
+        """
+        `path` is an optional URL path which will be sent in any request to this service.
+        """
+        port: NotRequired[pulumi.Input[int]]
+        """
+        If specified, the port on the service that hosting webhook. Default to 443 for backward compatibility. `port` should be a valid port number (1-65535, inclusive).
+        """
+elif False:
+    ServiceReferencePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ServiceReferencePatchArgs:
     def __init__(__self__, *,
@@ -2108,6 +2918,30 @@ class ServiceReferencePatchArgs:
         pulumi.set(self, "port", value)
 
 
+if not MYPY:
+    class ServiceReferenceArgsDict(TypedDict):
+        """
+        ServiceReference holds a reference to Service.legacy.k8s.io
+        """
+        name: pulumi.Input[str]
+        """
+        `name` is the name of the service. Required
+        """
+        namespace: pulumi.Input[str]
+        """
+        `namespace` is the namespace of the service. Required
+        """
+        path: NotRequired[pulumi.Input[str]]
+        """
+        `path` is an optional URL path which will be sent in any request to this service.
+        """
+        port: NotRequired[pulumi.Input[int]]
+        """
+        If specified, the port on the service that hosting webhook. Default to 443 for backward compatibility. `port` should be a valid port number (1-65535, inclusive).
+        """
+elif False:
+    ServiceReferenceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ServiceReferenceArgs:
     def __init__(__self__, *,
@@ -2178,6 +3012,18 @@ class ServiceReferenceArgs:
         pulumi.set(self, "port", value)
 
 
+if not MYPY:
+    class TypeCheckingArgsDict(TypedDict):
+        """
+        TypeChecking contains results of type checking the expressions in the ValidatingAdmissionPolicy
+        """
+        expression_warnings: NotRequired[pulumi.Input[Sequence[pulumi.Input['ExpressionWarningArgsDict']]]]
+        """
+        The type checking warnings for each expression.
+        """
+elif False:
+    TypeCheckingArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class TypeCheckingArgs:
     def __init__(__self__, *,
@@ -2201,6 +3047,48 @@ class TypeCheckingArgs:
     def expression_warnings(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['ExpressionWarningArgs']]]]):
         pulumi.set(self, "expression_warnings", value)
 
+
+if not MYPY:
+    class ValidatingAdmissionPolicyBindingSpecPatchArgsDict(TypedDict):
+        """
+        ValidatingAdmissionPolicyBindingSpec is the specification of the ValidatingAdmissionPolicyBinding.
+        """
+        match_resources: NotRequired[pulumi.Input['MatchResourcesPatchArgsDict']]
+        """
+        MatchResources declares what resources match this binding and will be validated by it. Note that this is intersected with the policy's matchConstraints, so only requests that are matched by the policy can be selected by this. If this is unset, all resources matched by the policy are validated by this binding When resourceRules is unset, it does not constrain resource matching. If a resource is matched by the other fields of this object, it will be validated. Note that this is differs from ValidatingAdmissionPolicy matchConstraints, where resourceRules are required.
+        """
+        param_ref: NotRequired[pulumi.Input['ParamRefPatchArgsDict']]
+        """
+        paramRef specifies the parameter resource used to configure the admission control policy. It should point to a resource of the type specified in ParamKind of the bound ValidatingAdmissionPolicy. If the policy specifies a ParamKind and the resource referred to by ParamRef does not exist, this binding is considered mis-configured and the FailurePolicy of the ValidatingAdmissionPolicy applied. If the policy does not specify a ParamKind then this field is ignored, and the rules are evaluated without a param.
+        """
+        policy_name: NotRequired[pulumi.Input[str]]
+        """
+        PolicyName references a ValidatingAdmissionPolicy name which the ValidatingAdmissionPolicyBinding binds to. If the referenced resource does not exist, this binding is considered invalid and will be ignored Required.
+        """
+        validation_actions: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        validationActions declares how Validations of the referenced ValidatingAdmissionPolicy are enforced. If a validation evaluates to false it is always enforced according to these actions.
+
+        Failures defined by the ValidatingAdmissionPolicy's FailurePolicy are enforced according to these actions only if the FailurePolicy is set to Fail, otherwise the failures are ignored. This includes compilation errors, runtime errors and misconfigurations of the policy.
+
+        validationActions is declared as a set of action values. Order does not matter. validationActions may not contain duplicates of the same action.
+
+        The supported actions values are:
+
+        "Deny" specifies that a validation failure results in a denied request.
+
+        "Warn" specifies that a validation failure is reported to the request client in HTTP Warning headers, with a warning code of 299. Warnings can be sent both for allowed or denied admission responses.
+
+        "Audit" specifies that a validation failure is included in the published audit event for the request. The audit event will contain a `validation.policy.admission.k8s.io/validation_failure` audit annotation with a value containing the details of the validation failures, formatted as a JSON list of objects, each with the following fields: - message: The validation failure message string - policy: The resource name of the ValidatingAdmissionPolicy - binding: The resource name of the ValidatingAdmissionPolicyBinding - expressionIndex: The index of the failed validations in the ValidatingAdmissionPolicy - validationActions: The enforcement actions enacted for the validation failure Example audit annotation: `"validation.policy.admission.k8s.io/validation_failure": "[{"message": "Invalid value", {"policy": "policy.example.com", {"binding": "policybinding.example.com", {"expressionIndex": "1", {"validationActions": ["Audit"]}]"`
+
+        Clients should expect to handle additional values by ignoring any values not recognized.
+
+        "Deny" and "Warn" may not be used together since this combination needlessly duplicates the validation failure both in the API response body and the HTTP warning headers.
+
+        Required.
+        """
+elif False:
+    ValidatingAdmissionPolicyBindingSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ValidatingAdmissionPolicyBindingSpecPatchArgs:
@@ -2310,6 +3198,48 @@ class ValidatingAdmissionPolicyBindingSpecPatchArgs:
         pulumi.set(self, "validation_actions", value)
 
 
+if not MYPY:
+    class ValidatingAdmissionPolicyBindingSpecArgsDict(TypedDict):
+        """
+        ValidatingAdmissionPolicyBindingSpec is the specification of the ValidatingAdmissionPolicyBinding.
+        """
+        match_resources: NotRequired[pulumi.Input['MatchResourcesArgsDict']]
+        """
+        MatchResources declares what resources match this binding and will be validated by it. Note that this is intersected with the policy's matchConstraints, so only requests that are matched by the policy can be selected by this. If this is unset, all resources matched by the policy are validated by this binding When resourceRules is unset, it does not constrain resource matching. If a resource is matched by the other fields of this object, it will be validated. Note that this is differs from ValidatingAdmissionPolicy matchConstraints, where resourceRules are required.
+        """
+        param_ref: NotRequired[pulumi.Input['ParamRefArgsDict']]
+        """
+        paramRef specifies the parameter resource used to configure the admission control policy. It should point to a resource of the type specified in ParamKind of the bound ValidatingAdmissionPolicy. If the policy specifies a ParamKind and the resource referred to by ParamRef does not exist, this binding is considered mis-configured and the FailurePolicy of the ValidatingAdmissionPolicy applied. If the policy does not specify a ParamKind then this field is ignored, and the rules are evaluated without a param.
+        """
+        policy_name: NotRequired[pulumi.Input[str]]
+        """
+        PolicyName references a ValidatingAdmissionPolicy name which the ValidatingAdmissionPolicyBinding binds to. If the referenced resource does not exist, this binding is considered invalid and will be ignored Required.
+        """
+        validation_actions: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        validationActions declares how Validations of the referenced ValidatingAdmissionPolicy are enforced. If a validation evaluates to false it is always enforced according to these actions.
+
+        Failures defined by the ValidatingAdmissionPolicy's FailurePolicy are enforced according to these actions only if the FailurePolicy is set to Fail, otherwise the failures are ignored. This includes compilation errors, runtime errors and misconfigurations of the policy.
+
+        validationActions is declared as a set of action values. Order does not matter. validationActions may not contain duplicates of the same action.
+
+        The supported actions values are:
+
+        "Deny" specifies that a validation failure results in a denied request.
+
+        "Warn" specifies that a validation failure is reported to the request client in HTTP Warning headers, with a warning code of 299. Warnings can be sent both for allowed or denied admission responses.
+
+        "Audit" specifies that a validation failure is included in the published audit event for the request. The audit event will contain a `validation.policy.admission.k8s.io/validation_failure` audit annotation with a value containing the details of the validation failures, formatted as a JSON list of objects, each with the following fields: - message: The validation failure message string - policy: The resource name of the ValidatingAdmissionPolicy - binding: The resource name of the ValidatingAdmissionPolicyBinding - expressionIndex: The index of the failed validations in the ValidatingAdmissionPolicy - validationActions: The enforcement actions enacted for the validation failure Example audit annotation: `"validation.policy.admission.k8s.io/validation_failure": "[{"message": "Invalid value", {"policy": "policy.example.com", {"binding": "policybinding.example.com", {"expressionIndex": "1", {"validationActions": ["Audit"]}]"`
+
+        Clients should expect to handle additional values by ignoring any values not recognized.
+
+        "Deny" and "Warn" may not be used together since this combination needlessly duplicates the validation failure both in the API response body and the HTTP warning headers.
+
+        Required.
+        """
+elif False:
+    ValidatingAdmissionPolicyBindingSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ValidatingAdmissionPolicyBindingSpecArgs:
     def __init__(__self__, *,
@@ -2418,6 +3348,34 @@ class ValidatingAdmissionPolicyBindingSpecArgs:
         pulumi.set(self, "validation_actions", value)
 
 
+if not MYPY:
+    class ValidatingAdmissionPolicyBindingArgsDict(TypedDict):
+        """
+        ValidatingAdmissionPolicyBinding binds the ValidatingAdmissionPolicy with paramerized resources. ValidatingAdmissionPolicyBinding and parameter CRDs together define how cluster administrators configure policies for clusters.
+
+        For a given admission request, each binding will cause its policy to be evaluated N times, where N is 1 for policies/bindings that don't use params, otherwise N is the number of parameters selected by the binding.
+
+        The CEL expressions of a policy must have a computed CEL cost below the maximum CEL budget. Each evaluation of the policy is given an independent CEL cost budget. Adding/removing policies, bindings, or params can not affect whether a given (policy, binding, param) combination is within its own CEL budget.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
+        """
+        spec: NotRequired[pulumi.Input['ValidatingAdmissionPolicyBindingSpecArgsDict']]
+        """
+        Specification of the desired behavior of the ValidatingAdmissionPolicyBinding.
+        """
+elif False:
+    ValidatingAdmissionPolicyBindingArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ValidatingAdmissionPolicyBindingArgs:
     def __init__(__self__, *,
@@ -2493,6 +3451,61 @@ class ValidatingAdmissionPolicyBindingArgs:
     def spec(self, value: Optional[pulumi.Input['ValidatingAdmissionPolicyBindingSpecArgs']]):
         pulumi.set(self, "spec", value)
 
+
+if not MYPY:
+    class ValidatingAdmissionPolicySpecPatchArgsDict(TypedDict):
+        """
+        ValidatingAdmissionPolicySpec is the specification of the desired behavior of the AdmissionPolicy.
+        """
+        audit_annotations: NotRequired[pulumi.Input[Sequence[pulumi.Input['AuditAnnotationPatchArgsDict']]]]
+        """
+        auditAnnotations contains CEL expressions which are used to produce audit annotations for the audit event of the API request. validations and auditAnnotations may not both be empty; a least one of validations or auditAnnotations is required.
+        """
+        failure_policy: NotRequired[pulumi.Input[str]]
+        """
+        failurePolicy defines how to handle failures for the admission policy. Failures can occur from CEL expression parse errors, type check errors, runtime errors and invalid or mis-configured policy definitions or bindings.
+
+        A policy is invalid if spec.paramKind refers to a non-existent Kind. A binding is invalid if spec.paramRef.name refers to a non-existent resource.
+
+        failurePolicy does not define how validations that evaluate to false are handled.
+
+        When failurePolicy is set to Fail, ValidatingAdmissionPolicyBinding validationActions define how failures are enforced.
+
+        Allowed values are Ignore or Fail. Defaults to Fail.
+        """
+        match_conditions: NotRequired[pulumi.Input[Sequence[pulumi.Input['MatchConditionPatchArgsDict']]]]
+        """
+        MatchConditions is a list of conditions that must be met for a request to be validated. Match conditions filter requests that have already been matched by the rules, namespaceSelector, and objectSelector. An empty list of matchConditions matches all requests. There are a maximum of 64 match conditions allowed.
+
+        If a parameter object is provided, it can be accessed via the `params` handle in the same manner as validation expressions.
+
+        The exact matching logic is (in order):
+          1. If ANY matchCondition evaluates to FALSE, the policy is skipped.
+          2. If ALL matchConditions evaluate to TRUE, the policy is evaluated.
+          3. If any matchCondition evaluates to an error (but none are FALSE):
+             - If failurePolicy=Fail, reject the request
+             - If failurePolicy=Ignore, the policy is skipped
+        """
+        match_constraints: NotRequired[pulumi.Input['MatchResourcesPatchArgsDict']]
+        """
+        MatchConstraints specifies what resources this policy is designed to validate. The AdmissionPolicy cares about a request if it matches _all_ Constraints. However, in order to prevent clusters from being put into an unstable state that cannot be recovered from via the API ValidatingAdmissionPolicy cannot match ValidatingAdmissionPolicy and ValidatingAdmissionPolicyBinding. Required.
+        """
+        param_kind: NotRequired[pulumi.Input['ParamKindPatchArgsDict']]
+        """
+        ParamKind specifies the kind of resources used to parameterize this policy. If absent, there are no parameters for this policy and the param CEL variable will not be provided to validation expressions. If ParamKind refers to a non-existent kind, this policy definition is mis-configured and the FailurePolicy is applied. If paramKind is specified but paramRef is unset in ValidatingAdmissionPolicyBinding, the params variable will be null.
+        """
+        validations: NotRequired[pulumi.Input[Sequence[pulumi.Input['ValidationPatchArgsDict']]]]
+        """
+        Validations contain CEL expressions which is used to apply the validation. Validations and AuditAnnotations may not both be empty; a minimum of one Validations or AuditAnnotations is required.
+        """
+        variables: NotRequired[pulumi.Input[Sequence[pulumi.Input['VariablePatchArgsDict']]]]
+        """
+        Variables contain definitions of variables that can be used in composition of other expressions. Each variable is defined as a named CEL expression. The variables defined here will be available under `variables` in other expressions of the policy except MatchConditions because MatchConditions are evaluated before the rest of the policy.
+
+        The expression of a variable can refer to other variables defined earlier in the list but not those after. Thus, Variables must be sorted by the order of first appearance and acyclic.
+        """
+elif False:
+    ValidatingAdmissionPolicySpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ValidatingAdmissionPolicySpecPatchArgs:
@@ -2652,6 +3665,61 @@ class ValidatingAdmissionPolicySpecPatchArgs:
         pulumi.set(self, "variables", value)
 
 
+if not MYPY:
+    class ValidatingAdmissionPolicySpecArgsDict(TypedDict):
+        """
+        ValidatingAdmissionPolicySpec is the specification of the desired behavior of the AdmissionPolicy.
+        """
+        audit_annotations: NotRequired[pulumi.Input[Sequence[pulumi.Input['AuditAnnotationArgsDict']]]]
+        """
+        auditAnnotations contains CEL expressions which are used to produce audit annotations for the audit event of the API request. validations and auditAnnotations may not both be empty; a least one of validations or auditAnnotations is required.
+        """
+        failure_policy: NotRequired[pulumi.Input[str]]
+        """
+        failurePolicy defines how to handle failures for the admission policy. Failures can occur from CEL expression parse errors, type check errors, runtime errors and invalid or mis-configured policy definitions or bindings.
+
+        A policy is invalid if spec.paramKind refers to a non-existent Kind. A binding is invalid if spec.paramRef.name refers to a non-existent resource.
+
+        failurePolicy does not define how validations that evaluate to false are handled.
+
+        When failurePolicy is set to Fail, ValidatingAdmissionPolicyBinding validationActions define how failures are enforced.
+
+        Allowed values are Ignore or Fail. Defaults to Fail.
+        """
+        match_conditions: NotRequired[pulumi.Input[Sequence[pulumi.Input['MatchConditionArgsDict']]]]
+        """
+        MatchConditions is a list of conditions that must be met for a request to be validated. Match conditions filter requests that have already been matched by the rules, namespaceSelector, and objectSelector. An empty list of matchConditions matches all requests. There are a maximum of 64 match conditions allowed.
+
+        If a parameter object is provided, it can be accessed via the `params` handle in the same manner as validation expressions.
+
+        The exact matching logic is (in order):
+          1. If ANY matchCondition evaluates to FALSE, the policy is skipped.
+          2. If ALL matchConditions evaluate to TRUE, the policy is evaluated.
+          3. If any matchCondition evaluates to an error (but none are FALSE):
+             - If failurePolicy=Fail, reject the request
+             - If failurePolicy=Ignore, the policy is skipped
+        """
+        match_constraints: NotRequired[pulumi.Input['MatchResourcesArgsDict']]
+        """
+        MatchConstraints specifies what resources this policy is designed to validate. The AdmissionPolicy cares about a request if it matches _all_ Constraints. However, in order to prevent clusters from being put into an unstable state that cannot be recovered from via the API ValidatingAdmissionPolicy cannot match ValidatingAdmissionPolicy and ValidatingAdmissionPolicyBinding. Required.
+        """
+        param_kind: NotRequired[pulumi.Input['ParamKindArgsDict']]
+        """
+        ParamKind specifies the kind of resources used to parameterize this policy. If absent, there are no parameters for this policy and the param CEL variable will not be provided to validation expressions. If ParamKind refers to a non-existent kind, this policy definition is mis-configured and the FailurePolicy is applied. If paramKind is specified but paramRef is unset in ValidatingAdmissionPolicyBinding, the params variable will be null.
+        """
+        validations: NotRequired[pulumi.Input[Sequence[pulumi.Input['ValidationArgsDict']]]]
+        """
+        Validations contain CEL expressions which is used to apply the validation. Validations and AuditAnnotations may not both be empty; a minimum of one Validations or AuditAnnotations is required.
+        """
+        variables: NotRequired[pulumi.Input[Sequence[pulumi.Input['VariableArgsDict']]]]
+        """
+        Variables contain definitions of variables that can be used in composition of other expressions. Each variable is defined as a named CEL expression. The variables defined here will be available under `variables` in other expressions of the policy except MatchConditions because MatchConditions are evaluated before the rest of the policy.
+
+        The expression of a variable can refer to other variables defined earlier in the list but not those after. Thus, Variables must be sorted by the order of first appearance and acyclic.
+        """
+elif False:
+    ValidatingAdmissionPolicySpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ValidatingAdmissionPolicySpecArgs:
     def __init__(__self__, *,
@@ -2810,6 +3878,26 @@ class ValidatingAdmissionPolicySpecArgs:
         pulumi.set(self, "variables", value)
 
 
+if not MYPY:
+    class ValidatingAdmissionPolicyStatusArgsDict(TypedDict):
+        """
+        ValidatingAdmissionPolicyStatus represents the status of an admission validation policy.
+        """
+        conditions: NotRequired[pulumi.Input[Sequence[pulumi.Input['_meta.v1.ConditionArgsDict']]]]
+        """
+        The conditions represent the latest available observations of a policy's current state.
+        """
+        observed_generation: NotRequired[pulumi.Input[int]]
+        """
+        The generation observed by the controller.
+        """
+        type_checking: NotRequired[pulumi.Input['TypeCheckingArgsDict']]
+        """
+        The results of type checking for each expression. Presence of this field indicates the completion of the type checking.
+        """
+elif False:
+    ValidatingAdmissionPolicyStatusArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ValidatingAdmissionPolicyStatusArgs:
     def __init__(__self__, *,
@@ -2865,6 +3953,34 @@ class ValidatingAdmissionPolicyStatusArgs:
     def type_checking(self, value: Optional[pulumi.Input['TypeCheckingArgs']]):
         pulumi.set(self, "type_checking", value)
 
+
+if not MYPY:
+    class ValidatingAdmissionPolicyArgsDict(TypedDict):
+        """
+        ValidatingAdmissionPolicy describes the definition of an admission validation policy that accepts or rejects an object without changing it.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
+        """
+        spec: NotRequired[pulumi.Input['ValidatingAdmissionPolicySpecArgsDict']]
+        """
+        Specification of the desired behavior of the ValidatingAdmissionPolicy.
+        """
+        status: NotRequired[pulumi.Input['ValidatingAdmissionPolicyStatusArgsDict']]
+        """
+        The status of the ValidatingAdmissionPolicy, including warnings that are useful to determine if the policy behaves in the expected way. Populated by the system. Read-only.
+        """
+elif False:
+    ValidatingAdmissionPolicyArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ValidatingAdmissionPolicyArgs:
@@ -2954,6 +4070,30 @@ class ValidatingAdmissionPolicyArgs:
         pulumi.set(self, "status", value)
 
 
+if not MYPY:
+    class ValidatingWebhookConfigurationArgsDict(TypedDict):
+        """
+        ValidatingWebhookConfiguration describes the configuration of and admission webhook that accept or reject and object without changing it.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
+        """
+        webhooks: NotRequired[pulumi.Input[Sequence[pulumi.Input['ValidatingWebhookArgsDict']]]]
+        """
+        Webhooks is a list of webhooks and the affected resources and operations.
+        """
+elif False:
+    ValidatingWebhookConfigurationArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ValidatingWebhookConfigurationArgs:
     def __init__(__self__, *,
@@ -3025,6 +4165,101 @@ class ValidatingWebhookConfigurationArgs:
     def webhooks(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['ValidatingWebhookArgs']]]]):
         pulumi.set(self, "webhooks", value)
 
+
+if not MYPY:
+    class ValidatingWebhookPatchArgsDict(TypedDict):
+        """
+        ValidatingWebhook describes an admission webhook and the resources and operations it applies to.
+        """
+        admission_review_versions: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        AdmissionReviewVersions is an ordered list of preferred `AdmissionReview` versions the Webhook expects. API server will try to use first version in the list which it supports. If none of the versions specified in this list supported by API server, validation will fail for this object. If a persisted webhook configuration specifies allowed versions and does not include any versions known to the API Server, calls to the webhook will fail and be subject to the failure policy.
+        """
+        client_config: NotRequired[pulumi.Input['WebhookClientConfigPatchArgsDict']]
+        """
+        ClientConfig defines how to communicate with the hook. Required
+        """
+        failure_policy: NotRequired[pulumi.Input[str]]
+        """
+        FailurePolicy defines how unrecognized errors from the admission endpoint are handled - allowed values are Ignore or Fail. Defaults to Fail.
+        """
+        match_conditions: NotRequired[pulumi.Input[Sequence[pulumi.Input['MatchConditionPatchArgsDict']]]]
+        """
+        MatchConditions is a list of conditions that must be met for a request to be sent to this webhook. Match conditions filter requests that have already been matched by the rules, namespaceSelector, and objectSelector. An empty list of matchConditions matches all requests. There are a maximum of 64 match conditions allowed.
+
+        The exact matching logic is (in order):
+          1. If ANY matchCondition evaluates to FALSE, the webhook is skipped.
+          2. If ALL matchConditions evaluate to TRUE, the webhook is called.
+          3. If any matchCondition evaluates to an error (but none are FALSE):
+             - If failurePolicy=Fail, reject the request
+             - If failurePolicy=Ignore, the error is ignored and the webhook is skipped
+        """
+        match_policy: NotRequired[pulumi.Input[str]]
+        """
+        matchPolicy defines how the "rules" list is used to match incoming requests. Allowed values are "Exact" or "Equivalent".
+
+        - Exact: match a request only if it exactly matches a specified rule. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, but "rules" only included `apiGroups:["apps"], apiVersions:["v1"], resources: ["deployments"]`, a request to apps/v1beta1 or extensions/v1beta1 would not be sent to the webhook.
+
+        - Equivalent: match a request if modifies a resource listed in rules, even via another API group or version. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, and "rules" only included `apiGroups:["apps"], apiVersions:["v1"], resources: ["deployments"]`, a request to apps/v1beta1 or extensions/v1beta1 would be converted to apps/v1 and sent to the webhook.
+
+        Defaults to "Equivalent"
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        The name of the admission webhook. Name should be fully qualified, e.g., imagepolicy.kubernetes.io, where "imagepolicy" is the name of the webhook, and kubernetes.io is the name of the organization. Required.
+        """
+        namespace_selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorPatchArgsDict']]
+        """
+        NamespaceSelector decides whether to run the webhook on an object based on whether the namespace for that object matches the selector. If the object itself is a namespace, the matching is performed on object.metadata.labels. If the object is another cluster scoped resource, it never skips the webhook.
+
+        For example, to run the webhook on any objects whose namespace is not associated with "runlevel" of "0" or "1";  you will set the selector as follows: "namespaceSelector": {
+          "matchExpressions": [
+            {
+              "key": "runlevel",
+              "operator": "NotIn",
+              "values": [
+                "0",
+                "1"
+              ]
+            }
+          ]
+        }
+
+        If instead you want to only run the webhook on any objects whose namespace is associated with the "environment" of "prod" or "staging"; you will set the selector as follows: "namespaceSelector": {
+          "matchExpressions": [
+            {
+              "key": "environment",
+              "operator": "In",
+              "values": [
+                "prod",
+                "staging"
+              ]
+            }
+          ]
+        }
+
+        See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels for more examples of label selectors.
+
+        Default to the empty LabelSelector, which matches everything.
+        """
+        object_selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorPatchArgsDict']]
+        """
+        ObjectSelector decides whether to run the webhook based on if the object has matching labels. objectSelector is evaluated against both the oldObject and newObject that would be sent to the webhook, and is considered to match if either object matches the selector. A null object (oldObject in the case of create, or newObject in the case of delete) or an object that cannot have labels (like a DeploymentRollback or a PodProxyOptions object) is not considered to match. Use the object selector only if the webhook is opt-in, because end users may skip the admission webhook by setting the labels. Default to the empty LabelSelector, which matches everything.
+        """
+        rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['RuleWithOperationsPatchArgsDict']]]]
+        """
+        Rules describes what operations on what resources/subresources the webhook cares about. The webhook cares about an operation if it matches _any_ Rule. However, in order to prevent ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks from putting the cluster in a state which cannot be recovered from without completely disabling the plugin, ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks are never called on admission requests for ValidatingWebhookConfiguration and MutatingWebhookConfiguration objects.
+        """
+        side_effects: NotRequired[pulumi.Input[str]]
+        """
+        SideEffects states whether this webhook has side effects. Acceptable values are: None, NoneOnDryRun (webhooks created via v1beta1 may also specify Some or Unknown). Webhooks with side effects MUST implement a reconciliation system, since a request may be rejected by a future step in the admission chain and the side effects therefore need to be undone. Requests with the dryRun attribute will be auto-rejected if they match a webhook with sideEffects == Unknown or Some.
+        """
+        timeout_seconds: NotRequired[pulumi.Input[int]]
+        """
+        TimeoutSeconds specifies the timeout for this webhook. After the timeout passes, the webhook call will be ignored or the API call will fail based on the failure policy. The timeout value must be between 1 and 30 seconds. Default to 10 seconds.
+        """
+elif False:
+    ValidatingWebhookPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ValidatingWebhookPatchArgs:
@@ -3296,6 +4531,101 @@ class ValidatingWebhookPatchArgs:
         pulumi.set(self, "timeout_seconds", value)
 
 
+if not MYPY:
+    class ValidatingWebhookArgsDict(TypedDict):
+        """
+        ValidatingWebhook describes an admission webhook and the resources and operations it applies to.
+        """
+        admission_review_versions: pulumi.Input[Sequence[pulumi.Input[str]]]
+        """
+        AdmissionReviewVersions is an ordered list of preferred `AdmissionReview` versions the Webhook expects. API server will try to use first version in the list which it supports. If none of the versions specified in this list supported by API server, validation will fail for this object. If a persisted webhook configuration specifies allowed versions and does not include any versions known to the API Server, calls to the webhook will fail and be subject to the failure policy.
+        """
+        client_config: pulumi.Input['WebhookClientConfigArgsDict']
+        """
+        ClientConfig defines how to communicate with the hook. Required
+        """
+        name: pulumi.Input[str]
+        """
+        The name of the admission webhook. Name should be fully qualified, e.g., imagepolicy.kubernetes.io, where "imagepolicy" is the name of the webhook, and kubernetes.io is the name of the organization. Required.
+        """
+        side_effects: pulumi.Input[str]
+        """
+        SideEffects states whether this webhook has side effects. Acceptable values are: None, NoneOnDryRun (webhooks created via v1beta1 may also specify Some or Unknown). Webhooks with side effects MUST implement a reconciliation system, since a request may be rejected by a future step in the admission chain and the side effects therefore need to be undone. Requests with the dryRun attribute will be auto-rejected if they match a webhook with sideEffects == Unknown or Some.
+        """
+        failure_policy: NotRequired[pulumi.Input[str]]
+        """
+        FailurePolicy defines how unrecognized errors from the admission endpoint are handled - allowed values are Ignore or Fail. Defaults to Fail.
+        """
+        match_conditions: NotRequired[pulumi.Input[Sequence[pulumi.Input['MatchConditionArgsDict']]]]
+        """
+        MatchConditions is a list of conditions that must be met for a request to be sent to this webhook. Match conditions filter requests that have already been matched by the rules, namespaceSelector, and objectSelector. An empty list of matchConditions matches all requests. There are a maximum of 64 match conditions allowed.
+
+        The exact matching logic is (in order):
+          1. If ANY matchCondition evaluates to FALSE, the webhook is skipped.
+          2. If ALL matchConditions evaluate to TRUE, the webhook is called.
+          3. If any matchCondition evaluates to an error (but none are FALSE):
+             - If failurePolicy=Fail, reject the request
+             - If failurePolicy=Ignore, the error is ignored and the webhook is skipped
+        """
+        match_policy: NotRequired[pulumi.Input[str]]
+        """
+        matchPolicy defines how the "rules" list is used to match incoming requests. Allowed values are "Exact" or "Equivalent".
+
+        - Exact: match a request only if it exactly matches a specified rule. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, but "rules" only included `apiGroups:["apps"], apiVersions:["v1"], resources: ["deployments"]`, a request to apps/v1beta1 or extensions/v1beta1 would not be sent to the webhook.
+
+        - Equivalent: match a request if modifies a resource listed in rules, even via another API group or version. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, and "rules" only included `apiGroups:["apps"], apiVersions:["v1"], resources: ["deployments"]`, a request to apps/v1beta1 or extensions/v1beta1 would be converted to apps/v1 and sent to the webhook.
+
+        Defaults to "Equivalent"
+        """
+        namespace_selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorArgsDict']]
+        """
+        NamespaceSelector decides whether to run the webhook on an object based on whether the namespace for that object matches the selector. If the object itself is a namespace, the matching is performed on object.metadata.labels. If the object is another cluster scoped resource, it never skips the webhook.
+
+        For example, to run the webhook on any objects whose namespace is not associated with "runlevel" of "0" or "1";  you will set the selector as follows: "namespaceSelector": {
+          "matchExpressions": [
+            {
+              "key": "runlevel",
+              "operator": "NotIn",
+              "values": [
+                "0",
+                "1"
+              ]
+            }
+          ]
+        }
+
+        If instead you want to only run the webhook on any objects whose namespace is associated with the "environment" of "prod" or "staging"; you will set the selector as follows: "namespaceSelector": {
+          "matchExpressions": [
+            {
+              "key": "environment",
+              "operator": "In",
+              "values": [
+                "prod",
+                "staging"
+              ]
+            }
+          ]
+        }
+
+        See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels for more examples of label selectors.
+
+        Default to the empty LabelSelector, which matches everything.
+        """
+        object_selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorArgsDict']]
+        """
+        ObjectSelector decides whether to run the webhook based on if the object has matching labels. objectSelector is evaluated against both the oldObject and newObject that would be sent to the webhook, and is considered to match if either object matches the selector. A null object (oldObject in the case of create, or newObject in the case of delete) or an object that cannot have labels (like a DeploymentRollback or a PodProxyOptions object) is not considered to match. Use the object selector only if the webhook is opt-in, because end users may skip the admission webhook by setting the labels. Default to the empty LabelSelector, which matches everything.
+        """
+        rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['RuleWithOperationsArgsDict']]]]
+        """
+        Rules describes what operations on what resources/subresources the webhook cares about. The webhook cares about an operation if it matches _any_ Rule. However, in order to prevent ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks from putting the cluster in a state which cannot be recovered from without completely disabling the plugin, ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks are never called on admission requests for ValidatingWebhookConfiguration and MutatingWebhookConfiguration objects.
+        """
+        timeout_seconds: NotRequired[pulumi.Input[int]]
+        """
+        TimeoutSeconds specifies the timeout for this webhook. After the timeout passes, the webhook call will be ignored or the API call will fail based on the failure policy. The timeout value must be between 1 and 30 seconds. Default to 10 seconds.
+        """
+elif False:
+    ValidatingWebhookArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ValidatingWebhookArgs:
     def __init__(__self__, *,
@@ -3562,6 +4892,55 @@ class ValidatingWebhookArgs:
         pulumi.set(self, "timeout_seconds", value)
 
 
+if not MYPY:
+    class ValidationPatchArgsDict(TypedDict):
+        """
+        Validation specifies the CEL expression which is used to apply the validation.
+        """
+        expression: NotRequired[pulumi.Input[str]]
+        """
+        Expression represents the expression which will be evaluated by CEL. ref: https://github.com/google/cel-spec CEL expressions have access to the contents of the API request/response, organized into CEL variables as well as some other useful variables:
+
+        - 'object' - The object from the incoming request. The value is null for DELETE requests. - 'oldObject' - The existing object. The value is null for CREATE requests. - 'request' - Attributes of the API request([ref](/pkg/apis/admission/types.go#AdmissionRequest)). - 'params' - Parameter resource referred to by the policy binding being evaluated. Only populated if the policy has a ParamKind. - 'namespaceObject' - The namespace object that the incoming object belongs to. The value is null for cluster-scoped resources. - 'variables' - Map of composited variables, from its name to its lazily evaluated value.
+          For example, a variable named 'foo' can be accessed as 'variables.foo'.
+        - 'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.
+          See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz
+        - 'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the
+          request resource.
+
+        The `apiVersion`, `kind`, `metadata.name` and `metadata.generateName` are always accessible from the root of the object. No other metadata properties are accessible.
+
+        Only property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible. Accessible property names are escaped according to the following rules when accessed in the expression: - '__' escapes to '__underscores__' - '.' escapes to '__dot__' - '-' escapes to '__dash__' - '/' escapes to '__slash__' - Property names that exactly match a CEL RESERVED keyword escape to '__{keyword}__'. The keywords are:
+        	  "true", "false", "null", "in", "as", "break", "const", "continue", "else", "for", "function", "if",
+        	  "import", "let", "loop", "package", "namespace", "return".
+        Examples:
+          - Expression accessing a property named "namespace": {"Expression": "object.__namespace__ > 0"}
+          - Expression accessing a property named "x-prop": {"Expression": "object.x__dash__prop > 0"}
+          - Expression accessing a property named "redact__d": {"Expression": "object.redact__underscores__d > 0"}
+
+        Equality on arrays with list type of 'set' or 'map' ignores element order, i.e. [1, 2] == [2, 1]. Concatenation on arrays with x-kubernetes-list-type use the semantics of the list type:
+          - 'set': `X + Y` performs a union where the array positions of all elements in `X` are preserved and
+            non-intersecting elements in `Y` are appended, retaining their partial order.
+          - 'map': `X + Y` performs a merge where the array positions of all keys in `X` are preserved but the values
+            are overwritten by values in `Y` when the key sets of `X` and `Y` intersect. Elements in `Y` with
+            non-intersecting keys are appended, retaining their partial order.
+        Required.
+        """
+        message: NotRequired[pulumi.Input[str]]
+        """
+        Message represents the message displayed when validation fails. The message is required if the Expression contains line breaks. The message must not contain line breaks. If unset, the message is "failed rule: {Rule}". e.g. "must be a URL with the host matching spec.host" If the Expression contains line breaks. Message is required. The message must not contain line breaks. If unset, the message is "failed Expression: {Expression}".
+        """
+        message_expression: NotRequired[pulumi.Input[str]]
+        """
+        messageExpression declares a CEL expression that evaluates to the validation failure message that is returned when this rule fails. Since messageExpression is used as a failure message, it must evaluate to a string. If both message and messageExpression are present on a validation, then messageExpression will be used if validation fails. If messageExpression results in a runtime error, the runtime error is logged, and the validation failure message is produced as if the messageExpression field were unset. If messageExpression evaluates to an empty string, a string with only spaces, or a string that contains line breaks, then the validation failure message will also be produced as if the messageExpression field were unset, and the fact that messageExpression produced an empty string/string with only spaces/string with line breaks will be logged. messageExpression has access to all the same variables as the `expression` except for 'authorizer' and 'authorizer.requestResource'. Example: "object.x must be less than max ("+string(params.max)+")"
+        """
+        reason: NotRequired[pulumi.Input[str]]
+        """
+        Reason represents a machine-readable description of why this validation failed. If this is the first validation in the list to fail, this reason, as well as the corresponding HTTP response code, are used in the HTTP response to the client. The currently supported reasons are: "Unauthorized", "Forbidden", "Invalid", "RequestEntityTooLarge". If not set, StatusReasonInvalid is used in the response to the client.
+        """
+elif False:
+    ValidationPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ValidationPatchArgs:
     def __init__(__self__, *,
@@ -3684,6 +5063,55 @@ class ValidationPatchArgs:
         pulumi.set(self, "reason", value)
 
 
+if not MYPY:
+    class ValidationArgsDict(TypedDict):
+        """
+        Validation specifies the CEL expression which is used to apply the validation.
+        """
+        expression: pulumi.Input[str]
+        """
+        Expression represents the expression which will be evaluated by CEL. ref: https://github.com/google/cel-spec CEL expressions have access to the contents of the API request/response, organized into CEL variables as well as some other useful variables:
+
+        - 'object' - The object from the incoming request. The value is null for DELETE requests. - 'oldObject' - The existing object. The value is null for CREATE requests. - 'request' - Attributes of the API request([ref](/pkg/apis/admission/types.go#AdmissionRequest)). - 'params' - Parameter resource referred to by the policy binding being evaluated. Only populated if the policy has a ParamKind. - 'namespaceObject' - The namespace object that the incoming object belongs to. The value is null for cluster-scoped resources. - 'variables' - Map of composited variables, from its name to its lazily evaluated value.
+          For example, a variable named 'foo' can be accessed as 'variables.foo'.
+        - 'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.
+          See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz
+        - 'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the
+          request resource.
+
+        The `apiVersion`, `kind`, `metadata.name` and `metadata.generateName` are always accessible from the root of the object. No other metadata properties are accessible.
+
+        Only property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible. Accessible property names are escaped according to the following rules when accessed in the expression: - '__' escapes to '__underscores__' - '.' escapes to '__dot__' - '-' escapes to '__dash__' - '/' escapes to '__slash__' - Property names that exactly match a CEL RESERVED keyword escape to '__{keyword}__'. The keywords are:
+        	  "true", "false", "null", "in", "as", "break", "const", "continue", "else", "for", "function", "if",
+        	  "import", "let", "loop", "package", "namespace", "return".
+        Examples:
+          - Expression accessing a property named "namespace": {"Expression": "object.__namespace__ > 0"}
+          - Expression accessing a property named "x-prop": {"Expression": "object.x__dash__prop > 0"}
+          - Expression accessing a property named "redact__d": {"Expression": "object.redact__underscores__d > 0"}
+
+        Equality on arrays with list type of 'set' or 'map' ignores element order, i.e. [1, 2] == [2, 1]. Concatenation on arrays with x-kubernetes-list-type use the semantics of the list type:
+          - 'set': `X + Y` performs a union where the array positions of all elements in `X` are preserved and
+            non-intersecting elements in `Y` are appended, retaining their partial order.
+          - 'map': `X + Y` performs a merge where the array positions of all keys in `X` are preserved but the values
+            are overwritten by values in `Y` when the key sets of `X` and `Y` intersect. Elements in `Y` with
+            non-intersecting keys are appended, retaining their partial order.
+        Required.
+        """
+        message: NotRequired[pulumi.Input[str]]
+        """
+        Message represents the message displayed when validation fails. The message is required if the Expression contains line breaks. The message must not contain line breaks. If unset, the message is "failed rule: {Rule}". e.g. "must be a URL with the host matching spec.host" If the Expression contains line breaks. Message is required. The message must not contain line breaks. If unset, the message is "failed Expression: {Expression}".
+        """
+        message_expression: NotRequired[pulumi.Input[str]]
+        """
+        messageExpression declares a CEL expression that evaluates to the validation failure message that is returned when this rule fails. Since messageExpression is used as a failure message, it must evaluate to a string. If both message and messageExpression are present on a validation, then messageExpression will be used if validation fails. If messageExpression results in a runtime error, the runtime error is logged, and the validation failure message is produced as if the messageExpression field were unset. If messageExpression evaluates to an empty string, a string with only spaces, or a string that contains line breaks, then the validation failure message will also be produced as if the messageExpression field were unset, and the fact that messageExpression produced an empty string/string with only spaces/string with line breaks will be logged. messageExpression has access to all the same variables as the `expression` except for 'authorizer' and 'authorizer.requestResource'. Example: "object.x must be less than max ("+string(params.max)+")"
+        """
+        reason: NotRequired[pulumi.Input[str]]
+        """
+        Reason represents a machine-readable description of why this validation failed. If this is the first validation in the list to fail, this reason, as well as the corresponding HTTP response code, are used in the HTTP response to the client. The currently supported reasons are: "Unauthorized", "Forbidden", "Invalid", "RequestEntityTooLarge". If not set, StatusReasonInvalid is used in the response to the client.
+        """
+elif False:
+    ValidationArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ValidationArgs:
     def __init__(__self__, *,
@@ -3805,6 +5233,22 @@ class ValidationArgs:
         pulumi.set(self, "reason", value)
 
 
+if not MYPY:
+    class VariablePatchArgsDict(TypedDict):
+        """
+        Variable is the definition of a variable that is used for composition. A variable is defined as a named expression.
+        """
+        expression: NotRequired[pulumi.Input[str]]
+        """
+        Expression is the expression that will be evaluated as the value of the variable. The CEL expression has access to the same identifiers as the CEL expressions in Validation.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name is the name of the variable. The name must be a valid CEL identifier and unique among all variables. The variable can be accessed in other expressions through `variables` For example, if name is "foo", the variable will be available as `variables.foo`
+        """
+elif False:
+    VariablePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class VariablePatchArgs:
     def __init__(__self__, *,
@@ -3845,6 +5289,22 @@ class VariablePatchArgs:
         pulumi.set(self, "name", value)
 
 
+if not MYPY:
+    class VariableArgsDict(TypedDict):
+        """
+        Variable is the definition of a variable that is used for composition. A variable is defined as a named expression.
+        """
+        expression: pulumi.Input[str]
+        """
+        Expression is the expression that will be evaluated as the value of the variable. The CEL expression has access to the same identifiers as the CEL expressions in Validation.
+        """
+        name: pulumi.Input[str]
+        """
+        Name is the name of the variable. The name must be a valid CEL identifier and unique among all variables. The variable can be accessed in other expressions through `variables` For example, if name is "foo", the variable will be available as `variables.foo`
+        """
+elif False:
+    VariableArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class VariableArgs:
     def __init__(__self__, *,
@@ -3882,6 +5342,38 @@ class VariableArgs:
     def name(self, value: pulumi.Input[str]):
         pulumi.set(self, "name", value)
 
+
+if not MYPY:
+    class WebhookClientConfigPatchArgsDict(TypedDict):
+        """
+        WebhookClientConfig contains the information to make a TLS connection with the webhook
+        """
+        ca_bundle: NotRequired[pulumi.Input[str]]
+        """
+        `caBundle` is a PEM encoded CA bundle which will be used to validate the webhook's server certificate. If unspecified, system trust roots on the apiserver are used.
+        """
+        service: NotRequired[pulumi.Input['ServiceReferencePatchArgsDict']]
+        """
+        `service` is a reference to the service for this webhook. Either `service` or `url` must be specified.
+
+        If the webhook is running within the cluster, then you should use `service`.
+        """
+        url: NotRequired[pulumi.Input[str]]
+        """
+        `url` gives the location of the webhook, in standard URL form (`scheme://host:port/path`). Exactly one of `url` or `service` must be specified.
+
+        The `host` should not refer to a service running in the cluster; use the `service` field instead. The host might be resolved via external DNS in some apiservers (e.g., `kube-apiserver` cannot resolve in-cluster DNS as that would be a layering violation). `host` may also be an IP address.
+
+        Please note that using `localhost` or `127.0.0.1` as a `host` is risky unless you take great care to run this webhook on all hosts which run an apiserver which might need to make calls to this webhook. Such installs are likely to be non-portable, i.e., not easy to turn up in a new cluster.
+
+        The scheme must be "https"; the URL must begin with "https://".
+
+        A path is optional, and if present may be any string permissible in a URL. You may use the path to pass an arbitrary string to the webhook, for example, a cluster identifier.
+
+        Attempting to use a user or basic auth e.g. "user:password@" is not allowed. Fragments ("#...") and query parameters ("?...") are not allowed, either.
+        """
+elif False:
+    WebhookClientConfigPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class WebhookClientConfigPatchArgs:
@@ -3962,6 +5454,38 @@ class WebhookClientConfigPatchArgs:
     def url(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "url", value)
 
+
+if not MYPY:
+    class WebhookClientConfigArgsDict(TypedDict):
+        """
+        WebhookClientConfig contains the information to make a TLS connection with the webhook
+        """
+        ca_bundle: NotRequired[pulumi.Input[str]]
+        """
+        `caBundle` is a PEM encoded CA bundle which will be used to validate the webhook's server certificate. If unspecified, system trust roots on the apiserver are used.
+        """
+        service: NotRequired[pulumi.Input['ServiceReferenceArgsDict']]
+        """
+        `service` is a reference to the service for this webhook. Either `service` or `url` must be specified.
+
+        If the webhook is running within the cluster, then you should use `service`.
+        """
+        url: NotRequired[pulumi.Input[str]]
+        """
+        `url` gives the location of the webhook, in standard URL form (`scheme://host:port/path`). Exactly one of `url` or `service` must be specified.
+
+        The `host` should not refer to a service running in the cluster; use the `service` field instead. The host might be resolved via external DNS in some apiservers (e.g., `kube-apiserver` cannot resolve in-cluster DNS as that would be a layering violation). `host` may also be an IP address.
+
+        Please note that using `localhost` or `127.0.0.1` as a `host` is risky unless you take great care to run this webhook on all hosts which run an apiserver which might need to make calls to this webhook. Such installs are likely to be non-portable, i.e., not easy to turn up in a new cluster.
+
+        The scheme must be "https"; the URL must begin with "https://".
+
+        A path is optional, and if present may be any string permissible in a URL. You may use the path to pass an arbitrary string to the webhook, for example, a cluster identifier.
+
+        Attempting to use a user or basic auth e.g. "user:password@" is not allowed. Fragments ("#...") and query parameters ("?...") are not allowed, either.
+        """
+elif False:
+    WebhookClientConfigArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class WebhookClientConfigArgs:

--- a/sdk/python/pulumi_kubernetes/admissionregistration/v1/outputs.py
+++ b/sdk/python/pulumi_kubernetes/admissionregistration/v1/outputs.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta

--- a/sdk/python/pulumi_kubernetes/admissionregistration/v1alpha1/ValidatingAdmissionPolicy.py
+++ b/sdk/python/pulumi_kubernetes/admissionregistration/v1alpha1/ValidatingAdmissionPolicy.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class ValidatingAdmissionPolicy(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ValidatingAdmissionPolicySpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ValidatingAdmissionPolicySpecArgs', 'ValidatingAdmissionPolicySpecArgsDict']]] = None,
                  __props__=None):
         """
         ValidatingAdmissionPolicy describes the definition of an admission validation policy that accepts or rejects an object without changing it.
@@ -103,8 +108,8 @@ class ValidatingAdmissionPolicy(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
-        :param pulumi.Input[pulumi.InputType['ValidatingAdmissionPolicySpecArgs']] spec: Specification of the desired behavior of the ValidatingAdmissionPolicy.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
+        :param pulumi.Input[Union['ValidatingAdmissionPolicySpecArgs', 'ValidatingAdmissionPolicySpecArgsDict']] spec: Specification of the desired behavior of the ValidatingAdmissionPolicy.
         """
         ...
     @overload
@@ -132,8 +137,8 @@ class ValidatingAdmissionPolicy(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ValidatingAdmissionPolicySpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ValidatingAdmissionPolicySpecArgs', 'ValidatingAdmissionPolicySpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/admissionregistration/v1alpha1/ValidatingAdmissionPolicyBinding.py
+++ b/sdk/python/pulumi_kubernetes/admissionregistration/v1alpha1/ValidatingAdmissionPolicyBinding.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class ValidatingAdmissionPolicyBinding(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ValidatingAdmissionPolicyBindingSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ValidatingAdmissionPolicyBindingSpecArgs', 'ValidatingAdmissionPolicyBindingSpecArgsDict']]] = None,
                  __props__=None):
         """
         ValidatingAdmissionPolicyBinding binds the ValidatingAdmissionPolicy with paramerized resources. ValidatingAdmissionPolicyBinding and parameter CRDs together define how cluster administrators configure policies for clusters.
@@ -107,8 +112,8 @@ class ValidatingAdmissionPolicyBinding(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
-        :param pulumi.Input[pulumi.InputType['ValidatingAdmissionPolicyBindingSpecArgs']] spec: Specification of the desired behavior of the ValidatingAdmissionPolicyBinding.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
+        :param pulumi.Input[Union['ValidatingAdmissionPolicyBindingSpecArgs', 'ValidatingAdmissionPolicyBindingSpecArgsDict']] spec: Specification of the desired behavior of the ValidatingAdmissionPolicyBinding.
         """
         ...
     @overload
@@ -140,8 +145,8 @@ class ValidatingAdmissionPolicyBinding(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ValidatingAdmissionPolicyBindingSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ValidatingAdmissionPolicyBindingSpecArgs', 'ValidatingAdmissionPolicyBindingSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/admissionregistration/v1alpha1/ValidatingAdmissionPolicyBindingList.py
+++ b/sdk/python/pulumi_kubernetes/admissionregistration/v1alpha1/ValidatingAdmissionPolicyBindingList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -92,9 +97,9 @@ class ValidatingAdmissionPolicyBindingList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ValidatingAdmissionPolicyBindingArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ValidatingAdmissionPolicyBindingArgs', 'ValidatingAdmissionPolicyBindingArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         ValidatingAdmissionPolicyBindingList is a list of ValidatingAdmissionPolicyBinding.
@@ -102,9 +107,9 @@ class ValidatingAdmissionPolicyBindingList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ValidatingAdmissionPolicyBindingArgs']]]] items: List of PolicyBinding.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['ValidatingAdmissionPolicyBindingArgs', 'ValidatingAdmissionPolicyBindingArgsDict']]]] items: List of PolicyBinding.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
         """
         ...
     @overload
@@ -131,9 +136,9 @@ class ValidatingAdmissionPolicyBindingList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ValidatingAdmissionPolicyBindingArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ValidatingAdmissionPolicyBindingArgs', 'ValidatingAdmissionPolicyBindingArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/admissionregistration/v1alpha1/ValidatingAdmissionPolicyBindingPatch.py
+++ b/sdk/python/pulumi_kubernetes/admissionregistration/v1alpha1/ValidatingAdmissionPolicyBindingPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class ValidatingAdmissionPolicyBindingPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ValidatingAdmissionPolicyBindingSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ValidatingAdmissionPolicyBindingSpecPatchArgs', 'ValidatingAdmissionPolicyBindingSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -113,8 +118,8 @@ class ValidatingAdmissionPolicyBindingPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
-        :param pulumi.Input[pulumi.InputType['ValidatingAdmissionPolicyBindingSpecPatchArgs']] spec: Specification of the desired behavior of the ValidatingAdmissionPolicyBinding.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
+        :param pulumi.Input[Union['ValidatingAdmissionPolicyBindingSpecPatchArgs', 'ValidatingAdmissionPolicyBindingSpecPatchArgsDict']] spec: Specification of the desired behavior of the ValidatingAdmissionPolicyBinding.
         """
         ...
     @overload
@@ -152,8 +157,8 @@ class ValidatingAdmissionPolicyBindingPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ValidatingAdmissionPolicyBindingSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ValidatingAdmissionPolicyBindingSpecPatchArgs', 'ValidatingAdmissionPolicyBindingSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/admissionregistration/v1alpha1/ValidatingAdmissionPolicyList.py
+++ b/sdk/python/pulumi_kubernetes/admissionregistration/v1alpha1/ValidatingAdmissionPolicyList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -92,9 +97,9 @@ class ValidatingAdmissionPolicyList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ValidatingAdmissionPolicyArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ValidatingAdmissionPolicyArgs', 'ValidatingAdmissionPolicyArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         ValidatingAdmissionPolicyList is a list of ValidatingAdmissionPolicy.
@@ -102,9 +107,9 @@ class ValidatingAdmissionPolicyList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ValidatingAdmissionPolicyArgs']]]] items: List of ValidatingAdmissionPolicy.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['ValidatingAdmissionPolicyArgs', 'ValidatingAdmissionPolicyArgsDict']]]] items: List of ValidatingAdmissionPolicy.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
         """
         ...
     @overload
@@ -131,9 +136,9 @@ class ValidatingAdmissionPolicyList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ValidatingAdmissionPolicyArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ValidatingAdmissionPolicyArgs', 'ValidatingAdmissionPolicyArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/admissionregistration/v1alpha1/ValidatingAdmissionPolicyPatch.py
+++ b/sdk/python/pulumi_kubernetes/admissionregistration/v1alpha1/ValidatingAdmissionPolicyPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class ValidatingAdmissionPolicyPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ValidatingAdmissionPolicySpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ValidatingAdmissionPolicySpecPatchArgs', 'ValidatingAdmissionPolicySpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -109,8 +114,8 @@ class ValidatingAdmissionPolicyPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
-        :param pulumi.Input[pulumi.InputType['ValidatingAdmissionPolicySpecPatchArgs']] spec: Specification of the desired behavior of the ValidatingAdmissionPolicy.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
+        :param pulumi.Input[Union['ValidatingAdmissionPolicySpecPatchArgs', 'ValidatingAdmissionPolicySpecPatchArgsDict']] spec: Specification of the desired behavior of the ValidatingAdmissionPolicy.
         """
         ...
     @overload
@@ -144,8 +149,8 @@ class ValidatingAdmissionPolicyPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ValidatingAdmissionPolicySpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ValidatingAdmissionPolicySpecPatchArgs', 'ValidatingAdmissionPolicySpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/admissionregistration/v1alpha1/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/admissionregistration/v1alpha1/_inputs.py
@@ -4,39 +4,97 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import meta as _meta
 
 __all__ = [
     'AuditAnnotationPatchArgs',
+    'AuditAnnotationPatchArgsDict',
     'AuditAnnotationArgs',
+    'AuditAnnotationArgsDict',
     'ExpressionWarningArgs',
+    'ExpressionWarningArgsDict',
     'MatchConditionPatchArgs',
+    'MatchConditionPatchArgsDict',
     'MatchConditionArgs',
+    'MatchConditionArgsDict',
     'MatchResourcesPatchArgs',
+    'MatchResourcesPatchArgsDict',
     'MatchResourcesArgs',
+    'MatchResourcesArgsDict',
     'NamedRuleWithOperationsPatchArgs',
+    'NamedRuleWithOperationsPatchArgsDict',
     'NamedRuleWithOperationsArgs',
+    'NamedRuleWithOperationsArgsDict',
     'ParamKindPatchArgs',
+    'ParamKindPatchArgsDict',
     'ParamKindArgs',
+    'ParamKindArgsDict',
     'ParamRefPatchArgs',
+    'ParamRefPatchArgsDict',
     'ParamRefArgs',
+    'ParamRefArgsDict',
     'TypeCheckingArgs',
+    'TypeCheckingArgsDict',
     'ValidatingAdmissionPolicyBindingSpecPatchArgs',
+    'ValidatingAdmissionPolicyBindingSpecPatchArgsDict',
     'ValidatingAdmissionPolicyBindingSpecArgs',
+    'ValidatingAdmissionPolicyBindingSpecArgsDict',
     'ValidatingAdmissionPolicyBindingArgs',
+    'ValidatingAdmissionPolicyBindingArgsDict',
     'ValidatingAdmissionPolicySpecPatchArgs',
+    'ValidatingAdmissionPolicySpecPatchArgsDict',
     'ValidatingAdmissionPolicySpecArgs',
+    'ValidatingAdmissionPolicySpecArgsDict',
     'ValidatingAdmissionPolicyStatusArgs',
+    'ValidatingAdmissionPolicyStatusArgsDict',
     'ValidatingAdmissionPolicyArgs',
+    'ValidatingAdmissionPolicyArgsDict',
     'ValidationPatchArgs',
+    'ValidationPatchArgsDict',
     'ValidationArgs',
+    'ValidationArgsDict',
     'VariablePatchArgs',
+    'VariablePatchArgsDict',
     'VariableArgs',
+    'VariableArgsDict',
 ]
+
+MYPY = False
+
+if not MYPY:
+    class AuditAnnotationPatchArgsDict(TypedDict):
+        """
+        AuditAnnotation describes how to produce an audit annotation for an API request.
+        """
+        key: NotRequired[pulumi.Input[str]]
+        """
+        key specifies the audit annotation key. The audit annotation keys of a ValidatingAdmissionPolicy must be unique. The key must be a qualified name ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.
+
+        The key is combined with the resource name of the ValidatingAdmissionPolicy to construct an audit annotation key: "{ValidatingAdmissionPolicy name}/{key}".
+
+        If an admission webhook uses the same resource name as this ValidatingAdmissionPolicy and the same audit annotation key, the annotation key will be identical. In this case, the first annotation written with the key will be included in the audit event and all subsequent annotations with the same key will be discarded.
+
+        Required.
+        """
+        value_expression: NotRequired[pulumi.Input[str]]
+        """
+        valueExpression represents the expression which is evaluated by CEL to produce an audit annotation value. The expression must evaluate to either a string or null value. If the expression evaluates to a string, the audit annotation is included with the string value. If the expression evaluates to null or empty string the audit annotation will be omitted. The valueExpression may be no longer than 5kb in length. If the result of the valueExpression is more than 10kb in length, it will be truncated to 10kb.
+
+        If multiple ValidatingAdmissionPolicyBinding resources match an API request, then the valueExpression will be evaluated for each binding. All unique values produced by the valueExpressions will be joined together in a comma-separated list.
+
+        Required.
+        """
+elif False:
+    AuditAnnotationPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class AuditAnnotationPatchArgs:
@@ -98,6 +156,32 @@ class AuditAnnotationPatchArgs:
         pulumi.set(self, "value_expression", value)
 
 
+if not MYPY:
+    class AuditAnnotationArgsDict(TypedDict):
+        """
+        AuditAnnotation describes how to produce an audit annotation for an API request.
+        """
+        key: pulumi.Input[str]
+        """
+        key specifies the audit annotation key. The audit annotation keys of a ValidatingAdmissionPolicy must be unique. The key must be a qualified name ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.
+
+        The key is combined with the resource name of the ValidatingAdmissionPolicy to construct an audit annotation key: "{ValidatingAdmissionPolicy name}/{key}".
+
+        If an admission webhook uses the same resource name as this ValidatingAdmissionPolicy and the same audit annotation key, the annotation key will be identical. In this case, the first annotation written with the key will be included in the audit event and all subsequent annotations with the same key will be discarded.
+
+        Required.
+        """
+        value_expression: pulumi.Input[str]
+        """
+        valueExpression represents the expression which is evaluated by CEL to produce an audit annotation value. The expression must evaluate to either a string or null value. If the expression evaluates to a string, the audit annotation is included with the string value. If the expression evaluates to null or empty string the audit annotation will be omitted. The valueExpression may be no longer than 5kb in length. If the result of the valueExpression is more than 10kb in length, it will be truncated to 10kb.
+
+        If multiple ValidatingAdmissionPolicyBinding resources match an API request, then the valueExpression will be evaluated for each binding. All unique values produced by the valueExpressions will be joined together in a comma-separated list.
+
+        Required.
+        """
+elif False:
+    AuditAnnotationArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class AuditAnnotationArgs:
     def __init__(__self__, *,
@@ -156,6 +240,22 @@ class AuditAnnotationArgs:
         pulumi.set(self, "value_expression", value)
 
 
+if not MYPY:
+    class ExpressionWarningArgsDict(TypedDict):
+        """
+        ExpressionWarning is a warning information that targets a specific expression.
+        """
+        field_ref: pulumi.Input[str]
+        """
+        The path to the field that refers the expression. For example, the reference to the expression of the first item of validations is "spec.validations[0].expression"
+        """
+        warning: pulumi.Input[str]
+        """
+        The content of type checking information in a human-readable form. Each line of the warning contains the type that the expression is checked against, followed by the type check error from the compiler.
+        """
+elif False:
+    ExpressionWarningArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ExpressionWarningArgs:
     def __init__(__self__, *,
@@ -193,6 +293,29 @@ class ExpressionWarningArgs:
     def warning(self, value: pulumi.Input[str]):
         pulumi.set(self, "warning", value)
 
+
+if not MYPY:
+    class MatchConditionPatchArgsDict(TypedDict):
+        expression: NotRequired[pulumi.Input[str]]
+        """
+        Expression represents the expression which will be evaluated by CEL. Must evaluate to bool. CEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:
+
+        'object' - The object from the incoming request. The value is null for DELETE requests. 'oldObject' - The existing object. The value is null for CREATE requests. 'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest). 'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.
+          See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz
+        'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the
+          request resource.
+        Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/
+
+        Required.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name is an identifier for this match condition, used for strategic merging of MatchConditions, as well as providing an identifier for logging purposes. A good name should be descriptive of the associated expression. Name must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')
+
+        Required.
+        """
+elif False:
+    MatchConditionPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class MatchConditionPatchArgs:
@@ -253,6 +376,29 @@ class MatchConditionPatchArgs:
         pulumi.set(self, "name", value)
 
 
+if not MYPY:
+    class MatchConditionArgsDict(TypedDict):
+        expression: pulumi.Input[str]
+        """
+        Expression represents the expression which will be evaluated by CEL. Must evaluate to bool. CEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:
+
+        'object' - The object from the incoming request. The value is null for DELETE requests. 'oldObject' - The existing object. The value is null for CREATE requests. 'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest). 'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.
+          See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz
+        'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the
+          request resource.
+        Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/
+
+        Required.
+        """
+        name: pulumi.Input[str]
+        """
+        Name is an identifier for this match condition, used for strategic merging of MatchConditions, as well as providing an identifier for logging purposes. A good name should be descriptive of the associated expression. Name must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')
+
+        Required.
+        """
+elif False:
+    MatchConditionArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class MatchConditionArgs:
     def __init__(__self__, *,
@@ -309,6 +455,70 @@ class MatchConditionArgs:
     def name(self, value: pulumi.Input[str]):
         pulumi.set(self, "name", value)
 
+
+if not MYPY:
+    class MatchResourcesPatchArgsDict(TypedDict):
+        """
+        MatchResources decides whether to run the admission control policy on an object based on whether it meets the match criteria. The exclude rules take precedence over include rules (if a resource matches both, it is excluded)
+        """
+        exclude_resource_rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['NamedRuleWithOperationsPatchArgsDict']]]]
+        """
+        ExcludeResourceRules describes what operations on what resources/subresources the ValidatingAdmissionPolicy should not care about. The exclude rules take precedence over include rules (if a resource matches both, it is excluded)
+        """
+        match_policy: NotRequired[pulumi.Input[str]]
+        """
+        matchPolicy defines how the "MatchResources" list is used to match incoming requests. Allowed values are "Exact" or "Equivalent".
+
+        - Exact: match a request only if it exactly matches a specified rule. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, but "rules" only included `apiGroups:["apps"], apiVersions:["v1"], resources: ["deployments"]`, a request to apps/v1beta1 or extensions/v1beta1 would not be sent to the ValidatingAdmissionPolicy.
+
+        - Equivalent: match a request if modifies a resource listed in rules, even via another API group or version. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, and "rules" only included `apiGroups:["apps"], apiVersions:["v1"], resources: ["deployments"]`, a request to apps/v1beta1 or extensions/v1beta1 would be converted to apps/v1 and sent to the ValidatingAdmissionPolicy.
+
+        Defaults to "Equivalent"
+        """
+        namespace_selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorPatchArgsDict']]
+        """
+        NamespaceSelector decides whether to run the admission control policy on an object based on whether the namespace for that object matches the selector. If the object itself is a namespace, the matching is performed on object.metadata.labels. If the object is another cluster scoped resource, it never skips the policy.
+
+        For example, to run the webhook on any objects whose namespace is not associated with "runlevel" of "0" or "1";  you will set the selector as follows: "namespaceSelector": {
+          "matchExpressions": [
+            {
+              "key": "runlevel",
+              "operator": "NotIn",
+              "values": [
+                "0",
+                "1"
+              ]
+            }
+          ]
+        }
+
+        If instead you want to only run the policy on any objects whose namespace is associated with the "environment" of "prod" or "staging"; you will set the selector as follows: "namespaceSelector": {
+          "matchExpressions": [
+            {
+              "key": "environment",
+              "operator": "In",
+              "values": [
+                "prod",
+                "staging"
+              ]
+            }
+          ]
+        }
+
+        See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/ for more examples of label selectors.
+
+        Default to the empty LabelSelector, which matches everything.
+        """
+        object_selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorPatchArgsDict']]
+        """
+        ObjectSelector decides whether to run the validation based on if the object has matching labels. objectSelector is evaluated against both the oldObject and newObject that would be sent to the cel validation, and is considered to match if either object matches the selector. A null object (oldObject in the case of create, or newObject in the case of delete) or an object that cannot have labels (like a DeploymentRollback or a PodProxyOptions object) is not considered to match. Use the object selector only if the webhook is opt-in, because end users may skip the admission webhook by setting the labels. Default to the empty LabelSelector, which matches everything.
+        """
+        resource_rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['NamedRuleWithOperationsPatchArgsDict']]]]
+        """
+        ResourceRules describes what operations on what resources/subresources the ValidatingAdmissionPolicy matches. The policy cares about an operation if it matches _any_ Rule.
+        """
+elif False:
+    MatchResourcesPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class MatchResourcesPatchArgs:
@@ -470,6 +680,70 @@ class MatchResourcesPatchArgs:
         pulumi.set(self, "resource_rules", value)
 
 
+if not MYPY:
+    class MatchResourcesArgsDict(TypedDict):
+        """
+        MatchResources decides whether to run the admission control policy on an object based on whether it meets the match criteria. The exclude rules take precedence over include rules (if a resource matches both, it is excluded)
+        """
+        exclude_resource_rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['NamedRuleWithOperationsArgsDict']]]]
+        """
+        ExcludeResourceRules describes what operations on what resources/subresources the ValidatingAdmissionPolicy should not care about. The exclude rules take precedence over include rules (if a resource matches both, it is excluded)
+        """
+        match_policy: NotRequired[pulumi.Input[str]]
+        """
+        matchPolicy defines how the "MatchResources" list is used to match incoming requests. Allowed values are "Exact" or "Equivalent".
+
+        - Exact: match a request only if it exactly matches a specified rule. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, but "rules" only included `apiGroups:["apps"], apiVersions:["v1"], resources: ["deployments"]`, a request to apps/v1beta1 or extensions/v1beta1 would not be sent to the ValidatingAdmissionPolicy.
+
+        - Equivalent: match a request if modifies a resource listed in rules, even via another API group or version. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, and "rules" only included `apiGroups:["apps"], apiVersions:["v1"], resources: ["deployments"]`, a request to apps/v1beta1 or extensions/v1beta1 would be converted to apps/v1 and sent to the ValidatingAdmissionPolicy.
+
+        Defaults to "Equivalent"
+        """
+        namespace_selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorArgsDict']]
+        """
+        NamespaceSelector decides whether to run the admission control policy on an object based on whether the namespace for that object matches the selector. If the object itself is a namespace, the matching is performed on object.metadata.labels. If the object is another cluster scoped resource, it never skips the policy.
+
+        For example, to run the webhook on any objects whose namespace is not associated with "runlevel" of "0" or "1";  you will set the selector as follows: "namespaceSelector": {
+          "matchExpressions": [
+            {
+              "key": "runlevel",
+              "operator": "NotIn",
+              "values": [
+                "0",
+                "1"
+              ]
+            }
+          ]
+        }
+
+        If instead you want to only run the policy on any objects whose namespace is associated with the "environment" of "prod" or "staging"; you will set the selector as follows: "namespaceSelector": {
+          "matchExpressions": [
+            {
+              "key": "environment",
+              "operator": "In",
+              "values": [
+                "prod",
+                "staging"
+              ]
+            }
+          ]
+        }
+
+        See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/ for more examples of label selectors.
+
+        Default to the empty LabelSelector, which matches everything.
+        """
+        object_selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorArgsDict']]
+        """
+        ObjectSelector decides whether to run the validation based on if the object has matching labels. objectSelector is evaluated against both the oldObject and newObject that would be sent to the cel validation, and is considered to match if either object matches the selector. A null object (oldObject in the case of create, or newObject in the case of delete) or an object that cannot have labels (like a DeploymentRollback or a PodProxyOptions object) is not considered to match. Use the object selector only if the webhook is opt-in, because end users may skip the admission webhook by setting the labels. Default to the empty LabelSelector, which matches everything.
+        """
+        resource_rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['NamedRuleWithOperationsArgsDict']]]]
+        """
+        ResourceRules describes what operations on what resources/subresources the ValidatingAdmissionPolicy matches. The policy cares about an operation if it matches _any_ Rule.
+        """
+elif False:
+    MatchResourcesArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class MatchResourcesArgs:
     def __init__(__self__, *,
@@ -630,6 +904,44 @@ class MatchResourcesArgs:
         pulumi.set(self, "resource_rules", value)
 
 
+if not MYPY:
+    class NamedRuleWithOperationsPatchArgsDict(TypedDict):
+        """
+        NamedRuleWithOperations is a tuple of Operations and Resources with ResourceNames.
+        """
+        api_groups: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        APIGroups is the API groups the resources belong to. '*' is all groups. If '*' is present, the length of the slice must be one. Required.
+        """
+        api_versions: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        APIVersions is the API versions the resources belong to. '*' is all versions. If '*' is present, the length of the slice must be one. Required.
+        """
+        operations: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Operations is the operations the admission hook cares about - CREATE, UPDATE, DELETE, CONNECT or * for all of those operations and any future admission operations that are added. If '*' is present, the length of the slice must be one. Required.
+        """
+        resource_names: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
+        """
+        resources: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Resources is a list of resources this rule applies to.
+
+        For example: 'pods' means pods. 'pods/log' means the log subresource of pods. '*' means all resources, but not subresources. 'pods/*' means all subresources of pods. '*/scale' means all scale subresources. '*/*' means all resources and their subresources.
+
+        If wildcard is present, the validation rule will ensure resources do not overlap with each other.
+
+        Depending on the enclosing object, subresources might not be allowed. Required.
+        """
+        scope: NotRequired[pulumi.Input[str]]
+        """
+        scope specifies the scope of this rule. Valid values are "Cluster", "Namespaced", and "*" "Cluster" means that only cluster-scoped resources will match this rule. Namespace API objects are cluster-scoped. "Namespaced" means that only namespaced resources will match this rule. "*" means that there are no scope restrictions. Subresources match the scope of their parent resource. Default is "*".
+        """
+elif False:
+    NamedRuleWithOperationsPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class NamedRuleWithOperationsPatchArgs:
     def __init__(__self__, *,
@@ -745,6 +1057,44 @@ class NamedRuleWithOperationsPatchArgs:
     def scope(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "scope", value)
 
+
+if not MYPY:
+    class NamedRuleWithOperationsArgsDict(TypedDict):
+        """
+        NamedRuleWithOperations is a tuple of Operations and Resources with ResourceNames.
+        """
+        api_groups: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        APIGroups is the API groups the resources belong to. '*' is all groups. If '*' is present, the length of the slice must be one. Required.
+        """
+        api_versions: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        APIVersions is the API versions the resources belong to. '*' is all versions. If '*' is present, the length of the slice must be one. Required.
+        """
+        operations: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Operations is the operations the admission hook cares about - CREATE, UPDATE, DELETE, CONNECT or * for all of those operations and any future admission operations that are added. If '*' is present, the length of the slice must be one. Required.
+        """
+        resource_names: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
+        """
+        resources: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Resources is a list of resources this rule applies to.
+
+        For example: 'pods' means pods. 'pods/log' means the log subresource of pods. '*' means all resources, but not subresources. 'pods/*' means all subresources of pods. '*/scale' means all scale subresources. '*/*' means all resources and their subresources.
+
+        If wildcard is present, the validation rule will ensure resources do not overlap with each other.
+
+        Depending on the enclosing object, subresources might not be allowed. Required.
+        """
+        scope: NotRequired[pulumi.Input[str]]
+        """
+        scope specifies the scope of this rule. Valid values are "Cluster", "Namespaced", and "*" "Cluster" means that only cluster-scoped resources will match this rule. Namespace API objects are cluster-scoped. "Namespaced" means that only namespaced resources will match this rule. "*" means that there are no scope restrictions. Subresources match the scope of their parent resource. Default is "*".
+        """
+elif False:
+    NamedRuleWithOperationsArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class NamedRuleWithOperationsArgs:
@@ -862,6 +1212,22 @@ class NamedRuleWithOperationsArgs:
         pulumi.set(self, "scope", value)
 
 
+if not MYPY:
+    class ParamKindPatchArgsDict(TypedDict):
+        """
+        ParamKind is a tuple of Group Kind and Version.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion is the API group version the resources belong to. In format of "group/version". Required.
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is the API kind the resources belong to. Required.
+        """
+elif False:
+    ParamKindPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ParamKindPatchArgs:
     def __init__(__self__, *,
@@ -902,6 +1268,22 @@ class ParamKindPatchArgs:
         pulumi.set(self, "kind", value)
 
 
+if not MYPY:
+    class ParamKindArgsDict(TypedDict):
+        """
+        ParamKind is a tuple of Group Kind and Version.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion is the API group version the resources belong to. In format of "group/version". Required.
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is the API kind the resources belong to. Required.
+        """
+elif False:
+    ParamKindArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ParamKindArgs:
     def __init__(__self__, *,
@@ -941,6 +1323,44 @@ class ParamKindArgs:
     def kind(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "kind", value)
 
+
+if not MYPY:
+    class ParamRefPatchArgsDict(TypedDict):
+        """
+        ParamRef describes how to locate the params to be used as input to expressions of rules applied by a policy binding.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        `name` is the name of the resource being referenced.
+
+        `name` and `selector` are mutually exclusive properties. If one is set, the other must be unset.
+        """
+        namespace: NotRequired[pulumi.Input[str]]
+        """
+        namespace is the namespace of the referenced resource. Allows limiting the search for params to a specific namespace. Applies to both `name` and `selector` fields.
+
+        A per-namespace parameter may be used by specifying a namespace-scoped `paramKind` in the policy and leaving this field empty.
+
+        - If `paramKind` is cluster-scoped, this field MUST be unset. Setting this field results in a configuration error.
+
+        - If `paramKind` is namespace-scoped, the namespace of the object being evaluated for admission will be used when this field is left unset. Take care that if this is left empty the binding must not match any cluster-scoped resources, which will result in an error.
+        """
+        parameter_not_found_action: NotRequired[pulumi.Input[str]]
+        """
+        `parameterNotFoundAction` controls the behavior of the binding when the resource exists, and name or selector is valid, but there are no parameters matched by the binding. If the value is set to `Allow`, then no matched parameters will be treated as successful validation by the binding. If set to `Deny`, then no matched parameters will be subject to the `failurePolicy` of the policy.
+
+        Allowed values are `Allow` or `Deny` Default to `Deny`
+        """
+        selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorPatchArgsDict']]
+        """
+        selector can be used to match multiple param objects based on their labels. Supply selector: {} to match all resources of the ParamKind.
+
+        If multiple params are found, they are all evaluated with the policy expressions and the results are ANDed together.
+
+        One of `name` or `selector` must be set, but `name` and `selector` are mutually exclusive properties. If one is set, the other must be unset.
+        """
+elif False:
+    ParamRefPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ParamRefPatchArgs:
@@ -1042,6 +1462,44 @@ class ParamRefPatchArgs:
         pulumi.set(self, "selector", value)
 
 
+if not MYPY:
+    class ParamRefArgsDict(TypedDict):
+        """
+        ParamRef describes how to locate the params to be used as input to expressions of rules applied by a policy binding.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        `name` is the name of the resource being referenced.
+
+        `name` and `selector` are mutually exclusive properties. If one is set, the other must be unset.
+        """
+        namespace: NotRequired[pulumi.Input[str]]
+        """
+        namespace is the namespace of the referenced resource. Allows limiting the search for params to a specific namespace. Applies to both `name` and `selector` fields.
+
+        A per-namespace parameter may be used by specifying a namespace-scoped `paramKind` in the policy and leaving this field empty.
+
+        - If `paramKind` is cluster-scoped, this field MUST be unset. Setting this field results in a configuration error.
+
+        - If `paramKind` is namespace-scoped, the namespace of the object being evaluated for admission will be used when this field is left unset. Take care that if this is left empty the binding must not match any cluster-scoped resources, which will result in an error.
+        """
+        parameter_not_found_action: NotRequired[pulumi.Input[str]]
+        """
+        `parameterNotFoundAction` controls the behavior of the binding when the resource exists, and name or selector is valid, but there are no parameters matched by the binding. If the value is set to `Allow`, then no matched parameters will be treated as successful validation by the binding. If set to `Deny`, then no matched parameters will be subject to the `failurePolicy` of the policy.
+
+        Allowed values are `Allow` or `Deny` Default to `Deny`
+        """
+        selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorArgsDict']]
+        """
+        selector can be used to match multiple param objects based on their labels. Supply selector: {} to match all resources of the ParamKind.
+
+        If multiple params are found, they are all evaluated with the policy expressions and the results are ANDed together.
+
+        One of `name` or `selector` must be set, but `name` and `selector` are mutually exclusive properties. If one is set, the other must be unset.
+        """
+elif False:
+    ParamRefArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ParamRefArgs:
     def __init__(__self__, *,
@@ -1142,6 +1600,18 @@ class ParamRefArgs:
         pulumi.set(self, "selector", value)
 
 
+if not MYPY:
+    class TypeCheckingArgsDict(TypedDict):
+        """
+        TypeChecking contains results of type checking the expressions in the ValidatingAdmissionPolicy
+        """
+        expression_warnings: NotRequired[pulumi.Input[Sequence[pulumi.Input['ExpressionWarningArgsDict']]]]
+        """
+        The type checking warnings for each expression.
+        """
+elif False:
+    TypeCheckingArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class TypeCheckingArgs:
     def __init__(__self__, *,
@@ -1165,6 +1635,48 @@ class TypeCheckingArgs:
     def expression_warnings(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['ExpressionWarningArgs']]]]):
         pulumi.set(self, "expression_warnings", value)
 
+
+if not MYPY:
+    class ValidatingAdmissionPolicyBindingSpecPatchArgsDict(TypedDict):
+        """
+        ValidatingAdmissionPolicyBindingSpec is the specification of the ValidatingAdmissionPolicyBinding.
+        """
+        match_resources: NotRequired[pulumi.Input['MatchResourcesPatchArgsDict']]
+        """
+        MatchResources declares what resources match this binding and will be validated by it. Note that this is intersected with the policy's matchConstraints, so only requests that are matched by the policy can be selected by this. If this is unset, all resources matched by the policy are validated by this binding When resourceRules is unset, it does not constrain resource matching. If a resource is matched by the other fields of this object, it will be validated. Note that this is differs from ValidatingAdmissionPolicy matchConstraints, where resourceRules are required.
+        """
+        param_ref: NotRequired[pulumi.Input['ParamRefPatchArgsDict']]
+        """
+        paramRef specifies the parameter resource used to configure the admission control policy. It should point to a resource of the type specified in ParamKind of the bound ValidatingAdmissionPolicy. If the policy specifies a ParamKind and the resource referred to by ParamRef does not exist, this binding is considered mis-configured and the FailurePolicy of the ValidatingAdmissionPolicy applied. If the policy does not specify a ParamKind then this field is ignored, and the rules are evaluated without a param.
+        """
+        policy_name: NotRequired[pulumi.Input[str]]
+        """
+        PolicyName references a ValidatingAdmissionPolicy name which the ValidatingAdmissionPolicyBinding binds to. If the referenced resource does not exist, this binding is considered invalid and will be ignored Required.
+        """
+        validation_actions: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        validationActions declares how Validations of the referenced ValidatingAdmissionPolicy are enforced. If a validation evaluates to false it is always enforced according to these actions.
+
+        Failures defined by the ValidatingAdmissionPolicy's FailurePolicy are enforced according to these actions only if the FailurePolicy is set to Fail, otherwise the failures are ignored. This includes compilation errors, runtime errors and misconfigurations of the policy.
+
+        validationActions is declared as a set of action values. Order does not matter. validationActions may not contain duplicates of the same action.
+
+        The supported actions values are:
+
+        "Deny" specifies that a validation failure results in a denied request.
+
+        "Warn" specifies that a validation failure is reported to the request client in HTTP Warning headers, with a warning code of 299. Warnings can be sent both for allowed or denied admission responses.
+
+        "Audit" specifies that a validation failure is included in the published audit event for the request. The audit event will contain a `validation.policy.admission.k8s.io/validation_failure` audit annotation with a value containing the details of the validation failures, formatted as a JSON list of objects, each with the following fields: - message: The validation failure message string - policy: The resource name of the ValidatingAdmissionPolicy - binding: The resource name of the ValidatingAdmissionPolicyBinding - expressionIndex: The index of the failed validations in the ValidatingAdmissionPolicy - validationActions: The enforcement actions enacted for the validation failure Example audit annotation: `"validation.policy.admission.k8s.io/validation_failure": "[{"message": "Invalid value", {"policy": "policy.example.com", {"binding": "policybinding.example.com", {"expressionIndex": "1", {"validationActions": ["Audit"]}]"`
+
+        Clients should expect to handle additional values by ignoring any values not recognized.
+
+        "Deny" and "Warn" may not be used together since this combination needlessly duplicates the validation failure both in the API response body and the HTTP warning headers.
+
+        Required.
+        """
+elif False:
+    ValidatingAdmissionPolicyBindingSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ValidatingAdmissionPolicyBindingSpecPatchArgs:
@@ -1274,6 +1786,48 @@ class ValidatingAdmissionPolicyBindingSpecPatchArgs:
         pulumi.set(self, "validation_actions", value)
 
 
+if not MYPY:
+    class ValidatingAdmissionPolicyBindingSpecArgsDict(TypedDict):
+        """
+        ValidatingAdmissionPolicyBindingSpec is the specification of the ValidatingAdmissionPolicyBinding.
+        """
+        match_resources: NotRequired[pulumi.Input['MatchResourcesArgsDict']]
+        """
+        MatchResources declares what resources match this binding and will be validated by it. Note that this is intersected with the policy's matchConstraints, so only requests that are matched by the policy can be selected by this. If this is unset, all resources matched by the policy are validated by this binding When resourceRules is unset, it does not constrain resource matching. If a resource is matched by the other fields of this object, it will be validated. Note that this is differs from ValidatingAdmissionPolicy matchConstraints, where resourceRules are required.
+        """
+        param_ref: NotRequired[pulumi.Input['ParamRefArgsDict']]
+        """
+        paramRef specifies the parameter resource used to configure the admission control policy. It should point to a resource of the type specified in ParamKind of the bound ValidatingAdmissionPolicy. If the policy specifies a ParamKind and the resource referred to by ParamRef does not exist, this binding is considered mis-configured and the FailurePolicy of the ValidatingAdmissionPolicy applied. If the policy does not specify a ParamKind then this field is ignored, and the rules are evaluated without a param.
+        """
+        policy_name: NotRequired[pulumi.Input[str]]
+        """
+        PolicyName references a ValidatingAdmissionPolicy name which the ValidatingAdmissionPolicyBinding binds to. If the referenced resource does not exist, this binding is considered invalid and will be ignored Required.
+        """
+        validation_actions: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        validationActions declares how Validations of the referenced ValidatingAdmissionPolicy are enforced. If a validation evaluates to false it is always enforced according to these actions.
+
+        Failures defined by the ValidatingAdmissionPolicy's FailurePolicy are enforced according to these actions only if the FailurePolicy is set to Fail, otherwise the failures are ignored. This includes compilation errors, runtime errors and misconfigurations of the policy.
+
+        validationActions is declared as a set of action values. Order does not matter. validationActions may not contain duplicates of the same action.
+
+        The supported actions values are:
+
+        "Deny" specifies that a validation failure results in a denied request.
+
+        "Warn" specifies that a validation failure is reported to the request client in HTTP Warning headers, with a warning code of 299. Warnings can be sent both for allowed or denied admission responses.
+
+        "Audit" specifies that a validation failure is included in the published audit event for the request. The audit event will contain a `validation.policy.admission.k8s.io/validation_failure` audit annotation with a value containing the details of the validation failures, formatted as a JSON list of objects, each with the following fields: - message: The validation failure message string - policy: The resource name of the ValidatingAdmissionPolicy - binding: The resource name of the ValidatingAdmissionPolicyBinding - expressionIndex: The index of the failed validations in the ValidatingAdmissionPolicy - validationActions: The enforcement actions enacted for the validation failure Example audit annotation: `"validation.policy.admission.k8s.io/validation_failure": "[{"message": "Invalid value", {"policy": "policy.example.com", {"binding": "policybinding.example.com", {"expressionIndex": "1", {"validationActions": ["Audit"]}]"`
+
+        Clients should expect to handle additional values by ignoring any values not recognized.
+
+        "Deny" and "Warn" may not be used together since this combination needlessly duplicates the validation failure both in the API response body and the HTTP warning headers.
+
+        Required.
+        """
+elif False:
+    ValidatingAdmissionPolicyBindingSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ValidatingAdmissionPolicyBindingSpecArgs:
     def __init__(__self__, *,
@@ -1382,6 +1936,34 @@ class ValidatingAdmissionPolicyBindingSpecArgs:
         pulumi.set(self, "validation_actions", value)
 
 
+if not MYPY:
+    class ValidatingAdmissionPolicyBindingArgsDict(TypedDict):
+        """
+        ValidatingAdmissionPolicyBinding binds the ValidatingAdmissionPolicy with paramerized resources. ValidatingAdmissionPolicyBinding and parameter CRDs together define how cluster administrators configure policies for clusters.
+
+        For a given admission request, each binding will cause its policy to be evaluated N times, where N is 1 for policies/bindings that don't use params, otherwise N is the number of parameters selected by the binding.
+
+        The CEL expressions of a policy must have a computed CEL cost below the maximum CEL budget. Each evaluation of the policy is given an independent CEL cost budget. Adding/removing policies, bindings, or params can not affect whether a given (policy, binding, param) combination is within its own CEL budget.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
+        """
+        spec: NotRequired[pulumi.Input['ValidatingAdmissionPolicyBindingSpecArgsDict']]
+        """
+        Specification of the desired behavior of the ValidatingAdmissionPolicyBinding.
+        """
+elif False:
+    ValidatingAdmissionPolicyBindingArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ValidatingAdmissionPolicyBindingArgs:
     def __init__(__self__, *,
@@ -1457,6 +2039,61 @@ class ValidatingAdmissionPolicyBindingArgs:
     def spec(self, value: Optional[pulumi.Input['ValidatingAdmissionPolicyBindingSpecArgs']]):
         pulumi.set(self, "spec", value)
 
+
+if not MYPY:
+    class ValidatingAdmissionPolicySpecPatchArgsDict(TypedDict):
+        """
+        ValidatingAdmissionPolicySpec is the specification of the desired behavior of the AdmissionPolicy.
+        """
+        audit_annotations: NotRequired[pulumi.Input[Sequence[pulumi.Input['AuditAnnotationPatchArgsDict']]]]
+        """
+        auditAnnotations contains CEL expressions which are used to produce audit annotations for the audit event of the API request. validations and auditAnnotations may not both be empty; a least one of validations or auditAnnotations is required.
+        """
+        failure_policy: NotRequired[pulumi.Input[str]]
+        """
+        failurePolicy defines how to handle failures for the admission policy. Failures can occur from CEL expression parse errors, type check errors, runtime errors and invalid or mis-configured policy definitions or bindings.
+
+        A policy is invalid if spec.paramKind refers to a non-existent Kind. A binding is invalid if spec.paramRef.name refers to a non-existent resource.
+
+        failurePolicy does not define how validations that evaluate to false are handled.
+
+        When failurePolicy is set to Fail, ValidatingAdmissionPolicyBinding validationActions define how failures are enforced.
+
+        Allowed values are Ignore or Fail. Defaults to Fail.
+        """
+        match_conditions: NotRequired[pulumi.Input[Sequence[pulumi.Input['MatchConditionPatchArgsDict']]]]
+        """
+        MatchConditions is a list of conditions that must be met for a request to be validated. Match conditions filter requests that have already been matched by the rules, namespaceSelector, and objectSelector. An empty list of matchConditions matches all requests. There are a maximum of 64 match conditions allowed.
+
+        If a parameter object is provided, it can be accessed via the `params` handle in the same manner as validation expressions.
+
+        The exact matching logic is (in order):
+          1. If ANY matchCondition evaluates to FALSE, the policy is skipped.
+          2. If ALL matchConditions evaluate to TRUE, the policy is evaluated.
+          3. If any matchCondition evaluates to an error (but none are FALSE):
+             - If failurePolicy=Fail, reject the request
+             - If failurePolicy=Ignore, the policy is skipped
+        """
+        match_constraints: NotRequired[pulumi.Input['MatchResourcesPatchArgsDict']]
+        """
+        MatchConstraints specifies what resources this policy is designed to validate. The AdmissionPolicy cares about a request if it matches _all_ Constraints. However, in order to prevent clusters from being put into an unstable state that cannot be recovered from via the API ValidatingAdmissionPolicy cannot match ValidatingAdmissionPolicy and ValidatingAdmissionPolicyBinding. Required.
+        """
+        param_kind: NotRequired[pulumi.Input['ParamKindPatchArgsDict']]
+        """
+        ParamKind specifies the kind of resources used to parameterize this policy. If absent, there are no parameters for this policy and the param CEL variable will not be provided to validation expressions. If ParamKind refers to a non-existent kind, this policy definition is mis-configured and the FailurePolicy is applied. If paramKind is specified but paramRef is unset in ValidatingAdmissionPolicyBinding, the params variable will be null.
+        """
+        validations: NotRequired[pulumi.Input[Sequence[pulumi.Input['ValidationPatchArgsDict']]]]
+        """
+        Validations contain CEL expressions which is used to apply the validation. Validations and AuditAnnotations may not both be empty; a minimum of one Validations or AuditAnnotations is required.
+        """
+        variables: NotRequired[pulumi.Input[Sequence[pulumi.Input['VariablePatchArgsDict']]]]
+        """
+        Variables contain definitions of variables that can be used in composition of other expressions. Each variable is defined as a named CEL expression. The variables defined here will be available under `variables` in other expressions of the policy except MatchConditions because MatchConditions are evaluated before the rest of the policy.
+
+        The expression of a variable can refer to other variables defined earlier in the list but not those after. Thus, Variables must be sorted by the order of first appearance and acyclic.
+        """
+elif False:
+    ValidatingAdmissionPolicySpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ValidatingAdmissionPolicySpecPatchArgs:
@@ -1616,6 +2253,61 @@ class ValidatingAdmissionPolicySpecPatchArgs:
         pulumi.set(self, "variables", value)
 
 
+if not MYPY:
+    class ValidatingAdmissionPolicySpecArgsDict(TypedDict):
+        """
+        ValidatingAdmissionPolicySpec is the specification of the desired behavior of the AdmissionPolicy.
+        """
+        validations: pulumi.Input[Sequence[pulumi.Input['ValidationArgsDict']]]
+        """
+        Validations contain CEL expressions which is used to apply the validation. Validations and AuditAnnotations may not both be empty; a minimum of one Validations or AuditAnnotations is required.
+        """
+        audit_annotations: NotRequired[pulumi.Input[Sequence[pulumi.Input['AuditAnnotationArgsDict']]]]
+        """
+        auditAnnotations contains CEL expressions which are used to produce audit annotations for the audit event of the API request. validations and auditAnnotations may not both be empty; a least one of validations or auditAnnotations is required.
+        """
+        failure_policy: NotRequired[pulumi.Input[str]]
+        """
+        failurePolicy defines how to handle failures for the admission policy. Failures can occur from CEL expression parse errors, type check errors, runtime errors and invalid or mis-configured policy definitions or bindings.
+
+        A policy is invalid if spec.paramKind refers to a non-existent Kind. A binding is invalid if spec.paramRef.name refers to a non-existent resource.
+
+        failurePolicy does not define how validations that evaluate to false are handled.
+
+        When failurePolicy is set to Fail, ValidatingAdmissionPolicyBinding validationActions define how failures are enforced.
+
+        Allowed values are Ignore or Fail. Defaults to Fail.
+        """
+        match_conditions: NotRequired[pulumi.Input[Sequence[pulumi.Input['MatchConditionArgsDict']]]]
+        """
+        MatchConditions is a list of conditions that must be met for a request to be validated. Match conditions filter requests that have already been matched by the rules, namespaceSelector, and objectSelector. An empty list of matchConditions matches all requests. There are a maximum of 64 match conditions allowed.
+
+        If a parameter object is provided, it can be accessed via the `params` handle in the same manner as validation expressions.
+
+        The exact matching logic is (in order):
+          1. If ANY matchCondition evaluates to FALSE, the policy is skipped.
+          2. If ALL matchConditions evaluate to TRUE, the policy is evaluated.
+          3. If any matchCondition evaluates to an error (but none are FALSE):
+             - If failurePolicy=Fail, reject the request
+             - If failurePolicy=Ignore, the policy is skipped
+        """
+        match_constraints: NotRequired[pulumi.Input['MatchResourcesArgsDict']]
+        """
+        MatchConstraints specifies what resources this policy is designed to validate. The AdmissionPolicy cares about a request if it matches _all_ Constraints. However, in order to prevent clusters from being put into an unstable state that cannot be recovered from via the API ValidatingAdmissionPolicy cannot match ValidatingAdmissionPolicy and ValidatingAdmissionPolicyBinding. Required.
+        """
+        param_kind: NotRequired[pulumi.Input['ParamKindArgsDict']]
+        """
+        ParamKind specifies the kind of resources used to parameterize this policy. If absent, there are no parameters for this policy and the param CEL variable will not be provided to validation expressions. If ParamKind refers to a non-existent kind, this policy definition is mis-configured and the FailurePolicy is applied. If paramKind is specified but paramRef is unset in ValidatingAdmissionPolicyBinding, the params variable will be null.
+        """
+        variables: NotRequired[pulumi.Input[Sequence[pulumi.Input['VariableArgsDict']]]]
+        """
+        Variables contain definitions of variables that can be used in composition of other expressions. Each variable is defined as a named CEL expression. The variables defined here will be available under `variables` in other expressions of the policy except MatchConditions because MatchConditions are evaluated before the rest of the policy.
+
+        The expression of a variable can refer to other variables defined earlier in the list but not those after. Thus, Variables must be sorted by the order of first appearance and acyclic.
+        """
+elif False:
+    ValidatingAdmissionPolicySpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ValidatingAdmissionPolicySpecArgs:
     def __init__(__self__, *,
@@ -1773,6 +2465,26 @@ class ValidatingAdmissionPolicySpecArgs:
         pulumi.set(self, "variables", value)
 
 
+if not MYPY:
+    class ValidatingAdmissionPolicyStatusArgsDict(TypedDict):
+        """
+        ValidatingAdmissionPolicyStatus represents the status of a ValidatingAdmissionPolicy.
+        """
+        conditions: NotRequired[pulumi.Input[Sequence[pulumi.Input['_meta.v1.ConditionArgsDict']]]]
+        """
+        The conditions represent the latest available observations of a policy's current state.
+        """
+        observed_generation: NotRequired[pulumi.Input[int]]
+        """
+        The generation observed by the controller.
+        """
+        type_checking: NotRequired[pulumi.Input['TypeCheckingArgsDict']]
+        """
+        The results of type checking for each expression. Presence of this field indicates the completion of the type checking.
+        """
+elif False:
+    ValidatingAdmissionPolicyStatusArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ValidatingAdmissionPolicyStatusArgs:
     def __init__(__self__, *,
@@ -1828,6 +2540,34 @@ class ValidatingAdmissionPolicyStatusArgs:
     def type_checking(self, value: Optional[pulumi.Input['TypeCheckingArgs']]):
         pulumi.set(self, "type_checking", value)
 
+
+if not MYPY:
+    class ValidatingAdmissionPolicyArgsDict(TypedDict):
+        """
+        ValidatingAdmissionPolicy describes the definition of an admission validation policy that accepts or rejects an object without changing it.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
+        """
+        spec: NotRequired[pulumi.Input['ValidatingAdmissionPolicySpecArgsDict']]
+        """
+        Specification of the desired behavior of the ValidatingAdmissionPolicy.
+        """
+        status: NotRequired[pulumi.Input['ValidatingAdmissionPolicyStatusArgsDict']]
+        """
+        The status of the ValidatingAdmissionPolicy, including warnings that are useful to determine if the policy behaves in the expected way. Populated by the system. Read-only.
+        """
+elif False:
+    ValidatingAdmissionPolicyArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ValidatingAdmissionPolicyArgs:
@@ -1916,6 +2656,55 @@ class ValidatingAdmissionPolicyArgs:
     def status(self, value: Optional[pulumi.Input['ValidatingAdmissionPolicyStatusArgs']]):
         pulumi.set(self, "status", value)
 
+
+if not MYPY:
+    class ValidationPatchArgsDict(TypedDict):
+        """
+        Validation specifies the CEL expression which is used to apply the validation.
+        """
+        expression: NotRequired[pulumi.Input[str]]
+        """
+        Expression represents the expression which will be evaluated by CEL. ref: https://github.com/google/cel-spec CEL expressions have access to the contents of the API request/response, organized into CEL variables as well as some other useful variables:
+
+        - 'object' - The object from the incoming request. The value is null for DELETE requests. - 'oldObject' - The existing object. The value is null for CREATE requests. - 'request' - Attributes of the API request([ref](/pkg/apis/admission/types.go#AdmissionRequest)). - 'params' - Parameter resource referred to by the policy binding being evaluated. Only populated if the policy has a ParamKind. - 'namespaceObject' - The namespace object that the incoming object belongs to. The value is null for cluster-scoped resources. - 'variables' - Map of composited variables, from its name to its lazily evaluated value.
+          For example, a variable named 'foo' can be accessed as 'variables.foo'.
+        - 'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.
+          See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz
+        - 'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the
+          request resource.
+
+        The `apiVersion`, `kind`, `metadata.name` and `metadata.generateName` are always accessible from the root of the object. No other metadata properties are accessible.
+
+        Only property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible. Accessible property names are escaped according to the following rules when accessed in the expression: - '__' escapes to '__underscores__' - '.' escapes to '__dot__' - '-' escapes to '__dash__' - '/' escapes to '__slash__' - Property names that exactly match a CEL RESERVED keyword escape to '__{keyword}__'. The keywords are:
+        	  "true", "false", "null", "in", "as", "break", "const", "continue", "else", "for", "function", "if",
+        	  "import", "let", "loop", "package", "namespace", "return".
+        Examples:
+          - Expression accessing a property named "namespace": {"Expression": "object.__namespace__ > 0"}
+          - Expression accessing a property named "x-prop": {"Expression": "object.x__dash__prop > 0"}
+          - Expression accessing a property named "redact__d": {"Expression": "object.redact__underscores__d > 0"}
+
+        Equality on arrays with list type of 'set' or 'map' ignores element order, i.e. [1, 2] == [2, 1]. Concatenation on arrays with x-kubernetes-list-type use the semantics of the list type:
+          - 'set': `X + Y` performs a union where the array positions of all elements in `X` are preserved and
+            non-intersecting elements in `Y` are appended, retaining their partial order.
+          - 'map': `X + Y` performs a merge where the array positions of all keys in `X` are preserved but the values
+            are overwritten by values in `Y` when the key sets of `X` and `Y` intersect. Elements in `Y` with
+            non-intersecting keys are appended, retaining their partial order.
+        Required.
+        """
+        message: NotRequired[pulumi.Input[str]]
+        """
+        Message represents the message displayed when validation fails. The message is required if the Expression contains line breaks. The message must not contain line breaks. If unset, the message is "failed rule: {Rule}". e.g. "must be a URL with the host matching spec.host" If the Expression contains line breaks. Message is required. The message must not contain line breaks. If unset, the message is "failed Expression: {Expression}".
+        """
+        message_expression: NotRequired[pulumi.Input[str]]
+        """
+        messageExpression declares a CEL expression that evaluates to the validation failure message that is returned when this rule fails. Since messageExpression is used as a failure message, it must evaluate to a string. If both message and messageExpression are present on a validation, then messageExpression will be used if validation fails. If messageExpression results in a runtime error, the runtime error is logged, and the validation failure message is produced as if the messageExpression field were unset. If messageExpression evaluates to an empty string, a string with only spaces, or a string that contains line breaks, then the validation failure message will also be produced as if the messageExpression field were unset, and the fact that messageExpression produced an empty string/string with only spaces/string with line breaks will be logged. messageExpression has access to all the same variables as the `expression` except for 'authorizer' and 'authorizer.requestResource'. Example: "object.x must be less than max ("+string(params.max)+")"
+        """
+        reason: NotRequired[pulumi.Input[str]]
+        """
+        Reason represents a machine-readable description of why this validation failed. If this is the first validation in the list to fail, this reason, as well as the corresponding HTTP response code, are used in the HTTP response to the client. The currently supported reasons are: "Unauthorized", "Forbidden", "Invalid", "RequestEntityTooLarge". If not set, StatusReasonInvalid is used in the response to the client.
+        """
+elif False:
+    ValidationPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ValidationPatchArgs:
@@ -2039,6 +2828,55 @@ class ValidationPatchArgs:
         pulumi.set(self, "reason", value)
 
 
+if not MYPY:
+    class ValidationArgsDict(TypedDict):
+        """
+        Validation specifies the CEL expression which is used to apply the validation.
+        """
+        expression: pulumi.Input[str]
+        """
+        Expression represents the expression which will be evaluated by CEL. ref: https://github.com/google/cel-spec CEL expressions have access to the contents of the API request/response, organized into CEL variables as well as some other useful variables:
+
+        - 'object' - The object from the incoming request. The value is null for DELETE requests. - 'oldObject' - The existing object. The value is null for CREATE requests. - 'request' - Attributes of the API request([ref](/pkg/apis/admission/types.go#AdmissionRequest)). - 'params' - Parameter resource referred to by the policy binding being evaluated. Only populated if the policy has a ParamKind. - 'namespaceObject' - The namespace object that the incoming object belongs to. The value is null for cluster-scoped resources. - 'variables' - Map of composited variables, from its name to its lazily evaluated value.
+          For example, a variable named 'foo' can be accessed as 'variables.foo'.
+        - 'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.
+          See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz
+        - 'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the
+          request resource.
+
+        The `apiVersion`, `kind`, `metadata.name` and `metadata.generateName` are always accessible from the root of the object. No other metadata properties are accessible.
+
+        Only property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible. Accessible property names are escaped according to the following rules when accessed in the expression: - '__' escapes to '__underscores__' - '.' escapes to '__dot__' - '-' escapes to '__dash__' - '/' escapes to '__slash__' - Property names that exactly match a CEL RESERVED keyword escape to '__{keyword}__'. The keywords are:
+        	  "true", "false", "null", "in", "as", "break", "const", "continue", "else", "for", "function", "if",
+        	  "import", "let", "loop", "package", "namespace", "return".
+        Examples:
+          - Expression accessing a property named "namespace": {"Expression": "object.__namespace__ > 0"}
+          - Expression accessing a property named "x-prop": {"Expression": "object.x__dash__prop > 0"}
+          - Expression accessing a property named "redact__d": {"Expression": "object.redact__underscores__d > 0"}
+
+        Equality on arrays with list type of 'set' or 'map' ignores element order, i.e. [1, 2] == [2, 1]. Concatenation on arrays with x-kubernetes-list-type use the semantics of the list type:
+          - 'set': `X + Y` performs a union where the array positions of all elements in `X` are preserved and
+            non-intersecting elements in `Y` are appended, retaining their partial order.
+          - 'map': `X + Y` performs a merge where the array positions of all keys in `X` are preserved but the values
+            are overwritten by values in `Y` when the key sets of `X` and `Y` intersect. Elements in `Y` with
+            non-intersecting keys are appended, retaining their partial order.
+        Required.
+        """
+        message: NotRequired[pulumi.Input[str]]
+        """
+        Message represents the message displayed when validation fails. The message is required if the Expression contains line breaks. The message must not contain line breaks. If unset, the message is "failed rule: {Rule}". e.g. "must be a URL with the host matching spec.host" If the Expression contains line breaks. Message is required. The message must not contain line breaks. If unset, the message is "failed Expression: {Expression}".
+        """
+        message_expression: NotRequired[pulumi.Input[str]]
+        """
+        messageExpression declares a CEL expression that evaluates to the validation failure message that is returned when this rule fails. Since messageExpression is used as a failure message, it must evaluate to a string. If both message and messageExpression are present on a validation, then messageExpression will be used if validation fails. If messageExpression results in a runtime error, the runtime error is logged, and the validation failure message is produced as if the messageExpression field were unset. If messageExpression evaluates to an empty string, a string with only spaces, or a string that contains line breaks, then the validation failure message will also be produced as if the messageExpression field were unset, and the fact that messageExpression produced an empty string/string with only spaces/string with line breaks will be logged. messageExpression has access to all the same variables as the `expression` except for 'authorizer' and 'authorizer.requestResource'. Example: "object.x must be less than max ("+string(params.max)+")"
+        """
+        reason: NotRequired[pulumi.Input[str]]
+        """
+        Reason represents a machine-readable description of why this validation failed. If this is the first validation in the list to fail, this reason, as well as the corresponding HTTP response code, are used in the HTTP response to the client. The currently supported reasons are: "Unauthorized", "Forbidden", "Invalid", "RequestEntityTooLarge". If not set, StatusReasonInvalid is used in the response to the client.
+        """
+elif False:
+    ValidationArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ValidationArgs:
     def __init__(__self__, *,
@@ -2160,6 +2998,22 @@ class ValidationArgs:
         pulumi.set(self, "reason", value)
 
 
+if not MYPY:
+    class VariablePatchArgsDict(TypedDict):
+        """
+        Variable is the definition of a variable that is used for composition.
+        """
+        expression: NotRequired[pulumi.Input[str]]
+        """
+        Expression is the expression that will be evaluated as the value of the variable. The CEL expression has access to the same identifiers as the CEL expressions in Validation.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name is the name of the variable. The name must be a valid CEL identifier and unique among all variables. The variable can be accessed in other expressions through `variables` For example, if name is "foo", the variable will be available as `variables.foo`
+        """
+elif False:
+    VariablePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class VariablePatchArgs:
     def __init__(__self__, *,
@@ -2199,6 +3053,22 @@ class VariablePatchArgs:
     def name(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "name", value)
 
+
+if not MYPY:
+    class VariableArgsDict(TypedDict):
+        """
+        Variable is the definition of a variable that is used for composition.
+        """
+        expression: pulumi.Input[str]
+        """
+        Expression is the expression that will be evaluated as the value of the variable. The CEL expression has access to the same identifiers as the CEL expressions in Validation.
+        """
+        name: pulumi.Input[str]
+        """
+        Name is the name of the variable. The name must be a valid CEL identifier and unique among all variables. The variable can be accessed in other expressions through `variables` For example, if name is "foo", the variable will be available as `variables.foo`
+        """
+elif False:
+    VariableArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class VariableArgs:

--- a/sdk/python/pulumi_kubernetes/admissionregistration/v1alpha1/outputs.py
+++ b/sdk/python/pulumi_kubernetes/admissionregistration/v1alpha1/outputs.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta

--- a/sdk/python/pulumi_kubernetes/admissionregistration/v1beta1/MutatingWebhookConfiguration.py
+++ b/sdk/python/pulumi_kubernetes/admissionregistration/v1beta1/MutatingWebhookConfiguration.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class MutatingWebhookConfiguration(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 webhooks: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['MutatingWebhookArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 webhooks: Optional[pulumi.Input[Sequence[pulumi.Input[Union['MutatingWebhookArgs', 'MutatingWebhookArgsDict']]]]] = None,
                  __props__=None):
         """
         MutatingWebhookConfiguration describes the configuration of and admission webhook that accept or reject and may change the object. Deprecated in v1.16, planned for removal in v1.19. Use admissionregistration.k8s.io/v1 MutatingWebhookConfiguration instead.
@@ -103,8 +108,8 @@ class MutatingWebhookConfiguration(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['MutatingWebhookArgs']]]] webhooks: Webhooks is a list of webhooks and the affected resources and operations.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['MutatingWebhookArgs', 'MutatingWebhookArgsDict']]]] webhooks: Webhooks is a list of webhooks and the affected resources and operations.
         """
         ...
     @overload
@@ -132,8 +137,8 @@ class MutatingWebhookConfiguration(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 webhooks: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['MutatingWebhookArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 webhooks: Optional[pulumi.Input[Sequence[pulumi.Input[Union['MutatingWebhookArgs', 'MutatingWebhookArgsDict']]]]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/admissionregistration/v1beta1/MutatingWebhookConfigurationList.py
+++ b/sdk/python/pulumi_kubernetes/admissionregistration/v1beta1/MutatingWebhookConfigurationList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class MutatingWebhookConfigurationList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['MutatingWebhookConfigurationArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['MutatingWebhookConfigurationArgs', 'MutatingWebhookConfigurationArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         MutatingWebhookConfigurationList is a list of MutatingWebhookConfiguration.
@@ -101,9 +106,9 @@ class MutatingWebhookConfigurationList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['MutatingWebhookConfigurationArgs']]]] items: List of MutatingWebhookConfiguration.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['MutatingWebhookConfigurationArgs', 'MutatingWebhookConfigurationArgsDict']]]] items: List of MutatingWebhookConfiguration.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class MutatingWebhookConfigurationList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['MutatingWebhookConfigurationArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['MutatingWebhookConfigurationArgs', 'MutatingWebhookConfigurationArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/admissionregistration/v1beta1/MutatingWebhookConfigurationPatch.py
+++ b/sdk/python/pulumi_kubernetes/admissionregistration/v1beta1/MutatingWebhookConfigurationPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class MutatingWebhookConfigurationPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 webhooks: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['MutatingWebhookPatchArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 webhooks: Optional[pulumi.Input[Sequence[pulumi.Input[Union['MutatingWebhookPatchArgs', 'MutatingWebhookPatchArgsDict']]]]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -109,8 +114,8 @@ class MutatingWebhookConfigurationPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['MutatingWebhookPatchArgs']]]] webhooks: Webhooks is a list of webhooks and the affected resources and operations.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['MutatingWebhookPatchArgs', 'MutatingWebhookPatchArgsDict']]]] webhooks: Webhooks is a list of webhooks and the affected resources and operations.
         """
         ...
     @overload
@@ -144,8 +149,8 @@ class MutatingWebhookConfigurationPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 webhooks: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['MutatingWebhookPatchArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 webhooks: Optional[pulumi.Input[Sequence[pulumi.Input[Union['MutatingWebhookPatchArgs', 'MutatingWebhookPatchArgsDict']]]]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/admissionregistration/v1beta1/ValidatingAdmissionPolicy.py
+++ b/sdk/python/pulumi_kubernetes/admissionregistration/v1beta1/ValidatingAdmissionPolicy.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class ValidatingAdmissionPolicy(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ValidatingAdmissionPolicySpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ValidatingAdmissionPolicySpecArgs', 'ValidatingAdmissionPolicySpecArgsDict']]] = None,
                  __props__=None):
         """
         ValidatingAdmissionPolicy describes the definition of an admission validation policy that accepts or rejects an object without changing it.
@@ -103,8 +108,8 @@ class ValidatingAdmissionPolicy(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
-        :param pulumi.Input[pulumi.InputType['ValidatingAdmissionPolicySpecArgs']] spec: Specification of the desired behavior of the ValidatingAdmissionPolicy.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
+        :param pulumi.Input[Union['ValidatingAdmissionPolicySpecArgs', 'ValidatingAdmissionPolicySpecArgsDict']] spec: Specification of the desired behavior of the ValidatingAdmissionPolicy.
         """
         ...
     @overload
@@ -132,8 +137,8 @@ class ValidatingAdmissionPolicy(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ValidatingAdmissionPolicySpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ValidatingAdmissionPolicySpecArgs', 'ValidatingAdmissionPolicySpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/admissionregistration/v1beta1/ValidatingAdmissionPolicyBinding.py
+++ b/sdk/python/pulumi_kubernetes/admissionregistration/v1beta1/ValidatingAdmissionPolicyBinding.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class ValidatingAdmissionPolicyBinding(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ValidatingAdmissionPolicyBindingSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ValidatingAdmissionPolicyBindingSpecArgs', 'ValidatingAdmissionPolicyBindingSpecArgsDict']]] = None,
                  __props__=None):
         """
         ValidatingAdmissionPolicyBinding binds the ValidatingAdmissionPolicy with paramerized resources. ValidatingAdmissionPolicyBinding and parameter CRDs together define how cluster administrators configure policies for clusters.
@@ -107,8 +112,8 @@ class ValidatingAdmissionPolicyBinding(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
-        :param pulumi.Input[pulumi.InputType['ValidatingAdmissionPolicyBindingSpecArgs']] spec: Specification of the desired behavior of the ValidatingAdmissionPolicyBinding.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
+        :param pulumi.Input[Union['ValidatingAdmissionPolicyBindingSpecArgs', 'ValidatingAdmissionPolicyBindingSpecArgsDict']] spec: Specification of the desired behavior of the ValidatingAdmissionPolicyBinding.
         """
         ...
     @overload
@@ -140,8 +145,8 @@ class ValidatingAdmissionPolicyBinding(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ValidatingAdmissionPolicyBindingSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ValidatingAdmissionPolicyBindingSpecArgs', 'ValidatingAdmissionPolicyBindingSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/admissionregistration/v1beta1/ValidatingAdmissionPolicyBindingList.py
+++ b/sdk/python/pulumi_kubernetes/admissionregistration/v1beta1/ValidatingAdmissionPolicyBindingList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -92,9 +97,9 @@ class ValidatingAdmissionPolicyBindingList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ValidatingAdmissionPolicyBindingArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ValidatingAdmissionPolicyBindingArgs', 'ValidatingAdmissionPolicyBindingArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         ValidatingAdmissionPolicyBindingList is a list of ValidatingAdmissionPolicyBinding.
@@ -102,9 +107,9 @@ class ValidatingAdmissionPolicyBindingList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ValidatingAdmissionPolicyBindingArgs']]]] items: List of PolicyBinding.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['ValidatingAdmissionPolicyBindingArgs', 'ValidatingAdmissionPolicyBindingArgsDict']]]] items: List of PolicyBinding.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
         """
         ...
     @overload
@@ -131,9 +136,9 @@ class ValidatingAdmissionPolicyBindingList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ValidatingAdmissionPolicyBindingArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ValidatingAdmissionPolicyBindingArgs', 'ValidatingAdmissionPolicyBindingArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/admissionregistration/v1beta1/ValidatingAdmissionPolicyBindingPatch.py
+++ b/sdk/python/pulumi_kubernetes/admissionregistration/v1beta1/ValidatingAdmissionPolicyBindingPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class ValidatingAdmissionPolicyBindingPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ValidatingAdmissionPolicyBindingSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ValidatingAdmissionPolicyBindingSpecPatchArgs', 'ValidatingAdmissionPolicyBindingSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -113,8 +118,8 @@ class ValidatingAdmissionPolicyBindingPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
-        :param pulumi.Input[pulumi.InputType['ValidatingAdmissionPolicyBindingSpecPatchArgs']] spec: Specification of the desired behavior of the ValidatingAdmissionPolicyBinding.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
+        :param pulumi.Input[Union['ValidatingAdmissionPolicyBindingSpecPatchArgs', 'ValidatingAdmissionPolicyBindingSpecPatchArgsDict']] spec: Specification of the desired behavior of the ValidatingAdmissionPolicyBinding.
         """
         ...
     @overload
@@ -152,8 +157,8 @@ class ValidatingAdmissionPolicyBindingPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ValidatingAdmissionPolicyBindingSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ValidatingAdmissionPolicyBindingSpecPatchArgs', 'ValidatingAdmissionPolicyBindingSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/admissionregistration/v1beta1/ValidatingAdmissionPolicyList.py
+++ b/sdk/python/pulumi_kubernetes/admissionregistration/v1beta1/ValidatingAdmissionPolicyList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -92,9 +97,9 @@ class ValidatingAdmissionPolicyList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ValidatingAdmissionPolicyArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ValidatingAdmissionPolicyArgs', 'ValidatingAdmissionPolicyArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         ValidatingAdmissionPolicyList is a list of ValidatingAdmissionPolicy.
@@ -102,9 +107,9 @@ class ValidatingAdmissionPolicyList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ValidatingAdmissionPolicyArgs']]]] items: List of ValidatingAdmissionPolicy.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['ValidatingAdmissionPolicyArgs', 'ValidatingAdmissionPolicyArgsDict']]]] items: List of ValidatingAdmissionPolicy.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
         """
         ...
     @overload
@@ -131,9 +136,9 @@ class ValidatingAdmissionPolicyList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ValidatingAdmissionPolicyArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ValidatingAdmissionPolicyArgs', 'ValidatingAdmissionPolicyArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/admissionregistration/v1beta1/ValidatingAdmissionPolicyPatch.py
+++ b/sdk/python/pulumi_kubernetes/admissionregistration/v1beta1/ValidatingAdmissionPolicyPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class ValidatingAdmissionPolicyPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ValidatingAdmissionPolicySpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ValidatingAdmissionPolicySpecPatchArgs', 'ValidatingAdmissionPolicySpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -109,8 +114,8 @@ class ValidatingAdmissionPolicyPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
-        :param pulumi.Input[pulumi.InputType['ValidatingAdmissionPolicySpecPatchArgs']] spec: Specification of the desired behavior of the ValidatingAdmissionPolicy.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
+        :param pulumi.Input[Union['ValidatingAdmissionPolicySpecPatchArgs', 'ValidatingAdmissionPolicySpecPatchArgsDict']] spec: Specification of the desired behavior of the ValidatingAdmissionPolicy.
         """
         ...
     @overload
@@ -144,8 +149,8 @@ class ValidatingAdmissionPolicyPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ValidatingAdmissionPolicySpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ValidatingAdmissionPolicySpecPatchArgs', 'ValidatingAdmissionPolicySpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/admissionregistration/v1beta1/ValidatingWebhookConfiguration.py
+++ b/sdk/python/pulumi_kubernetes/admissionregistration/v1beta1/ValidatingWebhookConfiguration.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class ValidatingWebhookConfiguration(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 webhooks: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ValidatingWebhookArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 webhooks: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ValidatingWebhookArgs', 'ValidatingWebhookArgsDict']]]]] = None,
                  __props__=None):
         """
         ValidatingWebhookConfiguration describes the configuration of and admission webhook that accept or reject and object without changing it. Deprecated in v1.16, planned for removal in v1.19. Use admissionregistration.k8s.io/v1 ValidatingWebhookConfiguration instead.
@@ -103,8 +108,8 @@ class ValidatingWebhookConfiguration(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ValidatingWebhookArgs']]]] webhooks: Webhooks is a list of webhooks and the affected resources and operations.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['ValidatingWebhookArgs', 'ValidatingWebhookArgsDict']]]] webhooks: Webhooks is a list of webhooks and the affected resources and operations.
         """
         ...
     @overload
@@ -132,8 +137,8 @@ class ValidatingWebhookConfiguration(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 webhooks: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ValidatingWebhookArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 webhooks: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ValidatingWebhookArgs', 'ValidatingWebhookArgsDict']]]]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/admissionregistration/v1beta1/ValidatingWebhookConfigurationList.py
+++ b/sdk/python/pulumi_kubernetes/admissionregistration/v1beta1/ValidatingWebhookConfigurationList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class ValidatingWebhookConfigurationList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ValidatingWebhookConfigurationArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ValidatingWebhookConfigurationArgs', 'ValidatingWebhookConfigurationArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         ValidatingWebhookConfigurationList is a list of ValidatingWebhookConfiguration.
@@ -101,9 +106,9 @@ class ValidatingWebhookConfigurationList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ValidatingWebhookConfigurationArgs']]]] items: List of ValidatingWebhookConfiguration.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['ValidatingWebhookConfigurationArgs', 'ValidatingWebhookConfigurationArgsDict']]]] items: List of ValidatingWebhookConfiguration.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class ValidatingWebhookConfigurationList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ValidatingWebhookConfigurationArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ValidatingWebhookConfigurationArgs', 'ValidatingWebhookConfigurationArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/admissionregistration/v1beta1/ValidatingWebhookConfigurationPatch.py
+++ b/sdk/python/pulumi_kubernetes/admissionregistration/v1beta1/ValidatingWebhookConfigurationPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class ValidatingWebhookConfigurationPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 webhooks: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ValidatingWebhookPatchArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 webhooks: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ValidatingWebhookPatchArgs', 'ValidatingWebhookPatchArgsDict']]]]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -109,8 +114,8 @@ class ValidatingWebhookConfigurationPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ValidatingWebhookPatchArgs']]]] webhooks: Webhooks is a list of webhooks and the affected resources and operations.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['ValidatingWebhookPatchArgs', 'ValidatingWebhookPatchArgsDict']]]] webhooks: Webhooks is a list of webhooks and the affected resources and operations.
         """
         ...
     @overload
@@ -144,8 +149,8 @@ class ValidatingWebhookConfigurationPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 webhooks: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ValidatingWebhookPatchArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 webhooks: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ValidatingWebhookPatchArgs', 'ValidatingWebhookPatchArgsDict']]]]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/admissionregistration/v1beta1/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/admissionregistration/v1beta1/_inputs.py
@@ -4,51 +4,121 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import meta as _meta
 
 __all__ = [
     'AuditAnnotationPatchArgs',
+    'AuditAnnotationPatchArgsDict',
     'AuditAnnotationArgs',
+    'AuditAnnotationArgsDict',
     'ExpressionWarningArgs',
+    'ExpressionWarningArgsDict',
     'MatchConditionPatchArgs',
+    'MatchConditionPatchArgsDict',
     'MatchConditionArgs',
+    'MatchConditionArgsDict',
     'MatchResourcesPatchArgs',
+    'MatchResourcesPatchArgsDict',
     'MatchResourcesArgs',
+    'MatchResourcesArgsDict',
     'MutatingWebhookConfigurationArgs',
+    'MutatingWebhookConfigurationArgsDict',
     'MutatingWebhookPatchArgs',
+    'MutatingWebhookPatchArgsDict',
     'MutatingWebhookArgs',
+    'MutatingWebhookArgsDict',
     'NamedRuleWithOperationsPatchArgs',
+    'NamedRuleWithOperationsPatchArgsDict',
     'NamedRuleWithOperationsArgs',
+    'NamedRuleWithOperationsArgsDict',
     'ParamKindPatchArgs',
+    'ParamKindPatchArgsDict',
     'ParamKindArgs',
+    'ParamKindArgsDict',
     'ParamRefPatchArgs',
+    'ParamRefPatchArgsDict',
     'ParamRefArgs',
+    'ParamRefArgsDict',
     'RuleWithOperationsPatchArgs',
+    'RuleWithOperationsPatchArgsDict',
     'RuleWithOperationsArgs',
+    'RuleWithOperationsArgsDict',
     'ServiceReferencePatchArgs',
+    'ServiceReferencePatchArgsDict',
     'ServiceReferenceArgs',
+    'ServiceReferenceArgsDict',
     'TypeCheckingArgs',
+    'TypeCheckingArgsDict',
     'ValidatingAdmissionPolicyBindingSpecPatchArgs',
+    'ValidatingAdmissionPolicyBindingSpecPatchArgsDict',
     'ValidatingAdmissionPolicyBindingSpecArgs',
+    'ValidatingAdmissionPolicyBindingSpecArgsDict',
     'ValidatingAdmissionPolicyBindingArgs',
+    'ValidatingAdmissionPolicyBindingArgsDict',
     'ValidatingAdmissionPolicySpecPatchArgs',
+    'ValidatingAdmissionPolicySpecPatchArgsDict',
     'ValidatingAdmissionPolicySpecArgs',
+    'ValidatingAdmissionPolicySpecArgsDict',
     'ValidatingAdmissionPolicyStatusArgs',
+    'ValidatingAdmissionPolicyStatusArgsDict',
     'ValidatingAdmissionPolicyArgs',
+    'ValidatingAdmissionPolicyArgsDict',
     'ValidatingWebhookConfigurationArgs',
+    'ValidatingWebhookConfigurationArgsDict',
     'ValidatingWebhookPatchArgs',
+    'ValidatingWebhookPatchArgsDict',
     'ValidatingWebhookArgs',
+    'ValidatingWebhookArgsDict',
     'ValidationPatchArgs',
+    'ValidationPatchArgsDict',
     'ValidationArgs',
+    'ValidationArgsDict',
     'VariablePatchArgs',
+    'VariablePatchArgsDict',
     'VariableArgs',
+    'VariableArgsDict',
     'WebhookClientConfigPatchArgs',
+    'WebhookClientConfigPatchArgsDict',
     'WebhookClientConfigArgs',
+    'WebhookClientConfigArgsDict',
 ]
+
+MYPY = False
+
+if not MYPY:
+    class AuditAnnotationPatchArgsDict(TypedDict):
+        """
+        AuditAnnotation describes how to produce an audit annotation for an API request.
+        """
+        key: NotRequired[pulumi.Input[str]]
+        """
+        key specifies the audit annotation key. The audit annotation keys of a ValidatingAdmissionPolicy must be unique. The key must be a qualified name ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.
+
+        The key is combined with the resource name of the ValidatingAdmissionPolicy to construct an audit annotation key: "{ValidatingAdmissionPolicy name}/{key}".
+
+        If an admission webhook uses the same resource name as this ValidatingAdmissionPolicy and the same audit annotation key, the annotation key will be identical. In this case, the first annotation written with the key will be included in the audit event and all subsequent annotations with the same key will be discarded.
+
+        Required.
+        """
+        value_expression: NotRequired[pulumi.Input[str]]
+        """
+        valueExpression represents the expression which is evaluated by CEL to produce an audit annotation value. The expression must evaluate to either a string or null value. If the expression evaluates to a string, the audit annotation is included with the string value. If the expression evaluates to null or empty string the audit annotation will be omitted. The valueExpression may be no longer than 5kb in length. If the result of the valueExpression is more than 10kb in length, it will be truncated to 10kb.
+
+        If multiple ValidatingAdmissionPolicyBinding resources match an API request, then the valueExpression will be evaluated for each binding. All unique values produced by the valueExpressions will be joined together in a comma-separated list.
+
+        Required.
+        """
+elif False:
+    AuditAnnotationPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class AuditAnnotationPatchArgs:
@@ -110,6 +180,32 @@ class AuditAnnotationPatchArgs:
         pulumi.set(self, "value_expression", value)
 
 
+if not MYPY:
+    class AuditAnnotationArgsDict(TypedDict):
+        """
+        AuditAnnotation describes how to produce an audit annotation for an API request.
+        """
+        key: pulumi.Input[str]
+        """
+        key specifies the audit annotation key. The audit annotation keys of a ValidatingAdmissionPolicy must be unique. The key must be a qualified name ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.
+
+        The key is combined with the resource name of the ValidatingAdmissionPolicy to construct an audit annotation key: "{ValidatingAdmissionPolicy name}/{key}".
+
+        If an admission webhook uses the same resource name as this ValidatingAdmissionPolicy and the same audit annotation key, the annotation key will be identical. In this case, the first annotation written with the key will be included in the audit event and all subsequent annotations with the same key will be discarded.
+
+        Required.
+        """
+        value_expression: pulumi.Input[str]
+        """
+        valueExpression represents the expression which is evaluated by CEL to produce an audit annotation value. The expression must evaluate to either a string or null value. If the expression evaluates to a string, the audit annotation is included with the string value. If the expression evaluates to null or empty string the audit annotation will be omitted. The valueExpression may be no longer than 5kb in length. If the result of the valueExpression is more than 10kb in length, it will be truncated to 10kb.
+
+        If multiple ValidatingAdmissionPolicyBinding resources match an API request, then the valueExpression will be evaluated for each binding. All unique values produced by the valueExpressions will be joined together in a comma-separated list.
+
+        Required.
+        """
+elif False:
+    AuditAnnotationArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class AuditAnnotationArgs:
     def __init__(__self__, *,
@@ -168,6 +264,22 @@ class AuditAnnotationArgs:
         pulumi.set(self, "value_expression", value)
 
 
+if not MYPY:
+    class ExpressionWarningArgsDict(TypedDict):
+        """
+        ExpressionWarning is a warning information that targets a specific expression.
+        """
+        field_ref: pulumi.Input[str]
+        """
+        The path to the field that refers the expression. For example, the reference to the expression of the first item of validations is "spec.validations[0].expression"
+        """
+        warning: pulumi.Input[str]
+        """
+        The content of type checking information in a human-readable form. Each line of the warning contains the type that the expression is checked against, followed by the type check error from the compiler.
+        """
+elif False:
+    ExpressionWarningArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ExpressionWarningArgs:
     def __init__(__self__, *,
@@ -205,6 +317,32 @@ class ExpressionWarningArgs:
     def warning(self, value: pulumi.Input[str]):
         pulumi.set(self, "warning", value)
 
+
+if not MYPY:
+    class MatchConditionPatchArgsDict(TypedDict):
+        """
+        MatchCondition represents a condition which must be fulfilled for a request to be sent to a webhook.
+        """
+        expression: NotRequired[pulumi.Input[str]]
+        """
+        Expression represents the expression which will be evaluated by CEL. Must evaluate to bool. CEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:
+
+        'object' - The object from the incoming request. The value is null for DELETE requests. 'oldObject' - The existing object. The value is null for CREATE requests. 'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest). 'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.
+          See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz
+        'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the
+          request resource.
+        Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/
+
+        Required.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name is an identifier for this match condition, used for strategic merging of MatchConditions, as well as providing an identifier for logging purposes. A good name should be descriptive of the associated expression. Name must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')
+
+        Required.
+        """
+elif False:
+    MatchConditionPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class MatchConditionPatchArgs:
@@ -266,6 +404,32 @@ class MatchConditionPatchArgs:
         pulumi.set(self, "name", value)
 
 
+if not MYPY:
+    class MatchConditionArgsDict(TypedDict):
+        """
+        MatchCondition represents a condition which must be fulfilled for a request to be sent to a webhook.
+        """
+        expression: pulumi.Input[str]
+        """
+        Expression represents the expression which will be evaluated by CEL. Must evaluate to bool. CEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:
+
+        'object' - The object from the incoming request. The value is null for DELETE requests. 'oldObject' - The existing object. The value is null for CREATE requests. 'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest). 'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.
+          See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz
+        'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the
+          request resource.
+        Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/
+
+        Required.
+        """
+        name: pulumi.Input[str]
+        """
+        Name is an identifier for this match condition, used for strategic merging of MatchConditions, as well as providing an identifier for logging purposes. A good name should be descriptive of the associated expression. Name must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')
+
+        Required.
+        """
+elif False:
+    MatchConditionArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class MatchConditionArgs:
     def __init__(__self__, *,
@@ -323,6 +487,70 @@ class MatchConditionArgs:
     def name(self, value: pulumi.Input[str]):
         pulumi.set(self, "name", value)
 
+
+if not MYPY:
+    class MatchResourcesPatchArgsDict(TypedDict):
+        """
+        MatchResources decides whether to run the admission control policy on an object based on whether it meets the match criteria. The exclude rules take precedence over include rules (if a resource matches both, it is excluded)
+        """
+        exclude_resource_rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['NamedRuleWithOperationsPatchArgsDict']]]]
+        """
+        ExcludeResourceRules describes what operations on what resources/subresources the ValidatingAdmissionPolicy should not care about. The exclude rules take precedence over include rules (if a resource matches both, it is excluded)
+        """
+        match_policy: NotRequired[pulumi.Input[str]]
+        """
+        matchPolicy defines how the "MatchResources" list is used to match incoming requests. Allowed values are "Exact" or "Equivalent".
+
+        - Exact: match a request only if it exactly matches a specified rule. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, but "rules" only included `apiGroups:["apps"], apiVersions:["v1"], resources: ["deployments"]`, a request to apps/v1beta1 or extensions/v1beta1 would not be sent to the ValidatingAdmissionPolicy.
+
+        - Equivalent: match a request if modifies a resource listed in rules, even via another API group or version. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, and "rules" only included `apiGroups:["apps"], apiVersions:["v1"], resources: ["deployments"]`, a request to apps/v1beta1 or extensions/v1beta1 would be converted to apps/v1 and sent to the ValidatingAdmissionPolicy.
+
+        Defaults to "Equivalent"
+        """
+        namespace_selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorPatchArgsDict']]
+        """
+        NamespaceSelector decides whether to run the admission control policy on an object based on whether the namespace for that object matches the selector. If the object itself is a namespace, the matching is performed on object.metadata.labels. If the object is another cluster scoped resource, it never skips the policy.
+
+        For example, to run the webhook on any objects whose namespace is not associated with "runlevel" of "0" or "1";  you will set the selector as follows: "namespaceSelector": {
+          "matchExpressions": [
+            {
+              "key": "runlevel",
+              "operator": "NotIn",
+              "values": [
+                "0",
+                "1"
+              ]
+            }
+          ]
+        }
+
+        If instead you want to only run the policy on any objects whose namespace is associated with the "environment" of "prod" or "staging"; you will set the selector as follows: "namespaceSelector": {
+          "matchExpressions": [
+            {
+              "key": "environment",
+              "operator": "In",
+              "values": [
+                "prod",
+                "staging"
+              ]
+            }
+          ]
+        }
+
+        See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/ for more examples of label selectors.
+
+        Default to the empty LabelSelector, which matches everything.
+        """
+        object_selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorPatchArgsDict']]
+        """
+        ObjectSelector decides whether to run the validation based on if the object has matching labels. objectSelector is evaluated against both the oldObject and newObject that would be sent to the cel validation, and is considered to match if either object matches the selector. A null object (oldObject in the case of create, or newObject in the case of delete) or an object that cannot have labels (like a DeploymentRollback or a PodProxyOptions object) is not considered to match. Use the object selector only if the webhook is opt-in, because end users may skip the admission webhook by setting the labels. Default to the empty LabelSelector, which matches everything.
+        """
+        resource_rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['NamedRuleWithOperationsPatchArgsDict']]]]
+        """
+        ResourceRules describes what operations on what resources/subresources the ValidatingAdmissionPolicy matches. The policy cares about an operation if it matches _any_ Rule.
+        """
+elif False:
+    MatchResourcesPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class MatchResourcesPatchArgs:
@@ -484,6 +712,70 @@ class MatchResourcesPatchArgs:
         pulumi.set(self, "resource_rules", value)
 
 
+if not MYPY:
+    class MatchResourcesArgsDict(TypedDict):
+        """
+        MatchResources decides whether to run the admission control policy on an object based on whether it meets the match criteria. The exclude rules take precedence over include rules (if a resource matches both, it is excluded)
+        """
+        exclude_resource_rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['NamedRuleWithOperationsArgsDict']]]]
+        """
+        ExcludeResourceRules describes what operations on what resources/subresources the ValidatingAdmissionPolicy should not care about. The exclude rules take precedence over include rules (if a resource matches both, it is excluded)
+        """
+        match_policy: NotRequired[pulumi.Input[str]]
+        """
+        matchPolicy defines how the "MatchResources" list is used to match incoming requests. Allowed values are "Exact" or "Equivalent".
+
+        - Exact: match a request only if it exactly matches a specified rule. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, but "rules" only included `apiGroups:["apps"], apiVersions:["v1"], resources: ["deployments"]`, a request to apps/v1beta1 or extensions/v1beta1 would not be sent to the ValidatingAdmissionPolicy.
+
+        - Equivalent: match a request if modifies a resource listed in rules, even via another API group or version. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, and "rules" only included `apiGroups:["apps"], apiVersions:["v1"], resources: ["deployments"]`, a request to apps/v1beta1 or extensions/v1beta1 would be converted to apps/v1 and sent to the ValidatingAdmissionPolicy.
+
+        Defaults to "Equivalent"
+        """
+        namespace_selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorArgsDict']]
+        """
+        NamespaceSelector decides whether to run the admission control policy on an object based on whether the namespace for that object matches the selector. If the object itself is a namespace, the matching is performed on object.metadata.labels. If the object is another cluster scoped resource, it never skips the policy.
+
+        For example, to run the webhook on any objects whose namespace is not associated with "runlevel" of "0" or "1";  you will set the selector as follows: "namespaceSelector": {
+          "matchExpressions": [
+            {
+              "key": "runlevel",
+              "operator": "NotIn",
+              "values": [
+                "0",
+                "1"
+              ]
+            }
+          ]
+        }
+
+        If instead you want to only run the policy on any objects whose namespace is associated with the "environment" of "prod" or "staging"; you will set the selector as follows: "namespaceSelector": {
+          "matchExpressions": [
+            {
+              "key": "environment",
+              "operator": "In",
+              "values": [
+                "prod",
+                "staging"
+              ]
+            }
+          ]
+        }
+
+        See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/ for more examples of label selectors.
+
+        Default to the empty LabelSelector, which matches everything.
+        """
+        object_selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorArgsDict']]
+        """
+        ObjectSelector decides whether to run the validation based on if the object has matching labels. objectSelector is evaluated against both the oldObject and newObject that would be sent to the cel validation, and is considered to match if either object matches the selector. A null object (oldObject in the case of create, or newObject in the case of delete) or an object that cannot have labels (like a DeploymentRollback or a PodProxyOptions object) is not considered to match. Use the object selector only if the webhook is opt-in, because end users may skip the admission webhook by setting the labels. Default to the empty LabelSelector, which matches everything.
+        """
+        resource_rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['NamedRuleWithOperationsArgsDict']]]]
+        """
+        ResourceRules describes what operations on what resources/subresources the ValidatingAdmissionPolicy matches. The policy cares about an operation if it matches _any_ Rule.
+        """
+elif False:
+    MatchResourcesArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class MatchResourcesArgs:
     def __init__(__self__, *,
@@ -644,6 +936,30 @@ class MatchResourcesArgs:
         pulumi.set(self, "resource_rules", value)
 
 
+if not MYPY:
+    class MutatingWebhookConfigurationArgsDict(TypedDict):
+        """
+        MutatingWebhookConfiguration describes the configuration of and admission webhook that accept or reject and may change the object. Deprecated in v1.16, planned for removal in v1.19. Use admissionregistration.k8s.io/v1 MutatingWebhookConfiguration instead.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
+        """
+        webhooks: NotRequired[pulumi.Input[Sequence[pulumi.Input['MutatingWebhookArgsDict']]]]
+        """
+        Webhooks is a list of webhooks and the affected resources and operations.
+        """
+elif False:
+    MutatingWebhookConfigurationArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class MutatingWebhookConfigurationArgs:
     def __init__(__self__, *,
@@ -715,6 +1031,100 @@ class MutatingWebhookConfigurationArgs:
     def webhooks(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['MutatingWebhookArgs']]]]):
         pulumi.set(self, "webhooks", value)
 
+
+if not MYPY:
+    class MutatingWebhookPatchArgsDict(TypedDict):
+        """
+        MutatingWebhook describes an admission webhook and the resources and operations it applies to.
+        """
+        admission_review_versions: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        AdmissionReviewVersions is an ordered list of preferred `AdmissionReview` versions the Webhook expects. API server will try to use first version in the list which it supports. If none of the versions specified in this list supported by API server, validation will fail for this object. If a persisted webhook configuration specifies allowed versions and does not include any versions known to the API Server, calls to the webhook will fail and be subject to the failure policy. Default to `['v1beta1']`.
+        """
+        client_config: NotRequired[pulumi.Input['WebhookClientConfigPatchArgsDict']]
+        """
+        ClientConfig defines how to communicate with the hook. Required
+        """
+        failure_policy: NotRequired[pulumi.Input[str]]
+        """
+        FailurePolicy defines how unrecognized errors from the admission endpoint are handled - allowed values are Ignore or Fail. Defaults to Ignore.
+        """
+        match_policy: NotRequired[pulumi.Input[str]]
+        """
+        matchPolicy defines how the "rules" list is used to match incoming requests. Allowed values are "Exact" or "Equivalent".
+
+        - Exact: match a request only if it exactly matches a specified rule. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, but "rules" only included `apiGroups:["apps"], apiVersions:["v1"], resources: ["deployments"]`, a request to apps/v1beta1 or extensions/v1beta1 would not be sent to the webhook.
+
+        - Equivalent: match a request if modifies a resource listed in rules, even via another API group or version. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, and "rules" only included `apiGroups:["apps"], apiVersions:["v1"], resources: ["deployments"]`, a request to apps/v1beta1 or extensions/v1beta1 would be converted to apps/v1 and sent to the webhook.
+
+        Defaults to "Exact"
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        The name of the admission webhook. Name should be fully qualified, e.g., imagepolicy.kubernetes.io, where "imagepolicy" is the name of the webhook, and kubernetes.io is the name of the organization. Required.
+        """
+        namespace_selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorPatchArgsDict']]
+        """
+        NamespaceSelector decides whether to run the webhook on an object based on whether the namespace for that object matches the selector. If the object itself is a namespace, the matching is performed on object.metadata.labels. If the object is another cluster scoped resource, it never skips the webhook.
+
+        For example, to run the webhook on any objects whose namespace is not associated with "runlevel" of "0" or "1";  you will set the selector as follows: "namespaceSelector": {
+          "matchExpressions": [
+            {
+              "key": "runlevel",
+              "operator": "NotIn",
+              "values": [
+                "0",
+                "1"
+              ]
+            }
+          ]
+        }
+
+        If instead you want to only run the webhook on any objects whose namespace is associated with the "environment" of "prod" or "staging"; you will set the selector as follows: "namespaceSelector": {
+          "matchExpressions": [
+            {
+              "key": "environment",
+              "operator": "In",
+              "values": [
+                "prod",
+                "staging"
+              ]
+            }
+          ]
+        }
+
+        See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/ for more examples of label selectors.
+
+        Default to the empty LabelSelector, which matches everything.
+        """
+        object_selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorPatchArgsDict']]
+        """
+        ObjectSelector decides whether to run the webhook based on if the object has matching labels. objectSelector is evaluated against both the oldObject and newObject that would be sent to the webhook, and is considered to match if either object matches the selector. A null object (oldObject in the case of create, or newObject in the case of delete) or an object that cannot have labels (like a DeploymentRollback or a PodProxyOptions object) is not considered to match. Use the object selector only if the webhook is opt-in, because end users may skip the admission webhook by setting the labels. Default to the empty LabelSelector, which matches everything.
+        """
+        reinvocation_policy: NotRequired[pulumi.Input[str]]
+        """
+        reinvocationPolicy indicates whether this webhook should be called multiple times as part of a single admission evaluation. Allowed values are "Never" and "IfNeeded".
+
+        Never: the webhook will not be called more than once in a single admission evaluation.
+
+        IfNeeded: the webhook will be called at least one additional time as part of the admission evaluation if the object being admitted is modified by other admission plugins after the initial webhook call. Webhooks that specify this option *must* be idempotent, able to process objects they previously admitted. Note: * the number of additional invocations is not guaranteed to be exactly one. * if additional invocations result in further modifications to the object, webhooks are not guaranteed to be invoked again. * webhooks that use this option may be reordered to minimize the number of additional invocations. * to validate an object after all mutations are guaranteed complete, use a validating admission webhook instead.
+
+        Defaults to "Never".
+        """
+        rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['RuleWithOperationsPatchArgsDict']]]]
+        """
+        Rules describes what operations on what resources/subresources the webhook cares about. The webhook cares about an operation if it matches _any_ Rule. However, in order to prevent ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks from putting the cluster in a state which cannot be recovered from without completely disabling the plugin, ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks are never called on admission requests for ValidatingWebhookConfiguration and MutatingWebhookConfiguration objects.
+        """
+        side_effects: NotRequired[pulumi.Input[str]]
+        """
+        SideEffects states whether this webhook has side effects. Acceptable values are: Unknown, None, Some, NoneOnDryRun Webhooks with side effects MUST implement a reconciliation system, since a request may be rejected by a future step in the admission change and the side effects therefore need to be undone. Requests with the dryRun attribute will be auto-rejected if they match a webhook with sideEffects == Unknown or Some. Defaults to Unknown.
+        """
+        timeout_seconds: NotRequired[pulumi.Input[int]]
+        """
+        TimeoutSeconds specifies the timeout for this webhook. After the timeout passes, the webhook call will be ignored or the API call will fail based on the failure policy. The timeout value must be between 1 and 30 seconds. Default to 30 seconds.
+        """
+elif False:
+    MutatingWebhookPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class MutatingWebhookPatchArgs:
@@ -984,6 +1394,100 @@ class MutatingWebhookPatchArgs:
         pulumi.set(self, "timeout_seconds", value)
 
 
+if not MYPY:
+    class MutatingWebhookArgsDict(TypedDict):
+        """
+        MutatingWebhook describes an admission webhook and the resources and operations it applies to.
+        """
+        client_config: pulumi.Input['WebhookClientConfigArgsDict']
+        """
+        ClientConfig defines how to communicate with the hook. Required
+        """
+        name: pulumi.Input[str]
+        """
+        The name of the admission webhook. Name should be fully qualified, e.g., imagepolicy.kubernetes.io, where "imagepolicy" is the name of the webhook, and kubernetes.io is the name of the organization. Required.
+        """
+        admission_review_versions: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        AdmissionReviewVersions is an ordered list of preferred `AdmissionReview` versions the Webhook expects. API server will try to use first version in the list which it supports. If none of the versions specified in this list supported by API server, validation will fail for this object. If a persisted webhook configuration specifies allowed versions and does not include any versions known to the API Server, calls to the webhook will fail and be subject to the failure policy. Default to `['v1beta1']`.
+        """
+        failure_policy: NotRequired[pulumi.Input[str]]
+        """
+        FailurePolicy defines how unrecognized errors from the admission endpoint are handled - allowed values are Ignore or Fail. Defaults to Ignore.
+        """
+        match_policy: NotRequired[pulumi.Input[str]]
+        """
+        matchPolicy defines how the "rules" list is used to match incoming requests. Allowed values are "Exact" or "Equivalent".
+
+        - Exact: match a request only if it exactly matches a specified rule. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, but "rules" only included `apiGroups:["apps"], apiVersions:["v1"], resources: ["deployments"]`, a request to apps/v1beta1 or extensions/v1beta1 would not be sent to the webhook.
+
+        - Equivalent: match a request if modifies a resource listed in rules, even via another API group or version. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, and "rules" only included `apiGroups:["apps"], apiVersions:["v1"], resources: ["deployments"]`, a request to apps/v1beta1 or extensions/v1beta1 would be converted to apps/v1 and sent to the webhook.
+
+        Defaults to "Exact"
+        """
+        namespace_selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorArgsDict']]
+        """
+        NamespaceSelector decides whether to run the webhook on an object based on whether the namespace for that object matches the selector. If the object itself is a namespace, the matching is performed on object.metadata.labels. If the object is another cluster scoped resource, it never skips the webhook.
+
+        For example, to run the webhook on any objects whose namespace is not associated with "runlevel" of "0" or "1";  you will set the selector as follows: "namespaceSelector": {
+          "matchExpressions": [
+            {
+              "key": "runlevel",
+              "operator": "NotIn",
+              "values": [
+                "0",
+                "1"
+              ]
+            }
+          ]
+        }
+
+        If instead you want to only run the webhook on any objects whose namespace is associated with the "environment" of "prod" or "staging"; you will set the selector as follows: "namespaceSelector": {
+          "matchExpressions": [
+            {
+              "key": "environment",
+              "operator": "In",
+              "values": [
+                "prod",
+                "staging"
+              ]
+            }
+          ]
+        }
+
+        See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/ for more examples of label selectors.
+
+        Default to the empty LabelSelector, which matches everything.
+        """
+        object_selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorArgsDict']]
+        """
+        ObjectSelector decides whether to run the webhook based on if the object has matching labels. objectSelector is evaluated against both the oldObject and newObject that would be sent to the webhook, and is considered to match if either object matches the selector. A null object (oldObject in the case of create, or newObject in the case of delete) or an object that cannot have labels (like a DeploymentRollback or a PodProxyOptions object) is not considered to match. Use the object selector only if the webhook is opt-in, because end users may skip the admission webhook by setting the labels. Default to the empty LabelSelector, which matches everything.
+        """
+        reinvocation_policy: NotRequired[pulumi.Input[str]]
+        """
+        reinvocationPolicy indicates whether this webhook should be called multiple times as part of a single admission evaluation. Allowed values are "Never" and "IfNeeded".
+
+        Never: the webhook will not be called more than once in a single admission evaluation.
+
+        IfNeeded: the webhook will be called at least one additional time as part of the admission evaluation if the object being admitted is modified by other admission plugins after the initial webhook call. Webhooks that specify this option *must* be idempotent, able to process objects they previously admitted. Note: * the number of additional invocations is not guaranteed to be exactly one. * if additional invocations result in further modifications to the object, webhooks are not guaranteed to be invoked again. * webhooks that use this option may be reordered to minimize the number of additional invocations. * to validate an object after all mutations are guaranteed complete, use a validating admission webhook instead.
+
+        Defaults to "Never".
+        """
+        rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['RuleWithOperationsArgsDict']]]]
+        """
+        Rules describes what operations on what resources/subresources the webhook cares about. The webhook cares about an operation if it matches _any_ Rule. However, in order to prevent ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks from putting the cluster in a state which cannot be recovered from without completely disabling the plugin, ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks are never called on admission requests for ValidatingWebhookConfiguration and MutatingWebhookConfiguration objects.
+        """
+        side_effects: NotRequired[pulumi.Input[str]]
+        """
+        SideEffects states whether this webhook has side effects. Acceptable values are: Unknown, None, Some, NoneOnDryRun Webhooks with side effects MUST implement a reconciliation system, since a request may be rejected by a future step in the admission change and the side effects therefore need to be undone. Requests with the dryRun attribute will be auto-rejected if they match a webhook with sideEffects == Unknown or Some. Defaults to Unknown.
+        """
+        timeout_seconds: NotRequired[pulumi.Input[int]]
+        """
+        TimeoutSeconds specifies the timeout for this webhook. After the timeout passes, the webhook call will be ignored or the API call will fail based on the failure policy. The timeout value must be between 1 and 30 seconds. Default to 30 seconds.
+        """
+elif False:
+    MutatingWebhookArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class MutatingWebhookArgs:
     def __init__(__self__, *,
@@ -1250,6 +1754,44 @@ class MutatingWebhookArgs:
         pulumi.set(self, "timeout_seconds", value)
 
 
+if not MYPY:
+    class NamedRuleWithOperationsPatchArgsDict(TypedDict):
+        """
+        NamedRuleWithOperations is a tuple of Operations and Resources with ResourceNames.
+        """
+        api_groups: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        APIGroups is the API groups the resources belong to. '*' is all groups. If '*' is present, the length of the slice must be one. Required.
+        """
+        api_versions: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        APIVersions is the API versions the resources belong to. '*' is all versions. If '*' is present, the length of the slice must be one. Required.
+        """
+        operations: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Operations is the operations the admission hook cares about - CREATE, UPDATE, DELETE, CONNECT or * for all of those operations and any future admission operations that are added. If '*' is present, the length of the slice must be one. Required.
+        """
+        resource_names: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
+        """
+        resources: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Resources is a list of resources this rule applies to.
+
+        For example: 'pods' means pods. 'pods/log' means the log subresource of pods. '*' means all resources, but not subresources. 'pods/*' means all subresources of pods. '*/scale' means all scale subresources. '*/*' means all resources and their subresources.
+
+        If wildcard is present, the validation rule will ensure resources do not overlap with each other.
+
+        Depending on the enclosing object, subresources might not be allowed. Required.
+        """
+        scope: NotRequired[pulumi.Input[str]]
+        """
+        scope specifies the scope of this rule. Valid values are "Cluster", "Namespaced", and "*" "Cluster" means that only cluster-scoped resources will match this rule. Namespace API objects are cluster-scoped. "Namespaced" means that only namespaced resources will match this rule. "*" means that there are no scope restrictions. Subresources match the scope of their parent resource. Default is "*".
+        """
+elif False:
+    NamedRuleWithOperationsPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class NamedRuleWithOperationsPatchArgs:
     def __init__(__self__, *,
@@ -1365,6 +1907,44 @@ class NamedRuleWithOperationsPatchArgs:
     def scope(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "scope", value)
 
+
+if not MYPY:
+    class NamedRuleWithOperationsArgsDict(TypedDict):
+        """
+        NamedRuleWithOperations is a tuple of Operations and Resources with ResourceNames.
+        """
+        api_groups: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        APIGroups is the API groups the resources belong to. '*' is all groups. If '*' is present, the length of the slice must be one. Required.
+        """
+        api_versions: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        APIVersions is the API versions the resources belong to. '*' is all versions. If '*' is present, the length of the slice must be one. Required.
+        """
+        operations: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Operations is the operations the admission hook cares about - CREATE, UPDATE, DELETE, CONNECT or * for all of those operations and any future admission operations that are added. If '*' is present, the length of the slice must be one. Required.
+        """
+        resource_names: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
+        """
+        resources: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Resources is a list of resources this rule applies to.
+
+        For example: 'pods' means pods. 'pods/log' means the log subresource of pods. '*' means all resources, but not subresources. 'pods/*' means all subresources of pods. '*/scale' means all scale subresources. '*/*' means all resources and their subresources.
+
+        If wildcard is present, the validation rule will ensure resources do not overlap with each other.
+
+        Depending on the enclosing object, subresources might not be allowed. Required.
+        """
+        scope: NotRequired[pulumi.Input[str]]
+        """
+        scope specifies the scope of this rule. Valid values are "Cluster", "Namespaced", and "*" "Cluster" means that only cluster-scoped resources will match this rule. Namespace API objects are cluster-scoped. "Namespaced" means that only namespaced resources will match this rule. "*" means that there are no scope restrictions. Subresources match the scope of their parent resource. Default is "*".
+        """
+elif False:
+    NamedRuleWithOperationsArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class NamedRuleWithOperationsArgs:
@@ -1482,6 +2062,22 @@ class NamedRuleWithOperationsArgs:
         pulumi.set(self, "scope", value)
 
 
+if not MYPY:
+    class ParamKindPatchArgsDict(TypedDict):
+        """
+        ParamKind is a tuple of Group Kind and Version.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion is the API group version the resources belong to. In format of "group/version". Required.
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is the API kind the resources belong to. Required.
+        """
+elif False:
+    ParamKindPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ParamKindPatchArgs:
     def __init__(__self__, *,
@@ -1522,6 +2118,22 @@ class ParamKindPatchArgs:
         pulumi.set(self, "kind", value)
 
 
+if not MYPY:
+    class ParamKindArgsDict(TypedDict):
+        """
+        ParamKind is a tuple of Group Kind and Version.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion is the API group version the resources belong to. In format of "group/version". Required.
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is the API kind the resources belong to. Required.
+        """
+elif False:
+    ParamKindArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ParamKindArgs:
     def __init__(__self__, *,
@@ -1561,6 +2173,48 @@ class ParamKindArgs:
     def kind(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "kind", value)
 
+
+if not MYPY:
+    class ParamRefPatchArgsDict(TypedDict):
+        """
+        ParamRef describes how to locate the params to be used as input to expressions of rules applied by a policy binding.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        name is the name of the resource being referenced.
+
+        One of `name` or `selector` must be set, but `name` and `selector` are mutually exclusive properties. If one is set, the other must be unset.
+
+        A single parameter used for all admission requests can be configured by setting the `name` field, leaving `selector` blank, and setting namespace if `paramKind` is namespace-scoped.
+        """
+        namespace: NotRequired[pulumi.Input[str]]
+        """
+        namespace is the namespace of the referenced resource. Allows limiting the search for params to a specific namespace. Applies to both `name` and `selector` fields.
+
+        A per-namespace parameter may be used by specifying a namespace-scoped `paramKind` in the policy and leaving this field empty.
+
+        - If `paramKind` is cluster-scoped, this field MUST be unset. Setting this field results in a configuration error.
+
+        - If `paramKind` is namespace-scoped, the namespace of the object being evaluated for admission will be used when this field is left unset. Take care that if this is left empty the binding must not match any cluster-scoped resources, which will result in an error.
+        """
+        parameter_not_found_action: NotRequired[pulumi.Input[str]]
+        """
+        `parameterNotFoundAction` controls the behavior of the binding when the resource exists, and name or selector is valid, but there are no parameters matched by the binding. If the value is set to `Allow`, then no matched parameters will be treated as successful validation by the binding. If set to `Deny`, then no matched parameters will be subject to the `failurePolicy` of the policy.
+
+        Allowed values are `Allow` or `Deny`
+
+        Required
+        """
+        selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorPatchArgsDict']]
+        """
+        selector can be used to match multiple param objects based on their labels. Supply selector: {} to match all resources of the ParamKind.
+
+        If multiple params are found, they are all evaluated with the policy expressions and the results are ANDed together.
+
+        One of `name` or `selector` must be set, but `name` and `selector` are mutually exclusive properties. If one is set, the other must be unset.
+        """
+elif False:
+    ParamRefPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ParamRefPatchArgs:
@@ -1670,6 +2324,48 @@ class ParamRefPatchArgs:
         pulumi.set(self, "selector", value)
 
 
+if not MYPY:
+    class ParamRefArgsDict(TypedDict):
+        """
+        ParamRef describes how to locate the params to be used as input to expressions of rules applied by a policy binding.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        name is the name of the resource being referenced.
+
+        One of `name` or `selector` must be set, but `name` and `selector` are mutually exclusive properties. If one is set, the other must be unset.
+
+        A single parameter used for all admission requests can be configured by setting the `name` field, leaving `selector` blank, and setting namespace if `paramKind` is namespace-scoped.
+        """
+        namespace: NotRequired[pulumi.Input[str]]
+        """
+        namespace is the namespace of the referenced resource. Allows limiting the search for params to a specific namespace. Applies to both `name` and `selector` fields.
+
+        A per-namespace parameter may be used by specifying a namespace-scoped `paramKind` in the policy and leaving this field empty.
+
+        - If `paramKind` is cluster-scoped, this field MUST be unset. Setting this field results in a configuration error.
+
+        - If `paramKind` is namespace-scoped, the namespace of the object being evaluated for admission will be used when this field is left unset. Take care that if this is left empty the binding must not match any cluster-scoped resources, which will result in an error.
+        """
+        parameter_not_found_action: NotRequired[pulumi.Input[str]]
+        """
+        `parameterNotFoundAction` controls the behavior of the binding when the resource exists, and name or selector is valid, but there are no parameters matched by the binding. If the value is set to `Allow`, then no matched parameters will be treated as successful validation by the binding. If set to `Deny`, then no matched parameters will be subject to the `failurePolicy` of the policy.
+
+        Allowed values are `Allow` or `Deny`
+
+        Required
+        """
+        selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorArgsDict']]
+        """
+        selector can be used to match multiple param objects based on their labels. Supply selector: {} to match all resources of the ParamKind.
+
+        If multiple params are found, they are all evaluated with the policy expressions and the results are ANDed together.
+
+        One of `name` or `selector` must be set, but `name` and `selector` are mutually exclusive properties. If one is set, the other must be unset.
+        """
+elif False:
+    ParamRefArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ParamRefArgs:
     def __init__(__self__, *,
@@ -1778,6 +2474,40 @@ class ParamRefArgs:
         pulumi.set(self, "selector", value)
 
 
+if not MYPY:
+    class RuleWithOperationsPatchArgsDict(TypedDict):
+        """
+        RuleWithOperations is a tuple of Operations and Resources. It is recommended to make sure that all the tuple expansions are valid.
+        """
+        api_groups: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        APIGroups is the API groups the resources belong to. '*' is all groups. If '*' is present, the length of the slice must be one. Required.
+        """
+        api_versions: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        APIVersions is the API versions the resources belong to. '*' is all versions. If '*' is present, the length of the slice must be one. Required.
+        """
+        operations: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Operations is the operations the admission hook cares about - CREATE, UPDATE, or * for all operations. If '*' is present, the length of the slice must be one. Required.
+        """
+        resources: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Resources is a list of resources this rule applies to.
+
+        For example: 'pods' means pods. 'pods/log' means the log subresource of pods. '*' means all resources, but not subresources. 'pods/*' means all subresources of pods. '*/scale' means all scale subresources. '*/*' means all resources and their subresources.
+
+        If wildcard is present, the validation rule will ensure resources do not overlap with each other.
+
+        Depending on the enclosing object, subresources might not be allowed. Required.
+        """
+        scope: NotRequired[pulumi.Input[str]]
+        """
+        scope specifies the scope of this rule. Valid values are "Cluster", "Namespaced", and "*" "Cluster" means that only cluster-scoped resources will match this rule. Namespace API objects are cluster-scoped. "Namespaced" means that only namespaced resources will match this rule. "*" means that there are no scope restrictions. Subresources match the scope of their parent resource. Default is "*".
+        """
+elif False:
+    RuleWithOperationsPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class RuleWithOperationsPatchArgs:
     def __init__(__self__, *,
@@ -1877,6 +2607,40 @@ class RuleWithOperationsPatchArgs:
     def scope(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "scope", value)
 
+
+if not MYPY:
+    class RuleWithOperationsArgsDict(TypedDict):
+        """
+        RuleWithOperations is a tuple of Operations and Resources. It is recommended to make sure that all the tuple expansions are valid.
+        """
+        api_groups: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        APIGroups is the API groups the resources belong to. '*' is all groups. If '*' is present, the length of the slice must be one. Required.
+        """
+        api_versions: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        APIVersions is the API versions the resources belong to. '*' is all versions. If '*' is present, the length of the slice must be one. Required.
+        """
+        operations: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Operations is the operations the admission hook cares about - CREATE, UPDATE, or * for all operations. If '*' is present, the length of the slice must be one. Required.
+        """
+        resources: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Resources is a list of resources this rule applies to.
+
+        For example: 'pods' means pods. 'pods/log' means the log subresource of pods. '*' means all resources, but not subresources. 'pods/*' means all subresources of pods. '*/scale' means all scale subresources. '*/*' means all resources and their subresources.
+
+        If wildcard is present, the validation rule will ensure resources do not overlap with each other.
+
+        Depending on the enclosing object, subresources might not be allowed. Required.
+        """
+        scope: NotRequired[pulumi.Input[str]]
+        """
+        scope specifies the scope of this rule. Valid values are "Cluster", "Namespaced", and "*" "Cluster" means that only cluster-scoped resources will match this rule. Namespace API objects are cluster-scoped. "Namespaced" means that only namespaced resources will match this rule. "*" means that there are no scope restrictions. Subresources match the scope of their parent resource. Default is "*".
+        """
+elif False:
+    RuleWithOperationsArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class RuleWithOperationsArgs:
@@ -1978,6 +2742,30 @@ class RuleWithOperationsArgs:
         pulumi.set(self, "scope", value)
 
 
+if not MYPY:
+    class ServiceReferencePatchArgsDict(TypedDict):
+        """
+        ServiceReference holds a reference to Service.legacy.k8s.io
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        `name` is the name of the service. Required
+        """
+        namespace: NotRequired[pulumi.Input[str]]
+        """
+        `namespace` is the namespace of the service. Required
+        """
+        path: NotRequired[pulumi.Input[str]]
+        """
+        `path` is an optional URL path which will be sent in any request to this service.
+        """
+        port: NotRequired[pulumi.Input[int]]
+        """
+        If specified, the port on the service that hosting webhook. Default to 443 for backward compatibility. `port` should be a valid port number (1-65535, inclusive).
+        """
+elif False:
+    ServiceReferencePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ServiceReferencePatchArgs:
     def __init__(__self__, *,
@@ -2050,6 +2838,30 @@ class ServiceReferencePatchArgs:
         pulumi.set(self, "port", value)
 
 
+if not MYPY:
+    class ServiceReferenceArgsDict(TypedDict):
+        """
+        ServiceReference holds a reference to Service.legacy.k8s.io
+        """
+        name: pulumi.Input[str]
+        """
+        `name` is the name of the service. Required
+        """
+        namespace: pulumi.Input[str]
+        """
+        `namespace` is the namespace of the service. Required
+        """
+        path: NotRequired[pulumi.Input[str]]
+        """
+        `path` is an optional URL path which will be sent in any request to this service.
+        """
+        port: NotRequired[pulumi.Input[int]]
+        """
+        If specified, the port on the service that hosting webhook. Default to 443 for backward compatibility. `port` should be a valid port number (1-65535, inclusive).
+        """
+elif False:
+    ServiceReferenceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ServiceReferenceArgs:
     def __init__(__self__, *,
@@ -2120,6 +2932,18 @@ class ServiceReferenceArgs:
         pulumi.set(self, "port", value)
 
 
+if not MYPY:
+    class TypeCheckingArgsDict(TypedDict):
+        """
+        TypeChecking contains results of type checking the expressions in the ValidatingAdmissionPolicy
+        """
+        expression_warnings: NotRequired[pulumi.Input[Sequence[pulumi.Input['ExpressionWarningArgsDict']]]]
+        """
+        The type checking warnings for each expression.
+        """
+elif False:
+    TypeCheckingArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class TypeCheckingArgs:
     def __init__(__self__, *,
@@ -2143,6 +2967,48 @@ class TypeCheckingArgs:
     def expression_warnings(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['ExpressionWarningArgs']]]]):
         pulumi.set(self, "expression_warnings", value)
 
+
+if not MYPY:
+    class ValidatingAdmissionPolicyBindingSpecPatchArgsDict(TypedDict):
+        """
+        ValidatingAdmissionPolicyBindingSpec is the specification of the ValidatingAdmissionPolicyBinding.
+        """
+        match_resources: NotRequired[pulumi.Input['MatchResourcesPatchArgsDict']]
+        """
+        MatchResources declares what resources match this binding and will be validated by it. Note that this is intersected with the policy's matchConstraints, so only requests that are matched by the policy can be selected by this. If this is unset, all resources matched by the policy are validated by this binding When resourceRules is unset, it does not constrain resource matching. If a resource is matched by the other fields of this object, it will be validated. Note that this is differs from ValidatingAdmissionPolicy matchConstraints, where resourceRules are required.
+        """
+        param_ref: NotRequired[pulumi.Input['ParamRefPatchArgsDict']]
+        """
+        paramRef specifies the parameter resource used to configure the admission control policy. It should point to a resource of the type specified in ParamKind of the bound ValidatingAdmissionPolicy. If the policy specifies a ParamKind and the resource referred to by ParamRef does not exist, this binding is considered mis-configured and the FailurePolicy of the ValidatingAdmissionPolicy applied. If the policy does not specify a ParamKind then this field is ignored, and the rules are evaluated without a param.
+        """
+        policy_name: NotRequired[pulumi.Input[str]]
+        """
+        PolicyName references a ValidatingAdmissionPolicy name which the ValidatingAdmissionPolicyBinding binds to. If the referenced resource does not exist, this binding is considered invalid and will be ignored Required.
+        """
+        validation_actions: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        validationActions declares how Validations of the referenced ValidatingAdmissionPolicy are enforced. If a validation evaluates to false it is always enforced according to these actions.
+
+        Failures defined by the ValidatingAdmissionPolicy's FailurePolicy are enforced according to these actions only if the FailurePolicy is set to Fail, otherwise the failures are ignored. This includes compilation errors, runtime errors and misconfigurations of the policy.
+
+        validationActions is declared as a set of action values. Order does not matter. validationActions may not contain duplicates of the same action.
+
+        The supported actions values are:
+
+        "Deny" specifies that a validation failure results in a denied request.
+
+        "Warn" specifies that a validation failure is reported to the request client in HTTP Warning headers, with a warning code of 299. Warnings can be sent both for allowed or denied admission responses.
+
+        "Audit" specifies that a validation failure is included in the published audit event for the request. The audit event will contain a `validation.policy.admission.k8s.io/validation_failure` audit annotation with a value containing the details of the validation failures, formatted as a JSON list of objects, each with the following fields: - message: The validation failure message string - policy: The resource name of the ValidatingAdmissionPolicy - binding: The resource name of the ValidatingAdmissionPolicyBinding - expressionIndex: The index of the failed validations in the ValidatingAdmissionPolicy - validationActions: The enforcement actions enacted for the validation failure Example audit annotation: `"validation.policy.admission.k8s.io/validation_failure": "[{"message": "Invalid value", {"policy": "policy.example.com", {"binding": "policybinding.example.com", {"expressionIndex": "1", {"validationActions": ["Audit"]}]"`
+
+        Clients should expect to handle additional values by ignoring any values not recognized.
+
+        "Deny" and "Warn" may not be used together since this combination needlessly duplicates the validation failure both in the API response body and the HTTP warning headers.
+
+        Required.
+        """
+elif False:
+    ValidatingAdmissionPolicyBindingSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ValidatingAdmissionPolicyBindingSpecPatchArgs:
@@ -2252,6 +3118,48 @@ class ValidatingAdmissionPolicyBindingSpecPatchArgs:
         pulumi.set(self, "validation_actions", value)
 
 
+if not MYPY:
+    class ValidatingAdmissionPolicyBindingSpecArgsDict(TypedDict):
+        """
+        ValidatingAdmissionPolicyBindingSpec is the specification of the ValidatingAdmissionPolicyBinding.
+        """
+        match_resources: NotRequired[pulumi.Input['MatchResourcesArgsDict']]
+        """
+        MatchResources declares what resources match this binding and will be validated by it. Note that this is intersected with the policy's matchConstraints, so only requests that are matched by the policy can be selected by this. If this is unset, all resources matched by the policy are validated by this binding When resourceRules is unset, it does not constrain resource matching. If a resource is matched by the other fields of this object, it will be validated. Note that this is differs from ValidatingAdmissionPolicy matchConstraints, where resourceRules are required.
+        """
+        param_ref: NotRequired[pulumi.Input['ParamRefArgsDict']]
+        """
+        paramRef specifies the parameter resource used to configure the admission control policy. It should point to a resource of the type specified in ParamKind of the bound ValidatingAdmissionPolicy. If the policy specifies a ParamKind and the resource referred to by ParamRef does not exist, this binding is considered mis-configured and the FailurePolicy of the ValidatingAdmissionPolicy applied. If the policy does not specify a ParamKind then this field is ignored, and the rules are evaluated without a param.
+        """
+        policy_name: NotRequired[pulumi.Input[str]]
+        """
+        PolicyName references a ValidatingAdmissionPolicy name which the ValidatingAdmissionPolicyBinding binds to. If the referenced resource does not exist, this binding is considered invalid and will be ignored Required.
+        """
+        validation_actions: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        validationActions declares how Validations of the referenced ValidatingAdmissionPolicy are enforced. If a validation evaluates to false it is always enforced according to these actions.
+
+        Failures defined by the ValidatingAdmissionPolicy's FailurePolicy are enforced according to these actions only if the FailurePolicy is set to Fail, otherwise the failures are ignored. This includes compilation errors, runtime errors and misconfigurations of the policy.
+
+        validationActions is declared as a set of action values. Order does not matter. validationActions may not contain duplicates of the same action.
+
+        The supported actions values are:
+
+        "Deny" specifies that a validation failure results in a denied request.
+
+        "Warn" specifies that a validation failure is reported to the request client in HTTP Warning headers, with a warning code of 299. Warnings can be sent both for allowed or denied admission responses.
+
+        "Audit" specifies that a validation failure is included in the published audit event for the request. The audit event will contain a `validation.policy.admission.k8s.io/validation_failure` audit annotation with a value containing the details of the validation failures, formatted as a JSON list of objects, each with the following fields: - message: The validation failure message string - policy: The resource name of the ValidatingAdmissionPolicy - binding: The resource name of the ValidatingAdmissionPolicyBinding - expressionIndex: The index of the failed validations in the ValidatingAdmissionPolicy - validationActions: The enforcement actions enacted for the validation failure Example audit annotation: `"validation.policy.admission.k8s.io/validation_failure": "[{"message": "Invalid value", {"policy": "policy.example.com", {"binding": "policybinding.example.com", {"expressionIndex": "1", {"validationActions": ["Audit"]}]"`
+
+        Clients should expect to handle additional values by ignoring any values not recognized.
+
+        "Deny" and "Warn" may not be used together since this combination needlessly duplicates the validation failure both in the API response body and the HTTP warning headers.
+
+        Required.
+        """
+elif False:
+    ValidatingAdmissionPolicyBindingSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ValidatingAdmissionPolicyBindingSpecArgs:
     def __init__(__self__, *,
@@ -2360,6 +3268,34 @@ class ValidatingAdmissionPolicyBindingSpecArgs:
         pulumi.set(self, "validation_actions", value)
 
 
+if not MYPY:
+    class ValidatingAdmissionPolicyBindingArgsDict(TypedDict):
+        """
+        ValidatingAdmissionPolicyBinding binds the ValidatingAdmissionPolicy with paramerized resources. ValidatingAdmissionPolicyBinding and parameter CRDs together define how cluster administrators configure policies for clusters.
+
+        For a given admission request, each binding will cause its policy to be evaluated N times, where N is 1 for policies/bindings that don't use params, otherwise N is the number of parameters selected by the binding.
+
+        The CEL expressions of a policy must have a computed CEL cost below the maximum CEL budget. Each evaluation of the policy is given an independent CEL cost budget. Adding/removing policies, bindings, or params can not affect whether a given (policy, binding, param) combination is within its own CEL budget.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
+        """
+        spec: NotRequired[pulumi.Input['ValidatingAdmissionPolicyBindingSpecArgsDict']]
+        """
+        Specification of the desired behavior of the ValidatingAdmissionPolicyBinding.
+        """
+elif False:
+    ValidatingAdmissionPolicyBindingArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ValidatingAdmissionPolicyBindingArgs:
     def __init__(__self__, *,
@@ -2435,6 +3371,61 @@ class ValidatingAdmissionPolicyBindingArgs:
     def spec(self, value: Optional[pulumi.Input['ValidatingAdmissionPolicyBindingSpecArgs']]):
         pulumi.set(self, "spec", value)
 
+
+if not MYPY:
+    class ValidatingAdmissionPolicySpecPatchArgsDict(TypedDict):
+        """
+        ValidatingAdmissionPolicySpec is the specification of the desired behavior of the AdmissionPolicy.
+        """
+        audit_annotations: NotRequired[pulumi.Input[Sequence[pulumi.Input['AuditAnnotationPatchArgsDict']]]]
+        """
+        auditAnnotations contains CEL expressions which are used to produce audit annotations for the audit event of the API request. validations and auditAnnotations may not both be empty; a least one of validations or auditAnnotations is required.
+        """
+        failure_policy: NotRequired[pulumi.Input[str]]
+        """
+        failurePolicy defines how to handle failures for the admission policy. Failures can occur from CEL expression parse errors, type check errors, runtime errors and invalid or mis-configured policy definitions or bindings.
+
+        A policy is invalid if spec.paramKind refers to a non-existent Kind. A binding is invalid if spec.paramRef.name refers to a non-existent resource.
+
+        failurePolicy does not define how validations that evaluate to false are handled.
+
+        When failurePolicy is set to Fail, ValidatingAdmissionPolicyBinding validationActions define how failures are enforced.
+
+        Allowed values are Ignore or Fail. Defaults to Fail.
+        """
+        match_conditions: NotRequired[pulumi.Input[Sequence[pulumi.Input['MatchConditionPatchArgsDict']]]]
+        """
+        MatchConditions is a list of conditions that must be met for a request to be validated. Match conditions filter requests that have already been matched by the rules, namespaceSelector, and objectSelector. An empty list of matchConditions matches all requests. There are a maximum of 64 match conditions allowed.
+
+        If a parameter object is provided, it can be accessed via the `params` handle in the same manner as validation expressions.
+
+        The exact matching logic is (in order):
+          1. If ANY matchCondition evaluates to FALSE, the policy is skipped.
+          2. If ALL matchConditions evaluate to TRUE, the policy is evaluated.
+          3. If any matchCondition evaluates to an error (but none are FALSE):
+             - If failurePolicy=Fail, reject the request
+             - If failurePolicy=Ignore, the policy is skipped
+        """
+        match_constraints: NotRequired[pulumi.Input['MatchResourcesPatchArgsDict']]
+        """
+        MatchConstraints specifies what resources this policy is designed to validate. The AdmissionPolicy cares about a request if it matches _all_ Constraints. However, in order to prevent clusters from being put into an unstable state that cannot be recovered from via the API ValidatingAdmissionPolicy cannot match ValidatingAdmissionPolicy and ValidatingAdmissionPolicyBinding. Required.
+        """
+        param_kind: NotRequired[pulumi.Input['ParamKindPatchArgsDict']]
+        """
+        ParamKind specifies the kind of resources used to parameterize this policy. If absent, there are no parameters for this policy and the param CEL variable will not be provided to validation expressions. If ParamKind refers to a non-existent kind, this policy definition is mis-configured and the FailurePolicy is applied. If paramKind is specified but paramRef is unset in ValidatingAdmissionPolicyBinding, the params variable will be null.
+        """
+        validations: NotRequired[pulumi.Input[Sequence[pulumi.Input['ValidationPatchArgsDict']]]]
+        """
+        Validations contain CEL expressions which is used to apply the validation. Validations and AuditAnnotations may not both be empty; a minimum of one Validations or AuditAnnotations is required.
+        """
+        variables: NotRequired[pulumi.Input[Sequence[pulumi.Input['VariablePatchArgsDict']]]]
+        """
+        Variables contain definitions of variables that can be used in composition of other expressions. Each variable is defined as a named CEL expression. The variables defined here will be available under `variables` in other expressions of the policy except MatchConditions because MatchConditions are evaluated before the rest of the policy.
+
+        The expression of a variable can refer to other variables defined earlier in the list but not those after. Thus, Variables must be sorted by the order of first appearance and acyclic.
+        """
+elif False:
+    ValidatingAdmissionPolicySpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ValidatingAdmissionPolicySpecPatchArgs:
@@ -2594,6 +3585,61 @@ class ValidatingAdmissionPolicySpecPatchArgs:
         pulumi.set(self, "variables", value)
 
 
+if not MYPY:
+    class ValidatingAdmissionPolicySpecArgsDict(TypedDict):
+        """
+        ValidatingAdmissionPolicySpec is the specification of the desired behavior of the AdmissionPolicy.
+        """
+        audit_annotations: NotRequired[pulumi.Input[Sequence[pulumi.Input['AuditAnnotationArgsDict']]]]
+        """
+        auditAnnotations contains CEL expressions which are used to produce audit annotations for the audit event of the API request. validations and auditAnnotations may not both be empty; a least one of validations or auditAnnotations is required.
+        """
+        failure_policy: NotRequired[pulumi.Input[str]]
+        """
+        failurePolicy defines how to handle failures for the admission policy. Failures can occur from CEL expression parse errors, type check errors, runtime errors and invalid or mis-configured policy definitions or bindings.
+
+        A policy is invalid if spec.paramKind refers to a non-existent Kind. A binding is invalid if spec.paramRef.name refers to a non-existent resource.
+
+        failurePolicy does not define how validations that evaluate to false are handled.
+
+        When failurePolicy is set to Fail, ValidatingAdmissionPolicyBinding validationActions define how failures are enforced.
+
+        Allowed values are Ignore or Fail. Defaults to Fail.
+        """
+        match_conditions: NotRequired[pulumi.Input[Sequence[pulumi.Input['MatchConditionArgsDict']]]]
+        """
+        MatchConditions is a list of conditions that must be met for a request to be validated. Match conditions filter requests that have already been matched by the rules, namespaceSelector, and objectSelector. An empty list of matchConditions matches all requests. There are a maximum of 64 match conditions allowed.
+
+        If a parameter object is provided, it can be accessed via the `params` handle in the same manner as validation expressions.
+
+        The exact matching logic is (in order):
+          1. If ANY matchCondition evaluates to FALSE, the policy is skipped.
+          2. If ALL matchConditions evaluate to TRUE, the policy is evaluated.
+          3. If any matchCondition evaluates to an error (but none are FALSE):
+             - If failurePolicy=Fail, reject the request
+             - If failurePolicy=Ignore, the policy is skipped
+        """
+        match_constraints: NotRequired[pulumi.Input['MatchResourcesArgsDict']]
+        """
+        MatchConstraints specifies what resources this policy is designed to validate. The AdmissionPolicy cares about a request if it matches _all_ Constraints. However, in order to prevent clusters from being put into an unstable state that cannot be recovered from via the API ValidatingAdmissionPolicy cannot match ValidatingAdmissionPolicy and ValidatingAdmissionPolicyBinding. Required.
+        """
+        param_kind: NotRequired[pulumi.Input['ParamKindArgsDict']]
+        """
+        ParamKind specifies the kind of resources used to parameterize this policy. If absent, there are no parameters for this policy and the param CEL variable will not be provided to validation expressions. If ParamKind refers to a non-existent kind, this policy definition is mis-configured and the FailurePolicy is applied. If paramKind is specified but paramRef is unset in ValidatingAdmissionPolicyBinding, the params variable will be null.
+        """
+        validations: NotRequired[pulumi.Input[Sequence[pulumi.Input['ValidationArgsDict']]]]
+        """
+        Validations contain CEL expressions which is used to apply the validation. Validations and AuditAnnotations may not both be empty; a minimum of one Validations or AuditAnnotations is required.
+        """
+        variables: NotRequired[pulumi.Input[Sequence[pulumi.Input['VariableArgsDict']]]]
+        """
+        Variables contain definitions of variables that can be used in composition of other expressions. Each variable is defined as a named CEL expression. The variables defined here will be available under `variables` in other expressions of the policy except MatchConditions because MatchConditions are evaluated before the rest of the policy.
+
+        The expression of a variable can refer to other variables defined earlier in the list but not those after. Thus, Variables must be sorted by the order of first appearance and acyclic.
+        """
+elif False:
+    ValidatingAdmissionPolicySpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ValidatingAdmissionPolicySpecArgs:
     def __init__(__self__, *,
@@ -2752,6 +3798,26 @@ class ValidatingAdmissionPolicySpecArgs:
         pulumi.set(self, "variables", value)
 
 
+if not MYPY:
+    class ValidatingAdmissionPolicyStatusArgsDict(TypedDict):
+        """
+        ValidatingAdmissionPolicyStatus represents the status of an admission validation policy.
+        """
+        conditions: NotRequired[pulumi.Input[Sequence[pulumi.Input['_meta.v1.ConditionArgsDict']]]]
+        """
+        The conditions represent the latest available observations of a policy's current state.
+        """
+        observed_generation: NotRequired[pulumi.Input[int]]
+        """
+        The generation observed by the controller.
+        """
+        type_checking: NotRequired[pulumi.Input['TypeCheckingArgsDict']]
+        """
+        The results of type checking for each expression. Presence of this field indicates the completion of the type checking.
+        """
+elif False:
+    ValidatingAdmissionPolicyStatusArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ValidatingAdmissionPolicyStatusArgs:
     def __init__(__self__, *,
@@ -2807,6 +3873,34 @@ class ValidatingAdmissionPolicyStatusArgs:
     def type_checking(self, value: Optional[pulumi.Input['TypeCheckingArgs']]):
         pulumi.set(self, "type_checking", value)
 
+
+if not MYPY:
+    class ValidatingAdmissionPolicyArgsDict(TypedDict):
+        """
+        ValidatingAdmissionPolicy describes the definition of an admission validation policy that accepts or rejects an object without changing it.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
+        """
+        spec: NotRequired[pulumi.Input['ValidatingAdmissionPolicySpecArgsDict']]
+        """
+        Specification of the desired behavior of the ValidatingAdmissionPolicy.
+        """
+        status: NotRequired[pulumi.Input['ValidatingAdmissionPolicyStatusArgsDict']]
+        """
+        The status of the ValidatingAdmissionPolicy, including warnings that are useful to determine if the policy behaves in the expected way. Populated by the system. Read-only.
+        """
+elif False:
+    ValidatingAdmissionPolicyArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ValidatingAdmissionPolicyArgs:
@@ -2896,6 +3990,30 @@ class ValidatingAdmissionPolicyArgs:
         pulumi.set(self, "status", value)
 
 
+if not MYPY:
+    class ValidatingWebhookConfigurationArgsDict(TypedDict):
+        """
+        ValidatingWebhookConfiguration describes the configuration of and admission webhook that accept or reject and object without changing it. Deprecated in v1.16, planned for removal in v1.19. Use admissionregistration.k8s.io/v1 ValidatingWebhookConfiguration instead.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
+        """
+        webhooks: NotRequired[pulumi.Input[Sequence[pulumi.Input['ValidatingWebhookArgsDict']]]]
+        """
+        Webhooks is a list of webhooks and the affected resources and operations.
+        """
+elif False:
+    ValidatingWebhookConfigurationArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ValidatingWebhookConfigurationArgs:
     def __init__(__self__, *,
@@ -2967,6 +4085,90 @@ class ValidatingWebhookConfigurationArgs:
     def webhooks(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['ValidatingWebhookArgs']]]]):
         pulumi.set(self, "webhooks", value)
 
+
+if not MYPY:
+    class ValidatingWebhookPatchArgsDict(TypedDict):
+        """
+        ValidatingWebhook describes an admission webhook and the resources and operations it applies to.
+        """
+        admission_review_versions: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        AdmissionReviewVersions is an ordered list of preferred `AdmissionReview` versions the Webhook expects. API server will try to use first version in the list which it supports. If none of the versions specified in this list supported by API server, validation will fail for this object. If a persisted webhook configuration specifies allowed versions and does not include any versions known to the API Server, calls to the webhook will fail and be subject to the failure policy. Default to `['v1beta1']`.
+        """
+        client_config: NotRequired[pulumi.Input['WebhookClientConfigPatchArgsDict']]
+        """
+        ClientConfig defines how to communicate with the hook. Required
+        """
+        failure_policy: NotRequired[pulumi.Input[str]]
+        """
+        FailurePolicy defines how unrecognized errors from the admission endpoint are handled - allowed values are Ignore or Fail. Defaults to Ignore.
+        """
+        match_policy: NotRequired[pulumi.Input[str]]
+        """
+        matchPolicy defines how the "rules" list is used to match incoming requests. Allowed values are "Exact" or "Equivalent".
+
+        - Exact: match a request only if it exactly matches a specified rule. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, but "rules" only included `apiGroups:["apps"], apiVersions:["v1"], resources: ["deployments"]`, a request to apps/v1beta1 or extensions/v1beta1 would not be sent to the webhook.
+
+        - Equivalent: match a request if modifies a resource listed in rules, even via another API group or version. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, and "rules" only included `apiGroups:["apps"], apiVersions:["v1"], resources: ["deployments"]`, a request to apps/v1beta1 or extensions/v1beta1 would be converted to apps/v1 and sent to the webhook.
+
+        Defaults to "Exact"
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        The name of the admission webhook. Name should be fully qualified, e.g., imagepolicy.kubernetes.io, where "imagepolicy" is the name of the webhook, and kubernetes.io is the name of the organization. Required.
+        """
+        namespace_selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorPatchArgsDict']]
+        """
+        NamespaceSelector decides whether to run the webhook on an object based on whether the namespace for that object matches the selector. If the object itself is a namespace, the matching is performed on object.metadata.labels. If the object is another cluster scoped resource, it never skips the webhook.
+
+        For example, to run the webhook on any objects whose namespace is not associated with "runlevel" of "0" or "1";  you will set the selector as follows: "namespaceSelector": {
+          "matchExpressions": [
+            {
+              "key": "runlevel",
+              "operator": "NotIn",
+              "values": [
+                "0",
+                "1"
+              ]
+            }
+          ]
+        }
+
+        If instead you want to only run the webhook on any objects whose namespace is associated with the "environment" of "prod" or "staging"; you will set the selector as follows: "namespaceSelector": {
+          "matchExpressions": [
+            {
+              "key": "environment",
+              "operator": "In",
+              "values": [
+                "prod",
+                "staging"
+              ]
+            }
+          ]
+        }
+
+        See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels for more examples of label selectors.
+
+        Default to the empty LabelSelector, which matches everything.
+        """
+        object_selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorPatchArgsDict']]
+        """
+        ObjectSelector decides whether to run the webhook based on if the object has matching labels. objectSelector is evaluated against both the oldObject and newObject that would be sent to the webhook, and is considered to match if either object matches the selector. A null object (oldObject in the case of create, or newObject in the case of delete) or an object that cannot have labels (like a DeploymentRollback or a PodProxyOptions object) is not considered to match. Use the object selector only if the webhook is opt-in, because end users may skip the admission webhook by setting the labels. Default to the empty LabelSelector, which matches everything.
+        """
+        rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['RuleWithOperationsPatchArgsDict']]]]
+        """
+        Rules describes what operations on what resources/subresources the webhook cares about. The webhook cares about an operation if it matches _any_ Rule. However, in order to prevent ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks from putting the cluster in a state which cannot be recovered from without completely disabling the plugin, ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks are never called on admission requests for ValidatingWebhookConfiguration and MutatingWebhookConfiguration objects.
+        """
+        side_effects: NotRequired[pulumi.Input[str]]
+        """
+        SideEffects states whether this webhook has side effects. Acceptable values are: Unknown, None, Some, NoneOnDryRun Webhooks with side effects MUST implement a reconciliation system, since a request may be rejected by a future step in the admission change and the side effects therefore need to be undone. Requests with the dryRun attribute will be auto-rejected if they match a webhook with sideEffects == Unknown or Some. Defaults to Unknown.
+        """
+        timeout_seconds: NotRequired[pulumi.Input[int]]
+        """
+        TimeoutSeconds specifies the timeout for this webhook. After the timeout passes, the webhook call will be ignored or the API call will fail based on the failure policy. The timeout value must be between 1 and 30 seconds. Default to 30 seconds.
+        """
+elif False:
+    ValidatingWebhookPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ValidatingWebhookPatchArgs:
@@ -3208,6 +4410,90 @@ class ValidatingWebhookPatchArgs:
         pulumi.set(self, "timeout_seconds", value)
 
 
+if not MYPY:
+    class ValidatingWebhookArgsDict(TypedDict):
+        """
+        ValidatingWebhook describes an admission webhook and the resources and operations it applies to.
+        """
+        client_config: pulumi.Input['WebhookClientConfigArgsDict']
+        """
+        ClientConfig defines how to communicate with the hook. Required
+        """
+        name: pulumi.Input[str]
+        """
+        The name of the admission webhook. Name should be fully qualified, e.g., imagepolicy.kubernetes.io, where "imagepolicy" is the name of the webhook, and kubernetes.io is the name of the organization. Required.
+        """
+        admission_review_versions: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        AdmissionReviewVersions is an ordered list of preferred `AdmissionReview` versions the Webhook expects. API server will try to use first version in the list which it supports. If none of the versions specified in this list supported by API server, validation will fail for this object. If a persisted webhook configuration specifies allowed versions and does not include any versions known to the API Server, calls to the webhook will fail and be subject to the failure policy. Default to `['v1beta1']`.
+        """
+        failure_policy: NotRequired[pulumi.Input[str]]
+        """
+        FailurePolicy defines how unrecognized errors from the admission endpoint are handled - allowed values are Ignore or Fail. Defaults to Ignore.
+        """
+        match_policy: NotRequired[pulumi.Input[str]]
+        """
+        matchPolicy defines how the "rules" list is used to match incoming requests. Allowed values are "Exact" or "Equivalent".
+
+        - Exact: match a request only if it exactly matches a specified rule. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, but "rules" only included `apiGroups:["apps"], apiVersions:["v1"], resources: ["deployments"]`, a request to apps/v1beta1 or extensions/v1beta1 would not be sent to the webhook.
+
+        - Equivalent: match a request if modifies a resource listed in rules, even via another API group or version. For example, if deployments can be modified via apps/v1, apps/v1beta1, and extensions/v1beta1, and "rules" only included `apiGroups:["apps"], apiVersions:["v1"], resources: ["deployments"]`, a request to apps/v1beta1 or extensions/v1beta1 would be converted to apps/v1 and sent to the webhook.
+
+        Defaults to "Exact"
+        """
+        namespace_selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorArgsDict']]
+        """
+        NamespaceSelector decides whether to run the webhook on an object based on whether the namespace for that object matches the selector. If the object itself is a namespace, the matching is performed on object.metadata.labels. If the object is another cluster scoped resource, it never skips the webhook.
+
+        For example, to run the webhook on any objects whose namespace is not associated with "runlevel" of "0" or "1";  you will set the selector as follows: "namespaceSelector": {
+          "matchExpressions": [
+            {
+              "key": "runlevel",
+              "operator": "NotIn",
+              "values": [
+                "0",
+                "1"
+              ]
+            }
+          ]
+        }
+
+        If instead you want to only run the webhook on any objects whose namespace is associated with the "environment" of "prod" or "staging"; you will set the selector as follows: "namespaceSelector": {
+          "matchExpressions": [
+            {
+              "key": "environment",
+              "operator": "In",
+              "values": [
+                "prod",
+                "staging"
+              ]
+            }
+          ]
+        }
+
+        See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels for more examples of label selectors.
+
+        Default to the empty LabelSelector, which matches everything.
+        """
+        object_selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorArgsDict']]
+        """
+        ObjectSelector decides whether to run the webhook based on if the object has matching labels. objectSelector is evaluated against both the oldObject and newObject that would be sent to the webhook, and is considered to match if either object matches the selector. A null object (oldObject in the case of create, or newObject in the case of delete) or an object that cannot have labels (like a DeploymentRollback or a PodProxyOptions object) is not considered to match. Use the object selector only if the webhook is opt-in, because end users may skip the admission webhook by setting the labels. Default to the empty LabelSelector, which matches everything.
+        """
+        rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['RuleWithOperationsArgsDict']]]]
+        """
+        Rules describes what operations on what resources/subresources the webhook cares about. The webhook cares about an operation if it matches _any_ Rule. However, in order to prevent ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks from putting the cluster in a state which cannot be recovered from without completely disabling the plugin, ValidatingAdmissionWebhooks and MutatingAdmissionWebhooks are never called on admission requests for ValidatingWebhookConfiguration and MutatingWebhookConfiguration objects.
+        """
+        side_effects: NotRequired[pulumi.Input[str]]
+        """
+        SideEffects states whether this webhook has side effects. Acceptable values are: Unknown, None, Some, NoneOnDryRun Webhooks with side effects MUST implement a reconciliation system, since a request may be rejected by a future step in the admission change and the side effects therefore need to be undone. Requests with the dryRun attribute will be auto-rejected if they match a webhook with sideEffects == Unknown or Some. Defaults to Unknown.
+        """
+        timeout_seconds: NotRequired[pulumi.Input[int]]
+        """
+        TimeoutSeconds specifies the timeout for this webhook. After the timeout passes, the webhook call will be ignored or the API call will fail based on the failure policy. The timeout value must be between 1 and 30 seconds. Default to 30 seconds.
+        """
+elif False:
+    ValidatingWebhookArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ValidatingWebhookArgs:
     def __init__(__self__, *,
@@ -3446,6 +4732,55 @@ class ValidatingWebhookArgs:
         pulumi.set(self, "timeout_seconds", value)
 
 
+if not MYPY:
+    class ValidationPatchArgsDict(TypedDict):
+        """
+        Validation specifies the CEL expression which is used to apply the validation.
+        """
+        expression: NotRequired[pulumi.Input[str]]
+        """
+        Expression represents the expression which will be evaluated by CEL. ref: https://github.com/google/cel-spec CEL expressions have access to the contents of the API request/response, organized into CEL variables as well as some other useful variables:
+
+        - 'object' - The object from the incoming request. The value is null for DELETE requests. - 'oldObject' - The existing object. The value is null for CREATE requests. - 'request' - Attributes of the API request([ref](/pkg/apis/admission/types.go#AdmissionRequest)). - 'params' - Parameter resource referred to by the policy binding being evaluated. Only populated if the policy has a ParamKind. - 'namespaceObject' - The namespace object that the incoming object belongs to. The value is null for cluster-scoped resources. - 'variables' - Map of composited variables, from its name to its lazily evaluated value.
+          For example, a variable named 'foo' can be accessed as 'variables.foo'.
+        - 'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.
+          See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz
+        - 'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the
+          request resource.
+
+        The `apiVersion`, `kind`, `metadata.name` and `metadata.generateName` are always accessible from the root of the object. No other metadata properties are accessible.
+
+        Only property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible. Accessible property names are escaped according to the following rules when accessed in the expression: - '__' escapes to '__underscores__' - '.' escapes to '__dot__' - '-' escapes to '__dash__' - '/' escapes to '__slash__' - Property names that exactly match a CEL RESERVED keyword escape to '__{keyword}__'. The keywords are:
+        	  "true", "false", "null", "in", "as", "break", "const", "continue", "else", "for", "function", "if",
+        	  "import", "let", "loop", "package", "namespace", "return".
+        Examples:
+          - Expression accessing a property named "namespace": {"Expression": "object.__namespace__ > 0"}
+          - Expression accessing a property named "x-prop": {"Expression": "object.x__dash__prop > 0"}
+          - Expression accessing a property named "redact__d": {"Expression": "object.redact__underscores__d > 0"}
+
+        Equality on arrays with list type of 'set' or 'map' ignores element order, i.e. [1, 2] == [2, 1]. Concatenation on arrays with x-kubernetes-list-type use the semantics of the list type:
+          - 'set': `X + Y` performs a union where the array positions of all elements in `X` are preserved and
+            non-intersecting elements in `Y` are appended, retaining their partial order.
+          - 'map': `X + Y` performs a merge where the array positions of all keys in `X` are preserved but the values
+            are overwritten by values in `Y` when the key sets of `X` and `Y` intersect. Elements in `Y` with
+            non-intersecting keys are appended, retaining their partial order.
+        Required.
+        """
+        message: NotRequired[pulumi.Input[str]]
+        """
+        Message represents the message displayed when validation fails. The message is required if the Expression contains line breaks. The message must not contain line breaks. If unset, the message is "failed rule: {Rule}". e.g. "must be a URL with the host matching spec.host" If the Expression contains line breaks. Message is required. The message must not contain line breaks. If unset, the message is "failed Expression: {Expression}".
+        """
+        message_expression: NotRequired[pulumi.Input[str]]
+        """
+        messageExpression declares a CEL expression that evaluates to the validation failure message that is returned when this rule fails. Since messageExpression is used as a failure message, it must evaluate to a string. If both message and messageExpression are present on a validation, then messageExpression will be used if validation fails. If messageExpression results in a runtime error, the runtime error is logged, and the validation failure message is produced as if the messageExpression field were unset. If messageExpression evaluates to an empty string, a string with only spaces, or a string that contains line breaks, then the validation failure message will also be produced as if the messageExpression field were unset, and the fact that messageExpression produced an empty string/string with only spaces/string with line breaks will be logged. messageExpression has access to all the same variables as the `expression` except for 'authorizer' and 'authorizer.requestResource'. Example: "object.x must be less than max ("+string(params.max)+")"
+        """
+        reason: NotRequired[pulumi.Input[str]]
+        """
+        Reason represents a machine-readable description of why this validation failed. If this is the first validation in the list to fail, this reason, as well as the corresponding HTTP response code, are used in the HTTP response to the client. The currently supported reasons are: "Unauthorized", "Forbidden", "Invalid", "RequestEntityTooLarge". If not set, StatusReasonInvalid is used in the response to the client.
+        """
+elif False:
+    ValidationPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ValidationPatchArgs:
     def __init__(__self__, *,
@@ -3568,6 +4903,55 @@ class ValidationPatchArgs:
         pulumi.set(self, "reason", value)
 
 
+if not MYPY:
+    class ValidationArgsDict(TypedDict):
+        """
+        Validation specifies the CEL expression which is used to apply the validation.
+        """
+        expression: pulumi.Input[str]
+        """
+        Expression represents the expression which will be evaluated by CEL. ref: https://github.com/google/cel-spec CEL expressions have access to the contents of the API request/response, organized into CEL variables as well as some other useful variables:
+
+        - 'object' - The object from the incoming request. The value is null for DELETE requests. - 'oldObject' - The existing object. The value is null for CREATE requests. - 'request' - Attributes of the API request([ref](/pkg/apis/admission/types.go#AdmissionRequest)). - 'params' - Parameter resource referred to by the policy binding being evaluated. Only populated if the policy has a ParamKind. - 'namespaceObject' - The namespace object that the incoming object belongs to. The value is null for cluster-scoped resources. - 'variables' - Map of composited variables, from its name to its lazily evaluated value.
+          For example, a variable named 'foo' can be accessed as 'variables.foo'.
+        - 'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.
+          See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz
+        - 'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the
+          request resource.
+
+        The `apiVersion`, `kind`, `metadata.name` and `metadata.generateName` are always accessible from the root of the object. No other metadata properties are accessible.
+
+        Only property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible. Accessible property names are escaped according to the following rules when accessed in the expression: - '__' escapes to '__underscores__' - '.' escapes to '__dot__' - '-' escapes to '__dash__' - '/' escapes to '__slash__' - Property names that exactly match a CEL RESERVED keyword escape to '__{keyword}__'. The keywords are:
+        	  "true", "false", "null", "in", "as", "break", "const", "continue", "else", "for", "function", "if",
+        	  "import", "let", "loop", "package", "namespace", "return".
+        Examples:
+          - Expression accessing a property named "namespace": {"Expression": "object.__namespace__ > 0"}
+          - Expression accessing a property named "x-prop": {"Expression": "object.x__dash__prop > 0"}
+          - Expression accessing a property named "redact__d": {"Expression": "object.redact__underscores__d > 0"}
+
+        Equality on arrays with list type of 'set' or 'map' ignores element order, i.e. [1, 2] == [2, 1]. Concatenation on arrays with x-kubernetes-list-type use the semantics of the list type:
+          - 'set': `X + Y` performs a union where the array positions of all elements in `X` are preserved and
+            non-intersecting elements in `Y` are appended, retaining their partial order.
+          - 'map': `X + Y` performs a merge where the array positions of all keys in `X` are preserved but the values
+            are overwritten by values in `Y` when the key sets of `X` and `Y` intersect. Elements in `Y` with
+            non-intersecting keys are appended, retaining their partial order.
+        Required.
+        """
+        message: NotRequired[pulumi.Input[str]]
+        """
+        Message represents the message displayed when validation fails. The message is required if the Expression contains line breaks. The message must not contain line breaks. If unset, the message is "failed rule: {Rule}". e.g. "must be a URL with the host matching spec.host" If the Expression contains line breaks. Message is required. The message must not contain line breaks. If unset, the message is "failed Expression: {Expression}".
+        """
+        message_expression: NotRequired[pulumi.Input[str]]
+        """
+        messageExpression declares a CEL expression that evaluates to the validation failure message that is returned when this rule fails. Since messageExpression is used as a failure message, it must evaluate to a string. If both message and messageExpression are present on a validation, then messageExpression will be used if validation fails. If messageExpression results in a runtime error, the runtime error is logged, and the validation failure message is produced as if the messageExpression field were unset. If messageExpression evaluates to an empty string, a string with only spaces, or a string that contains line breaks, then the validation failure message will also be produced as if the messageExpression field were unset, and the fact that messageExpression produced an empty string/string with only spaces/string with line breaks will be logged. messageExpression has access to all the same variables as the `expression` except for 'authorizer' and 'authorizer.requestResource'. Example: "object.x must be less than max ("+string(params.max)+")"
+        """
+        reason: NotRequired[pulumi.Input[str]]
+        """
+        Reason represents a machine-readable description of why this validation failed. If this is the first validation in the list to fail, this reason, as well as the corresponding HTTP response code, are used in the HTTP response to the client. The currently supported reasons are: "Unauthorized", "Forbidden", "Invalid", "RequestEntityTooLarge". If not set, StatusReasonInvalid is used in the response to the client.
+        """
+elif False:
+    ValidationArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ValidationArgs:
     def __init__(__self__, *,
@@ -3689,6 +5073,22 @@ class ValidationArgs:
         pulumi.set(self, "reason", value)
 
 
+if not MYPY:
+    class VariablePatchArgsDict(TypedDict):
+        """
+        Variable is the definition of a variable that is used for composition. A variable is defined as a named expression.
+        """
+        expression: NotRequired[pulumi.Input[str]]
+        """
+        Expression is the expression that will be evaluated as the value of the variable. The CEL expression has access to the same identifiers as the CEL expressions in Validation.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name is the name of the variable. The name must be a valid CEL identifier and unique among all variables. The variable can be accessed in other expressions through `variables` For example, if name is "foo", the variable will be available as `variables.foo`
+        """
+elif False:
+    VariablePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class VariablePatchArgs:
     def __init__(__self__, *,
@@ -3729,6 +5129,22 @@ class VariablePatchArgs:
         pulumi.set(self, "name", value)
 
 
+if not MYPY:
+    class VariableArgsDict(TypedDict):
+        """
+        Variable is the definition of a variable that is used for composition. A variable is defined as a named expression.
+        """
+        expression: pulumi.Input[str]
+        """
+        Expression is the expression that will be evaluated as the value of the variable. The CEL expression has access to the same identifiers as the CEL expressions in Validation.
+        """
+        name: pulumi.Input[str]
+        """
+        Name is the name of the variable. The name must be a valid CEL identifier and unique among all variables. The variable can be accessed in other expressions through `variables` For example, if name is "foo", the variable will be available as `variables.foo`
+        """
+elif False:
+    VariableArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class VariableArgs:
     def __init__(__self__, *,
@@ -3766,6 +5182,38 @@ class VariableArgs:
     def name(self, value: pulumi.Input[str]):
         pulumi.set(self, "name", value)
 
+
+if not MYPY:
+    class WebhookClientConfigPatchArgsDict(TypedDict):
+        """
+        WebhookClientConfig contains the information to make a TLS connection with the webhook
+        """
+        ca_bundle: NotRequired[pulumi.Input[str]]
+        """
+        `caBundle` is a PEM encoded CA bundle which will be used to validate the webhook's server certificate. If unspecified, system trust roots on the apiserver are used.
+        """
+        service: NotRequired[pulumi.Input['ServiceReferencePatchArgsDict']]
+        """
+        `service` is a reference to the service for this webhook. Either `service` or `url` must be specified.
+
+        If the webhook is running within the cluster, then you should use `service`.
+        """
+        url: NotRequired[pulumi.Input[str]]
+        """
+        `url` gives the location of the webhook, in standard URL form (`scheme://host:port/path`). Exactly one of `url` or `service` must be specified.
+
+        The `host` should not refer to a service running in the cluster; use the `service` field instead. The host might be resolved via external DNS in some apiservers (e.g., `kube-apiserver` cannot resolve in-cluster DNS as that would be a layering violation). `host` may also be an IP address.
+
+        Please note that using `localhost` or `127.0.0.1` as a `host` is risky unless you take great care to run this webhook on all hosts which run an apiserver which might need to make calls to this webhook. Such installs are likely to be non-portable, i.e., not easy to turn up in a new cluster.
+
+        The scheme must be "https"; the URL must begin with "https://".
+
+        A path is optional, and if present may be any string permissible in a URL. You may use the path to pass an arbitrary string to the webhook, for example, a cluster identifier.
+
+        Attempting to use a user or basic auth e.g. "user:password@" is not allowed. Fragments ("#...") and query parameters ("?...") are not allowed, either.
+        """
+elif False:
+    WebhookClientConfigPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class WebhookClientConfigPatchArgs:
@@ -3846,6 +5294,38 @@ class WebhookClientConfigPatchArgs:
     def url(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "url", value)
 
+
+if not MYPY:
+    class WebhookClientConfigArgsDict(TypedDict):
+        """
+        WebhookClientConfig contains the information to make a TLS connection with the webhook
+        """
+        ca_bundle: NotRequired[pulumi.Input[str]]
+        """
+        `caBundle` is a PEM encoded CA bundle which will be used to validate the webhook's server certificate. If unspecified, system trust roots on the apiserver are used.
+        """
+        service: NotRequired[pulumi.Input['ServiceReferenceArgsDict']]
+        """
+        `service` is a reference to the service for this webhook. Either `service` or `url` must be specified.
+
+        If the webhook is running within the cluster, then you should use `service`.
+        """
+        url: NotRequired[pulumi.Input[str]]
+        """
+        `url` gives the location of the webhook, in standard URL form (`scheme://host:port/path`). Exactly one of `url` or `service` must be specified.
+
+        The `host` should not refer to a service running in the cluster; use the `service` field instead. The host might be resolved via external DNS in some apiservers (e.g., `kube-apiserver` cannot resolve in-cluster DNS as that would be a layering violation). `host` may also be an IP address.
+
+        Please note that using `localhost` or `127.0.0.1` as a `host` is risky unless you take great care to run this webhook on all hosts which run an apiserver which might need to make calls to this webhook. Such installs are likely to be non-portable, i.e., not easy to turn up in a new cluster.
+
+        The scheme must be "https"; the URL must begin with "https://".
+
+        A path is optional, and if present may be any string permissible in a URL. You may use the path to pass an arbitrary string to the webhook, for example, a cluster identifier.
+
+        Attempting to use a user or basic auth e.g. "user:password@" is not allowed. Fragments ("#...") and query parameters ("?...") are not allowed, either.
+        """
+elif False:
+    WebhookClientConfigArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class WebhookClientConfigArgs:

--- a/sdk/python/pulumi_kubernetes/admissionregistration/v1beta1/outputs.py
+++ b/sdk/python/pulumi_kubernetes/admissionregistration/v1beta1/outputs.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta

--- a/sdk/python/pulumi_kubernetes/apiextensions/v1/CustomResourceDefinition.py
+++ b/sdk/python/pulumi_kubernetes/apiextensions/v1/CustomResourceDefinition.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -92,8 +97,8 @@ class CustomResourceDefinition(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['CustomResourceDefinitionSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['CustomResourceDefinitionSpecArgs', 'CustomResourceDefinitionSpecArgsDict']]] = None,
                  __props__=None):
         """
         CustomResourceDefinition represents a resource that should be exposed on the API server.  Its name MUST be in the format <.spec.name>.<.spec.group>.
@@ -102,8 +107,8 @@ class CustomResourceDefinition(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['CustomResourceDefinitionSpecArgs']] spec: spec describes how the user wants the resources to appear
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['CustomResourceDefinitionSpecArgs', 'CustomResourceDefinitionSpecArgsDict']] spec: spec describes how the user wants the resources to appear
         """
         ...
     @overload
@@ -131,8 +136,8 @@ class CustomResourceDefinition(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['CustomResourceDefinitionSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['CustomResourceDefinitionSpecArgs', 'CustomResourceDefinitionSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/apiextensions/v1/CustomResourceDefinitionList.py
+++ b/sdk/python/pulumi_kubernetes/apiextensions/v1/CustomResourceDefinitionList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class CustomResourceDefinitionList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['CustomResourceDefinitionArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['CustomResourceDefinitionArgs', 'CustomResourceDefinitionArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         CustomResourceDefinitionList is a list of CustomResourceDefinition objects.
@@ -101,9 +106,9 @@ class CustomResourceDefinitionList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['CustomResourceDefinitionArgs']]]] items: items list individual CustomResourceDefinition objects
+        :param pulumi.Input[Sequence[pulumi.Input[Union['CustomResourceDefinitionArgs', 'CustomResourceDefinitionArgsDict']]]] items: items list individual CustomResourceDefinition objects
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard object's metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard object's metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class CustomResourceDefinitionList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['CustomResourceDefinitionArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['CustomResourceDefinitionArgs', 'CustomResourceDefinitionArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/apiextensions/v1/CustomResourceDefinitionPatch.py
+++ b/sdk/python/pulumi_kubernetes/apiextensions/v1/CustomResourceDefinitionPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class CustomResourceDefinitionPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['CustomResourceDefinitionSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['CustomResourceDefinitionSpecPatchArgs', 'CustomResourceDefinitionSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -109,8 +114,8 @@ class CustomResourceDefinitionPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['CustomResourceDefinitionSpecPatchArgs']] spec: spec describes how the user wants the resources to appear
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['CustomResourceDefinitionSpecPatchArgs', 'CustomResourceDefinitionSpecPatchArgsDict']] spec: spec describes how the user wants the resources to appear
         """
         ...
     @overload
@@ -144,8 +149,8 @@ class CustomResourceDefinitionPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['CustomResourceDefinitionSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['CustomResourceDefinitionSpecPatchArgs', 'CustomResourceDefinitionSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/apiextensions/v1/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/apiextensions/v1/_inputs.py
@@ -4,47 +4,119 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import meta as _meta
 
 __all__ = [
     'CustomResourceColumnDefinitionPatchArgs',
+    'CustomResourceColumnDefinitionPatchArgsDict',
     'CustomResourceColumnDefinitionArgs',
+    'CustomResourceColumnDefinitionArgsDict',
     'CustomResourceConversionPatchArgs',
+    'CustomResourceConversionPatchArgsDict',
     'CustomResourceConversionArgs',
+    'CustomResourceConversionArgsDict',
     'CustomResourceDefinitionConditionArgs',
+    'CustomResourceDefinitionConditionArgsDict',
     'CustomResourceDefinitionNamesPatchArgs',
+    'CustomResourceDefinitionNamesPatchArgsDict',
     'CustomResourceDefinitionNamesArgs',
+    'CustomResourceDefinitionNamesArgsDict',
     'CustomResourceDefinitionSpecPatchArgs',
+    'CustomResourceDefinitionSpecPatchArgsDict',
     'CustomResourceDefinitionSpecArgs',
+    'CustomResourceDefinitionSpecArgsDict',
     'CustomResourceDefinitionStatusArgs',
+    'CustomResourceDefinitionStatusArgsDict',
     'CustomResourceDefinitionVersionPatchArgs',
+    'CustomResourceDefinitionVersionPatchArgsDict',
     'CustomResourceDefinitionVersionArgs',
+    'CustomResourceDefinitionVersionArgsDict',
     'CustomResourceDefinitionArgs',
+    'CustomResourceDefinitionArgsDict',
     'CustomResourceSubresourceScalePatchArgs',
+    'CustomResourceSubresourceScalePatchArgsDict',
     'CustomResourceSubresourceScaleArgs',
+    'CustomResourceSubresourceScaleArgsDict',
     'CustomResourceSubresourcesPatchArgs',
+    'CustomResourceSubresourcesPatchArgsDict',
     'CustomResourceSubresourcesArgs',
+    'CustomResourceSubresourcesArgsDict',
     'CustomResourceValidationPatchArgs',
+    'CustomResourceValidationPatchArgsDict',
     'CustomResourceValidationArgs',
+    'CustomResourceValidationArgsDict',
     'ExternalDocumentationPatchArgs',
+    'ExternalDocumentationPatchArgsDict',
     'ExternalDocumentationArgs',
+    'ExternalDocumentationArgsDict',
     'JSONSchemaPropsPatchArgs',
+    'JSONSchemaPropsPatchArgsDict',
     'JSONSchemaPropsArgs',
+    'JSONSchemaPropsArgsDict',
     'SelectableFieldPatchArgs',
+    'SelectableFieldPatchArgsDict',
     'SelectableFieldArgs',
+    'SelectableFieldArgsDict',
     'ServiceReferencePatchArgs',
+    'ServiceReferencePatchArgsDict',
     'ServiceReferenceArgs',
+    'ServiceReferenceArgsDict',
     'ValidationRulePatchArgs',
+    'ValidationRulePatchArgsDict',
     'ValidationRuleArgs',
+    'ValidationRuleArgsDict',
     'WebhookClientConfigPatchArgs',
+    'WebhookClientConfigPatchArgsDict',
     'WebhookClientConfigArgs',
+    'WebhookClientConfigArgsDict',
     'WebhookConversionPatchArgs',
+    'WebhookConversionPatchArgsDict',
     'WebhookConversionArgs',
+    'WebhookConversionArgsDict',
 ]
+
+MYPY = False
+
+if not MYPY:
+    class CustomResourceColumnDefinitionPatchArgsDict(TypedDict):
+        """
+        CustomResourceColumnDefinition specifies a column for server side printing.
+        """
+        description: NotRequired[pulumi.Input[str]]
+        """
+        description is a human readable description of this column.
+        """
+        format: NotRequired[pulumi.Input[str]]
+        """
+        format is an optional OpenAPI type definition for this column. The 'name' format is applied to the primary identifier column to assist in clients identifying column is the resource name. See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types for details.
+        """
+        json_path: NotRequired[pulumi.Input[str]]
+        """
+        jsonPath is a simple JSON path (i.e. with array notation) which is evaluated against each custom resource to produce the value for this column.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        name is a human readable name for the column.
+        """
+        priority: NotRequired[pulumi.Input[int]]
+        """
+        priority is an integer defining the relative importance of this column compared to others. Lower numbers are considered higher priority. Columns that may be omitted in limited space scenarios should be given a priority greater than 0.
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        type is an OpenAPI type definition for this column. See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types for details.
+        """
+elif False:
+    CustomResourceColumnDefinitionPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class CustomResourceColumnDefinitionPatchArgs:
@@ -150,6 +222,38 @@ class CustomResourceColumnDefinitionPatchArgs:
         pulumi.set(self, "type", value)
 
 
+if not MYPY:
+    class CustomResourceColumnDefinitionArgsDict(TypedDict):
+        """
+        CustomResourceColumnDefinition specifies a column for server side printing.
+        """
+        json_path: pulumi.Input[str]
+        """
+        jsonPath is a simple JSON path (i.e. with array notation) which is evaluated against each custom resource to produce the value for this column.
+        """
+        name: pulumi.Input[str]
+        """
+        name is a human readable name for the column.
+        """
+        type: pulumi.Input[str]
+        """
+        type is an OpenAPI type definition for this column. See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types for details.
+        """
+        description: NotRequired[pulumi.Input[str]]
+        """
+        description is a human readable description of this column.
+        """
+        format: NotRequired[pulumi.Input[str]]
+        """
+        format is an optional OpenAPI type definition for this column. The 'name' format is applied to the primary identifier column to assist in clients identifying column is the resource name. See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types for details.
+        """
+        priority: NotRequired[pulumi.Input[int]]
+        """
+        priority is an integer defining the relative importance of this column compared to others. Lower numbers are considered higher priority. Columns that may be omitted in limited space scenarios should be given a priority greater than 0.
+        """
+elif False:
+    CustomResourceColumnDefinitionArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CustomResourceColumnDefinitionArgs:
     def __init__(__self__, *,
@@ -251,6 +355,23 @@ class CustomResourceColumnDefinitionArgs:
         pulumi.set(self, "priority", value)
 
 
+if not MYPY:
+    class CustomResourceConversionPatchArgsDict(TypedDict):
+        """
+        CustomResourceConversion describes how to convert different versions of a CR.
+        """
+        strategy: NotRequired[pulumi.Input[str]]
+        """
+        strategy specifies how custom resources are converted between versions. Allowed values are: - `"None"`: The converter only change the apiVersion and would not touch any other field in the custom resource. - `"Webhook"`: API Server will call to an external webhook to do the conversion. Additional information
+          is needed for this option. This requires spec.preserveUnknownFields to be false, and spec.conversion.webhook to be set.
+        """
+        webhook: NotRequired[pulumi.Input['WebhookConversionPatchArgsDict']]
+        """
+        webhook describes how to call the conversion webhook. Required when `strategy` is set to `"Webhook"`.
+        """
+elif False:
+    CustomResourceConversionPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CustomResourceConversionPatchArgs:
     def __init__(__self__, *,
@@ -293,6 +414,23 @@ class CustomResourceConversionPatchArgs:
         pulumi.set(self, "webhook", value)
 
 
+if not MYPY:
+    class CustomResourceConversionArgsDict(TypedDict):
+        """
+        CustomResourceConversion describes how to convert different versions of a CR.
+        """
+        strategy: pulumi.Input[str]
+        """
+        strategy specifies how custom resources are converted between versions. Allowed values are: - `"None"`: The converter only change the apiVersion and would not touch any other field in the custom resource. - `"Webhook"`: API Server will call to an external webhook to do the conversion. Additional information
+          is needed for this option. This requires spec.preserveUnknownFields to be false, and spec.conversion.webhook to be set.
+        """
+        webhook: NotRequired[pulumi.Input['WebhookConversionArgsDict']]
+        """
+        webhook describes how to call the conversion webhook. Required when `strategy` is set to `"Webhook"`.
+        """
+elif False:
+    CustomResourceConversionArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CustomResourceConversionArgs:
     def __init__(__self__, *,
@@ -333,6 +471,34 @@ class CustomResourceConversionArgs:
     def webhook(self, value: Optional[pulumi.Input['WebhookConversionArgs']]):
         pulumi.set(self, "webhook", value)
 
+
+if not MYPY:
+    class CustomResourceDefinitionConditionArgsDict(TypedDict):
+        """
+        CustomResourceDefinitionCondition contains details for the current condition of this pod.
+        """
+        status: pulumi.Input[str]
+        """
+        status is the status of the condition. Can be True, False, Unknown.
+        """
+        type: pulumi.Input[str]
+        """
+        type is the type of the condition. Types include Established, NamesAccepted and Terminating.
+        """
+        last_transition_time: NotRequired[pulumi.Input[str]]
+        """
+        lastTransitionTime last time the condition transitioned from one status to another.
+        """
+        message: NotRequired[pulumi.Input[str]]
+        """
+        message is a human-readable message indicating details about last transition.
+        """
+        reason: NotRequired[pulumi.Input[str]]
+        """
+        reason is a unique, one-word, CamelCase reason for the condition's last transition.
+        """
+elif False:
+    CustomResourceDefinitionConditionArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class CustomResourceDefinitionConditionArgs:
@@ -419,6 +585,38 @@ class CustomResourceDefinitionConditionArgs:
     def reason(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "reason", value)
 
+
+if not MYPY:
+    class CustomResourceDefinitionNamesPatchArgsDict(TypedDict):
+        """
+        CustomResourceDefinitionNames indicates the names to serve this CustomResourceDefinition
+        """
+        categories: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        categories is a list of grouped resources this custom resource belongs to (e.g. 'all'). This is published in API discovery documents, and used by clients to support invocations like `kubectl get all`.
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        kind is the serialized kind of the resource. It is normally CamelCase and singular. Custom resource instances will use this value as the `kind` attribute in API calls.
+        """
+        list_kind: NotRequired[pulumi.Input[str]]
+        """
+        listKind is the serialized kind of the list for this resource. Defaults to "`kind`List".
+        """
+        plural: NotRequired[pulumi.Input[str]]
+        """
+        plural is the plural name of the resource to serve. The custom resources are served under `/apis/<group>/<version>/.../<plural>`. Must match the name of the CustomResourceDefinition (in the form `<names.plural>.<group>`). Must be all lowercase.
+        """
+        short_names: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        shortNames are short names for the resource, exposed in API discovery documents, and used by clients to support invocations like `kubectl get <shortname>`. It must be all lowercase.
+        """
+        singular: NotRequired[pulumi.Input[str]]
+        """
+        singular is the singular name of the resource. It must be all lowercase. Defaults to lowercased `kind`.
+        """
+elif False:
+    CustomResourceDefinitionNamesPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class CustomResourceDefinitionNamesPatchArgs:
@@ -524,6 +722,38 @@ class CustomResourceDefinitionNamesPatchArgs:
         pulumi.set(self, "singular", value)
 
 
+if not MYPY:
+    class CustomResourceDefinitionNamesArgsDict(TypedDict):
+        """
+        CustomResourceDefinitionNames indicates the names to serve this CustomResourceDefinition
+        """
+        kind: pulumi.Input[str]
+        """
+        kind is the serialized kind of the resource. It is normally CamelCase and singular. Custom resource instances will use this value as the `kind` attribute in API calls.
+        """
+        plural: pulumi.Input[str]
+        """
+        plural is the plural name of the resource to serve. The custom resources are served under `/apis/<group>/<version>/.../<plural>`. Must match the name of the CustomResourceDefinition (in the form `<names.plural>.<group>`). Must be all lowercase.
+        """
+        categories: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        categories is a list of grouped resources this custom resource belongs to (e.g. 'all'). This is published in API discovery documents, and used by clients to support invocations like `kubectl get all`.
+        """
+        list_kind: NotRequired[pulumi.Input[str]]
+        """
+        listKind is the serialized kind of the list for this resource. Defaults to "`kind`List".
+        """
+        short_names: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        shortNames are short names for the resource, exposed in API discovery documents, and used by clients to support invocations like `kubectl get <shortname>`. It must be all lowercase.
+        """
+        singular: NotRequired[pulumi.Input[str]]
+        """
+        singular is the singular name of the resource. It must be all lowercase. Defaults to lowercased `kind`.
+        """
+elif False:
+    CustomResourceDefinitionNamesArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CustomResourceDefinitionNamesArgs:
     def __init__(__self__, *,
@@ -625,6 +855,38 @@ class CustomResourceDefinitionNamesArgs:
     def singular(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "singular", value)
 
+
+if not MYPY:
+    class CustomResourceDefinitionSpecPatchArgsDict(TypedDict):
+        """
+        CustomResourceDefinitionSpec describes how a user wants their resource to appear
+        """
+        conversion: NotRequired[pulumi.Input['CustomResourceConversionPatchArgsDict']]
+        """
+        conversion defines conversion settings for the CRD.
+        """
+        group: NotRequired[pulumi.Input[str]]
+        """
+        group is the API group of the defined custom resource. The custom resources are served under `/apis/<group>/...`. Must match the name of the CustomResourceDefinition (in the form `<names.plural>.<group>`).
+        """
+        names: NotRequired[pulumi.Input['CustomResourceDefinitionNamesPatchArgsDict']]
+        """
+        names specify the resource and kind names for the custom resource.
+        """
+        preserve_unknown_fields: NotRequired[pulumi.Input[bool]]
+        """
+        preserveUnknownFields indicates that object fields which are not specified in the OpenAPI schema should be preserved when persisting to storage. apiVersion, kind, metadata and known fields inside metadata are always preserved. This field is deprecated in favor of setting `x-preserve-unknown-fields` to true in `spec.versions[*].schema.openAPIV3Schema`. See https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#field-pruning for details.
+        """
+        scope: NotRequired[pulumi.Input[str]]
+        """
+        scope indicates whether the defined custom resource is cluster- or namespace-scoped. Allowed values are `Cluster` and `Namespaced`.
+        """
+        versions: NotRequired[pulumi.Input[Sequence[pulumi.Input['CustomResourceDefinitionVersionPatchArgsDict']]]]
+        """
+        versions is the list of all API versions of the defined custom resource. Version names are used to compute the order in which served versions are listed in API discovery. If the version string is "kube-like", it will sort above non "kube-like" version strings, which are ordered lexicographically. "Kube-like" versions start with a "v", then are followed by a number (the major version), then optionally the string "alpha" or "beta" and another number (the minor version). These are sorted first by GA > beta > alpha (where GA is a version with no suffix such as beta or alpha), and then by comparing major version, then minor version. An example sorted list of versions: v10, v2, v1, v11beta2, v10beta3, v3beta1, v12alpha1, v11alpha2, foo1, foo10.
+        """
+elif False:
+    CustomResourceDefinitionSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class CustomResourceDefinitionSpecPatchArgs:
@@ -730,6 +992,38 @@ class CustomResourceDefinitionSpecPatchArgs:
         pulumi.set(self, "versions", value)
 
 
+if not MYPY:
+    class CustomResourceDefinitionSpecArgsDict(TypedDict):
+        """
+        CustomResourceDefinitionSpec describes how a user wants their resource to appear
+        """
+        group: pulumi.Input[str]
+        """
+        group is the API group of the defined custom resource. The custom resources are served under `/apis/<group>/...`. Must match the name of the CustomResourceDefinition (in the form `<names.plural>.<group>`).
+        """
+        names: pulumi.Input['CustomResourceDefinitionNamesArgsDict']
+        """
+        names specify the resource and kind names for the custom resource.
+        """
+        scope: pulumi.Input[str]
+        """
+        scope indicates whether the defined custom resource is cluster- or namespace-scoped. Allowed values are `Cluster` and `Namespaced`.
+        """
+        versions: pulumi.Input[Sequence[pulumi.Input['CustomResourceDefinitionVersionArgsDict']]]
+        """
+        versions is the list of all API versions of the defined custom resource. Version names are used to compute the order in which served versions are listed in API discovery. If the version string is "kube-like", it will sort above non "kube-like" version strings, which are ordered lexicographically. "Kube-like" versions start with a "v", then are followed by a number (the major version), then optionally the string "alpha" or "beta" and another number (the minor version). These are sorted first by GA > beta > alpha (where GA is a version with no suffix such as beta or alpha), and then by comparing major version, then minor version. An example sorted list of versions: v10, v2, v1, v11beta2, v10beta3, v3beta1, v12alpha1, v11alpha2, foo1, foo10.
+        """
+        conversion: NotRequired[pulumi.Input['CustomResourceConversionArgsDict']]
+        """
+        conversion defines conversion settings for the CRD.
+        """
+        preserve_unknown_fields: NotRequired[pulumi.Input[bool]]
+        """
+        preserveUnknownFields indicates that object fields which are not specified in the OpenAPI schema should be preserved when persisting to storage. apiVersion, kind, metadata and known fields inside metadata are always preserved. This field is deprecated in favor of setting `x-preserve-unknown-fields` to true in `spec.versions[*].schema.openAPIV3Schema`. See https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#field-pruning for details.
+        """
+elif False:
+    CustomResourceDefinitionSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CustomResourceDefinitionSpecArgs:
     def __init__(__self__, *,
@@ -830,6 +1124,26 @@ class CustomResourceDefinitionSpecArgs:
         pulumi.set(self, "preserve_unknown_fields", value)
 
 
+if not MYPY:
+    class CustomResourceDefinitionStatusArgsDict(TypedDict):
+        """
+        CustomResourceDefinitionStatus indicates the state of the CustomResourceDefinition
+        """
+        accepted_names: pulumi.Input['CustomResourceDefinitionNamesArgsDict']
+        """
+        acceptedNames are the names that are actually being used to serve discovery. They may be different than the names in spec.
+        """
+        stored_versions: pulumi.Input[Sequence[pulumi.Input[str]]]
+        """
+        storedVersions lists all versions of CustomResources that were ever persisted. Tracking these versions allows a migration path for stored versions in etcd. The field is mutable so a migration controller can finish a migration to another version (ensuring no old objects are left in storage), and then remove the rest of the versions from this list. Versions may not be removed from `spec.versions` while they exist in this list.
+        """
+        conditions: NotRequired[pulumi.Input[Sequence[pulumi.Input['CustomResourceDefinitionConditionArgsDict']]]]
+        """
+        conditions indicate state for particular aspects of a CustomResourceDefinition
+        """
+elif False:
+    CustomResourceDefinitionStatusArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CustomResourceDefinitionStatusArgs:
     def __init__(__self__, *,
@@ -883,6 +1197,50 @@ class CustomResourceDefinitionStatusArgs:
     def conditions(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['CustomResourceDefinitionConditionArgs']]]]):
         pulumi.set(self, "conditions", value)
 
+
+if not MYPY:
+    class CustomResourceDefinitionVersionPatchArgsDict(TypedDict):
+        """
+        CustomResourceDefinitionVersion describes a version for CRD.
+        """
+        additional_printer_columns: NotRequired[pulumi.Input[Sequence[pulumi.Input['CustomResourceColumnDefinitionPatchArgsDict']]]]
+        """
+        additionalPrinterColumns specifies additional columns returned in Table output. See https://kubernetes.io/docs/reference/using-api/api-concepts/#receiving-resources-as-tables for details. If no columns are specified, a single column displaying the age of the custom resource is used.
+        """
+        deprecated: NotRequired[pulumi.Input[bool]]
+        """
+        deprecated indicates this version of the custom resource API is deprecated. When set to true, API requests to this version receive a warning header in the server response. Defaults to false.
+        """
+        deprecation_warning: NotRequired[pulumi.Input[str]]
+        """
+        deprecationWarning overrides the default warning returned to API clients. May only be set when `deprecated` is true. The default warning indicates this version is deprecated and recommends use of the newest served version of equal or greater stability, if one exists.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        name is the version name, e.g. “v1”, “v2beta1”, etc. The custom resources are served under this version at `/apis/<group>/<version>/...` if `served` is true.
+        """
+        schema: NotRequired[pulumi.Input['CustomResourceValidationPatchArgsDict']]
+        """
+        schema describes the schema used for validation, pruning, and defaulting of this version of the custom resource.
+        """
+        selectable_fields: NotRequired[pulumi.Input[Sequence[pulumi.Input['SelectableFieldPatchArgsDict']]]]
+        """
+        selectableFields specifies paths to fields that may be used as field selectors. A maximum of 8 selectable fields are allowed. See https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors
+        """
+        served: NotRequired[pulumi.Input[bool]]
+        """
+        served is a flag enabling/disabling this version from being served via REST APIs
+        """
+        storage: NotRequired[pulumi.Input[bool]]
+        """
+        storage indicates this version should be used when persisting custom resources to storage. There must be exactly one version with storage=true.
+        """
+        subresources: NotRequired[pulumi.Input['CustomResourceSubresourcesPatchArgsDict']]
+        """
+        subresources specify what subresources this version of the defined custom resource have.
+        """
+elif False:
+    CustomResourceDefinitionVersionPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class CustomResourceDefinitionVersionPatchArgs:
@@ -1036,6 +1394,50 @@ class CustomResourceDefinitionVersionPatchArgs:
         pulumi.set(self, "subresources", value)
 
 
+if not MYPY:
+    class CustomResourceDefinitionVersionArgsDict(TypedDict):
+        """
+        CustomResourceDefinitionVersion describes a version for CRD.
+        """
+        name: pulumi.Input[str]
+        """
+        name is the version name, e.g. “v1”, “v2beta1”, etc. The custom resources are served under this version at `/apis/<group>/<version>/...` if `served` is true.
+        """
+        served: pulumi.Input[bool]
+        """
+        served is a flag enabling/disabling this version from being served via REST APIs
+        """
+        storage: pulumi.Input[bool]
+        """
+        storage indicates this version should be used when persisting custom resources to storage. There must be exactly one version with storage=true.
+        """
+        additional_printer_columns: NotRequired[pulumi.Input[Sequence[pulumi.Input['CustomResourceColumnDefinitionArgsDict']]]]
+        """
+        additionalPrinterColumns specifies additional columns returned in Table output. See https://kubernetes.io/docs/reference/using-api/api-concepts/#receiving-resources-as-tables for details. If no columns are specified, a single column displaying the age of the custom resource is used.
+        """
+        deprecated: NotRequired[pulumi.Input[bool]]
+        """
+        deprecated indicates this version of the custom resource API is deprecated. When set to true, API requests to this version receive a warning header in the server response. Defaults to false.
+        """
+        deprecation_warning: NotRequired[pulumi.Input[str]]
+        """
+        deprecationWarning overrides the default warning returned to API clients. May only be set when `deprecated` is true. The default warning indicates this version is deprecated and recommends use of the newest served version of equal or greater stability, if one exists.
+        """
+        schema: NotRequired[pulumi.Input['CustomResourceValidationArgsDict']]
+        """
+        schema describes the schema used for validation, pruning, and defaulting of this version of the custom resource.
+        """
+        selectable_fields: NotRequired[pulumi.Input[Sequence[pulumi.Input['SelectableFieldArgsDict']]]]
+        """
+        selectableFields specifies paths to fields that may be used as field selectors. A maximum of 8 selectable fields are allowed. See https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors
+        """
+        subresources: NotRequired[pulumi.Input['CustomResourceSubresourcesArgsDict']]
+        """
+        subresources specify what subresources this version of the defined custom resource have.
+        """
+elif False:
+    CustomResourceDefinitionVersionArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CustomResourceDefinitionVersionArgs:
     def __init__(__self__, *,
@@ -1185,6 +1587,34 @@ class CustomResourceDefinitionVersionArgs:
         pulumi.set(self, "subresources", value)
 
 
+if not MYPY:
+    class CustomResourceDefinitionArgsDict(TypedDict):
+        """
+        CustomResourceDefinition represents a resource that should be exposed on the API server.  Its name MUST be in the format <.spec.name>.<.spec.group>.
+        """
+        spec: pulumi.Input['CustomResourceDefinitionSpecArgsDict']
+        """
+        spec describes how the user wants the resources to appear
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        status: NotRequired[pulumi.Input['CustomResourceDefinitionStatusArgsDict']]
+        """
+        status indicates the actual state of the CustomResourceDefinition
+        """
+elif False:
+    CustomResourceDefinitionArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CustomResourceDefinitionArgs:
     def __init__(__self__, *,
@@ -1272,6 +1702,26 @@ class CustomResourceDefinitionArgs:
         pulumi.set(self, "status", value)
 
 
+if not MYPY:
+    class CustomResourceSubresourceScalePatchArgsDict(TypedDict):
+        """
+        CustomResourceSubresourceScale defines how to serve the scale subresource for CustomResources.
+        """
+        label_selector_path: NotRequired[pulumi.Input[str]]
+        """
+        labelSelectorPath defines the JSON path inside of a custom resource that corresponds to Scale `status.selector`. Only JSON paths without the array notation are allowed. Must be a JSON Path under `.status` or `.spec`. Must be set to work with HorizontalPodAutoscaler. The field pointed by this JSON path must be a string field (not a complex selector struct) which contains a serialized label selector in string form. More info: https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions#scale-subresource If there is no value under the given path in the custom resource, the `status.selector` value in the `/scale` subresource will default to the empty string.
+        """
+        spec_replicas_path: NotRequired[pulumi.Input[str]]
+        """
+        specReplicasPath defines the JSON path inside of a custom resource that corresponds to Scale `spec.replicas`. Only JSON paths without the array notation are allowed. Must be a JSON Path under `.spec`. If there is no value under the given path in the custom resource, the `/scale` subresource will return an error on GET.
+        """
+        status_replicas_path: NotRequired[pulumi.Input[str]]
+        """
+        statusReplicasPath defines the JSON path inside of a custom resource that corresponds to Scale `status.replicas`. Only JSON paths without the array notation are allowed. Must be a JSON Path under `.status`. If there is no value under the given path in the custom resource, the `status.replicas` value in the `/scale` subresource will default to 0.
+        """
+elif False:
+    CustomResourceSubresourceScalePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CustomResourceSubresourceScalePatchArgs:
     def __init__(__self__, *,
@@ -1328,6 +1778,26 @@ class CustomResourceSubresourceScalePatchArgs:
         pulumi.set(self, "status_replicas_path", value)
 
 
+if not MYPY:
+    class CustomResourceSubresourceScaleArgsDict(TypedDict):
+        """
+        CustomResourceSubresourceScale defines how to serve the scale subresource for CustomResources.
+        """
+        spec_replicas_path: pulumi.Input[str]
+        """
+        specReplicasPath defines the JSON path inside of a custom resource that corresponds to Scale `spec.replicas`. Only JSON paths without the array notation are allowed. Must be a JSON Path under `.spec`. If there is no value under the given path in the custom resource, the `/scale` subresource will return an error on GET.
+        """
+        status_replicas_path: pulumi.Input[str]
+        """
+        statusReplicasPath defines the JSON path inside of a custom resource that corresponds to Scale `status.replicas`. Only JSON paths without the array notation are allowed. Must be a JSON Path under `.status`. If there is no value under the given path in the custom resource, the `status.replicas` value in the `/scale` subresource will default to 0.
+        """
+        label_selector_path: NotRequired[pulumi.Input[str]]
+        """
+        labelSelectorPath defines the JSON path inside of a custom resource that corresponds to Scale `status.selector`. Only JSON paths without the array notation are allowed. Must be a JSON Path under `.status` or `.spec`. Must be set to work with HorizontalPodAutoscaler. The field pointed by this JSON path must be a string field (not a complex selector struct) which contains a serialized label selector in string form. More info: https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions#scale-subresource If there is no value under the given path in the custom resource, the `status.selector` value in the `/scale` subresource will default to the empty string.
+        """
+elif False:
+    CustomResourceSubresourceScaleArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CustomResourceSubresourceScaleArgs:
     def __init__(__self__, *,
@@ -1382,6 +1852,22 @@ class CustomResourceSubresourceScaleArgs:
         pulumi.set(self, "label_selector_path", value)
 
 
+if not MYPY:
+    class CustomResourceSubresourcesPatchArgsDict(TypedDict):
+        """
+        CustomResourceSubresources defines the status and scale subresources for CustomResources.
+        """
+        scale: NotRequired[pulumi.Input['CustomResourceSubresourceScalePatchArgsDict']]
+        """
+        scale indicates the custom resource should serve a `/scale` subresource that returns an `autoscaling/v1` Scale object.
+        """
+        status: NotRequired[Any]
+        """
+        status indicates the custom resource should serve a `/status` subresource. When enabled: 1. requests to the custom resource primary endpoint ignore changes to the `status` stanza of the object. 2. requests to the custom resource `/status` subresource ignore changes to anything other than the `status` stanza of the object.
+        """
+elif False:
+    CustomResourceSubresourcesPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CustomResourceSubresourcesPatchArgs:
     def __init__(__self__, *,
@@ -1421,6 +1907,22 @@ class CustomResourceSubresourcesPatchArgs:
     def status(self, value: Optional[Any]):
         pulumi.set(self, "status", value)
 
+
+if not MYPY:
+    class CustomResourceSubresourcesArgsDict(TypedDict):
+        """
+        CustomResourceSubresources defines the status and scale subresources for CustomResources.
+        """
+        scale: NotRequired[pulumi.Input['CustomResourceSubresourceScaleArgsDict']]
+        """
+        scale indicates the custom resource should serve a `/scale` subresource that returns an `autoscaling/v1` Scale object.
+        """
+        status: NotRequired[Any]
+        """
+        status indicates the custom resource should serve a `/status` subresource. When enabled: 1. requests to the custom resource primary endpoint ignore changes to the `status` stanza of the object. 2. requests to the custom resource `/status` subresource ignore changes to anything other than the `status` stanza of the object.
+        """
+elif False:
+    CustomResourceSubresourcesArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class CustomResourceSubresourcesArgs:
@@ -1462,6 +1964,18 @@ class CustomResourceSubresourcesArgs:
         pulumi.set(self, "status", value)
 
 
+if not MYPY:
+    class CustomResourceValidationPatchArgsDict(TypedDict):
+        """
+        CustomResourceValidation is a list of validation methods for CustomResources.
+        """
+        open_apiv3_schema: NotRequired[pulumi.Input['JSONSchemaPropsPatchArgsDict']]
+        """
+        openAPIV3Schema is the OpenAPI v3 schema to use for validation and pruning.
+        """
+elif False:
+    CustomResourceValidationPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CustomResourceValidationPatchArgs:
     def __init__(__self__, *,
@@ -1486,6 +2000,18 @@ class CustomResourceValidationPatchArgs:
         pulumi.set(self, "open_apiv3_schema", value)
 
 
+if not MYPY:
+    class CustomResourceValidationArgsDict(TypedDict):
+        """
+        CustomResourceValidation is a list of validation methods for CustomResources.
+        """
+        open_apiv3_schema: NotRequired[pulumi.Input['JSONSchemaPropsArgsDict']]
+        """
+        openAPIV3Schema is the OpenAPI v3 schema to use for validation and pruning.
+        """
+elif False:
+    CustomResourceValidationArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CustomResourceValidationArgs:
     def __init__(__self__, *,
@@ -1509,6 +2035,16 @@ class CustomResourceValidationArgs:
     def open_apiv3_schema(self, value: Optional[pulumi.Input['JSONSchemaPropsArgs']]):
         pulumi.set(self, "open_apiv3_schema", value)
 
+
+if not MYPY:
+    class ExternalDocumentationPatchArgsDict(TypedDict):
+        """
+        ExternalDocumentation allows referencing an external resource for extended documentation.
+        """
+        description: NotRequired[pulumi.Input[str]]
+        url: NotRequired[pulumi.Input[str]]
+elif False:
+    ExternalDocumentationPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ExternalDocumentationPatchArgs:
@@ -1542,6 +2078,16 @@ class ExternalDocumentationPatchArgs:
         pulumi.set(self, "url", value)
 
 
+if not MYPY:
+    class ExternalDocumentationArgsDict(TypedDict):
+        """
+        ExternalDocumentation allows referencing an external resource for extended documentation.
+        """
+        description: NotRequired[pulumi.Input[str]]
+        url: NotRequired[pulumi.Input[str]]
+elif False:
+    ExternalDocumentationArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ExternalDocumentationArgs:
     def __init__(__self__, *,
@@ -1573,6 +2119,120 @@ class ExternalDocumentationArgs:
     def url(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "url", value)
 
+
+if not MYPY:
+    class JSONSchemaPropsPatchArgsDict(TypedDict):
+        """
+        JSONSchemaProps is a JSON-Schema following Specification Draft 4 (http://json-schema.org/).
+        """
+        _ref: NotRequired[pulumi.Input[str]]
+        _schema: NotRequired[pulumi.Input[str]]
+        additional_items: NotRequired[pulumi.Input[Union['JSONSchemaPropsArgsDict', bool]]]
+        additional_properties: NotRequired[pulumi.Input[Union['JSONSchemaPropsArgsDict', bool]]]
+        all_of: NotRequired[pulumi.Input[Sequence[pulumi.Input['JSONSchemaPropsPatchArgsDict']]]]
+        any_of: NotRequired[pulumi.Input[Sequence[pulumi.Input['JSONSchemaPropsPatchArgsDict']]]]
+        default: NotRequired[Any]
+        """
+        default is a default value for undefined object fields. Defaulting is a beta feature under the CustomResourceDefaulting feature gate. Defaulting requires spec.preserveUnknownFields to be false.
+        """
+        definitions: NotRequired[pulumi.Input[Mapping[str, pulumi.Input['JSONSchemaPropsArgsDict']]]]
+        dependencies: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[Union['JSONSchemaPropsArgsDict', Sequence[pulumi.Input[str]]]]]]]
+        description: NotRequired[pulumi.Input[str]]
+        enum: NotRequired[pulumi.Input[Sequence[Any]]]
+        example: NotRequired[Any]
+        exclusive_maximum: NotRequired[pulumi.Input[bool]]
+        exclusive_minimum: NotRequired[pulumi.Input[bool]]
+        external_docs: NotRequired[pulumi.Input['ExternalDocumentationPatchArgsDict']]
+        format: NotRequired[pulumi.Input[str]]
+        """
+        format is an OpenAPI v3 format string. Unknown formats are ignored. The following formats are validated:
+
+        - bsonobjectid: a bson object ID, i.e. a 24 characters hex string - uri: an URI as parsed by Golang net/url.ParseRequestURI - email: an email address as parsed by Golang net/mail.ParseAddress - hostname: a valid representation for an Internet host name, as defined by RFC 1034, section 3.1 [RFC1034]. - ipv4: an IPv4 IP as parsed by Golang net.ParseIP - ipv6: an IPv6 IP as parsed by Golang net.ParseIP - cidr: a CIDR as parsed by Golang net.ParseCIDR - mac: a MAC address as parsed by Golang net.ParseMAC - uuid: an UUID that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$ - uuid3: an UUID3 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?3[0-9a-f]{3}-?[0-9a-f]{4}-?[0-9a-f]{12}$ - uuid4: an UUID4 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?4[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$ - uuid5: an UUID5 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?5[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$ - isbn: an ISBN10 or ISBN13 number string like "0321751043" or "978-0321751041" - isbn10: an ISBN10 number string like "0321751043" - isbn13: an ISBN13 number string like "978-0321751041" - creditcard: a credit card number defined by the regex ^(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|6(?:011|5[0-9][0-9])[0-9]{12}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|(?:2131|1800|35\\d{3})\\d{11})$ with any non digit characters mixed in - ssn: a U.S. social security number following the regex ^\\d{3}[- ]?\\d{2}[- ]?\\d{4}$ - hexcolor: an hexadecimal color code like "#FFFFFF: following the regex ^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$ - rgbcolor: an RGB color code like rgb like "rgb(255,255,2559" - byte: base64 encoded binary data - password: any kind of string - date: a date string like "2006-01-02" as defined by full-date in RFC3339 - duration: a duration string like "22 ns" as parsed by Golang time.ParseDuration or compatible with Scala duration format - datetime: a date time string like "2014-12-15T19:30:20.000Z" as defined by date-time in RFC3339.
+        """
+        id: NotRequired[pulumi.Input[str]]
+        items: NotRequired[pulumi.Input[Union['JSONSchemaPropsArgsDict', Sequence[Any]]]]
+        max_items: NotRequired[pulumi.Input[int]]
+        max_length: NotRequired[pulumi.Input[int]]
+        max_properties: NotRequired[pulumi.Input[int]]
+        maximum: NotRequired[pulumi.Input[float]]
+        min_items: NotRequired[pulumi.Input[int]]
+        min_length: NotRequired[pulumi.Input[int]]
+        min_properties: NotRequired[pulumi.Input[int]]
+        minimum: NotRequired[pulumi.Input[float]]
+        multiple_of: NotRequired[pulumi.Input[float]]
+        not_: NotRequired[pulumi.Input['JSONSchemaPropsPatchArgsDict']]
+        nullable: NotRequired[pulumi.Input[bool]]
+        one_of: NotRequired[pulumi.Input[Sequence[pulumi.Input['JSONSchemaPropsPatchArgsDict']]]]
+        pattern: NotRequired[pulumi.Input[str]]
+        pattern_properties: NotRequired[pulumi.Input[Mapping[str, pulumi.Input['JSONSchemaPropsArgsDict']]]]
+        properties: NotRequired[pulumi.Input[Mapping[str, pulumi.Input['JSONSchemaPropsArgsDict']]]]
+        required: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        title: NotRequired[pulumi.Input[str]]
+        type: NotRequired[pulumi.Input[str]]
+        unique_items: NotRequired[pulumi.Input[bool]]
+        x_kubernetes_embedded_resource: NotRequired[pulumi.Input[bool]]
+        """
+        x-kubernetes-embedded-resource defines that the value is an embedded Kubernetes runtime.Object, with TypeMeta and ObjectMeta. The type must be object. It is allowed to further restrict the embedded object. kind, apiVersion and metadata are validated automatically. x-kubernetes-preserve-unknown-fields is allowed to be true, but does not have to be if the object is fully specified (up to kind, apiVersion, metadata).
+        """
+        x_kubernetes_int_or_string: NotRequired[pulumi.Input[bool]]
+        """
+        x-kubernetes-int-or-string specifies that this value is either an integer or a string. If this is true, an empty type is allowed and type as child of anyOf is permitted if following one of the following patterns:
+
+        1) anyOf:
+           - type: integer
+           - type: string
+        2) allOf:
+           - anyOf:
+             - type: integer
+             - type: string
+           - ... zero or more
+        """
+        x_kubernetes_list_map_keys: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        x-kubernetes-list-map-keys annotates an array with the x-kubernetes-list-type `map` by specifying the keys used as the index of the map.
+
+        This tag MUST only be used on lists that have the "x-kubernetes-list-type" extension set to "map". Also, the values specified for this attribute must be a scalar typed field of the child structure (no nesting is supported).
+
+        The properties specified must either be required or have a default value, to ensure those properties are present for all list items.
+        """
+        x_kubernetes_list_type: NotRequired[pulumi.Input[str]]
+        """
+        x-kubernetes-list-type annotates an array to further describe its topology. This extension must only be used on lists and may have 3 possible values:
+
+        1) `atomic`: the list is treated as a single entity, like a scalar.
+             Atomic lists will be entirely replaced when updated. This extension
+             may be used on any type of list (struct, scalar, ...).
+        2) `set`:
+             Sets are lists that must not have multiple items with the same value. Each
+             value must be a scalar, an object with x-kubernetes-map-type `atomic` or an
+             array with x-kubernetes-list-type `atomic`.
+        3) `map`:
+             These lists are like maps in that their elements have a non-index key
+             used to identify them. Order is preserved upon merge. The map tag
+             must only be used on a list with elements of type object.
+        Defaults to atomic for arrays.
+        """
+        x_kubernetes_map_type: NotRequired[pulumi.Input[str]]
+        """
+        x-kubernetes-map-type annotates an object to further describe its topology. This extension must only be used when type is object and may have 2 possible values:
+
+        1) `granular`:
+             These maps are actual maps (key-value pairs) and each fields are independent
+             from each other (they can each be manipulated by separate actors). This is
+             the default behaviour for all maps.
+        2) `atomic`: the list is treated as a single entity, like a scalar.
+             Atomic maps will be entirely replaced when updated.
+        """
+        x_kubernetes_preserve_unknown_fields: NotRequired[pulumi.Input[bool]]
+        """
+        x-kubernetes-preserve-unknown-fields stops the API server decoding step from pruning fields which are not specified in the validation schema. This affects fields recursively, but switches back to normal pruning behaviour if nested properties or additionalProperties are specified in the schema. This can either be true or undefined. False is forbidden.
+        """
+        x_kubernetes_validations: NotRequired[pulumi.Input[Sequence[pulumi.Input['ValidationRulePatchArgsDict']]]]
+        """
+        x-kubernetes-validations describes a list of validation rules written in the CEL expression language. This field is an alpha-level. Using this field requires the feature gate `CustomResourceValidationExpressions` to be enabled.
+        """
+elif False:
+    JSONSchemaPropsPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class JSONSchemaPropsPatchArgs:
@@ -2216,6 +2876,120 @@ class JSONSchemaPropsPatchArgs:
         pulumi.set(self, "x_kubernetes_validations", value)
 
 
+if not MYPY:
+    class JSONSchemaPropsArgsDict(TypedDict):
+        """
+        JSONSchemaProps is a JSON-Schema following Specification Draft 4 (http://json-schema.org/).
+        """
+        _ref: NotRequired[pulumi.Input[str]]
+        _schema: NotRequired[pulumi.Input[str]]
+        additional_items: NotRequired[pulumi.Input[Union['JSONSchemaPropsArgsDict', bool]]]
+        additional_properties: NotRequired[pulumi.Input[Union['JSONSchemaPropsArgsDict', bool]]]
+        all_of: NotRequired[pulumi.Input[Sequence[pulumi.Input['JSONSchemaPropsArgsDict']]]]
+        any_of: NotRequired[pulumi.Input[Sequence[pulumi.Input['JSONSchemaPropsArgsDict']]]]
+        default: NotRequired[Any]
+        """
+        default is a default value for undefined object fields. Defaulting is a beta feature under the CustomResourceDefaulting feature gate. Defaulting requires spec.preserveUnknownFields to be false.
+        """
+        definitions: NotRequired[pulumi.Input[Mapping[str, pulumi.Input['JSONSchemaPropsArgsDict']]]]
+        dependencies: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[Union['JSONSchemaPropsArgsDict', Sequence[pulumi.Input[str]]]]]]]
+        description: NotRequired[pulumi.Input[str]]
+        enum: NotRequired[pulumi.Input[Sequence[Any]]]
+        example: NotRequired[Any]
+        exclusive_maximum: NotRequired[pulumi.Input[bool]]
+        exclusive_minimum: NotRequired[pulumi.Input[bool]]
+        external_docs: NotRequired[pulumi.Input['ExternalDocumentationArgsDict']]
+        format: NotRequired[pulumi.Input[str]]
+        """
+        format is an OpenAPI v3 format string. Unknown formats are ignored. The following formats are validated:
+
+        - bsonobjectid: a bson object ID, i.e. a 24 characters hex string - uri: an URI as parsed by Golang net/url.ParseRequestURI - email: an email address as parsed by Golang net/mail.ParseAddress - hostname: a valid representation for an Internet host name, as defined by RFC 1034, section 3.1 [RFC1034]. - ipv4: an IPv4 IP as parsed by Golang net.ParseIP - ipv6: an IPv6 IP as parsed by Golang net.ParseIP - cidr: a CIDR as parsed by Golang net.ParseCIDR - mac: a MAC address as parsed by Golang net.ParseMAC - uuid: an UUID that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$ - uuid3: an UUID3 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?3[0-9a-f]{3}-?[0-9a-f]{4}-?[0-9a-f]{12}$ - uuid4: an UUID4 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?4[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$ - uuid5: an UUID5 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?5[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$ - isbn: an ISBN10 or ISBN13 number string like "0321751043" or "978-0321751041" - isbn10: an ISBN10 number string like "0321751043" - isbn13: an ISBN13 number string like "978-0321751041" - creditcard: a credit card number defined by the regex ^(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|6(?:011|5[0-9][0-9])[0-9]{12}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|(?:2131|1800|35\\d{3})\\d{11})$ with any non digit characters mixed in - ssn: a U.S. social security number following the regex ^\\d{3}[- ]?\\d{2}[- ]?\\d{4}$ - hexcolor: an hexadecimal color code like "#FFFFFF: following the regex ^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$ - rgbcolor: an RGB color code like rgb like "rgb(255,255,2559" - byte: base64 encoded binary data - password: any kind of string - date: a date string like "2006-01-02" as defined by full-date in RFC3339 - duration: a duration string like "22 ns" as parsed by Golang time.ParseDuration or compatible with Scala duration format - datetime: a date time string like "2014-12-15T19:30:20.000Z" as defined by date-time in RFC3339.
+        """
+        id: NotRequired[pulumi.Input[str]]
+        items: NotRequired[pulumi.Input[Union['JSONSchemaPropsArgsDict', Sequence[Any]]]]
+        max_items: NotRequired[pulumi.Input[int]]
+        max_length: NotRequired[pulumi.Input[int]]
+        max_properties: NotRequired[pulumi.Input[int]]
+        maximum: NotRequired[pulumi.Input[float]]
+        min_items: NotRequired[pulumi.Input[int]]
+        min_length: NotRequired[pulumi.Input[int]]
+        min_properties: NotRequired[pulumi.Input[int]]
+        minimum: NotRequired[pulumi.Input[float]]
+        multiple_of: NotRequired[pulumi.Input[float]]
+        not_: NotRequired[pulumi.Input['JSONSchemaPropsArgsDict']]
+        nullable: NotRequired[pulumi.Input[bool]]
+        one_of: NotRequired[pulumi.Input[Sequence[pulumi.Input['JSONSchemaPropsArgsDict']]]]
+        pattern: NotRequired[pulumi.Input[str]]
+        pattern_properties: NotRequired[pulumi.Input[Mapping[str, pulumi.Input['JSONSchemaPropsArgsDict']]]]
+        properties: NotRequired[pulumi.Input[Mapping[str, pulumi.Input['JSONSchemaPropsArgsDict']]]]
+        required: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        title: NotRequired[pulumi.Input[str]]
+        type: NotRequired[pulumi.Input[str]]
+        unique_items: NotRequired[pulumi.Input[bool]]
+        x_kubernetes_embedded_resource: NotRequired[pulumi.Input[bool]]
+        """
+        x-kubernetes-embedded-resource defines that the value is an embedded Kubernetes runtime.Object, with TypeMeta and ObjectMeta. The type must be object. It is allowed to further restrict the embedded object. kind, apiVersion and metadata are validated automatically. x-kubernetes-preserve-unknown-fields is allowed to be true, but does not have to be if the object is fully specified (up to kind, apiVersion, metadata).
+        """
+        x_kubernetes_int_or_string: NotRequired[pulumi.Input[bool]]
+        """
+        x-kubernetes-int-or-string specifies that this value is either an integer or a string. If this is true, an empty type is allowed and type as child of anyOf is permitted if following one of the following patterns:
+
+        1) anyOf:
+           - type: integer
+           - type: string
+        2) allOf:
+           - anyOf:
+             - type: integer
+             - type: string
+           - ... zero or more
+        """
+        x_kubernetes_list_map_keys: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        x-kubernetes-list-map-keys annotates an array with the x-kubernetes-list-type `map` by specifying the keys used as the index of the map.
+
+        This tag MUST only be used on lists that have the "x-kubernetes-list-type" extension set to "map". Also, the values specified for this attribute must be a scalar typed field of the child structure (no nesting is supported).
+
+        The properties specified must either be required or have a default value, to ensure those properties are present for all list items.
+        """
+        x_kubernetes_list_type: NotRequired[pulumi.Input[str]]
+        """
+        x-kubernetes-list-type annotates an array to further describe its topology. This extension must only be used on lists and may have 3 possible values:
+
+        1) `atomic`: the list is treated as a single entity, like a scalar.
+             Atomic lists will be entirely replaced when updated. This extension
+             may be used on any type of list (struct, scalar, ...).
+        2) `set`:
+             Sets are lists that must not have multiple items with the same value. Each
+             value must be a scalar, an object with x-kubernetes-map-type `atomic` or an
+             array with x-kubernetes-list-type `atomic`.
+        3) `map`:
+             These lists are like maps in that their elements have a non-index key
+             used to identify them. Order is preserved upon merge. The map tag
+             must only be used on a list with elements of type object.
+        Defaults to atomic for arrays.
+        """
+        x_kubernetes_map_type: NotRequired[pulumi.Input[str]]
+        """
+        x-kubernetes-map-type annotates an object to further describe its topology. This extension must only be used when type is object and may have 2 possible values:
+
+        1) `granular`:
+             These maps are actual maps (key-value pairs) and each fields are independent
+             from each other (they can each be manipulated by separate actors). This is
+             the default behaviour for all maps.
+        2) `atomic`: the list is treated as a single entity, like a scalar.
+             Atomic maps will be entirely replaced when updated.
+        """
+        x_kubernetes_preserve_unknown_fields: NotRequired[pulumi.Input[bool]]
+        """
+        x-kubernetes-preserve-unknown-fields stops the API server decoding step from pruning fields which are not specified in the validation schema. This affects fields recursively, but switches back to normal pruning behaviour if nested properties or additionalProperties are specified in the schema. This can either be true or undefined. False is forbidden.
+        """
+        x_kubernetes_validations: NotRequired[pulumi.Input[Sequence[pulumi.Input['ValidationRuleArgsDict']]]]
+        """
+        x-kubernetes-validations describes a list of validation rules written in the CEL expression language. This field is an alpha-level. Using this field requires the feature gate `CustomResourceValidationExpressions` to be enabled.
+        """
+elif False:
+    JSONSchemaPropsArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class JSONSchemaPropsArgs:
     def __init__(__self__, *,
@@ -2858,6 +3632,18 @@ class JSONSchemaPropsArgs:
         pulumi.set(self, "x_kubernetes_validations", value)
 
 
+if not MYPY:
+    class SelectableFieldPatchArgsDict(TypedDict):
+        """
+        SelectableField specifies the JSON path of a field that may be used with field selectors.
+        """
+        json_path: NotRequired[pulumi.Input[str]]
+        """
+        jsonPath is a simple JSON path which is evaluated against each custom resource to produce a field selector value. Only JSON paths without the array notation are allowed. Must point to a field of type string, boolean or integer. Types with enum values and strings with formats are allowed. If jsonPath refers to absent field in a resource, the jsonPath evaluates to an empty string. Must not point to metdata fields. Required.
+        """
+elif False:
+    SelectableFieldPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class SelectableFieldPatchArgs:
     def __init__(__self__, *,
@@ -2882,6 +3668,18 @@ class SelectableFieldPatchArgs:
         pulumi.set(self, "json_path", value)
 
 
+if not MYPY:
+    class SelectableFieldArgsDict(TypedDict):
+        """
+        SelectableField specifies the JSON path of a field that may be used with field selectors.
+        """
+        json_path: pulumi.Input[str]
+        """
+        jsonPath is a simple JSON path which is evaluated against each custom resource to produce a field selector value. Only JSON paths without the array notation are allowed. Must point to a field of type string, boolean or integer. Types with enum values and strings with formats are allowed. If jsonPath refers to absent field in a resource, the jsonPath evaluates to an empty string. Must not point to metdata fields. Required.
+        """
+elif False:
+    SelectableFieldArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class SelectableFieldArgs:
     def __init__(__self__, *,
@@ -2904,6 +3702,30 @@ class SelectableFieldArgs:
     def json_path(self, value: pulumi.Input[str]):
         pulumi.set(self, "json_path", value)
 
+
+if not MYPY:
+    class ServiceReferencePatchArgsDict(TypedDict):
+        """
+        ServiceReference holds a reference to Service.legacy.k8s.io
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        name is the name of the service. Required
+        """
+        namespace: NotRequired[pulumi.Input[str]]
+        """
+        namespace is the namespace of the service. Required
+        """
+        path: NotRequired[pulumi.Input[str]]
+        """
+        path is an optional URL path at which the webhook will be contacted.
+        """
+        port: NotRequired[pulumi.Input[int]]
+        """
+        port is an optional service port at which the webhook will be contacted. `port` should be a valid port number (1-65535, inclusive). Defaults to 443 for backward compatibility.
+        """
+elif False:
+    ServiceReferencePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ServiceReferencePatchArgs:
@@ -2977,6 +3799,30 @@ class ServiceReferencePatchArgs:
         pulumi.set(self, "port", value)
 
 
+if not MYPY:
+    class ServiceReferenceArgsDict(TypedDict):
+        """
+        ServiceReference holds a reference to Service.legacy.k8s.io
+        """
+        name: pulumi.Input[str]
+        """
+        name is the name of the service. Required
+        """
+        namespace: pulumi.Input[str]
+        """
+        namespace is the namespace of the service. Required
+        """
+        path: NotRequired[pulumi.Input[str]]
+        """
+        path is an optional URL path at which the webhook will be contacted.
+        """
+        port: NotRequired[pulumi.Input[int]]
+        """
+        port is an optional service port at which the webhook will be contacted. `port` should be a valid port number (1-65535, inclusive). Defaults to 443 for backward compatibility.
+        """
+elif False:
+    ServiceReferenceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ServiceReferenceArgs:
     def __init__(__self__, *,
@@ -3046,6 +3892,76 @@ class ServiceReferenceArgs:
     def port(self, value: Optional[pulumi.Input[int]]):
         pulumi.set(self, "port", value)
 
+
+if not MYPY:
+    class ValidationRulePatchArgsDict(TypedDict):
+        """
+        ValidationRule describes a validation rule written in the CEL expression language.
+        """
+        field_path: NotRequired[pulumi.Input[str]]
+        """
+        fieldPath represents the field path returned when the validation fails. It must be a relative JSON path (i.e. with array notation) scoped to the location of this x-kubernetes-validations extension in the schema and refer to an existing field. e.g. when validation checks if a specific attribute `foo` under a map `testMap`, the fieldPath could be set to `.testMap.foo` If the validation checks two lists must have unique attributes, the fieldPath could be set to either of the list: e.g. `.testList` It does not support list numeric index. It supports child operation to refer to an existing field currently. Refer to [JSONPath support in Kubernetes](https://kubernetes.io/docs/reference/kubectl/jsonpath/) for more info. Numeric index of array is not supported. For field name which contains special characters, use `['specialName']` to refer the field name. e.g. for attribute `foo.34$` appears in a list `testList`, the fieldPath could be set to `.testList['foo.34$']`
+        """
+        message: NotRequired[pulumi.Input[str]]
+        """
+        Message represents the message displayed when validation fails. The message is required if the Rule contains line breaks. The message must not contain line breaks. If unset, the message is "failed rule: {Rule}". e.g. "must be a URL with the host matching spec.host"
+        """
+        message_expression: NotRequired[pulumi.Input[str]]
+        """
+        MessageExpression declares a CEL expression that evaluates to the validation failure message that is returned when this rule fails. Since messageExpression is used as a failure message, it must evaluate to a string. If both message and messageExpression are present on a rule, then messageExpression will be used if validation fails. If messageExpression results in a runtime error, the runtime error is logged, and the validation failure message is produced as if the messageExpression field were unset. If messageExpression evaluates to an empty string, a string with only spaces, or a string that contains line breaks, then the validation failure message will also be produced as if the messageExpression field were unset, and the fact that messageExpression produced an empty string/string with only spaces/string with line breaks will be logged. messageExpression has access to all the same variables as the rule; the only difference is the return type. Example: "x must be less than max ("+string(self.max)+")"
+        """
+        optional_old_self: NotRequired[pulumi.Input[bool]]
+        """
+        optionalOldSelf is used to opt a transition rule into evaluation even when the object is first created, or if the old object is missing the value.
+
+        When enabled `oldSelf` will be a CEL optional whose value will be `None` if there is no old value, or when the object is initially created.
+
+        You may check for presence of oldSelf using `oldSelf.hasValue()` and unwrap it after checking using `oldSelf.value()`. Check the CEL documentation for Optional types for more information: https://pkg.go.dev/github.com/google/cel-go/cel#OptionalTypes
+
+        May not be set unless `oldSelf` is used in `rule`.
+        """
+        reason: NotRequired[pulumi.Input[str]]
+        """
+        reason provides a machine-readable validation failure reason that is returned to the caller when a request fails this validation rule. The HTTP status code returned to the caller will match the reason of the reason of the first failed validation rule. The currently supported reasons are: "FieldValueInvalid", "FieldValueForbidden", "FieldValueRequired", "FieldValueDuplicate". If not set, default to use "FieldValueInvalid". All future added reasons must be accepted by clients when reading this value and unknown reasons should be treated as FieldValueInvalid.
+        """
+        rule: NotRequired[pulumi.Input[str]]
+        """
+        Rule represents the expression which will be evaluated by CEL. ref: https://github.com/google/cel-spec The Rule is scoped to the location of the x-kubernetes-validations extension in the schema. The `self` variable in the CEL expression is bound to the scoped value. Example: - Rule scoped to the root of a resource with a status subresource: {"rule": "self.status.actual <= self.spec.maxDesired"}
+
+        If the Rule is scoped to an object with properties, the accessible properties of the object are field selectable via `self.field` and field presence can be checked via `has(self.field)`. Null valued fields are treated as absent fields in CEL expressions. If the Rule is scoped to an object with additionalProperties (i.e. a map) the value of the map are accessible via `self[mapKey]`, map containment can be checked via `mapKey in self` and all entries of the map are accessible via CEL macros and functions such as `self.all(...)`. If the Rule is scoped to an array, the elements of the array are accessible via `self[i]` and also by macros and functions. If the Rule is scoped to a scalar, `self` is bound to the scalar value. Examples: - Rule scoped to a map of objects: {"rule": "self.components['Widget'].priority < 10"} - Rule scoped to a list of integers: {"rule": "self.values.all(value, value >= 0 && value < 100)"} - Rule scoped to a string value: {"rule": "self.startsWith('kube')"}
+
+        The `apiVersion`, `kind`, `metadata.name` and `metadata.generateName` are always accessible from the root of the object and from any x-kubernetes-embedded-resource annotated objects. No other metadata properties are accessible.
+
+        Unknown data preserved in custom resources via x-kubernetes-preserve-unknown-fields is not accessible in CEL expressions. This includes: - Unknown field values that are preserved by object schemas with x-kubernetes-preserve-unknown-fields. - Object properties where the property schema is of an "unknown type". An "unknown type" is recursively defined as:
+          - A schema with no type and x-kubernetes-preserve-unknown-fields set to true
+          - An array where the items schema is of an "unknown type"
+          - An object where the additionalProperties schema is of an "unknown type"
+
+        Only property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible. Accessible property names are escaped according to the following rules when accessed in the expression: - '__' escapes to '__underscores__' - '.' escapes to '__dot__' - '-' escapes to '__dash__' - '/' escapes to '__slash__' - Property names that exactly match a CEL RESERVED keyword escape to '__{keyword}__'. The keywords are:
+        	  "true", "false", "null", "in", "as", "break", "const", "continue", "else", "for", "function", "if",
+        	  "import", "let", "loop", "package", "namespace", "return".
+        Examples:
+          - Rule accessing a property named "namespace": {"rule": "self.__namespace__ > 0"}
+          - Rule accessing a property named "x-prop": {"rule": "self.x__dash__prop > 0"}
+          - Rule accessing a property named "redact__d": {"rule": "self.redact__underscores__d > 0"}
+
+        Equality on arrays with x-kubernetes-list-type of 'set' or 'map' ignores element order, i.e. [1, 2] == [2, 1]. Concatenation on arrays with x-kubernetes-list-type use the semantics of the list type:
+          - 'set': `X + Y` performs a union where the array positions of all elements in `X` are preserved and
+            non-intersecting elements in `Y` are appended, retaining their partial order.
+          - 'map': `X + Y` performs a merge where the array positions of all keys in `X` are preserved but the values
+            are overwritten by values in `Y` when the key sets of `X` and `Y` intersect. Elements in `Y` with
+            non-intersecting keys are appended, retaining their partial order.
+
+        If `rule` makes use of the `oldSelf` variable it is implicitly a `transition rule`.
+
+        By default, the `oldSelf` variable is the same type as `self`. When `optionalOldSelf` is true, the `oldSelf` variable is a CEL optional
+         variable whose value() is the same type as `self`.
+        See the documentation for the `optionalOldSelf` field for details.
+
+        Transition rules by default are applied only on UPDATE requests and are skipped if an old value could not be found. You can opt a transition rule into unconditional evaluation by setting `optionalOldSelf` to true.
+        """
+elif False:
+    ValidationRulePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ValidationRulePatchArgs:
@@ -3227,6 +4143,76 @@ class ValidationRulePatchArgs:
         pulumi.set(self, "rule", value)
 
 
+if not MYPY:
+    class ValidationRuleArgsDict(TypedDict):
+        """
+        ValidationRule describes a validation rule written in the CEL expression language.
+        """
+        rule: pulumi.Input[str]
+        """
+        Rule represents the expression which will be evaluated by CEL. ref: https://github.com/google/cel-spec The Rule is scoped to the location of the x-kubernetes-validations extension in the schema. The `self` variable in the CEL expression is bound to the scoped value. Example: - Rule scoped to the root of a resource with a status subresource: {"rule": "self.status.actual <= self.spec.maxDesired"}
+
+        If the Rule is scoped to an object with properties, the accessible properties of the object are field selectable via `self.field` and field presence can be checked via `has(self.field)`. Null valued fields are treated as absent fields in CEL expressions. If the Rule is scoped to an object with additionalProperties (i.e. a map) the value of the map are accessible via `self[mapKey]`, map containment can be checked via `mapKey in self` and all entries of the map are accessible via CEL macros and functions such as `self.all(...)`. If the Rule is scoped to an array, the elements of the array are accessible via `self[i]` and also by macros and functions. If the Rule is scoped to a scalar, `self` is bound to the scalar value. Examples: - Rule scoped to a map of objects: {"rule": "self.components['Widget'].priority < 10"} - Rule scoped to a list of integers: {"rule": "self.values.all(value, value >= 0 && value < 100)"} - Rule scoped to a string value: {"rule": "self.startsWith('kube')"}
+
+        The `apiVersion`, `kind`, `metadata.name` and `metadata.generateName` are always accessible from the root of the object and from any x-kubernetes-embedded-resource annotated objects. No other metadata properties are accessible.
+
+        Unknown data preserved in custom resources via x-kubernetes-preserve-unknown-fields is not accessible in CEL expressions. This includes: - Unknown field values that are preserved by object schemas with x-kubernetes-preserve-unknown-fields. - Object properties where the property schema is of an "unknown type". An "unknown type" is recursively defined as:
+          - A schema with no type and x-kubernetes-preserve-unknown-fields set to true
+          - An array where the items schema is of an "unknown type"
+          - An object where the additionalProperties schema is of an "unknown type"
+
+        Only property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` are accessible. Accessible property names are escaped according to the following rules when accessed in the expression: - '__' escapes to '__underscores__' - '.' escapes to '__dot__' - '-' escapes to '__dash__' - '/' escapes to '__slash__' - Property names that exactly match a CEL RESERVED keyword escape to '__{keyword}__'. The keywords are:
+        	  "true", "false", "null", "in", "as", "break", "const", "continue", "else", "for", "function", "if",
+        	  "import", "let", "loop", "package", "namespace", "return".
+        Examples:
+          - Rule accessing a property named "namespace": {"rule": "self.__namespace__ > 0"}
+          - Rule accessing a property named "x-prop": {"rule": "self.x__dash__prop > 0"}
+          - Rule accessing a property named "redact__d": {"rule": "self.redact__underscores__d > 0"}
+
+        Equality on arrays with x-kubernetes-list-type of 'set' or 'map' ignores element order, i.e. [1, 2] == [2, 1]. Concatenation on arrays with x-kubernetes-list-type use the semantics of the list type:
+          - 'set': `X + Y` performs a union where the array positions of all elements in `X` are preserved and
+            non-intersecting elements in `Y` are appended, retaining their partial order.
+          - 'map': `X + Y` performs a merge where the array positions of all keys in `X` are preserved but the values
+            are overwritten by values in `Y` when the key sets of `X` and `Y` intersect. Elements in `Y` with
+            non-intersecting keys are appended, retaining their partial order.
+
+        If `rule` makes use of the `oldSelf` variable it is implicitly a `transition rule`.
+
+        By default, the `oldSelf` variable is the same type as `self`. When `optionalOldSelf` is true, the `oldSelf` variable is a CEL optional
+         variable whose value() is the same type as `self`.
+        See the documentation for the `optionalOldSelf` field for details.
+
+        Transition rules by default are applied only on UPDATE requests and are skipped if an old value could not be found. You can opt a transition rule into unconditional evaluation by setting `optionalOldSelf` to true.
+        """
+        field_path: NotRequired[pulumi.Input[str]]
+        """
+        fieldPath represents the field path returned when the validation fails. It must be a relative JSON path (i.e. with array notation) scoped to the location of this x-kubernetes-validations extension in the schema and refer to an existing field. e.g. when validation checks if a specific attribute `foo` under a map `testMap`, the fieldPath could be set to `.testMap.foo` If the validation checks two lists must have unique attributes, the fieldPath could be set to either of the list: e.g. `.testList` It does not support list numeric index. It supports child operation to refer to an existing field currently. Refer to [JSONPath support in Kubernetes](https://kubernetes.io/docs/reference/kubectl/jsonpath/) for more info. Numeric index of array is not supported. For field name which contains special characters, use `['specialName']` to refer the field name. e.g. for attribute `foo.34$` appears in a list `testList`, the fieldPath could be set to `.testList['foo.34$']`
+        """
+        message: NotRequired[pulumi.Input[str]]
+        """
+        Message represents the message displayed when validation fails. The message is required if the Rule contains line breaks. The message must not contain line breaks. If unset, the message is "failed rule: {Rule}". e.g. "must be a URL with the host matching spec.host"
+        """
+        message_expression: NotRequired[pulumi.Input[str]]
+        """
+        MessageExpression declares a CEL expression that evaluates to the validation failure message that is returned when this rule fails. Since messageExpression is used as a failure message, it must evaluate to a string. If both message and messageExpression are present on a rule, then messageExpression will be used if validation fails. If messageExpression results in a runtime error, the runtime error is logged, and the validation failure message is produced as if the messageExpression field were unset. If messageExpression evaluates to an empty string, a string with only spaces, or a string that contains line breaks, then the validation failure message will also be produced as if the messageExpression field were unset, and the fact that messageExpression produced an empty string/string with only spaces/string with line breaks will be logged. messageExpression has access to all the same variables as the rule; the only difference is the return type. Example: "x must be less than max ("+string(self.max)+")"
+        """
+        optional_old_self: NotRequired[pulumi.Input[bool]]
+        """
+        optionalOldSelf is used to opt a transition rule into evaluation even when the object is first created, or if the old object is missing the value.
+
+        When enabled `oldSelf` will be a CEL optional whose value will be `None` if there is no old value, or when the object is initially created.
+
+        You may check for presence of oldSelf using `oldSelf.hasValue()` and unwrap it after checking using `oldSelf.value()`. Check the CEL documentation for Optional types for more information: https://pkg.go.dev/github.com/google/cel-go/cel#OptionalTypes
+
+        May not be set unless `oldSelf` is used in `rule`.
+        """
+        reason: NotRequired[pulumi.Input[str]]
+        """
+        reason provides a machine-readable validation failure reason that is returned to the caller when a request fails this validation rule. The HTTP status code returned to the caller will match the reason of the reason of the first failed validation rule. The currently supported reasons are: "FieldValueInvalid", "FieldValueForbidden", "FieldValueRequired", "FieldValueDuplicate". If not set, default to use "FieldValueInvalid". All future added reasons must be accepted by clients when reading this value and unknown reasons should be treated as FieldValueInvalid.
+        """
+elif False:
+    ValidationRuleArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ValidationRuleArgs:
     def __init__(__self__, *,
@@ -3406,6 +4392,38 @@ class ValidationRuleArgs:
         pulumi.set(self, "reason", value)
 
 
+if not MYPY:
+    class WebhookClientConfigPatchArgsDict(TypedDict):
+        """
+        WebhookClientConfig contains the information to make a TLS connection with the webhook.
+        """
+        ca_bundle: NotRequired[pulumi.Input[str]]
+        """
+        caBundle is a PEM encoded CA bundle which will be used to validate the webhook's server certificate. If unspecified, system trust roots on the apiserver are used.
+        """
+        service: NotRequired[pulumi.Input['ServiceReferencePatchArgsDict']]
+        """
+        service is a reference to the service for this webhook. Either service or url must be specified.
+
+        If the webhook is running within the cluster, then you should use `service`.
+        """
+        url: NotRequired[pulumi.Input[str]]
+        """
+        url gives the location of the webhook, in standard URL form (`scheme://host:port/path`). Exactly one of `url` or `service` must be specified.
+
+        The `host` should not refer to a service running in the cluster; use the `service` field instead. The host might be resolved via external DNS in some apiservers (e.g., `kube-apiserver` cannot resolve in-cluster DNS as that would be a layering violation). `host` may also be an IP address.
+
+        Please note that using `localhost` or `127.0.0.1` as a `host` is risky unless you take great care to run this webhook on all hosts which run an apiserver which might need to make calls to this webhook. Such installs are likely to be non-portable, i.e., not easy to turn up in a new cluster.
+
+        The scheme must be "https"; the URL must begin with "https://".
+
+        A path is optional, and if present may be any string permissible in a URL. You may use the path to pass an arbitrary string to the webhook, for example, a cluster identifier.
+
+        Attempting to use a user or basic auth e.g. "user:password@" is not allowed. Fragments ("#...") and query parameters ("?...") are not allowed, either.
+        """
+elif False:
+    WebhookClientConfigPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class WebhookClientConfigPatchArgs:
     def __init__(__self__, *,
@@ -3485,6 +4503,38 @@ class WebhookClientConfigPatchArgs:
     def url(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "url", value)
 
+
+if not MYPY:
+    class WebhookClientConfigArgsDict(TypedDict):
+        """
+        WebhookClientConfig contains the information to make a TLS connection with the webhook.
+        """
+        ca_bundle: NotRequired[pulumi.Input[str]]
+        """
+        caBundle is a PEM encoded CA bundle which will be used to validate the webhook's server certificate. If unspecified, system trust roots on the apiserver are used.
+        """
+        service: NotRequired[pulumi.Input['ServiceReferenceArgsDict']]
+        """
+        service is a reference to the service for this webhook. Either service or url must be specified.
+
+        If the webhook is running within the cluster, then you should use `service`.
+        """
+        url: NotRequired[pulumi.Input[str]]
+        """
+        url gives the location of the webhook, in standard URL form (`scheme://host:port/path`). Exactly one of `url` or `service` must be specified.
+
+        The `host` should not refer to a service running in the cluster; use the `service` field instead. The host might be resolved via external DNS in some apiservers (e.g., `kube-apiserver` cannot resolve in-cluster DNS as that would be a layering violation). `host` may also be an IP address.
+
+        Please note that using `localhost` or `127.0.0.1` as a `host` is risky unless you take great care to run this webhook on all hosts which run an apiserver which might need to make calls to this webhook. Such installs are likely to be non-portable, i.e., not easy to turn up in a new cluster.
+
+        The scheme must be "https"; the URL must begin with "https://".
+
+        A path is optional, and if present may be any string permissible in a URL. You may use the path to pass an arbitrary string to the webhook, for example, a cluster identifier.
+
+        Attempting to use a user or basic auth e.g. "user:password@" is not allowed. Fragments ("#...") and query parameters ("?...") are not allowed, either.
+        """
+elif False:
+    WebhookClientConfigArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class WebhookClientConfigArgs:
@@ -3566,6 +4616,22 @@ class WebhookClientConfigArgs:
         pulumi.set(self, "url", value)
 
 
+if not MYPY:
+    class WebhookConversionPatchArgsDict(TypedDict):
+        """
+        WebhookConversion describes how to call a conversion webhook
+        """
+        client_config: NotRequired[pulumi.Input['WebhookClientConfigPatchArgsDict']]
+        """
+        clientConfig is the instructions for how to call the webhook if strategy is `Webhook`.
+        """
+        conversion_review_versions: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        conversionReviewVersions is an ordered list of preferred `ConversionReview` versions the Webhook expects. The API server will use the first version in the list which it supports. If none of the versions specified in this list are supported by API server, conversion will fail for the custom resource. If a persisted Webhook configuration specifies allowed versions and does not include any versions known to the API Server, calls to the webhook will fail.
+        """
+elif False:
+    WebhookConversionPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class WebhookConversionPatchArgs:
     def __init__(__self__, *,
@@ -3605,6 +4671,22 @@ class WebhookConversionPatchArgs:
     def conversion_review_versions(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]):
         pulumi.set(self, "conversion_review_versions", value)
 
+
+if not MYPY:
+    class WebhookConversionArgsDict(TypedDict):
+        """
+        WebhookConversion describes how to call a conversion webhook
+        """
+        conversion_review_versions: pulumi.Input[Sequence[pulumi.Input[str]]]
+        """
+        conversionReviewVersions is an ordered list of preferred `ConversionReview` versions the Webhook expects. The API server will use the first version in the list which it supports. If none of the versions specified in this list are supported by API server, conversion will fail for the custom resource. If a persisted Webhook configuration specifies allowed versions and does not include any versions known to the API Server, calls to the webhook will fail.
+        """
+        client_config: NotRequired[pulumi.Input['WebhookClientConfigArgsDict']]
+        """
+        clientConfig is the instructions for how to call the webhook if strategy is `Webhook`.
+        """
+elif False:
+    WebhookConversionArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class WebhookConversionArgs:

--- a/sdk/python/pulumi_kubernetes/apiextensions/v1/outputs.py
+++ b/sdk/python/pulumi_kubernetes/apiextensions/v1/outputs.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta

--- a/sdk/python/pulumi_kubernetes/apiextensions/v1beta1/CustomResourceDefinition.py
+++ b/sdk/python/pulumi_kubernetes/apiextensions/v1beta1/CustomResourceDefinition.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -88,8 +93,8 @@ class CustomResourceDefinition(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['CustomResourceDefinitionSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['CustomResourceDefinitionSpecArgs', 'CustomResourceDefinitionSpecArgsDict']]] = None,
                  __props__=None):
         """
         CustomResourceDefinition represents a resource that should be exposed on the API server.  Its name MUST be in the format <.spec.name>.<.spec.group>. Deprecated in v1.16, planned for removal in v1.19. Use apiextensions.k8s.io/v1 CustomResourceDefinition instead.
@@ -98,7 +103,7 @@ class CustomResourceDefinition(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['CustomResourceDefinitionSpecArgs']] spec: spec describes how the user wants the resources to appear
+        :param pulumi.Input[Union['CustomResourceDefinitionSpecArgs', 'CustomResourceDefinitionSpecArgsDict']] spec: spec describes how the user wants the resources to appear
         """
         ...
     @overload
@@ -126,8 +131,8 @@ class CustomResourceDefinition(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['CustomResourceDefinitionSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['CustomResourceDefinitionSpecArgs', 'CustomResourceDefinitionSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/apiextensions/v1beta1/CustomResourceDefinitionList.py
+++ b/sdk/python/pulumi_kubernetes/apiextensions/v1beta1/CustomResourceDefinitionList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -87,9 +92,9 @@ class CustomResourceDefinitionList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['CustomResourceDefinitionArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['CustomResourceDefinitionArgs', 'CustomResourceDefinitionArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         CustomResourceDefinitionList is a list of CustomResourceDefinition objects.
@@ -97,7 +102,7 @@ class CustomResourceDefinitionList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['CustomResourceDefinitionArgs']]]] items: items list individual CustomResourceDefinition objects
+        :param pulumi.Input[Sequence[pulumi.Input[Union['CustomResourceDefinitionArgs', 'CustomResourceDefinitionArgsDict']]]] items: items list individual CustomResourceDefinition objects
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
         """
         ...
@@ -125,9 +130,9 @@ class CustomResourceDefinitionList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['CustomResourceDefinitionArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['CustomResourceDefinitionArgs', 'CustomResourceDefinitionArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/apiextensions/v1beta1/CustomResourceDefinitionPatch.py
+++ b/sdk/python/pulumi_kubernetes/apiextensions/v1beta1/CustomResourceDefinitionPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -89,8 +94,8 @@ class CustomResourceDefinitionPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['CustomResourceDefinitionSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['CustomResourceDefinitionSpecPatchArgs', 'CustomResourceDefinitionSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -105,7 +110,7 @@ class CustomResourceDefinitionPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['CustomResourceDefinitionSpecPatchArgs']] spec: spec describes how the user wants the resources to appear
+        :param pulumi.Input[Union['CustomResourceDefinitionSpecPatchArgs', 'CustomResourceDefinitionSpecPatchArgsDict']] spec: spec describes how the user wants the resources to appear
         """
         ...
     @overload
@@ -139,8 +144,8 @@ class CustomResourceDefinitionPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['CustomResourceDefinitionSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['CustomResourceDefinitionSpecPatchArgs', 'CustomResourceDefinitionSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/apiextensions/v1beta1/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/apiextensions/v1beta1/_inputs.py
@@ -4,41 +4,107 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import meta as _meta
 
 __all__ = [
     'CustomResourceColumnDefinitionPatchArgs',
+    'CustomResourceColumnDefinitionPatchArgsDict',
     'CustomResourceColumnDefinitionArgs',
+    'CustomResourceColumnDefinitionArgsDict',
     'CustomResourceConversionPatchArgs',
+    'CustomResourceConversionPatchArgsDict',
     'CustomResourceConversionArgs',
+    'CustomResourceConversionArgsDict',
     'CustomResourceDefinitionConditionArgs',
+    'CustomResourceDefinitionConditionArgsDict',
     'CustomResourceDefinitionNamesPatchArgs',
+    'CustomResourceDefinitionNamesPatchArgsDict',
     'CustomResourceDefinitionNamesArgs',
+    'CustomResourceDefinitionNamesArgsDict',
     'CustomResourceDefinitionSpecPatchArgs',
+    'CustomResourceDefinitionSpecPatchArgsDict',
     'CustomResourceDefinitionSpecArgs',
+    'CustomResourceDefinitionSpecArgsDict',
     'CustomResourceDefinitionStatusArgs',
+    'CustomResourceDefinitionStatusArgsDict',
     'CustomResourceDefinitionVersionPatchArgs',
+    'CustomResourceDefinitionVersionPatchArgsDict',
     'CustomResourceDefinitionVersionArgs',
+    'CustomResourceDefinitionVersionArgsDict',
     'CustomResourceDefinitionArgs',
+    'CustomResourceDefinitionArgsDict',
     'CustomResourceSubresourceScalePatchArgs',
+    'CustomResourceSubresourceScalePatchArgsDict',
     'CustomResourceSubresourceScaleArgs',
+    'CustomResourceSubresourceScaleArgsDict',
     'CustomResourceSubresourcesPatchArgs',
+    'CustomResourceSubresourcesPatchArgsDict',
     'CustomResourceSubresourcesArgs',
+    'CustomResourceSubresourcesArgsDict',
     'CustomResourceValidationPatchArgs',
+    'CustomResourceValidationPatchArgsDict',
     'CustomResourceValidationArgs',
+    'CustomResourceValidationArgsDict',
     'ExternalDocumentationPatchArgs',
+    'ExternalDocumentationPatchArgsDict',
     'ExternalDocumentationArgs',
+    'ExternalDocumentationArgsDict',
     'JSONSchemaPropsPatchArgs',
+    'JSONSchemaPropsPatchArgsDict',
     'JSONSchemaPropsArgs',
+    'JSONSchemaPropsArgsDict',
     'ServiceReferencePatchArgs',
+    'ServiceReferencePatchArgsDict',
     'ServiceReferenceArgs',
+    'ServiceReferenceArgsDict',
     'WebhookClientConfigPatchArgs',
+    'WebhookClientConfigPatchArgsDict',
     'WebhookClientConfigArgs',
+    'WebhookClientConfigArgsDict',
 ]
+
+MYPY = False
+
+if not MYPY:
+    class CustomResourceColumnDefinitionPatchArgsDict(TypedDict):
+        """
+        CustomResourceColumnDefinition specifies a column for server side printing.
+        """
+        json_path: NotRequired[pulumi.Input[str]]
+        """
+        JSONPath is a simple JSON path (i.e. with array notation) which is evaluated against each custom resource to produce the value for this column.
+        """
+        description: NotRequired[pulumi.Input[str]]
+        """
+        description is a human readable description of this column.
+        """
+        format: NotRequired[pulumi.Input[str]]
+        """
+        format is an optional OpenAPI type definition for this column. The 'name' format is applied to the primary identifier column to assist in clients identifying column is the resource name. See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types for details.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        name is a human readable name for the column.
+        """
+        priority: NotRequired[pulumi.Input[int]]
+        """
+        priority is an integer defining the relative importance of this column compared to others. Lower numbers are considered higher priority. Columns that may be omitted in limited space scenarios should be given a priority greater than 0.
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        type is an OpenAPI type definition for this column. See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types for details.
+        """
+elif False:
+    CustomResourceColumnDefinitionPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class CustomResourceColumnDefinitionPatchArgs:
@@ -144,6 +210,38 @@ class CustomResourceColumnDefinitionPatchArgs:
         pulumi.set(self, "type", value)
 
 
+if not MYPY:
+    class CustomResourceColumnDefinitionArgsDict(TypedDict):
+        """
+        CustomResourceColumnDefinition specifies a column for server side printing.
+        """
+        json_path: pulumi.Input[str]
+        """
+        JSONPath is a simple JSON path (i.e. with array notation) which is evaluated against each custom resource to produce the value for this column.
+        """
+        name: pulumi.Input[str]
+        """
+        name is a human readable name for the column.
+        """
+        type: pulumi.Input[str]
+        """
+        type is an OpenAPI type definition for this column. See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types for details.
+        """
+        description: NotRequired[pulumi.Input[str]]
+        """
+        description is a human readable description of this column.
+        """
+        format: NotRequired[pulumi.Input[str]]
+        """
+        format is an optional OpenAPI type definition for this column. The 'name' format is applied to the primary identifier column to assist in clients identifying column is the resource name. See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types for details.
+        """
+        priority: NotRequired[pulumi.Input[int]]
+        """
+        priority is an integer defining the relative importance of this column compared to others. Lower numbers are considered higher priority. Columns that may be omitted in limited space scenarios should be given a priority greater than 0.
+        """
+elif False:
+    CustomResourceColumnDefinitionArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CustomResourceColumnDefinitionArgs:
     def __init__(__self__, *,
@@ -245,6 +343,27 @@ class CustomResourceColumnDefinitionArgs:
         pulumi.set(self, "priority", value)
 
 
+if not MYPY:
+    class CustomResourceConversionPatchArgsDict(TypedDict):
+        """
+        CustomResourceConversion describes how to convert different versions of a CR.
+        """
+        conversion_review_versions: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        conversionReviewVersions is an ordered list of preferred `ConversionReview` versions the Webhook expects. The API server will use the first version in the list which it supports. If none of the versions specified in this list are supported by API server, conversion will fail for the custom resource. If a persisted Webhook configuration specifies allowed versions and does not include any versions known to the API Server, calls to the webhook will fail. Defaults to `["v1beta1"]`.
+        """
+        strategy: NotRequired[pulumi.Input[str]]
+        """
+        strategy specifies how custom resources are converted between versions. Allowed values are: - `None`: The converter only change the apiVersion and would not touch any other field in the custom resource. - `Webhook`: API Server will call to an external webhook to do the conversion. Additional information
+          is needed for this option. This requires spec.preserveUnknownFields to be false, and spec.conversion.webhookClientConfig to be set.
+        """
+        webhook_client_config: NotRequired[pulumi.Input['WebhookClientConfigPatchArgsDict']]
+        """
+        webhookClientConfig is the instructions for how to call the webhook if strategy is `Webhook`. Required when `strategy` is set to `Webhook`.
+        """
+elif False:
+    CustomResourceConversionPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CustomResourceConversionPatchArgs:
     def __init__(__self__, *,
@@ -303,6 +422,27 @@ class CustomResourceConversionPatchArgs:
         pulumi.set(self, "webhook_client_config", value)
 
 
+if not MYPY:
+    class CustomResourceConversionArgsDict(TypedDict):
+        """
+        CustomResourceConversion describes how to convert different versions of a CR.
+        """
+        strategy: pulumi.Input[str]
+        """
+        strategy specifies how custom resources are converted between versions. Allowed values are: - `None`: The converter only change the apiVersion and would not touch any other field in the custom resource. - `Webhook`: API Server will call to an external webhook to do the conversion. Additional information
+          is needed for this option. This requires spec.preserveUnknownFields to be false, and spec.conversion.webhookClientConfig to be set.
+        """
+        conversion_review_versions: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        conversionReviewVersions is an ordered list of preferred `ConversionReview` versions the Webhook expects. The API server will use the first version in the list which it supports. If none of the versions specified in this list are supported by API server, conversion will fail for the custom resource. If a persisted Webhook configuration specifies allowed versions and does not include any versions known to the API Server, calls to the webhook will fail. Defaults to `["v1beta1"]`.
+        """
+        webhook_client_config: NotRequired[pulumi.Input['WebhookClientConfigArgsDict']]
+        """
+        webhookClientConfig is the instructions for how to call the webhook if strategy is `Webhook`. Required when `strategy` is set to `Webhook`.
+        """
+elif False:
+    CustomResourceConversionArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CustomResourceConversionArgs:
     def __init__(__self__, *,
@@ -359,6 +499,34 @@ class CustomResourceConversionArgs:
     def webhook_client_config(self, value: Optional[pulumi.Input['WebhookClientConfigArgs']]):
         pulumi.set(self, "webhook_client_config", value)
 
+
+if not MYPY:
+    class CustomResourceDefinitionConditionArgsDict(TypedDict):
+        """
+        CustomResourceDefinitionCondition contains details for the current condition of this pod.
+        """
+        status: pulumi.Input[str]
+        """
+        status is the status of the condition. Can be True, False, Unknown.
+        """
+        type: pulumi.Input[str]
+        """
+        type is the type of the condition. Types include Established, NamesAccepted and Terminating.
+        """
+        last_transition_time: NotRequired[pulumi.Input[str]]
+        """
+        lastTransitionTime last time the condition transitioned from one status to another.
+        """
+        message: NotRequired[pulumi.Input[str]]
+        """
+        message is a human-readable message indicating details about last transition.
+        """
+        reason: NotRequired[pulumi.Input[str]]
+        """
+        reason is a unique, one-word, CamelCase reason for the condition's last transition.
+        """
+elif False:
+    CustomResourceDefinitionConditionArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class CustomResourceDefinitionConditionArgs:
@@ -445,6 +613,38 @@ class CustomResourceDefinitionConditionArgs:
     def reason(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "reason", value)
 
+
+if not MYPY:
+    class CustomResourceDefinitionNamesPatchArgsDict(TypedDict):
+        """
+        CustomResourceDefinitionNames indicates the names to serve this CustomResourceDefinition
+        """
+        categories: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        categories is a list of grouped resources this custom resource belongs to (e.g. 'all'). This is published in API discovery documents, and used by clients to support invocations like `kubectl get all`.
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        kind is the serialized kind of the resource. It is normally CamelCase and singular. Custom resource instances will use this value as the `kind` attribute in API calls.
+        """
+        list_kind: NotRequired[pulumi.Input[str]]
+        """
+        listKind is the serialized kind of the list for this resource. Defaults to "`kind`List".
+        """
+        plural: NotRequired[pulumi.Input[str]]
+        """
+        plural is the plural name of the resource to serve. The custom resources are served under `/apis/<group>/<version>/.../<plural>`. Must match the name of the CustomResourceDefinition (in the form `<names.plural>.<group>`). Must be all lowercase.
+        """
+        short_names: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        shortNames are short names for the resource, exposed in API discovery documents, and used by clients to support invocations like `kubectl get <shortname>`. It must be all lowercase.
+        """
+        singular: NotRequired[pulumi.Input[str]]
+        """
+        singular is the singular name of the resource. It must be all lowercase. Defaults to lowercased `kind`.
+        """
+elif False:
+    CustomResourceDefinitionNamesPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class CustomResourceDefinitionNamesPatchArgs:
@@ -550,6 +750,38 @@ class CustomResourceDefinitionNamesPatchArgs:
         pulumi.set(self, "singular", value)
 
 
+if not MYPY:
+    class CustomResourceDefinitionNamesArgsDict(TypedDict):
+        """
+        CustomResourceDefinitionNames indicates the names to serve this CustomResourceDefinition
+        """
+        kind: pulumi.Input[str]
+        """
+        kind is the serialized kind of the resource. It is normally CamelCase and singular. Custom resource instances will use this value as the `kind` attribute in API calls.
+        """
+        plural: pulumi.Input[str]
+        """
+        plural is the plural name of the resource to serve. The custom resources are served under `/apis/<group>/<version>/.../<plural>`. Must match the name of the CustomResourceDefinition (in the form `<names.plural>.<group>`). Must be all lowercase.
+        """
+        categories: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        categories is a list of grouped resources this custom resource belongs to (e.g. 'all'). This is published in API discovery documents, and used by clients to support invocations like `kubectl get all`.
+        """
+        list_kind: NotRequired[pulumi.Input[str]]
+        """
+        listKind is the serialized kind of the list for this resource. Defaults to "`kind`List".
+        """
+        short_names: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        shortNames are short names for the resource, exposed in API discovery documents, and used by clients to support invocations like `kubectl get <shortname>`. It must be all lowercase.
+        """
+        singular: NotRequired[pulumi.Input[str]]
+        """
+        singular is the singular name of the resource. It must be all lowercase. Defaults to lowercased `kind`.
+        """
+elif False:
+    CustomResourceDefinitionNamesArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CustomResourceDefinitionNamesArgs:
     def __init__(__self__, *,
@@ -651,6 +883,54 @@ class CustomResourceDefinitionNamesArgs:
     def singular(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "singular", value)
 
+
+if not MYPY:
+    class CustomResourceDefinitionSpecPatchArgsDict(TypedDict):
+        """
+        CustomResourceDefinitionSpec describes how a user wants their resource to appear
+        """
+        additional_printer_columns: NotRequired[pulumi.Input[Sequence[pulumi.Input['CustomResourceColumnDefinitionPatchArgsDict']]]]
+        """
+        additionalPrinterColumns specifies additional columns returned in Table output. See https://kubernetes.io/docs/reference/using-api/api-concepts/#receiving-resources-as-tables for details. If present, this field configures columns for all versions. Top-level and per-version columns are mutually exclusive. If no top-level or per-version columns are specified, a single column displaying the age of the custom resource is used.
+        """
+        conversion: NotRequired[pulumi.Input['CustomResourceConversionPatchArgsDict']]
+        """
+        conversion defines conversion settings for the CRD.
+        """
+        group: NotRequired[pulumi.Input[str]]
+        """
+        group is the API group of the defined custom resource. The custom resources are served under `/apis/<group>/...`. Must match the name of the CustomResourceDefinition (in the form `<names.plural>.<group>`).
+        """
+        names: NotRequired[pulumi.Input['CustomResourceDefinitionNamesPatchArgsDict']]
+        """
+        names specify the resource and kind names for the custom resource.
+        """
+        preserve_unknown_fields: NotRequired[pulumi.Input[bool]]
+        """
+        preserveUnknownFields indicates that object fields which are not specified in the OpenAPI schema should be preserved when persisting to storage. apiVersion, kind, metadata and known fields inside metadata are always preserved. If false, schemas must be defined for all versions. Defaults to true in v1beta for backwards compatibility. Deprecated: will be required to be false in v1. Preservation of unknown fields can be specified in the validation schema using the `x-kubernetes-preserve-unknown-fields: true` extension. See https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#pruning-versus-preserving-unknown-fields for details.
+        """
+        scope: NotRequired[pulumi.Input[str]]
+        """
+        scope indicates whether the defined custom resource is cluster- or namespace-scoped. Allowed values are `Cluster` and `Namespaced`. Default is `Namespaced`.
+        """
+        subresources: NotRequired[pulumi.Input['CustomResourceSubresourcesPatchArgsDict']]
+        """
+        subresources specify what subresources the defined custom resource has. If present, this field configures subresources for all versions. Top-level and per-version subresources are mutually exclusive.
+        """
+        validation: NotRequired[pulumi.Input['CustomResourceValidationPatchArgsDict']]
+        """
+        validation describes the schema used for validation and pruning of the custom resource. If present, this validation schema is used to validate all versions. Top-level and per-version schemas are mutually exclusive.
+        """
+        version: NotRequired[pulumi.Input[str]]
+        """
+        version is the API version of the defined custom resource. The custom resources are served under `/apis/<group>/<version>/...`. Must match the name of the first item in the `versions` list if `version` and `versions` are both specified. Optional if `versions` is specified. Deprecated: use `versions` instead.
+        """
+        versions: NotRequired[pulumi.Input[Sequence[pulumi.Input['CustomResourceDefinitionVersionPatchArgsDict']]]]
+        """
+        versions is the list of all API versions of the defined custom resource. Optional if `version` is specified. The name of the first item in the `versions` list must match the `version` field if `version` and `versions` are both specified. Version names are used to compute the order in which served versions are listed in API discovery. If the version string is "kube-like", it will sort above non "kube-like" version strings, which are ordered lexicographically. "Kube-like" versions start with a "v", then are followed by a number (the major version), then optionally the string "alpha" or "beta" and another number (the minor version). These are sorted first by GA > beta > alpha (where GA is a version with no suffix such as beta or alpha), and then by comparing major version, then minor version. An example sorted list of versions: v10, v2, v1, v11beta2, v10beta3, v3beta1, v12alpha1, v11alpha2, foo1, foo10.
+        """
+elif False:
+    CustomResourceDefinitionSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class CustomResourceDefinitionSpecPatchArgs:
@@ -820,6 +1100,54 @@ class CustomResourceDefinitionSpecPatchArgs:
         pulumi.set(self, "versions", value)
 
 
+if not MYPY:
+    class CustomResourceDefinitionSpecArgsDict(TypedDict):
+        """
+        CustomResourceDefinitionSpec describes how a user wants their resource to appear
+        """
+        group: pulumi.Input[str]
+        """
+        group is the API group of the defined custom resource. The custom resources are served under `/apis/<group>/...`. Must match the name of the CustomResourceDefinition (in the form `<names.plural>.<group>`).
+        """
+        names: pulumi.Input['CustomResourceDefinitionNamesArgsDict']
+        """
+        names specify the resource and kind names for the custom resource.
+        """
+        scope: pulumi.Input[str]
+        """
+        scope indicates whether the defined custom resource is cluster- or namespace-scoped. Allowed values are `Cluster` and `Namespaced`. Default is `Namespaced`.
+        """
+        additional_printer_columns: NotRequired[pulumi.Input[Sequence[pulumi.Input['CustomResourceColumnDefinitionArgsDict']]]]
+        """
+        additionalPrinterColumns specifies additional columns returned in Table output. See https://kubernetes.io/docs/reference/using-api/api-concepts/#receiving-resources-as-tables for details. If present, this field configures columns for all versions. Top-level and per-version columns are mutually exclusive. If no top-level or per-version columns are specified, a single column displaying the age of the custom resource is used.
+        """
+        conversion: NotRequired[pulumi.Input['CustomResourceConversionArgsDict']]
+        """
+        conversion defines conversion settings for the CRD.
+        """
+        preserve_unknown_fields: NotRequired[pulumi.Input[bool]]
+        """
+        preserveUnknownFields indicates that object fields which are not specified in the OpenAPI schema should be preserved when persisting to storage. apiVersion, kind, metadata and known fields inside metadata are always preserved. If false, schemas must be defined for all versions. Defaults to true in v1beta for backwards compatibility. Deprecated: will be required to be false in v1. Preservation of unknown fields can be specified in the validation schema using the `x-kubernetes-preserve-unknown-fields: true` extension. See https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#pruning-versus-preserving-unknown-fields for details.
+        """
+        subresources: NotRequired[pulumi.Input['CustomResourceSubresourcesArgsDict']]
+        """
+        subresources specify what subresources the defined custom resource has. If present, this field configures subresources for all versions. Top-level and per-version subresources are mutually exclusive.
+        """
+        validation: NotRequired[pulumi.Input['CustomResourceValidationArgsDict']]
+        """
+        validation describes the schema used for validation and pruning of the custom resource. If present, this validation schema is used to validate all versions. Top-level and per-version schemas are mutually exclusive.
+        """
+        version: NotRequired[pulumi.Input[str]]
+        """
+        version is the API version of the defined custom resource. The custom resources are served under `/apis/<group>/<version>/...`. Must match the name of the first item in the `versions` list if `version` and `versions` are both specified. Optional if `versions` is specified. Deprecated: use `versions` instead.
+        """
+        versions: NotRequired[pulumi.Input[Sequence[pulumi.Input['CustomResourceDefinitionVersionArgsDict']]]]
+        """
+        versions is the list of all API versions of the defined custom resource. Optional if `version` is specified. The name of the first item in the `versions` list must match the `version` field if `version` and `versions` are both specified. Version names are used to compute the order in which served versions are listed in API discovery. If the version string is "kube-like", it will sort above non "kube-like" version strings, which are ordered lexicographically. "Kube-like" versions start with a "v", then are followed by a number (the major version), then optionally the string "alpha" or "beta" and another number (the minor version). These are sorted first by GA > beta > alpha (where GA is a version with no suffix such as beta or alpha), and then by comparing major version, then minor version. An example sorted list of versions: v10, v2, v1, v11beta2, v10beta3, v3beta1, v12alpha1, v11alpha2, foo1, foo10.
+        """
+elif False:
+    CustomResourceDefinitionSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CustomResourceDefinitionSpecArgs:
     def __init__(__self__, *,
@@ -985,6 +1313,26 @@ class CustomResourceDefinitionSpecArgs:
         pulumi.set(self, "versions", value)
 
 
+if not MYPY:
+    class CustomResourceDefinitionStatusArgsDict(TypedDict):
+        """
+        CustomResourceDefinitionStatus indicates the state of the CustomResourceDefinition
+        """
+        accepted_names: pulumi.Input['CustomResourceDefinitionNamesArgsDict']
+        """
+        acceptedNames are the names that are actually being used to serve discovery. They may be different than the names in spec.
+        """
+        stored_versions: pulumi.Input[Sequence[pulumi.Input[str]]]
+        """
+        storedVersions lists all versions of CustomResources that were ever persisted. Tracking these versions allows a migration path for stored versions in etcd. The field is mutable so a migration controller can finish a migration to another version (ensuring no old objects are left in storage), and then remove the rest of the versions from this list. Versions may not be removed from `spec.versions` while they exist in this list.
+        """
+        conditions: NotRequired[pulumi.Input[Sequence[pulumi.Input['CustomResourceDefinitionConditionArgsDict']]]]
+        """
+        conditions indicate state for particular aspects of a CustomResourceDefinition
+        """
+elif False:
+    CustomResourceDefinitionStatusArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CustomResourceDefinitionStatusArgs:
     def __init__(__self__, *,
@@ -1038,6 +1386,46 @@ class CustomResourceDefinitionStatusArgs:
     def conditions(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['CustomResourceDefinitionConditionArgs']]]]):
         pulumi.set(self, "conditions", value)
 
+
+if not MYPY:
+    class CustomResourceDefinitionVersionPatchArgsDict(TypedDict):
+        """
+        CustomResourceDefinitionVersion describes a version for CRD.
+        """
+        additional_printer_columns: NotRequired[pulumi.Input[Sequence[pulumi.Input['CustomResourceColumnDefinitionPatchArgsDict']]]]
+        """
+        additionalPrinterColumns specifies additional columns returned in Table output. See https://kubernetes.io/docs/reference/using-api/api-concepts/#receiving-resources-as-tables for details. Top-level and per-version columns are mutually exclusive. Per-version columns must not all be set to identical values (top-level columns should be used instead). If no top-level or per-version columns are specified, a single column displaying the age of the custom resource is used.
+        """
+        deprecated: NotRequired[pulumi.Input[bool]]
+        """
+        deprecated indicates this version of the custom resource API is deprecated. When set to true, API requests to this version receive a warning header in the server response. Defaults to false.
+        """
+        deprecation_warning: NotRequired[pulumi.Input[str]]
+        """
+        deprecationWarning overrides the default warning returned to API clients. May only be set when `deprecated` is true. The default warning indicates this version is deprecated and recommends use of the newest served version of equal or greater stability, if one exists.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        name is the version name, e.g. “v1”, “v2beta1”, etc. The custom resources are served under this version at `/apis/<group>/<version>/...` if `served` is true.
+        """
+        schema: NotRequired[pulumi.Input['CustomResourceValidationPatchArgsDict']]
+        """
+        schema describes the schema used for validation and pruning of this version of the custom resource. Top-level and per-version schemas are mutually exclusive. Per-version schemas must not all be set to identical values (top-level validation schema should be used instead).
+        """
+        served: NotRequired[pulumi.Input[bool]]
+        """
+        served is a flag enabling/disabling this version from being served via REST APIs
+        """
+        storage: NotRequired[pulumi.Input[bool]]
+        """
+        storage indicates this version should be used when persisting custom resources to storage. There must be exactly one version with storage=true.
+        """
+        subresources: NotRequired[pulumi.Input['CustomResourceSubresourcesPatchArgsDict']]
+        """
+        subresources specify what subresources this version of the defined custom resource have. Top-level and per-version subresources are mutually exclusive. Per-version subresources must not all be set to identical values (top-level subresources should be used instead).
+        """
+elif False:
+    CustomResourceDefinitionVersionPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class CustomResourceDefinitionVersionPatchArgs:
@@ -1175,6 +1563,46 @@ class CustomResourceDefinitionVersionPatchArgs:
         pulumi.set(self, "subresources", value)
 
 
+if not MYPY:
+    class CustomResourceDefinitionVersionArgsDict(TypedDict):
+        """
+        CustomResourceDefinitionVersion describes a version for CRD.
+        """
+        name: pulumi.Input[str]
+        """
+        name is the version name, e.g. “v1”, “v2beta1”, etc. The custom resources are served under this version at `/apis/<group>/<version>/...` if `served` is true.
+        """
+        served: pulumi.Input[bool]
+        """
+        served is a flag enabling/disabling this version from being served via REST APIs
+        """
+        storage: pulumi.Input[bool]
+        """
+        storage indicates this version should be used when persisting custom resources to storage. There must be exactly one version with storage=true.
+        """
+        additional_printer_columns: NotRequired[pulumi.Input[Sequence[pulumi.Input['CustomResourceColumnDefinitionArgsDict']]]]
+        """
+        additionalPrinterColumns specifies additional columns returned in Table output. See https://kubernetes.io/docs/reference/using-api/api-concepts/#receiving-resources-as-tables for details. Top-level and per-version columns are mutually exclusive. Per-version columns must not all be set to identical values (top-level columns should be used instead). If no top-level or per-version columns are specified, a single column displaying the age of the custom resource is used.
+        """
+        deprecated: NotRequired[pulumi.Input[bool]]
+        """
+        deprecated indicates this version of the custom resource API is deprecated. When set to true, API requests to this version receive a warning header in the server response. Defaults to false.
+        """
+        deprecation_warning: NotRequired[pulumi.Input[str]]
+        """
+        deprecationWarning overrides the default warning returned to API clients. May only be set when `deprecated` is true. The default warning indicates this version is deprecated and recommends use of the newest served version of equal or greater stability, if one exists.
+        """
+        schema: NotRequired[pulumi.Input['CustomResourceValidationArgsDict']]
+        """
+        schema describes the schema used for validation and pruning of this version of the custom resource. Top-level and per-version schemas are mutually exclusive. Per-version schemas must not all be set to identical values (top-level validation schema should be used instead).
+        """
+        subresources: NotRequired[pulumi.Input['CustomResourceSubresourcesArgsDict']]
+        """
+        subresources specify what subresources this version of the defined custom resource have. Top-level and per-version subresources are mutually exclusive. Per-version subresources must not all be set to identical values (top-level subresources should be used instead).
+        """
+elif False:
+    CustomResourceDefinitionVersionArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CustomResourceDefinitionVersionArgs:
     def __init__(__self__, *,
@@ -1308,6 +1736,31 @@ class CustomResourceDefinitionVersionArgs:
         pulumi.set(self, "subresources", value)
 
 
+if not MYPY:
+    class CustomResourceDefinitionArgsDict(TypedDict):
+        """
+        CustomResourceDefinition represents a resource that should be exposed on the API server.  Its name MUST be in the format <.spec.name>.<.spec.group>. Deprecated in v1.16, planned for removal in v1.19. Use apiextensions.k8s.io/v1 CustomResourceDefinition instead.
+        """
+        spec: pulumi.Input['CustomResourceDefinitionSpecArgsDict']
+        """
+        spec describes how the user wants the resources to appear
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        status: NotRequired[pulumi.Input['CustomResourceDefinitionStatusArgsDict']]
+        """
+        status indicates the actual state of the CustomResourceDefinition
+        """
+elif False:
+    CustomResourceDefinitionArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CustomResourceDefinitionArgs:
     def __init__(__self__, *,
@@ -1391,6 +1844,26 @@ class CustomResourceDefinitionArgs:
         pulumi.set(self, "status", value)
 
 
+if not MYPY:
+    class CustomResourceSubresourceScalePatchArgsDict(TypedDict):
+        """
+        CustomResourceSubresourceScale defines how to serve the scale subresource for CustomResources.
+        """
+        label_selector_path: NotRequired[pulumi.Input[str]]
+        """
+        labelSelectorPath defines the JSON path inside of a custom resource that corresponds to Scale `status.selector`. Only JSON paths without the array notation are allowed. Must be a JSON Path under `.status` or `.spec`. Must be set to work with HorizontalPodAutoscaler. The field pointed by this JSON path must be a string field (not a complex selector struct) which contains a serialized label selector in string form. More info: https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions#scale-subresource If there is no value under the given path in the custom resource, the `status.selector` value in the `/scale` subresource will default to the empty string.
+        """
+        spec_replicas_path: NotRequired[pulumi.Input[str]]
+        """
+        specReplicasPath defines the JSON path inside of a custom resource that corresponds to Scale `spec.replicas`. Only JSON paths without the array notation are allowed. Must be a JSON Path under `.spec`. If there is no value under the given path in the custom resource, the `/scale` subresource will return an error on GET.
+        """
+        status_replicas_path: NotRequired[pulumi.Input[str]]
+        """
+        statusReplicasPath defines the JSON path inside of a custom resource that corresponds to Scale `status.replicas`. Only JSON paths without the array notation are allowed. Must be a JSON Path under `.status`. If there is no value under the given path in the custom resource, the `status.replicas` value in the `/scale` subresource will default to 0.
+        """
+elif False:
+    CustomResourceSubresourceScalePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CustomResourceSubresourceScalePatchArgs:
     def __init__(__self__, *,
@@ -1447,6 +1920,26 @@ class CustomResourceSubresourceScalePatchArgs:
         pulumi.set(self, "status_replicas_path", value)
 
 
+if not MYPY:
+    class CustomResourceSubresourceScaleArgsDict(TypedDict):
+        """
+        CustomResourceSubresourceScale defines how to serve the scale subresource for CustomResources.
+        """
+        spec_replicas_path: pulumi.Input[str]
+        """
+        specReplicasPath defines the JSON path inside of a custom resource that corresponds to Scale `spec.replicas`. Only JSON paths without the array notation are allowed. Must be a JSON Path under `.spec`. If there is no value under the given path in the custom resource, the `/scale` subresource will return an error on GET.
+        """
+        status_replicas_path: pulumi.Input[str]
+        """
+        statusReplicasPath defines the JSON path inside of a custom resource that corresponds to Scale `status.replicas`. Only JSON paths without the array notation are allowed. Must be a JSON Path under `.status`. If there is no value under the given path in the custom resource, the `status.replicas` value in the `/scale` subresource will default to 0.
+        """
+        label_selector_path: NotRequired[pulumi.Input[str]]
+        """
+        labelSelectorPath defines the JSON path inside of a custom resource that corresponds to Scale `status.selector`. Only JSON paths without the array notation are allowed. Must be a JSON Path under `.status` or `.spec`. Must be set to work with HorizontalPodAutoscaler. The field pointed by this JSON path must be a string field (not a complex selector struct) which contains a serialized label selector in string form. More info: https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions#scale-subresource If there is no value under the given path in the custom resource, the `status.selector` value in the `/scale` subresource will default to the empty string.
+        """
+elif False:
+    CustomResourceSubresourceScaleArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CustomResourceSubresourceScaleArgs:
     def __init__(__self__, *,
@@ -1501,6 +1994,22 @@ class CustomResourceSubresourceScaleArgs:
         pulumi.set(self, "label_selector_path", value)
 
 
+if not MYPY:
+    class CustomResourceSubresourcesPatchArgsDict(TypedDict):
+        """
+        CustomResourceSubresources defines the status and scale subresources for CustomResources.
+        """
+        scale: NotRequired[pulumi.Input['CustomResourceSubresourceScalePatchArgsDict']]
+        """
+        scale indicates the custom resource should serve a `/scale` subresource that returns an `autoscaling/v1` Scale object.
+        """
+        status: NotRequired[Any]
+        """
+        status indicates the custom resource should serve a `/status` subresource. When enabled: 1. requests to the custom resource primary endpoint ignore changes to the `status` stanza of the object. 2. requests to the custom resource `/status` subresource ignore changes to anything other than the `status` stanza of the object.
+        """
+elif False:
+    CustomResourceSubresourcesPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CustomResourceSubresourcesPatchArgs:
     def __init__(__self__, *,
@@ -1540,6 +2049,22 @@ class CustomResourceSubresourcesPatchArgs:
     def status(self, value: Optional[Any]):
         pulumi.set(self, "status", value)
 
+
+if not MYPY:
+    class CustomResourceSubresourcesArgsDict(TypedDict):
+        """
+        CustomResourceSubresources defines the status and scale subresources for CustomResources.
+        """
+        scale: NotRequired[pulumi.Input['CustomResourceSubresourceScaleArgsDict']]
+        """
+        scale indicates the custom resource should serve a `/scale` subresource that returns an `autoscaling/v1` Scale object.
+        """
+        status: NotRequired[Any]
+        """
+        status indicates the custom resource should serve a `/status` subresource. When enabled: 1. requests to the custom resource primary endpoint ignore changes to the `status` stanza of the object. 2. requests to the custom resource `/status` subresource ignore changes to anything other than the `status` stanza of the object.
+        """
+elif False:
+    CustomResourceSubresourcesArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class CustomResourceSubresourcesArgs:
@@ -1581,6 +2106,18 @@ class CustomResourceSubresourcesArgs:
         pulumi.set(self, "status", value)
 
 
+if not MYPY:
+    class CustomResourceValidationPatchArgsDict(TypedDict):
+        """
+        CustomResourceValidation is a list of validation methods for CustomResources.
+        """
+        open_apiv3_schema: NotRequired[pulumi.Input['JSONSchemaPropsPatchArgsDict']]
+        """
+        openAPIV3Schema is the OpenAPI v3 schema to use for validation and pruning.
+        """
+elif False:
+    CustomResourceValidationPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CustomResourceValidationPatchArgs:
     def __init__(__self__, *,
@@ -1605,6 +2142,18 @@ class CustomResourceValidationPatchArgs:
         pulumi.set(self, "open_apiv3_schema", value)
 
 
+if not MYPY:
+    class CustomResourceValidationArgsDict(TypedDict):
+        """
+        CustomResourceValidation is a list of validation methods for CustomResources.
+        """
+        open_apiv3_schema: NotRequired[pulumi.Input['JSONSchemaPropsArgsDict']]
+        """
+        openAPIV3Schema is the OpenAPI v3 schema to use for validation and pruning.
+        """
+elif False:
+    CustomResourceValidationArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CustomResourceValidationArgs:
     def __init__(__self__, *,
@@ -1628,6 +2177,16 @@ class CustomResourceValidationArgs:
     def open_apiv3_schema(self, value: Optional[pulumi.Input['JSONSchemaPropsArgs']]):
         pulumi.set(self, "open_apiv3_schema", value)
 
+
+if not MYPY:
+    class ExternalDocumentationPatchArgsDict(TypedDict):
+        """
+        ExternalDocumentation allows referencing an external resource for extended documentation.
+        """
+        description: NotRequired[pulumi.Input[str]]
+        url: NotRequired[pulumi.Input[str]]
+elif False:
+    ExternalDocumentationPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ExternalDocumentationPatchArgs:
@@ -1661,6 +2220,16 @@ class ExternalDocumentationPatchArgs:
         pulumi.set(self, "url", value)
 
 
+if not MYPY:
+    class ExternalDocumentationArgsDict(TypedDict):
+        """
+        ExternalDocumentation allows referencing an external resource for extended documentation.
+        """
+        description: NotRequired[pulumi.Input[str]]
+        url: NotRequired[pulumi.Input[str]]
+elif False:
+    ExternalDocumentationArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ExternalDocumentationArgs:
     def __init__(__self__, *,
@@ -1692,6 +2261,114 @@ class ExternalDocumentationArgs:
     def url(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "url", value)
 
+
+if not MYPY:
+    class JSONSchemaPropsPatchArgsDict(TypedDict):
+        """
+        JSONSchemaProps is a JSON-Schema following Specification Draft 4 (http://json-schema.org/).
+        """
+        _ref: NotRequired[pulumi.Input[str]]
+        _schema: NotRequired[pulumi.Input[str]]
+        additional_items: NotRequired[pulumi.Input[Union['JSONSchemaPropsArgsDict', bool]]]
+        additional_properties: NotRequired[pulumi.Input[Union['JSONSchemaPropsArgsDict', bool]]]
+        all_of: NotRequired[pulumi.Input[Sequence[pulumi.Input['JSONSchemaPropsPatchArgsDict']]]]
+        any_of: NotRequired[pulumi.Input[Sequence[pulumi.Input['JSONSchemaPropsPatchArgsDict']]]]
+        default: NotRequired[Any]
+        """
+        default is a default value for undefined object fields. Defaulting is a beta feature under the CustomResourceDefaulting feature gate. CustomResourceDefinitions with defaults must be created using the v1 (or newer) CustomResourceDefinition API.
+        """
+        definitions: NotRequired[pulumi.Input[Mapping[str, pulumi.Input['JSONSchemaPropsArgsDict']]]]
+        dependencies: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[Union['JSONSchemaPropsArgsDict', Sequence[pulumi.Input[str]]]]]]]
+        description: NotRequired[pulumi.Input[str]]
+        enum: NotRequired[pulumi.Input[Sequence[Any]]]
+        example: NotRequired[Any]
+        exclusive_maximum: NotRequired[pulumi.Input[bool]]
+        exclusive_minimum: NotRequired[pulumi.Input[bool]]
+        external_docs: NotRequired[pulumi.Input['ExternalDocumentationPatchArgsDict']]
+        format: NotRequired[pulumi.Input[str]]
+        """
+        format is an OpenAPI v3 format string. Unknown formats are ignored. The following formats are validated:
+
+        - bsonobjectid: a bson object ID, i.e. a 24 characters hex string - uri: an URI as parsed by Golang net/url.ParseRequestURI - email: an email address as parsed by Golang net/mail.ParseAddress - hostname: a valid representation for an Internet host name, as defined by RFC 1034, section 3.1 [RFC1034]. - ipv4: an IPv4 IP as parsed by Golang net.ParseIP - ipv6: an IPv6 IP as parsed by Golang net.ParseIP - cidr: a CIDR as parsed by Golang net.ParseCIDR - mac: a MAC address as parsed by Golang net.ParseMAC - uuid: an UUID that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$ - uuid3: an UUID3 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?3[0-9a-f]{3}-?[0-9a-f]{4}-?[0-9a-f]{12}$ - uuid4: an UUID4 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?4[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$ - uuid5: an UUID5 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?5[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$ - isbn: an ISBN10 or ISBN13 number string like "0321751043" or "978-0321751041" - isbn10: an ISBN10 number string like "0321751043" - isbn13: an ISBN13 number string like "978-0321751041" - creditcard: a credit card number defined by the regex ^(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|6(?:011|5[0-9][0-9])[0-9]{12}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|(?:2131|1800|35\\d{3})\\d{11})$ with any non digit characters mixed in - ssn: a U.S. social security number following the regex ^\\d{3}[- ]?\\d{2}[- ]?\\d{4}$ - hexcolor: an hexadecimal color code like "#FFFFFF: following the regex ^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$ - rgbcolor: an RGB color code like rgb like "rgb(255,255,2559" - byte: base64 encoded binary data - password: any kind of string - date: a date string like "2006-01-02" as defined by full-date in RFC3339 - duration: a duration string like "22 ns" as parsed by Golang time.ParseDuration or compatible with Scala duration format - datetime: a date time string like "2014-12-15T19:30:20.000Z" as defined by date-time in RFC3339.
+        """
+        id: NotRequired[pulumi.Input[str]]
+        items: NotRequired[pulumi.Input[Union['JSONSchemaPropsArgsDict', Sequence[Any]]]]
+        max_items: NotRequired[pulumi.Input[int]]
+        max_length: NotRequired[pulumi.Input[int]]
+        max_properties: NotRequired[pulumi.Input[int]]
+        maximum: NotRequired[pulumi.Input[float]]
+        min_items: NotRequired[pulumi.Input[int]]
+        min_length: NotRequired[pulumi.Input[int]]
+        min_properties: NotRequired[pulumi.Input[int]]
+        minimum: NotRequired[pulumi.Input[float]]
+        multiple_of: NotRequired[pulumi.Input[float]]
+        not_: NotRequired[pulumi.Input['JSONSchemaPropsPatchArgsDict']]
+        nullable: NotRequired[pulumi.Input[bool]]
+        one_of: NotRequired[pulumi.Input[Sequence[pulumi.Input['JSONSchemaPropsPatchArgsDict']]]]
+        pattern: NotRequired[pulumi.Input[str]]
+        pattern_properties: NotRequired[pulumi.Input[Mapping[str, pulumi.Input['JSONSchemaPropsArgsDict']]]]
+        properties: NotRequired[pulumi.Input[Mapping[str, pulumi.Input['JSONSchemaPropsArgsDict']]]]
+        required: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        title: NotRequired[pulumi.Input[str]]
+        type: NotRequired[pulumi.Input[str]]
+        unique_items: NotRequired[pulumi.Input[bool]]
+        x_kubernetes_embedded_resource: NotRequired[pulumi.Input[bool]]
+        """
+        x-kubernetes-embedded-resource defines that the value is an embedded Kubernetes runtime.Object, with TypeMeta and ObjectMeta. The type must be object. It is allowed to further restrict the embedded object. kind, apiVersion and metadata are validated automatically. x-kubernetes-preserve-unknown-fields is allowed to be true, but does not have to be if the object is fully specified (up to kind, apiVersion, metadata).
+        """
+        x_kubernetes_int_or_string: NotRequired[pulumi.Input[bool]]
+        """
+        x-kubernetes-int-or-string specifies that this value is either an integer or a string. If this is true, an empty type is allowed and type as child of anyOf is permitted if following one of the following patterns:
+
+        1) anyOf:
+           - type: integer
+           - type: string
+        2) allOf:
+           - anyOf:
+             - type: integer
+             - type: string
+           - ... zero or more
+        """
+        x_kubernetes_list_map_keys: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        x-kubernetes-list-map-keys annotates an array with the x-kubernetes-list-type `map` by specifying the keys used as the index of the map.
+
+        This tag MUST only be used on lists that have the "x-kubernetes-list-type" extension set to "map". Also, the values specified for this attribute must be a scalar typed field of the child structure (no nesting is supported).
+        """
+        x_kubernetes_list_type: NotRequired[pulumi.Input[str]]
+        """
+        x-kubernetes-list-type annotates an array to further describe its topology. This extension must only be used on lists and may have 3 possible values:
+
+        1) `atomic`: the list is treated as a single entity, like a scalar.
+             Atomic lists will be entirely replaced when updated. This extension
+             may be used on any type of list (struct, scalar, ...).
+        2) `set`:
+             Sets are lists that must not have multiple items with the same value. Each
+             value must be a scalar, an object with x-kubernetes-map-type `atomic` or an
+             array with x-kubernetes-list-type `atomic`.
+        3) `map`:
+             These lists are like maps in that their elements have a non-index key
+             used to identify them. Order is preserved upon merge. The map tag
+             must only be used on a list with elements of type object.
+        Defaults to atomic for arrays.
+        """
+        x_kubernetes_map_type: NotRequired[pulumi.Input[str]]
+        """
+        x-kubernetes-map-type annotates an object to further describe its topology. This extension must only be used when type is object and may have 2 possible values:
+
+        1) `granular`:
+             These maps are actual maps (key-value pairs) and each fields are independent
+             from each other (they can each be manipulated by separate actors). This is
+             the default behaviour for all maps.
+        2) `atomic`: the list is treated as a single entity, like a scalar.
+             Atomic maps will be entirely replaced when updated.
+        """
+        x_kubernetes_preserve_unknown_fields: NotRequired[pulumi.Input[bool]]
+        """
+        x-kubernetes-preserve-unknown-fields stops the API server decoding step from pruning fields which are not specified in the validation schema. This affects fields recursively, but switches back to normal pruning behaviour if nested properties or additionalProperties are specified in the schema. This can either be true or undefined. False is forbidden.
+        """
+elif False:
+    JSONSchemaPropsPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class JSONSchemaPropsPatchArgs:
@@ -2315,6 +2992,114 @@ class JSONSchemaPropsPatchArgs:
         pulumi.set(self, "x_kubernetes_preserve_unknown_fields", value)
 
 
+if not MYPY:
+    class JSONSchemaPropsArgsDict(TypedDict):
+        """
+        JSONSchemaProps is a JSON-Schema following Specification Draft 4 (http://json-schema.org/).
+        """
+        _ref: NotRequired[pulumi.Input[str]]
+        _schema: NotRequired[pulumi.Input[str]]
+        additional_items: NotRequired[pulumi.Input[Union['JSONSchemaPropsArgsDict', bool]]]
+        additional_properties: NotRequired[pulumi.Input[Union['JSONSchemaPropsArgsDict', bool]]]
+        all_of: NotRequired[pulumi.Input[Sequence[pulumi.Input['JSONSchemaPropsArgsDict']]]]
+        any_of: NotRequired[pulumi.Input[Sequence[pulumi.Input['JSONSchemaPropsArgsDict']]]]
+        default: NotRequired[Any]
+        """
+        default is a default value for undefined object fields. Defaulting is a beta feature under the CustomResourceDefaulting feature gate. CustomResourceDefinitions with defaults must be created using the v1 (or newer) CustomResourceDefinition API.
+        """
+        definitions: NotRequired[pulumi.Input[Mapping[str, pulumi.Input['JSONSchemaPropsArgsDict']]]]
+        dependencies: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[Union['JSONSchemaPropsArgsDict', Sequence[pulumi.Input[str]]]]]]]
+        description: NotRequired[pulumi.Input[str]]
+        enum: NotRequired[pulumi.Input[Sequence[Any]]]
+        example: NotRequired[Any]
+        exclusive_maximum: NotRequired[pulumi.Input[bool]]
+        exclusive_minimum: NotRequired[pulumi.Input[bool]]
+        external_docs: NotRequired[pulumi.Input['ExternalDocumentationArgsDict']]
+        format: NotRequired[pulumi.Input[str]]
+        """
+        format is an OpenAPI v3 format string. Unknown formats are ignored. The following formats are validated:
+
+        - bsonobjectid: a bson object ID, i.e. a 24 characters hex string - uri: an URI as parsed by Golang net/url.ParseRequestURI - email: an email address as parsed by Golang net/mail.ParseAddress - hostname: a valid representation for an Internet host name, as defined by RFC 1034, section 3.1 [RFC1034]. - ipv4: an IPv4 IP as parsed by Golang net.ParseIP - ipv6: an IPv6 IP as parsed by Golang net.ParseIP - cidr: a CIDR as parsed by Golang net.ParseCIDR - mac: a MAC address as parsed by Golang net.ParseMAC - uuid: an UUID that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$ - uuid3: an UUID3 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?3[0-9a-f]{3}-?[0-9a-f]{4}-?[0-9a-f]{12}$ - uuid4: an UUID4 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?4[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$ - uuid5: an UUID5 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?5[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$ - isbn: an ISBN10 or ISBN13 number string like "0321751043" or "978-0321751041" - isbn10: an ISBN10 number string like "0321751043" - isbn13: an ISBN13 number string like "978-0321751041" - creditcard: a credit card number defined by the regex ^(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|6(?:011|5[0-9][0-9])[0-9]{12}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|(?:2131|1800|35\\d{3})\\d{11})$ with any non digit characters mixed in - ssn: a U.S. social security number following the regex ^\\d{3}[- ]?\\d{2}[- ]?\\d{4}$ - hexcolor: an hexadecimal color code like "#FFFFFF: following the regex ^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$ - rgbcolor: an RGB color code like rgb like "rgb(255,255,2559" - byte: base64 encoded binary data - password: any kind of string - date: a date string like "2006-01-02" as defined by full-date in RFC3339 - duration: a duration string like "22 ns" as parsed by Golang time.ParseDuration or compatible with Scala duration format - datetime: a date time string like "2014-12-15T19:30:20.000Z" as defined by date-time in RFC3339.
+        """
+        id: NotRequired[pulumi.Input[str]]
+        items: NotRequired[pulumi.Input[Union['JSONSchemaPropsArgsDict', Sequence[Any]]]]
+        max_items: NotRequired[pulumi.Input[int]]
+        max_length: NotRequired[pulumi.Input[int]]
+        max_properties: NotRequired[pulumi.Input[int]]
+        maximum: NotRequired[pulumi.Input[float]]
+        min_items: NotRequired[pulumi.Input[int]]
+        min_length: NotRequired[pulumi.Input[int]]
+        min_properties: NotRequired[pulumi.Input[int]]
+        minimum: NotRequired[pulumi.Input[float]]
+        multiple_of: NotRequired[pulumi.Input[float]]
+        not_: NotRequired[pulumi.Input['JSONSchemaPropsArgsDict']]
+        nullable: NotRequired[pulumi.Input[bool]]
+        one_of: NotRequired[pulumi.Input[Sequence[pulumi.Input['JSONSchemaPropsArgsDict']]]]
+        pattern: NotRequired[pulumi.Input[str]]
+        pattern_properties: NotRequired[pulumi.Input[Mapping[str, pulumi.Input['JSONSchemaPropsArgsDict']]]]
+        properties: NotRequired[pulumi.Input[Mapping[str, pulumi.Input['JSONSchemaPropsArgsDict']]]]
+        required: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        title: NotRequired[pulumi.Input[str]]
+        type: NotRequired[pulumi.Input[str]]
+        unique_items: NotRequired[pulumi.Input[bool]]
+        x_kubernetes_embedded_resource: NotRequired[pulumi.Input[bool]]
+        """
+        x-kubernetes-embedded-resource defines that the value is an embedded Kubernetes runtime.Object, with TypeMeta and ObjectMeta. The type must be object. It is allowed to further restrict the embedded object. kind, apiVersion and metadata are validated automatically. x-kubernetes-preserve-unknown-fields is allowed to be true, but does not have to be if the object is fully specified (up to kind, apiVersion, metadata).
+        """
+        x_kubernetes_int_or_string: NotRequired[pulumi.Input[bool]]
+        """
+        x-kubernetes-int-or-string specifies that this value is either an integer or a string. If this is true, an empty type is allowed and type as child of anyOf is permitted if following one of the following patterns:
+
+        1) anyOf:
+           - type: integer
+           - type: string
+        2) allOf:
+           - anyOf:
+             - type: integer
+             - type: string
+           - ... zero or more
+        """
+        x_kubernetes_list_map_keys: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        x-kubernetes-list-map-keys annotates an array with the x-kubernetes-list-type `map` by specifying the keys used as the index of the map.
+
+        This tag MUST only be used on lists that have the "x-kubernetes-list-type" extension set to "map". Also, the values specified for this attribute must be a scalar typed field of the child structure (no nesting is supported).
+        """
+        x_kubernetes_list_type: NotRequired[pulumi.Input[str]]
+        """
+        x-kubernetes-list-type annotates an array to further describe its topology. This extension must only be used on lists and may have 3 possible values:
+
+        1) `atomic`: the list is treated as a single entity, like a scalar.
+             Atomic lists will be entirely replaced when updated. This extension
+             may be used on any type of list (struct, scalar, ...).
+        2) `set`:
+             Sets are lists that must not have multiple items with the same value. Each
+             value must be a scalar, an object with x-kubernetes-map-type `atomic` or an
+             array with x-kubernetes-list-type `atomic`.
+        3) `map`:
+             These lists are like maps in that their elements have a non-index key
+             used to identify them. Order is preserved upon merge. The map tag
+             must only be used on a list with elements of type object.
+        Defaults to atomic for arrays.
+        """
+        x_kubernetes_map_type: NotRequired[pulumi.Input[str]]
+        """
+        x-kubernetes-map-type annotates an object to further describe its topology. This extension must only be used when type is object and may have 2 possible values:
+
+        1) `granular`:
+             These maps are actual maps (key-value pairs) and each fields are independent
+             from each other (they can each be manipulated by separate actors). This is
+             the default behaviour for all maps.
+        2) `atomic`: the list is treated as a single entity, like a scalar.
+             Atomic maps will be entirely replaced when updated.
+        """
+        x_kubernetes_preserve_unknown_fields: NotRequired[pulumi.Input[bool]]
+        """
+        x-kubernetes-preserve-unknown-fields stops the API server decoding step from pruning fields which are not specified in the validation schema. This affects fields recursively, but switches back to normal pruning behaviour if nested properties or additionalProperties are specified in the schema. This can either be true or undefined. False is forbidden.
+        """
+elif False:
+    JSONSchemaPropsArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class JSONSchemaPropsArgs:
     def __init__(__self__, *,
@@ -2937,6 +3722,30 @@ class JSONSchemaPropsArgs:
         pulumi.set(self, "x_kubernetes_preserve_unknown_fields", value)
 
 
+if not MYPY:
+    class ServiceReferencePatchArgsDict(TypedDict):
+        """
+        ServiceReference holds a reference to Service.legacy.k8s.io
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        name is the name of the service. Required
+        """
+        namespace: NotRequired[pulumi.Input[str]]
+        """
+        namespace is the namespace of the service. Required
+        """
+        path: NotRequired[pulumi.Input[str]]
+        """
+        path is an optional URL path at which the webhook will be contacted.
+        """
+        port: NotRequired[pulumi.Input[int]]
+        """
+        port is an optional service port at which the webhook will be contacted. `port` should be a valid port number (1-65535, inclusive). Defaults to 443 for backward compatibility.
+        """
+elif False:
+    ServiceReferencePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ServiceReferencePatchArgs:
     def __init__(__self__, *,
@@ -3009,6 +3818,30 @@ class ServiceReferencePatchArgs:
         pulumi.set(self, "port", value)
 
 
+if not MYPY:
+    class ServiceReferenceArgsDict(TypedDict):
+        """
+        ServiceReference holds a reference to Service.legacy.k8s.io
+        """
+        name: pulumi.Input[str]
+        """
+        name is the name of the service. Required
+        """
+        namespace: pulumi.Input[str]
+        """
+        namespace is the namespace of the service. Required
+        """
+        path: NotRequired[pulumi.Input[str]]
+        """
+        path is an optional URL path at which the webhook will be contacted.
+        """
+        port: NotRequired[pulumi.Input[int]]
+        """
+        port is an optional service port at which the webhook will be contacted. `port` should be a valid port number (1-65535, inclusive). Defaults to 443 for backward compatibility.
+        """
+elif False:
+    ServiceReferenceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ServiceReferenceArgs:
     def __init__(__self__, *,
@@ -3078,6 +3911,38 @@ class ServiceReferenceArgs:
     def port(self, value: Optional[pulumi.Input[int]]):
         pulumi.set(self, "port", value)
 
+
+if not MYPY:
+    class WebhookClientConfigPatchArgsDict(TypedDict):
+        """
+        WebhookClientConfig contains the information to make a TLS connection with the webhook.
+        """
+        ca_bundle: NotRequired[pulumi.Input[str]]
+        """
+        caBundle is a PEM encoded CA bundle which will be used to validate the webhook's server certificate. If unspecified, system trust roots on the apiserver are used.
+        """
+        service: NotRequired[pulumi.Input['ServiceReferencePatchArgsDict']]
+        """
+        service is a reference to the service for this webhook. Either service or url must be specified.
+
+        If the webhook is running within the cluster, then you should use `service`.
+        """
+        url: NotRequired[pulumi.Input[str]]
+        """
+        url gives the location of the webhook, in standard URL form (`scheme://host:port/path`). Exactly one of `url` or `service` must be specified.
+
+        The `host` should not refer to a service running in the cluster; use the `service` field instead. The host might be resolved via external DNS in some apiservers (e.g., `kube-apiserver` cannot resolve in-cluster DNS as that would be a layering violation). `host` may also be an IP address.
+
+        Please note that using `localhost` or `127.0.0.1` as a `host` is risky unless you take great care to run this webhook on all hosts which run an apiserver which might need to make calls to this webhook. Such installs are likely to be non-portable, i.e., not easy to turn up in a new cluster.
+
+        The scheme must be "https"; the URL must begin with "https://".
+
+        A path is optional, and if present may be any string permissible in a URL. You may use the path to pass an arbitrary string to the webhook, for example, a cluster identifier.
+
+        Attempting to use a user or basic auth e.g. "user:password@" is not allowed. Fragments ("#...") and query parameters ("?...") are not allowed, either.
+        """
+elif False:
+    WebhookClientConfigPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class WebhookClientConfigPatchArgs:
@@ -3158,6 +4023,38 @@ class WebhookClientConfigPatchArgs:
     def url(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "url", value)
 
+
+if not MYPY:
+    class WebhookClientConfigArgsDict(TypedDict):
+        """
+        WebhookClientConfig contains the information to make a TLS connection with the webhook.
+        """
+        ca_bundle: NotRequired[pulumi.Input[str]]
+        """
+        caBundle is a PEM encoded CA bundle which will be used to validate the webhook's server certificate. If unspecified, system trust roots on the apiserver are used.
+        """
+        service: NotRequired[pulumi.Input['ServiceReferenceArgsDict']]
+        """
+        service is a reference to the service for this webhook. Either service or url must be specified.
+
+        If the webhook is running within the cluster, then you should use `service`.
+        """
+        url: NotRequired[pulumi.Input[str]]
+        """
+        url gives the location of the webhook, in standard URL form (`scheme://host:port/path`). Exactly one of `url` or `service` must be specified.
+
+        The `host` should not refer to a service running in the cluster; use the `service` field instead. The host might be resolved via external DNS in some apiservers (e.g., `kube-apiserver` cannot resolve in-cluster DNS as that would be a layering violation). `host` may also be an IP address.
+
+        Please note that using `localhost` or `127.0.0.1` as a `host` is risky unless you take great care to run this webhook on all hosts which run an apiserver which might need to make calls to this webhook. Such installs are likely to be non-portable, i.e., not easy to turn up in a new cluster.
+
+        The scheme must be "https"; the URL must begin with "https://".
+
+        A path is optional, and if present may be any string permissible in a URL. You may use the path to pass an arbitrary string to the webhook, for example, a cluster identifier.
+
+        Attempting to use a user or basic auth e.g. "user:password@" is not allowed. Fragments ("#...") and query parameters ("?...") are not allowed, either.
+        """
+elif False:
+    WebhookClientConfigArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class WebhookClientConfigArgs:

--- a/sdk/python/pulumi_kubernetes/apiextensions/v1beta1/outputs.py
+++ b/sdk/python/pulumi_kubernetes/apiextensions/v1beta1/outputs.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta

--- a/sdk/python/pulumi_kubernetes/apiregistration/v1/APIService.py
+++ b/sdk/python/pulumi_kubernetes/apiregistration/v1/APIService.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class APIService(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['APIServiceSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['APIServiceSpecArgs', 'APIServiceSpecArgsDict']]] = None,
                  __props__=None):
         """
         APIService represents a server for a particular GroupVersion. Name must be "version.group".
@@ -103,8 +108,8 @@ class APIService(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['APIServiceSpecArgs']] spec: Spec contains information for locating and communicating with a server
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['APIServiceSpecArgs', 'APIServiceSpecArgsDict']] spec: Spec contains information for locating and communicating with a server
         """
         ...
     @overload
@@ -132,8 +137,8 @@ class APIService(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['APIServiceSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['APIServiceSpecArgs', 'APIServiceSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/apiregistration/v1/APIServiceList.py
+++ b/sdk/python/pulumi_kubernetes/apiregistration/v1/APIServiceList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class APIServiceList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['APIServiceArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['APIServiceArgs', 'APIServiceArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         APIServiceList is a list of APIService objects.
@@ -101,9 +106,9 @@ class APIServiceList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['APIServiceArgs']]]] items: Items is the list of APIService
+        :param pulumi.Input[Sequence[pulumi.Input[Union['APIServiceArgs', 'APIServiceArgsDict']]]] items: Items is the list of APIService
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class APIServiceList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['APIServiceArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['APIServiceArgs', 'APIServiceArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/apiregistration/v1/APIServicePatch.py
+++ b/sdk/python/pulumi_kubernetes/apiregistration/v1/APIServicePatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class APIServicePatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['APIServiceSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['APIServiceSpecPatchArgs', 'APIServiceSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -109,8 +114,8 @@ class APIServicePatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['APIServiceSpecPatchArgs']] spec: Spec contains information for locating and communicating with a server
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['APIServiceSpecPatchArgs', 'APIServiceSpecPatchArgsDict']] spec: Spec contains information for locating and communicating with a server
         """
         ...
     @overload
@@ -144,8 +149,8 @@ class APIServicePatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['APIServiceSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['APIServiceSpecPatchArgs', 'APIServiceSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/apiregistration/v1/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/apiregistration/v1/_inputs.py
@@ -4,21 +4,63 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import meta as _meta
 
 __all__ = [
     'APIServiceConditionArgs',
+    'APIServiceConditionArgsDict',
     'APIServiceSpecPatchArgs',
+    'APIServiceSpecPatchArgsDict',
     'APIServiceSpecArgs',
+    'APIServiceSpecArgsDict',
     'APIServiceStatusArgs',
+    'APIServiceStatusArgsDict',
     'APIServiceArgs',
+    'APIServiceArgsDict',
     'ServiceReferencePatchArgs',
+    'ServiceReferencePatchArgsDict',
     'ServiceReferenceArgs',
+    'ServiceReferenceArgsDict',
 ]
+
+MYPY = False
+
+if not MYPY:
+    class APIServiceConditionArgsDict(TypedDict):
+        """
+        APIServiceCondition describes the state of an APIService at a particular point
+        """
+        status: pulumi.Input[str]
+        """
+        Status is the status of the condition. Can be True, False, Unknown.
+        """
+        type: pulumi.Input[str]
+        """
+        Type is the type of the condition.
+        """
+        last_transition_time: NotRequired[pulumi.Input[str]]
+        """
+        Last time the condition transitioned from one status to another.
+        """
+        message: NotRequired[pulumi.Input[str]]
+        """
+        Human-readable message indicating details about last transition.
+        """
+        reason: NotRequired[pulumi.Input[str]]
+        """
+        Unique, one-word, CamelCase reason for the condition's last transition.
+        """
+elif False:
+    APIServiceConditionArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class APIServiceConditionArgs:
@@ -105,6 +147,42 @@ class APIServiceConditionArgs:
     def reason(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "reason", value)
 
+
+if not MYPY:
+    class APIServiceSpecPatchArgsDict(TypedDict):
+        """
+        APIServiceSpec contains information for locating and communicating with a server. Only https is supported, though you are able to disable certificate verification.
+        """
+        ca_bundle: NotRequired[pulumi.Input[str]]
+        """
+        CABundle is a PEM encoded CA bundle which will be used to validate an API server's serving certificate. If unspecified, system trust roots on the apiserver are used.
+        """
+        group: NotRequired[pulumi.Input[str]]
+        """
+        Group is the API group name this server hosts
+        """
+        group_priority_minimum: NotRequired[pulumi.Input[int]]
+        """
+        GroupPriorityMinimum is the priority this group should have at least. Higher priority means that the group is preferred by clients over lower priority ones. Note that other versions of this group might specify even higher GroupPriorityMinimum values such that the whole group gets a higher priority. The primary sort is based on GroupPriorityMinimum, ordered highest number to lowest (20 before 10). The secondary sort is based on the alphabetical comparison of the name of the object.  (v1.bar before v1.foo) We'd recommend something like: *.k8s.io (except extensions) at 18000 and PaaSes (OpenShift, Deis) are recommended to be in the 2000s
+        """
+        insecure_skip_tls_verify: NotRequired[pulumi.Input[bool]]
+        """
+        InsecureSkipTLSVerify disables TLS certificate verification when communicating with this server. This is strongly discouraged.  You should use the CABundle instead.
+        """
+        service: NotRequired[pulumi.Input['ServiceReferencePatchArgsDict']]
+        """
+        Service is a reference to the service for this API server.  It must communicate on port 443. If the Service is nil, that means the handling for the API groupversion is handled locally on this server. The call will simply delegate to the normal handler chain to be fulfilled.
+        """
+        version: NotRequired[pulumi.Input[str]]
+        """
+        Version is the API version this server hosts.  For example, "v1"
+        """
+        version_priority: NotRequired[pulumi.Input[int]]
+        """
+        VersionPriority controls the ordering of this API version inside of its group.  Must be greater than zero. The primary sort is based on VersionPriority, ordered highest to lowest (20 before 10). Since it's inside of a group, the number can be small, probably in the 10s. In case of equal version priorities, the version string will be used to compute the order inside a group. If the version string is "kube-like", it will sort above non "kube-like" version strings, which are ordered lexicographically. "Kube-like" versions start with a "v", then are followed by a number (the major version), then optionally the string "alpha" or "beta" and another number (the minor version). These are sorted first by GA > beta > alpha (where GA is a version with no suffix such as beta or alpha), and then by comparing major version, then minor version. An example sorted list of versions: v10, v2, v1, v11beta2, v10beta3, v3beta1, v12alpha1, v11alpha2, foo1, foo10.
+        """
+elif False:
+    APIServiceSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class APIServiceSpecPatchArgs:
@@ -226,6 +304,42 @@ class APIServiceSpecPatchArgs:
         pulumi.set(self, "version_priority", value)
 
 
+if not MYPY:
+    class APIServiceSpecArgsDict(TypedDict):
+        """
+        APIServiceSpec contains information for locating and communicating with a server. Only https is supported, though you are able to disable certificate verification.
+        """
+        group_priority_minimum: pulumi.Input[int]
+        """
+        GroupPriorityMinimum is the priority this group should have at least. Higher priority means that the group is preferred by clients over lower priority ones. Note that other versions of this group might specify even higher GroupPriorityMinimum values such that the whole group gets a higher priority. The primary sort is based on GroupPriorityMinimum, ordered highest number to lowest (20 before 10). The secondary sort is based on the alphabetical comparison of the name of the object.  (v1.bar before v1.foo) We'd recommend something like: *.k8s.io (except extensions) at 18000 and PaaSes (OpenShift, Deis) are recommended to be in the 2000s
+        """
+        version_priority: pulumi.Input[int]
+        """
+        VersionPriority controls the ordering of this API version inside of its group.  Must be greater than zero. The primary sort is based on VersionPriority, ordered highest to lowest (20 before 10). Since it's inside of a group, the number can be small, probably in the 10s. In case of equal version priorities, the version string will be used to compute the order inside a group. If the version string is "kube-like", it will sort above non "kube-like" version strings, which are ordered lexicographically. "Kube-like" versions start with a "v", then are followed by a number (the major version), then optionally the string "alpha" or "beta" and another number (the minor version). These are sorted first by GA > beta > alpha (where GA is a version with no suffix such as beta or alpha), and then by comparing major version, then minor version. An example sorted list of versions: v10, v2, v1, v11beta2, v10beta3, v3beta1, v12alpha1, v11alpha2, foo1, foo10.
+        """
+        ca_bundle: NotRequired[pulumi.Input[str]]
+        """
+        CABundle is a PEM encoded CA bundle which will be used to validate an API server's serving certificate. If unspecified, system trust roots on the apiserver are used.
+        """
+        group: NotRequired[pulumi.Input[str]]
+        """
+        Group is the API group name this server hosts
+        """
+        insecure_skip_tls_verify: NotRequired[pulumi.Input[bool]]
+        """
+        InsecureSkipTLSVerify disables TLS certificate verification when communicating with this server. This is strongly discouraged.  You should use the CABundle instead.
+        """
+        service: NotRequired[pulumi.Input['ServiceReferenceArgsDict']]
+        """
+        Service is a reference to the service for this API server.  It must communicate on port 443. If the Service is nil, that means the handling for the API groupversion is handled locally on this server. The call will simply delegate to the normal handler chain to be fulfilled.
+        """
+        version: NotRequired[pulumi.Input[str]]
+        """
+        Version is the API version this server hosts.  For example, "v1"
+        """
+elif False:
+    APIServiceSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class APIServiceSpecArgs:
     def __init__(__self__, *,
@@ -344,6 +458,18 @@ class APIServiceSpecArgs:
         pulumi.set(self, "version", value)
 
 
+if not MYPY:
+    class APIServiceStatusArgsDict(TypedDict):
+        """
+        APIServiceStatus contains derived information about an API server
+        """
+        conditions: NotRequired[pulumi.Input[Sequence[pulumi.Input['APIServiceConditionArgsDict']]]]
+        """
+        Current service state of apiService.
+        """
+elif False:
+    APIServiceStatusArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class APIServiceStatusArgs:
     def __init__(__self__, *,
@@ -367,6 +493,34 @@ class APIServiceStatusArgs:
     def conditions(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['APIServiceConditionArgs']]]]):
         pulumi.set(self, "conditions", value)
 
+
+if not MYPY:
+    class APIServiceArgsDict(TypedDict):
+        """
+        APIService represents a server for a particular GroupVersion. Name must be "version.group".
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['APIServiceSpecArgsDict']]
+        """
+        Spec contains information for locating and communicating with a server
+        """
+        status: NotRequired[pulumi.Input['APIServiceStatusArgsDict']]
+        """
+        Status contains derived information about an API server
+        """
+elif False:
+    APIServiceArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class APIServiceArgs:
@@ -456,6 +610,26 @@ class APIServiceArgs:
         pulumi.set(self, "status", value)
 
 
+if not MYPY:
+    class ServiceReferencePatchArgsDict(TypedDict):
+        """
+        ServiceReference holds a reference to Service.legacy.k8s.io
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name is the name of the service
+        """
+        namespace: NotRequired[pulumi.Input[str]]
+        """
+        Namespace is the namespace of the service
+        """
+        port: NotRequired[pulumi.Input[int]]
+        """
+        If specified, the port on the service that hosting webhook. Default to 443 for backward compatibility. `port` should be a valid port number (1-65535, inclusive).
+        """
+elif False:
+    ServiceReferencePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ServiceReferencePatchArgs:
     def __init__(__self__, *,
@@ -511,6 +685,26 @@ class ServiceReferencePatchArgs:
     def port(self, value: Optional[pulumi.Input[int]]):
         pulumi.set(self, "port", value)
 
+
+if not MYPY:
+    class ServiceReferenceArgsDict(TypedDict):
+        """
+        ServiceReference holds a reference to Service.legacy.k8s.io
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name is the name of the service
+        """
+        namespace: NotRequired[pulumi.Input[str]]
+        """
+        Namespace is the namespace of the service
+        """
+        port: NotRequired[pulumi.Input[int]]
+        """
+        If specified, the port on the service that hosting webhook. Default to 443 for backward compatibility. `port` should be a valid port number (1-65535, inclusive).
+        """
+elif False:
+    ServiceReferenceArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ServiceReferenceArgs:

--- a/sdk/python/pulumi_kubernetes/apiregistration/v1/outputs.py
+++ b/sdk/python/pulumi_kubernetes/apiregistration/v1/outputs.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta

--- a/sdk/python/pulumi_kubernetes/apiregistration/v1beta1/APIService.py
+++ b/sdk/python/pulumi_kubernetes/apiregistration/v1beta1/APIService.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -89,8 +94,8 @@ class APIService(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['APIServiceSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['APIServiceSpecArgs', 'APIServiceSpecArgsDict']]] = None,
                  __props__=None):
         """
         APIService represents a server for a particular GroupVersion. Name must be "version.group".
@@ -99,7 +104,7 @@ class APIService(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['APIServiceSpecArgs']] spec: Spec contains information for locating and communicating with a server
+        :param pulumi.Input[Union['APIServiceSpecArgs', 'APIServiceSpecArgsDict']] spec: Spec contains information for locating and communicating with a server
         """
         ...
     @overload
@@ -127,8 +132,8 @@ class APIService(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['APIServiceSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['APIServiceSpecArgs', 'APIServiceSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/apiregistration/v1beta1/APIServiceList.py
+++ b/sdk/python/pulumi_kubernetes/apiregistration/v1beta1/APIServiceList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -83,9 +88,9 @@ class APIServiceList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['APIServiceArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['APIServiceArgs', 'APIServiceArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         APIServiceList is a list of APIService objects.
@@ -120,9 +125,9 @@ class APIServiceList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['APIServiceArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['APIServiceArgs', 'APIServiceArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/apiregistration/v1beta1/APIServicePatch.py
+++ b/sdk/python/pulumi_kubernetes/apiregistration/v1beta1/APIServicePatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -89,8 +94,8 @@ class APIServicePatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['APIServiceSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['APIServiceSpecPatchArgs', 'APIServiceSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -105,7 +110,7 @@ class APIServicePatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['APIServiceSpecPatchArgs']] spec: Spec contains information for locating and communicating with a server
+        :param pulumi.Input[Union['APIServiceSpecPatchArgs', 'APIServiceSpecPatchArgsDict']] spec: Spec contains information for locating and communicating with a server
         """
         ...
     @overload
@@ -139,8 +144,8 @@ class APIServicePatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['APIServiceSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['APIServiceSpecPatchArgs', 'APIServiceSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/apiregistration/v1beta1/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/apiregistration/v1beta1/_inputs.py
@@ -4,21 +4,63 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import meta as _meta
 
 __all__ = [
     'APIServiceConditionArgs',
+    'APIServiceConditionArgsDict',
     'APIServiceSpecPatchArgs',
+    'APIServiceSpecPatchArgsDict',
     'APIServiceSpecArgs',
+    'APIServiceSpecArgsDict',
     'APIServiceStatusArgs',
+    'APIServiceStatusArgsDict',
     'APIServiceArgs',
+    'APIServiceArgsDict',
     'ServiceReferencePatchArgs',
+    'ServiceReferencePatchArgsDict',
     'ServiceReferenceArgs',
+    'ServiceReferenceArgsDict',
 ]
+
+MYPY = False
+
+if not MYPY:
+    class APIServiceConditionArgsDict(TypedDict):
+        """
+        APIServiceCondition describes the state of an APIService at a particular point
+        """
+        status: pulumi.Input[str]
+        """
+        Status is the status of the condition. Can be True, False, Unknown.
+        """
+        type: pulumi.Input[str]
+        """
+        Type is the type of the condition.
+        """
+        last_transition_time: NotRequired[pulumi.Input[str]]
+        """
+        Last time the condition transitioned from one status to another.
+        """
+        message: NotRequired[pulumi.Input[str]]
+        """
+        Human-readable message indicating details about last transition.
+        """
+        reason: NotRequired[pulumi.Input[str]]
+        """
+        Unique, one-word, CamelCase reason for the condition's last transition.
+        """
+elif False:
+    APIServiceConditionArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class APIServiceConditionArgs:
@@ -105,6 +147,42 @@ class APIServiceConditionArgs:
     def reason(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "reason", value)
 
+
+if not MYPY:
+    class APIServiceSpecPatchArgsDict(TypedDict):
+        """
+        APIServiceSpec contains information for locating and communicating with a server. Only https is supported, though you are able to disable certificate verification.
+        """
+        ca_bundle: NotRequired[pulumi.Input[str]]
+        """
+        CABundle is a PEM encoded CA bundle which will be used to validate an API server's serving certificate. If unspecified, system trust roots on the apiserver are used.
+        """
+        group: NotRequired[pulumi.Input[str]]
+        """
+        Group is the API group name this server hosts
+        """
+        group_priority_minimum: NotRequired[pulumi.Input[int]]
+        """
+        GroupPriorityMininum is the priority this group should have at least. Higher priority means that the group is preferred by clients over lower priority ones. Note that other versions of this group might specify even higher GroupPriorityMininum values such that the whole group gets a higher priority. The primary sort is based on GroupPriorityMinimum, ordered highest number to lowest (20 before 10). The secondary sort is based on the alphabetical comparison of the name of the object.  (v1.bar before v1.foo) We'd recommend something like: *.k8s.io (except extensions) at 18000 and PaaSes (OpenShift, Deis) are recommended to be in the 2000s
+        """
+        insecure_skip_tls_verify: NotRequired[pulumi.Input[bool]]
+        """
+        InsecureSkipTLSVerify disables TLS certificate verification when communicating with this server. This is strongly discouraged.  You should use the CABundle instead.
+        """
+        service: NotRequired[pulumi.Input['ServiceReferencePatchArgsDict']]
+        """
+        Service is a reference to the service for this API server.  It must communicate on port 443 If the Service is nil, that means the handling for the API groupversion is handled locally on this server. The call will simply delegate to the normal handler chain to be fulfilled.
+        """
+        version: NotRequired[pulumi.Input[str]]
+        """
+        Version is the API version this server hosts.  For example, "v1"
+        """
+        version_priority: NotRequired[pulumi.Input[int]]
+        """
+        VersionPriority controls the ordering of this API version inside of its group.  Must be greater than zero. The primary sort is based on VersionPriority, ordered highest to lowest (20 before 10). Since it's inside of a group, the number can be small, probably in the 10s. In case of equal version priorities, the version string will be used to compute the order inside a group. If the version string is "kube-like", it will sort above non "kube-like" version strings, which are ordered lexicographically. "Kube-like" versions start with a "v", then are followed by a number (the major version), then optionally the string "alpha" or "beta" and another number (the minor version). These are sorted first by GA > beta > alpha (where GA is a version with no suffix such as beta or alpha), and then by comparing major version, then minor version. An example sorted list of versions: v10, v2, v1, v11beta2, v10beta3, v3beta1, v12alpha1, v11alpha2, foo1, foo10.
+        """
+elif False:
+    APIServiceSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class APIServiceSpecPatchArgs:
@@ -226,6 +304,42 @@ class APIServiceSpecPatchArgs:
         pulumi.set(self, "version_priority", value)
 
 
+if not MYPY:
+    class APIServiceSpecArgsDict(TypedDict):
+        """
+        APIServiceSpec contains information for locating and communicating with a server. Only https is supported, though you are able to disable certificate verification.
+        """
+        group_priority_minimum: pulumi.Input[int]
+        """
+        GroupPriorityMininum is the priority this group should have at least. Higher priority means that the group is preferred by clients over lower priority ones. Note that other versions of this group might specify even higher GroupPriorityMininum values such that the whole group gets a higher priority. The primary sort is based on GroupPriorityMinimum, ordered highest number to lowest (20 before 10). The secondary sort is based on the alphabetical comparison of the name of the object.  (v1.bar before v1.foo) We'd recommend something like: *.k8s.io (except extensions) at 18000 and PaaSes (OpenShift, Deis) are recommended to be in the 2000s
+        """
+        service: pulumi.Input['ServiceReferenceArgsDict']
+        """
+        Service is a reference to the service for this API server.  It must communicate on port 443 If the Service is nil, that means the handling for the API groupversion is handled locally on this server. The call will simply delegate to the normal handler chain to be fulfilled.
+        """
+        version_priority: pulumi.Input[int]
+        """
+        VersionPriority controls the ordering of this API version inside of its group.  Must be greater than zero. The primary sort is based on VersionPriority, ordered highest to lowest (20 before 10). Since it's inside of a group, the number can be small, probably in the 10s. In case of equal version priorities, the version string will be used to compute the order inside a group. If the version string is "kube-like", it will sort above non "kube-like" version strings, which are ordered lexicographically. "Kube-like" versions start with a "v", then are followed by a number (the major version), then optionally the string "alpha" or "beta" and another number (the minor version). These are sorted first by GA > beta > alpha (where GA is a version with no suffix such as beta or alpha), and then by comparing major version, then minor version. An example sorted list of versions: v10, v2, v1, v11beta2, v10beta3, v3beta1, v12alpha1, v11alpha2, foo1, foo10.
+        """
+        ca_bundle: NotRequired[pulumi.Input[str]]
+        """
+        CABundle is a PEM encoded CA bundle which will be used to validate an API server's serving certificate. If unspecified, system trust roots on the apiserver are used.
+        """
+        group: NotRequired[pulumi.Input[str]]
+        """
+        Group is the API group name this server hosts
+        """
+        insecure_skip_tls_verify: NotRequired[pulumi.Input[bool]]
+        """
+        InsecureSkipTLSVerify disables TLS certificate verification when communicating with this server. This is strongly discouraged.  You should use the CABundle instead.
+        """
+        version: NotRequired[pulumi.Input[str]]
+        """
+        Version is the API version this server hosts.  For example, "v1"
+        """
+elif False:
+    APIServiceSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class APIServiceSpecArgs:
     def __init__(__self__, *,
@@ -343,6 +457,18 @@ class APIServiceSpecArgs:
         pulumi.set(self, "version", value)
 
 
+if not MYPY:
+    class APIServiceStatusArgsDict(TypedDict):
+        """
+        APIServiceStatus contains derived information about an API server
+        """
+        conditions: NotRequired[pulumi.Input[Sequence[pulumi.Input['APIServiceConditionArgsDict']]]]
+        """
+        Current service state of apiService.
+        """
+elif False:
+    APIServiceStatusArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class APIServiceStatusArgs:
     def __init__(__self__, *,
@@ -366,6 +492,31 @@ class APIServiceStatusArgs:
     def conditions(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['APIServiceConditionArgs']]]]):
         pulumi.set(self, "conditions", value)
 
+
+if not MYPY:
+    class APIServiceArgsDict(TypedDict):
+        """
+        APIService represents a server for a particular GroupVersion. Name must be "version.group".
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        spec: NotRequired[pulumi.Input['APIServiceSpecArgsDict']]
+        """
+        Spec contains information for locating and communicating with a server
+        """
+        status: NotRequired[pulumi.Input['APIServiceStatusArgsDict']]
+        """
+        Status contains derived information about an API server
+        """
+elif False:
+    APIServiceArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class APIServiceArgs:
@@ -451,6 +602,26 @@ class APIServiceArgs:
         pulumi.set(self, "status", value)
 
 
+if not MYPY:
+    class ServiceReferencePatchArgsDict(TypedDict):
+        """
+        ServiceReference holds a reference to Service.legacy.k8s.io
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name is the name of the service
+        """
+        namespace: NotRequired[pulumi.Input[str]]
+        """
+        Namespace is the namespace of the service
+        """
+        port: NotRequired[pulumi.Input[int]]
+        """
+        If specified, the port on the service that hosting webhook. Default to 443 for backward compatibility. `port` should be a valid port number (1-65535, inclusive).
+        """
+elif False:
+    ServiceReferencePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ServiceReferencePatchArgs:
     def __init__(__self__, *,
@@ -506,6 +677,26 @@ class ServiceReferencePatchArgs:
     def port(self, value: Optional[pulumi.Input[int]]):
         pulumi.set(self, "port", value)
 
+
+if not MYPY:
+    class ServiceReferenceArgsDict(TypedDict):
+        """
+        ServiceReference holds a reference to Service.legacy.k8s.io
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name is the name of the service
+        """
+        namespace: NotRequired[pulumi.Input[str]]
+        """
+        Namespace is the namespace of the service
+        """
+        port: NotRequired[pulumi.Input[int]]
+        """
+        If specified, the port on the service that hosting webhook. Default to 443 for backward compatibility. `port` should be a valid port number (1-65535, inclusive).
+        """
+elif False:
+    ServiceReferenceArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ServiceReferenceArgs:

--- a/sdk/python/pulumi_kubernetes/apiregistration/v1beta1/outputs.py
+++ b/sdk/python/pulumi_kubernetes/apiregistration/v1beta1/outputs.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta

--- a/sdk/python/pulumi_kubernetes/apps/v1/ControllerRevision.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1/ControllerRevision.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import meta as _meta
 
@@ -107,7 +112,7 @@ class ControllerRevision(pulumi.CustomResource):
                  api_version: Optional[pulumi.Input[str]] = None,
                  data: Optional[Any] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
                  revision: Optional[pulumi.Input[int]] = None,
                  __props__=None):
         """
@@ -118,7 +123,7 @@ class ControllerRevision(pulumi.CustomResource):
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param Any data: Data is the serialized representation of the state.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         :param pulumi.Input[int] revision: Revision indicates the revision of the state represented by Data.
         """
         ...
@@ -148,7 +153,7 @@ class ControllerRevision(pulumi.CustomResource):
                  api_version: Optional[pulumi.Input[str]] = None,
                  data: Optional[Any] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
                  revision: Optional[pulumi.Input[int]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)

--- a/sdk/python/pulumi_kubernetes/apps/v1/ControllerRevisionList.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1/ControllerRevisionList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class ControllerRevisionList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ControllerRevisionArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ControllerRevisionArgs', 'ControllerRevisionArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         ControllerRevisionList is a resource containing a list of ControllerRevision objects.
@@ -101,9 +106,9 @@ class ControllerRevisionList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ControllerRevisionArgs']]]] items: Items is the list of ControllerRevisions
+        :param pulumi.Input[Sequence[pulumi.Input[Union['ControllerRevisionArgs', 'ControllerRevisionArgsDict']]]] items: Items is the list of ControllerRevisions
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class ControllerRevisionList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ControllerRevisionArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ControllerRevisionArgs', 'ControllerRevisionArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/apps/v1/ControllerRevisionPatch.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1/ControllerRevisionPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import meta as _meta
 
@@ -108,7 +113,7 @@ class ControllerRevisionPatch(pulumi.CustomResource):
                  api_version: Optional[pulumi.Input[str]] = None,
                  data: Optional[Any] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
                  revision: Optional[pulumi.Input[int]] = None,
                  __props__=None):
         """
@@ -125,7 +130,7 @@ class ControllerRevisionPatch(pulumi.CustomResource):
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param Any data: Data is the serialized representation of the state.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         :param pulumi.Input[int] revision: Revision indicates the revision of the state represented by Data.
         """
         ...
@@ -161,7 +166,7 @@ class ControllerRevisionPatch(pulumi.CustomResource):
                  api_version: Optional[pulumi.Input[str]] = None,
                  data: Optional[Any] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
                  revision: Optional[pulumi.Input[int]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)

--- a/sdk/python/pulumi_kubernetes/apps/v1/DaemonSet.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1/DaemonSet.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -94,8 +99,8 @@ class DaemonSet(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['DaemonSetSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['DaemonSetSpecArgs', 'DaemonSetSpecArgsDict']]] = None,
                  __props__=None):
         """
         DaemonSet represents the configuration of a daemon set.
@@ -104,8 +109,8 @@ class DaemonSet(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['DaemonSetSpecArgs']] spec: The desired behavior of this daemon set. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['DaemonSetSpecArgs', 'DaemonSetSpecArgsDict']] spec: The desired behavior of this daemon set. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -133,8 +138,8 @@ class DaemonSet(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['DaemonSetSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['DaemonSetSpecArgs', 'DaemonSetSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/apps/v1/DaemonSetList.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1/DaemonSetList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -92,9 +97,9 @@ class DaemonSetList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['DaemonSetArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['DaemonSetArgs', 'DaemonSetArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         DaemonSetList is a collection of daemon sets.
@@ -102,9 +107,9 @@ class DaemonSetList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['DaemonSetArgs']]]] items: A list of daemon sets.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['DaemonSetArgs', 'DaemonSetArgsDict']]]] items: A list of daemon sets.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -131,9 +136,9 @@ class DaemonSetList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['DaemonSetArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['DaemonSetArgs', 'DaemonSetArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/apps/v1/DaemonSetPatch.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1/DaemonSetPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -94,8 +99,8 @@ class DaemonSetPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['DaemonSetSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['DaemonSetSpecPatchArgs', 'DaemonSetSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -110,8 +115,8 @@ class DaemonSetPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['DaemonSetSpecPatchArgs']] spec: The desired behavior of this daemon set. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['DaemonSetSpecPatchArgs', 'DaemonSetSpecPatchArgsDict']] spec: The desired behavior of this daemon set. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -145,8 +150,8 @@ class DaemonSetPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['DaemonSetSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['DaemonSetSpecPatchArgs', 'DaemonSetSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/apps/v1/Deployment.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1/Deployment.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -94,8 +99,8 @@ class Deployment(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['DeploymentSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['DeploymentSpecArgs', 'DeploymentSpecArgsDict']]] = None,
                  __props__=None):
         """
         Deployment enables declarative updates for Pods and ReplicaSets.
@@ -201,8 +206,8 @@ class Deployment(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['DeploymentSpecArgs']] spec: Specification of the desired behavior of the Deployment.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['DeploymentSpecArgs', 'DeploymentSpecArgsDict']] spec: Specification of the desired behavior of the Deployment.
         """
         ...
     @overload
@@ -327,8 +332,8 @@ class Deployment(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['DeploymentSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['DeploymentSpecArgs', 'DeploymentSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/apps/v1/DeploymentList.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1/DeploymentList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -92,9 +97,9 @@ class DeploymentList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['DeploymentArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['DeploymentArgs', 'DeploymentArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         DeploymentList is a list of Deployments.
@@ -102,9 +107,9 @@ class DeploymentList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['DeploymentArgs']]]] items: Items is the list of Deployments.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['DeploymentArgs', 'DeploymentArgsDict']]]] items: Items is the list of Deployments.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata.
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata.
         """
         ...
     @overload
@@ -131,9 +136,9 @@ class DeploymentList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['DeploymentArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['DeploymentArgs', 'DeploymentArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/apps/v1/DeploymentPatch.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1/DeploymentPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -94,8 +99,8 @@ class DeploymentPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['DeploymentSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['DeploymentSpecPatchArgs', 'DeploymentSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -132,8 +137,8 @@ class DeploymentPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['DeploymentSpecPatchArgs']] spec: Specification of the desired behavior of the Deployment.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['DeploymentSpecPatchArgs', 'DeploymentSpecPatchArgsDict']] spec: Specification of the desired behavior of the Deployment.
         """
         ...
     @overload
@@ -189,8 +194,8 @@ class DeploymentPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['DeploymentSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['DeploymentSpecPatchArgs', 'DeploymentSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/apps/v1/ReplicaSet.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1/ReplicaSet.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -94,8 +99,8 @@ class ReplicaSet(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ReplicaSetSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ReplicaSetSpecArgs', 'ReplicaSetSpecArgsDict']]] = None,
                  __props__=None):
         """
         ReplicaSet ensures that a specified number of pod replicas are running at any given time.
@@ -104,8 +109,8 @@ class ReplicaSet(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: If the Labels of a ReplicaSet are empty, they are defaulted to be the same as the Pod(s) that the ReplicaSet manages. Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['ReplicaSetSpecArgs']] spec: Spec defines the specification of the desired behavior of the ReplicaSet. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: If the Labels of a ReplicaSet are empty, they are defaulted to be the same as the Pod(s) that the ReplicaSet manages. Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['ReplicaSetSpecArgs', 'ReplicaSetSpecArgsDict']] spec: Spec defines the specification of the desired behavior of the ReplicaSet. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -133,8 +138,8 @@ class ReplicaSet(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ReplicaSetSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ReplicaSetSpecArgs', 'ReplicaSetSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/apps/v1/ReplicaSetList.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1/ReplicaSetList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -92,9 +97,9 @@ class ReplicaSetList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ReplicaSetArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ReplicaSetArgs', 'ReplicaSetArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         ReplicaSetList is a collection of ReplicaSets.
@@ -102,9 +107,9 @@ class ReplicaSetList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ReplicaSetArgs']]]] items: List of ReplicaSets. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller
+        :param pulumi.Input[Sequence[pulumi.Input[Union['ReplicaSetArgs', 'ReplicaSetArgsDict']]]] items: List of ReplicaSets. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
         """
         ...
     @overload
@@ -131,9 +136,9 @@ class ReplicaSetList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ReplicaSetArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ReplicaSetArgs', 'ReplicaSetArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/apps/v1/ReplicaSetPatch.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1/ReplicaSetPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -94,8 +99,8 @@ class ReplicaSetPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ReplicaSetSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ReplicaSetSpecPatchArgs', 'ReplicaSetSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -110,8 +115,8 @@ class ReplicaSetPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: If the Labels of a ReplicaSet are empty, they are defaulted to be the same as the Pod(s) that the ReplicaSet manages. Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['ReplicaSetSpecPatchArgs']] spec: Spec defines the specification of the desired behavior of the ReplicaSet. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: If the Labels of a ReplicaSet are empty, they are defaulted to be the same as the Pod(s) that the ReplicaSet manages. Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['ReplicaSetSpecPatchArgs', 'ReplicaSetSpecPatchArgsDict']] spec: Spec defines the specification of the desired behavior of the ReplicaSet. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -145,8 +150,8 @@ class ReplicaSetPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ReplicaSetSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ReplicaSetSpecPatchArgs', 'ReplicaSetSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/apps/v1/StatefulSet.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1/StatefulSet.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -94,8 +99,8 @@ class StatefulSet(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['StatefulSetSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['StatefulSetSpecArgs', 'StatefulSetSpecArgsDict']]] = None,
                  __props__=None):
         """
         StatefulSet represents a set of pods with consistent identities. Identities are defined as:
@@ -260,8 +265,8 @@ class StatefulSet(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['StatefulSetSpecArgs']] spec: Spec defines the desired identities of pods in this set.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['StatefulSetSpecArgs', 'StatefulSetSpecArgsDict']] spec: Spec defines the desired identities of pods in this set.
         """
         ...
     @overload
@@ -445,8 +450,8 @@ class StatefulSet(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['StatefulSetSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['StatefulSetSpecArgs', 'StatefulSetSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/apps/v1/StatefulSetList.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1/StatefulSetList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -92,9 +97,9 @@ class StatefulSetList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['StatefulSetArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['StatefulSetArgs', 'StatefulSetArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         StatefulSetList is a collection of StatefulSets.
@@ -102,9 +107,9 @@ class StatefulSetList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['StatefulSetArgs']]]] items: Items is the list of stateful sets.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['StatefulSetArgs', 'StatefulSetArgsDict']]]] items: Items is the list of stateful sets.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -131,9 +136,9 @@ class StatefulSetList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['StatefulSetArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['StatefulSetArgs', 'StatefulSetArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/apps/v1/StatefulSetPatch.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1/StatefulSetPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -94,8 +99,8 @@ class StatefulSetPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['StatefulSetSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['StatefulSetSpecPatchArgs', 'StatefulSetSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -127,8 +132,8 @@ class StatefulSetPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['StatefulSetSpecPatchArgs']] spec: Spec defines the desired identities of pods in this set.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['StatefulSetSpecPatchArgs', 'StatefulSetSpecPatchArgsDict']] spec: Spec defines the desired identities of pods in this set.
         """
         ...
     @overload
@@ -179,8 +184,8 @@ class StatefulSetPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['StatefulSetSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['StatefulSetSpecPatchArgs', 'StatefulSetSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/apps/v1/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1/_inputs.py
@@ -4,52 +4,124 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import core as _core
 from ... import meta as _meta
 
 __all__ = [
     'ControllerRevisionArgs',
+    'ControllerRevisionArgsDict',
     'DaemonSetConditionArgs',
+    'DaemonSetConditionArgsDict',
     'DaemonSetSpecPatchArgs',
+    'DaemonSetSpecPatchArgsDict',
     'DaemonSetSpecArgs',
+    'DaemonSetSpecArgsDict',
     'DaemonSetStatusArgs',
+    'DaemonSetStatusArgsDict',
     'DaemonSetUpdateStrategyPatchArgs',
+    'DaemonSetUpdateStrategyPatchArgsDict',
     'DaemonSetUpdateStrategyArgs',
+    'DaemonSetUpdateStrategyArgsDict',
     'DaemonSetArgs',
+    'DaemonSetArgsDict',
     'DeploymentConditionArgs',
+    'DeploymentConditionArgsDict',
     'DeploymentSpecPatchArgs',
+    'DeploymentSpecPatchArgsDict',
     'DeploymentSpecArgs',
+    'DeploymentSpecArgsDict',
     'DeploymentStatusArgs',
+    'DeploymentStatusArgsDict',
     'DeploymentStrategyPatchArgs',
+    'DeploymentStrategyPatchArgsDict',
     'DeploymentStrategyArgs',
+    'DeploymentStrategyArgsDict',
     'DeploymentArgs',
+    'DeploymentArgsDict',
     'ReplicaSetConditionArgs',
+    'ReplicaSetConditionArgsDict',
     'ReplicaSetSpecPatchArgs',
+    'ReplicaSetSpecPatchArgsDict',
     'ReplicaSetSpecArgs',
+    'ReplicaSetSpecArgsDict',
     'ReplicaSetStatusArgs',
+    'ReplicaSetStatusArgsDict',
     'ReplicaSetArgs',
+    'ReplicaSetArgsDict',
     'RollingUpdateDaemonSetPatchArgs',
+    'RollingUpdateDaemonSetPatchArgsDict',
     'RollingUpdateDaemonSetArgs',
+    'RollingUpdateDaemonSetArgsDict',
     'RollingUpdateDeploymentPatchArgs',
+    'RollingUpdateDeploymentPatchArgsDict',
     'RollingUpdateDeploymentArgs',
+    'RollingUpdateDeploymentArgsDict',
     'RollingUpdateStatefulSetStrategyPatchArgs',
+    'RollingUpdateStatefulSetStrategyPatchArgsDict',
     'RollingUpdateStatefulSetStrategyArgs',
+    'RollingUpdateStatefulSetStrategyArgsDict',
     'StatefulSetConditionArgs',
+    'StatefulSetConditionArgsDict',
     'StatefulSetOrdinalsPatchArgs',
+    'StatefulSetOrdinalsPatchArgsDict',
     'StatefulSetOrdinalsArgs',
+    'StatefulSetOrdinalsArgsDict',
     'StatefulSetPersistentVolumeClaimRetentionPolicyPatchArgs',
+    'StatefulSetPersistentVolumeClaimRetentionPolicyPatchArgsDict',
     'StatefulSetPersistentVolumeClaimRetentionPolicyArgs',
+    'StatefulSetPersistentVolumeClaimRetentionPolicyArgsDict',
     'StatefulSetSpecPatchArgs',
+    'StatefulSetSpecPatchArgsDict',
     'StatefulSetSpecArgs',
+    'StatefulSetSpecArgsDict',
     'StatefulSetStatusArgs',
+    'StatefulSetStatusArgsDict',
     'StatefulSetUpdateStrategyPatchArgs',
+    'StatefulSetUpdateStrategyPatchArgsDict',
     'StatefulSetUpdateStrategyArgs',
+    'StatefulSetUpdateStrategyArgsDict',
     'StatefulSetArgs',
+    'StatefulSetArgsDict',
 ]
+
+MYPY = False
+
+if not MYPY:
+    class ControllerRevisionArgsDict(TypedDict):
+        """
+        ControllerRevision implements an immutable snapshot of state data. Clients are responsible for serializing and deserializing the objects that contain their internal state. Once a ControllerRevision has been successfully created, it can not be updated. The API Server will fail validation of all requests that attempt to mutate the Data field. ControllerRevisions may, however, be deleted. Note that, due to its use by both the DaemonSet and StatefulSet controllers for update and rollback, this object is beta. However, it may be subject to name and representation changes in future releases, and clients should not depend on its stability. It is primarily for internal use by controllers.
+        """
+        revision: pulumi.Input[int]
+        """
+        Revision indicates the revision of the state represented by Data.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        data: NotRequired[Any]
+        """
+        Data is the serialized representation of the state.
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+elif False:
+    ControllerRevisionArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ControllerRevisionArgs:
@@ -138,6 +210,34 @@ class ControllerRevisionArgs:
         pulumi.set(self, "metadata", value)
 
 
+if not MYPY:
+    class DaemonSetConditionArgsDict(TypedDict):
+        """
+        DaemonSetCondition describes the state of a DaemonSet at a certain point.
+        """
+        status: pulumi.Input[str]
+        """
+        Status of the condition, one of True, False, Unknown.
+        """
+        type: pulumi.Input[str]
+        """
+        Type of DaemonSet condition.
+        """
+        last_transition_time: NotRequired[pulumi.Input[str]]
+        """
+        Last time the condition transitioned from one status to another.
+        """
+        message: NotRequired[pulumi.Input[str]]
+        """
+        A human readable message indicating details about the transition.
+        """
+        reason: NotRequired[pulumi.Input[str]]
+        """
+        The reason for the condition's last transition.
+        """
+elif False:
+    DaemonSetConditionArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class DaemonSetConditionArgs:
     def __init__(__self__, *,
@@ -223,6 +323,34 @@ class DaemonSetConditionArgs:
     def reason(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "reason", value)
 
+
+if not MYPY:
+    class DaemonSetSpecPatchArgsDict(TypedDict):
+        """
+        DaemonSetSpec is the specification of a daemon set.
+        """
+        min_ready_seconds: NotRequired[pulumi.Input[int]]
+        """
+        The minimum number of seconds for which a newly created DaemonSet pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready).
+        """
+        revision_history_limit: NotRequired[pulumi.Input[int]]
+        """
+        The number of old history to retain to allow rollback. This is a pointer to distinguish between explicit zero and not specified. Defaults to 10.
+        """
+        selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorPatchArgsDict']]
+        """
+        A label query over pods that are managed by the daemon set. Must match in order to be controlled. It must match the pod template's labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+        """
+        template: NotRequired[pulumi.Input['_core.v1.PodTemplateSpecPatchArgsDict']]
+        """
+        An object that describes the pod that will be created. The DaemonSet will create exactly one copy of this pod on every node that matches the template's node selector (or on every node if no node selector is specified). The only allowed template.spec.restartPolicy value is "Always". More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template
+        """
+        update_strategy: NotRequired[pulumi.Input['DaemonSetUpdateStrategyPatchArgsDict']]
+        """
+        An update strategy to replace existing DaemonSet pods with new pods.
+        """
+elif False:
+    DaemonSetSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class DaemonSetSpecPatchArgs:
@@ -312,6 +440,34 @@ class DaemonSetSpecPatchArgs:
         pulumi.set(self, "update_strategy", value)
 
 
+if not MYPY:
+    class DaemonSetSpecArgsDict(TypedDict):
+        """
+        DaemonSetSpec is the specification of a daemon set.
+        """
+        selector: pulumi.Input['_meta.v1.LabelSelectorArgsDict']
+        """
+        A label query over pods that are managed by the daemon set. Must match in order to be controlled. It must match the pod template's labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+        """
+        template: pulumi.Input['_core.v1.PodTemplateSpecArgsDict']
+        """
+        An object that describes the pod that will be created. The DaemonSet will create exactly one copy of this pod on every node that matches the template's node selector (or on every node if no node selector is specified). The only allowed template.spec.restartPolicy value is "Always". More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template
+        """
+        min_ready_seconds: NotRequired[pulumi.Input[int]]
+        """
+        The minimum number of seconds for which a newly created DaemonSet pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready).
+        """
+        revision_history_limit: NotRequired[pulumi.Input[int]]
+        """
+        The number of old history to retain to allow rollback. This is a pointer to distinguish between explicit zero and not specified. Defaults to 10.
+        """
+        update_strategy: NotRequired[pulumi.Input['DaemonSetUpdateStrategyArgsDict']]
+        """
+        An update strategy to replace existing DaemonSet pods with new pods.
+        """
+elif False:
+    DaemonSetSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class DaemonSetSpecArgs:
     def __init__(__self__, *,
@@ -397,6 +553,54 @@ class DaemonSetSpecArgs:
     def update_strategy(self, value: Optional[pulumi.Input['DaemonSetUpdateStrategyArgs']]):
         pulumi.set(self, "update_strategy", value)
 
+
+if not MYPY:
+    class DaemonSetStatusArgsDict(TypedDict):
+        """
+        DaemonSetStatus represents the current status of a daemon set.
+        """
+        current_number_scheduled: pulumi.Input[int]
+        """
+        The number of nodes that are running at least 1 daemon pod and are supposed to run the daemon pod. More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
+        """
+        desired_number_scheduled: pulumi.Input[int]
+        """
+        The total number of nodes that should be running the daemon pod (including nodes correctly running the daemon pod). More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
+        """
+        number_misscheduled: pulumi.Input[int]
+        """
+        The number of nodes that are running the daemon pod, but are not supposed to run the daemon pod. More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
+        """
+        number_ready: pulumi.Input[int]
+        """
+        numberReady is the number of nodes that should be running the daemon pod and have one or more of the daemon pod running with a Ready Condition.
+        """
+        collision_count: NotRequired[pulumi.Input[int]]
+        """
+        Count of hash collisions for the DaemonSet. The DaemonSet controller uses this field as a collision avoidance mechanism when it needs to create the name for the newest ControllerRevision.
+        """
+        conditions: NotRequired[pulumi.Input[Sequence[pulumi.Input['DaemonSetConditionArgsDict']]]]
+        """
+        Represents the latest available observations of a DaemonSet's current state.
+        """
+        number_available: NotRequired[pulumi.Input[int]]
+        """
+        The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and available (ready for at least spec.minReadySeconds)
+        """
+        number_unavailable: NotRequired[pulumi.Input[int]]
+        """
+        The number of nodes that should be running the daemon pod and have none of the daemon pod running and available (ready for at least spec.minReadySeconds)
+        """
+        observed_generation: NotRequired[pulumi.Input[int]]
+        """
+        The most recent generation observed by the daemon set controller.
+        """
+        updated_number_scheduled: NotRequired[pulumi.Input[int]]
+        """
+        The total number of nodes that are running updated daemon pod
+        """
+elif False:
+    DaemonSetStatusArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class DaemonSetStatusArgs:
@@ -562,6 +766,22 @@ class DaemonSetStatusArgs:
         pulumi.set(self, "updated_number_scheduled", value)
 
 
+if not MYPY:
+    class DaemonSetUpdateStrategyPatchArgsDict(TypedDict):
+        """
+        DaemonSetUpdateStrategy is a struct used to control the update strategy for a DaemonSet.
+        """
+        rolling_update: NotRequired[pulumi.Input['RollingUpdateDaemonSetPatchArgsDict']]
+        """
+        Rolling update config params. Present only if type = "RollingUpdate".
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        Type of daemon set update. Can be "RollingUpdate" or "OnDelete". Default is RollingUpdate.
+        """
+elif False:
+    DaemonSetUpdateStrategyPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class DaemonSetUpdateStrategyPatchArgs:
     def __init__(__self__, *,
@@ -602,6 +822,22 @@ class DaemonSetUpdateStrategyPatchArgs:
         pulumi.set(self, "type", value)
 
 
+if not MYPY:
+    class DaemonSetUpdateStrategyArgsDict(TypedDict):
+        """
+        DaemonSetUpdateStrategy is a struct used to control the update strategy for a DaemonSet.
+        """
+        rolling_update: NotRequired[pulumi.Input['RollingUpdateDaemonSetArgsDict']]
+        """
+        Rolling update config params. Present only if type = "RollingUpdate".
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        Type of daemon set update. Can be "RollingUpdate" or "OnDelete". Default is RollingUpdate.
+        """
+elif False:
+    DaemonSetUpdateStrategyArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class DaemonSetUpdateStrategyArgs:
     def __init__(__self__, *,
@@ -641,6 +877,34 @@ class DaemonSetUpdateStrategyArgs:
     def type(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "type", value)
 
+
+if not MYPY:
+    class DaemonSetArgsDict(TypedDict):
+        """
+        DaemonSet represents the configuration of a daemon set.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['DaemonSetSpecArgsDict']]
+        """
+        The desired behavior of this daemon set. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+        status: NotRequired[pulumi.Input['DaemonSetStatusArgsDict']]
+        """
+        The current status of this daemon set. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+elif False:
+    DaemonSetArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class DaemonSetArgs:
@@ -729,6 +993,38 @@ class DaemonSetArgs:
     def status(self, value: Optional[pulumi.Input['DaemonSetStatusArgs']]):
         pulumi.set(self, "status", value)
 
+
+if not MYPY:
+    class DeploymentConditionArgsDict(TypedDict):
+        """
+        DeploymentCondition describes the state of a deployment at a certain point.
+        """
+        status: pulumi.Input[str]
+        """
+        Status of the condition, one of True, False, Unknown.
+        """
+        type: pulumi.Input[str]
+        """
+        Type of deployment condition.
+        """
+        last_transition_time: NotRequired[pulumi.Input[str]]
+        """
+        Last time the condition transitioned from one status to another.
+        """
+        last_update_time: NotRequired[pulumi.Input[str]]
+        """
+        The last time this condition was updated.
+        """
+        message: NotRequired[pulumi.Input[str]]
+        """
+        A human readable message indicating details about the transition.
+        """
+        reason: NotRequired[pulumi.Input[str]]
+        """
+        The reason for the condition's last transition.
+        """
+elif False:
+    DeploymentConditionArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class DeploymentConditionArgs:
@@ -831,6 +1127,46 @@ class DeploymentConditionArgs:
     def reason(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "reason", value)
 
+
+if not MYPY:
+    class DeploymentSpecPatchArgsDict(TypedDict):
+        """
+        DeploymentSpec is the specification of the desired behavior of the Deployment.
+        """
+        min_ready_seconds: NotRequired[pulumi.Input[int]]
+        """
+        Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)
+        """
+        paused: NotRequired[pulumi.Input[bool]]
+        """
+        Indicates that the deployment is paused.
+        """
+        progress_deadline_seconds: NotRequired[pulumi.Input[int]]
+        """
+        The maximum time in seconds for a deployment to make progress before it is considered to be failed. The deployment controller will continue to process failed deployments and a condition with a ProgressDeadlineExceeded reason will be surfaced in the deployment status. Note that progress will not be estimated during the time a deployment is paused. Defaults to 600s.
+        """
+        replicas: NotRequired[pulumi.Input[int]]
+        """
+        Number of desired pods. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1.
+        """
+        revision_history_limit: NotRequired[pulumi.Input[int]]
+        """
+        The number of old ReplicaSets to retain to allow rollback. This is a pointer to distinguish between explicit zero and not specified. Defaults to 10.
+        """
+        selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorPatchArgsDict']]
+        """
+        Label selector for pods. Existing ReplicaSets whose pods are selected by this will be the ones affected by this deployment. It must match the pod template's labels.
+        """
+        strategy: NotRequired[pulumi.Input['DeploymentStrategyPatchArgsDict']]
+        """
+        The deployment strategy to use to replace existing pods with new ones.
+        """
+        template: NotRequired[pulumi.Input['_core.v1.PodTemplateSpecPatchArgsDict']]
+        """
+        Template describes the pods that will be created. The only allowed template.spec.restartPolicy value is "Always".
+        """
+elif False:
+    DeploymentSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class DeploymentSpecPatchArgs:
@@ -968,6 +1304,46 @@ class DeploymentSpecPatchArgs:
         pulumi.set(self, "template", value)
 
 
+if not MYPY:
+    class DeploymentSpecArgsDict(TypedDict):
+        """
+        DeploymentSpec is the specification of the desired behavior of the Deployment.
+        """
+        selector: pulumi.Input['_meta.v1.LabelSelectorArgsDict']
+        """
+        Label selector for pods. Existing ReplicaSets whose pods are selected by this will be the ones affected by this deployment. It must match the pod template's labels.
+        """
+        template: pulumi.Input['_core.v1.PodTemplateSpecArgsDict']
+        """
+        Template describes the pods that will be created. The only allowed template.spec.restartPolicy value is "Always".
+        """
+        min_ready_seconds: NotRequired[pulumi.Input[int]]
+        """
+        Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)
+        """
+        paused: NotRequired[pulumi.Input[bool]]
+        """
+        Indicates that the deployment is paused.
+        """
+        progress_deadline_seconds: NotRequired[pulumi.Input[int]]
+        """
+        The maximum time in seconds for a deployment to make progress before it is considered to be failed. The deployment controller will continue to process failed deployments and a condition with a ProgressDeadlineExceeded reason will be surfaced in the deployment status. Note that progress will not be estimated during the time a deployment is paused. Defaults to 600s.
+        """
+        replicas: NotRequired[pulumi.Input[int]]
+        """
+        Number of desired pods. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1.
+        """
+        revision_history_limit: NotRequired[pulumi.Input[int]]
+        """
+        The number of old ReplicaSets to retain to allow rollback. This is a pointer to distinguish between explicit zero and not specified. Defaults to 10.
+        """
+        strategy: NotRequired[pulumi.Input['DeploymentStrategyArgsDict']]
+        """
+        The deployment strategy to use to replace existing pods with new ones.
+        """
+elif False:
+    DeploymentSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class DeploymentSpecArgs:
     def __init__(__self__, *,
@@ -1101,6 +1477,46 @@ class DeploymentSpecArgs:
     def strategy(self, value: Optional[pulumi.Input['DeploymentStrategyArgs']]):
         pulumi.set(self, "strategy", value)
 
+
+if not MYPY:
+    class DeploymentStatusArgsDict(TypedDict):
+        """
+        DeploymentStatus is the most recently observed status of the Deployment.
+        """
+        available_replicas: NotRequired[pulumi.Input[int]]
+        """
+        Total number of available pods (ready for at least minReadySeconds) targeted by this deployment.
+        """
+        collision_count: NotRequired[pulumi.Input[int]]
+        """
+        Count of hash collisions for the Deployment. The Deployment controller uses this field as a collision avoidance mechanism when it needs to create the name for the newest ReplicaSet.
+        """
+        conditions: NotRequired[pulumi.Input[Sequence[pulumi.Input['DeploymentConditionArgsDict']]]]
+        """
+        Represents the latest available observations of a deployment's current state.
+        """
+        observed_generation: NotRequired[pulumi.Input[int]]
+        """
+        The generation observed by the deployment controller.
+        """
+        ready_replicas: NotRequired[pulumi.Input[int]]
+        """
+        readyReplicas is the number of pods targeted by this Deployment with a Ready Condition.
+        """
+        replicas: NotRequired[pulumi.Input[int]]
+        """
+        Total number of non-terminated pods targeted by this deployment (their labels match the selector).
+        """
+        unavailable_replicas: NotRequired[pulumi.Input[int]]
+        """
+        Total number of unavailable pods targeted by this deployment. This is the total number of pods that are still required for the deployment to have 100% available capacity. They may either be pods that are running but not yet available or pods that still have not been created.
+        """
+        updated_replicas: NotRequired[pulumi.Input[int]]
+        """
+        Total number of non-terminated pods targeted by this deployment that have the desired template spec.
+        """
+elif False:
+    DeploymentStatusArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class DeploymentStatusArgs:
@@ -1238,6 +1654,22 @@ class DeploymentStatusArgs:
         pulumi.set(self, "updated_replicas", value)
 
 
+if not MYPY:
+    class DeploymentStrategyPatchArgsDict(TypedDict):
+        """
+        DeploymentStrategy describes how to replace existing pods with new ones.
+        """
+        rolling_update: NotRequired[pulumi.Input['RollingUpdateDeploymentPatchArgsDict']]
+        """
+        Rolling update config params. Present only if DeploymentStrategyType = RollingUpdate.
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        Type of deployment. Can be "Recreate" or "RollingUpdate". Default is RollingUpdate.
+        """
+elif False:
+    DeploymentStrategyPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class DeploymentStrategyPatchArgs:
     def __init__(__self__, *,
@@ -1278,6 +1710,22 @@ class DeploymentStrategyPatchArgs:
         pulumi.set(self, "type", value)
 
 
+if not MYPY:
+    class DeploymentStrategyArgsDict(TypedDict):
+        """
+        DeploymentStrategy describes how to replace existing pods with new ones.
+        """
+        rolling_update: NotRequired[pulumi.Input['RollingUpdateDeploymentArgsDict']]
+        """
+        Rolling update config params. Present only if DeploymentStrategyType = RollingUpdate.
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        Type of deployment. Can be "Recreate" or "RollingUpdate". Default is RollingUpdate.
+        """
+elif False:
+    DeploymentStrategyArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class DeploymentStrategyArgs:
     def __init__(__self__, *,
@@ -1317,6 +1765,56 @@ class DeploymentStrategyArgs:
     def type(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "type", value)
 
+
+if not MYPY:
+    class DeploymentArgsDict(TypedDict):
+        """
+        Deployment enables declarative updates for Pods and ReplicaSets.
+
+        This resource waits until its status is ready before registering success
+        for create/update, and populating output properties from the current state of the resource.
+        The following conditions are used to determine whether the resource creation has
+        succeeded or failed:
+
+        1. The Deployment has begun to be updated by the Deployment controller. If the current
+           generation of the Deployment is > 1, then this means that the current generation must
+           be different from the generation reported by the last outputs.
+        2. There exists a ReplicaSet whose revision is equal to the current revision of the
+           Deployment.
+        3. The Deployment's '.status.conditions' has a status of type 'Available' whose 'status'
+           member is set to 'True'.
+        4. If the Deployment has generation > 1, then '.status.conditions' has a status of type
+           'Progressing', whose 'status' member is set to 'True', and whose 'reason' is
+           'NewReplicaSetAvailable'. For generation <= 1, this status field does not exist,
+           because it doesn't do a rollout (i.e., it simply creates the Deployment and
+           corresponding ReplicaSet), and therefore there is no rollout to mark as 'Progressing'.
+
+        If the Deployment has not reached a Ready state after 10 minutes, it will
+        time out and mark the resource update as Failed. You can override the default timeout value
+        by setting the 'customTimeouts' option on the resource.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['DeploymentSpecArgsDict']]
+        """
+        Specification of the desired behavior of the Deployment.
+        """
+        status: NotRequired[pulumi.Input['DeploymentStatusArgsDict']]
+        """
+        Most recently observed status of the Deployment.
+        """
+elif False:
+    DeploymentArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class DeploymentArgs:
@@ -1428,6 +1926,34 @@ class DeploymentArgs:
         pulumi.set(self, "status", value)
 
 
+if not MYPY:
+    class ReplicaSetConditionArgsDict(TypedDict):
+        """
+        ReplicaSetCondition describes the state of a replica set at a certain point.
+        """
+        status: pulumi.Input[str]
+        """
+        Status of the condition, one of True, False, Unknown.
+        """
+        type: pulumi.Input[str]
+        """
+        Type of replica set condition.
+        """
+        last_transition_time: NotRequired[pulumi.Input[str]]
+        """
+        The last time the condition transitioned from one status to another.
+        """
+        message: NotRequired[pulumi.Input[str]]
+        """
+        A human readable message indicating details about the transition.
+        """
+        reason: NotRequired[pulumi.Input[str]]
+        """
+        The reason for the condition's last transition.
+        """
+elif False:
+    ReplicaSetConditionArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ReplicaSetConditionArgs:
     def __init__(__self__, *,
@@ -1514,6 +2040,30 @@ class ReplicaSetConditionArgs:
         pulumi.set(self, "reason", value)
 
 
+if not MYPY:
+    class ReplicaSetSpecPatchArgsDict(TypedDict):
+        """
+        ReplicaSetSpec is the specification of a ReplicaSet.
+        """
+        min_ready_seconds: NotRequired[pulumi.Input[int]]
+        """
+        Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)
+        """
+        replicas: NotRequired[pulumi.Input[int]]
+        """
+        Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller
+        """
+        selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorPatchArgsDict']]
+        """
+        Selector is a label query over pods that should match the replica count. Label keys and values that must match in order to be controlled by this replica set. It must match the pod template's labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+        """
+        template: NotRequired[pulumi.Input['_core.v1.PodTemplateSpecPatchArgsDict']]
+        """
+        Template is the object that describes the pod that will be created if insufficient replicas are detected. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template
+        """
+elif False:
+    ReplicaSetSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ReplicaSetSpecPatchArgs:
     def __init__(__self__, *,
@@ -1586,6 +2136,30 @@ class ReplicaSetSpecPatchArgs:
         pulumi.set(self, "template", value)
 
 
+if not MYPY:
+    class ReplicaSetSpecArgsDict(TypedDict):
+        """
+        ReplicaSetSpec is the specification of a ReplicaSet.
+        """
+        selector: pulumi.Input['_meta.v1.LabelSelectorArgsDict']
+        """
+        Selector is a label query over pods that should match the replica count. Label keys and values that must match in order to be controlled by this replica set. It must match the pod template's labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+        """
+        min_ready_seconds: NotRequired[pulumi.Input[int]]
+        """
+        Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)
+        """
+        replicas: NotRequired[pulumi.Input[int]]
+        """
+        Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller
+        """
+        template: NotRequired[pulumi.Input['_core.v1.PodTemplateSpecArgsDict']]
+        """
+        Template is the object that describes the pod that will be created if insufficient replicas are detected. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template
+        """
+elif False:
+    ReplicaSetSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ReplicaSetSpecArgs:
     def __init__(__self__, *,
@@ -1656,6 +2230,38 @@ class ReplicaSetSpecArgs:
     def template(self, value: Optional[pulumi.Input['_core.v1.PodTemplateSpecArgs']]):
         pulumi.set(self, "template", value)
 
+
+if not MYPY:
+    class ReplicaSetStatusArgsDict(TypedDict):
+        """
+        ReplicaSetStatus represents the current status of a ReplicaSet.
+        """
+        replicas: pulumi.Input[int]
+        """
+        Replicas is the most recently observed number of replicas. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller
+        """
+        available_replicas: NotRequired[pulumi.Input[int]]
+        """
+        The number of available replicas (ready for at least minReadySeconds) for this replica set.
+        """
+        conditions: NotRequired[pulumi.Input[Sequence[pulumi.Input['ReplicaSetConditionArgsDict']]]]
+        """
+        Represents the latest available observations of a replica set's current state.
+        """
+        fully_labeled_replicas: NotRequired[pulumi.Input[int]]
+        """
+        The number of pods that have labels matching the labels of the pod template of the replicaset.
+        """
+        observed_generation: NotRequired[pulumi.Input[int]]
+        """
+        ObservedGeneration reflects the generation of the most recently observed ReplicaSet.
+        """
+        ready_replicas: NotRequired[pulumi.Input[int]]
+        """
+        readyReplicas is the number of pods targeted by this ReplicaSet with a Ready Condition.
+        """
+elif False:
+    ReplicaSetStatusArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ReplicaSetStatusArgs:
@@ -1760,6 +2366,34 @@ class ReplicaSetStatusArgs:
         pulumi.set(self, "ready_replicas", value)
 
 
+if not MYPY:
+    class ReplicaSetArgsDict(TypedDict):
+        """
+        ReplicaSet ensures that a specified number of pod replicas are running at any given time.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        If the Labels of a ReplicaSet are empty, they are defaulted to be the same as the Pod(s) that the ReplicaSet manages. Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['ReplicaSetSpecArgsDict']]
+        """
+        Spec defines the specification of the desired behavior of the ReplicaSet. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+        status: NotRequired[pulumi.Input['ReplicaSetStatusArgsDict']]
+        """
+        Status is the most recently observed status of the ReplicaSet. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+elif False:
+    ReplicaSetArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ReplicaSetArgs:
     def __init__(__self__, *,
@@ -1848,6 +2482,22 @@ class ReplicaSetArgs:
         pulumi.set(self, "status", value)
 
 
+if not MYPY:
+    class RollingUpdateDaemonSetPatchArgsDict(TypedDict):
+        """
+        Spec to control the desired behavior of daemon set rolling update.
+        """
+        max_surge: NotRequired[pulumi.Input[Union[int, str]]]
+        """
+        The maximum number of nodes with an existing available DaemonSet pod that can have an updated DaemonSet pod during during an update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up to a minimum of 1. Default value is 0. Example: when this is set to 30%, at most 30% of the total number of nodes that should be running the daemon pod (i.e. status.desiredNumberScheduled) can have their a new pod created before the old pod is marked as deleted. The update starts by launching new pods on 30% of nodes. Once an updated pod is available (Ready for at least minReadySeconds) the old DaemonSet pod on that node is marked deleted. If the old pod becomes unavailable for any reason (Ready transitions to false, is evicted, or is drained) an updated pod is immediatedly created on that node without considering surge limits. Allowing surge implies the possibility that the resources consumed by the daemonset on any given node can double if the readiness check fails, and so resource intensive daemonsets should take into account that they may cause evictions during disruption.
+        """
+        max_unavailable: NotRequired[pulumi.Input[Union[int, str]]]
+        """
+        The maximum number of DaemonSet pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of total number of DaemonSet pods at the start of the update (ex: 10%). Absolute number is calculated from percentage by rounding up. This cannot be 0 if MaxSurge is 0 Default value is 1. Example: when this is set to 30%, at most 30% of the total number of nodes that should be running the daemon pod (i.e. status.desiredNumberScheduled) can have their pods stopped for an update at any given time. The update starts by stopping at most 30% of those DaemonSet pods and then brings up new DaemonSet pods in their place. Once the new pods are available, it then proceeds onto other DaemonSet pods, thus ensuring that at least 70% of original number of DaemonSet pods are available at all times during the update.
+        """
+elif False:
+    RollingUpdateDaemonSetPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class RollingUpdateDaemonSetPatchArgs:
     def __init__(__self__, *,
@@ -1887,6 +2537,22 @@ class RollingUpdateDaemonSetPatchArgs:
     def max_unavailable(self, value: Optional[pulumi.Input[Union[int, str]]]):
         pulumi.set(self, "max_unavailable", value)
 
+
+if not MYPY:
+    class RollingUpdateDaemonSetArgsDict(TypedDict):
+        """
+        Spec to control the desired behavior of daemon set rolling update.
+        """
+        max_surge: NotRequired[pulumi.Input[Union[int, str]]]
+        """
+        The maximum number of nodes with an existing available DaemonSet pod that can have an updated DaemonSet pod during during an update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up to a minimum of 1. Default value is 0. Example: when this is set to 30%, at most 30% of the total number of nodes that should be running the daemon pod (i.e. status.desiredNumberScheduled) can have their a new pod created before the old pod is marked as deleted. The update starts by launching new pods on 30% of nodes. Once an updated pod is available (Ready for at least minReadySeconds) the old DaemonSet pod on that node is marked deleted. If the old pod becomes unavailable for any reason (Ready transitions to false, is evicted, or is drained) an updated pod is immediatedly created on that node without considering surge limits. Allowing surge implies the possibility that the resources consumed by the daemonset on any given node can double if the readiness check fails, and so resource intensive daemonsets should take into account that they may cause evictions during disruption.
+        """
+        max_unavailable: NotRequired[pulumi.Input[Union[int, str]]]
+        """
+        The maximum number of DaemonSet pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of total number of DaemonSet pods at the start of the update (ex: 10%). Absolute number is calculated from percentage by rounding up. This cannot be 0 if MaxSurge is 0 Default value is 1. Example: when this is set to 30%, at most 30% of the total number of nodes that should be running the daemon pod (i.e. status.desiredNumberScheduled) can have their pods stopped for an update at any given time. The update starts by stopping at most 30% of those DaemonSet pods and then brings up new DaemonSet pods in their place. Once the new pods are available, it then proceeds onto other DaemonSet pods, thus ensuring that at least 70% of original number of DaemonSet pods are available at all times during the update.
+        """
+elif False:
+    RollingUpdateDaemonSetArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class RollingUpdateDaemonSetArgs:
@@ -1928,6 +2594,22 @@ class RollingUpdateDaemonSetArgs:
         pulumi.set(self, "max_unavailable", value)
 
 
+if not MYPY:
+    class RollingUpdateDeploymentPatchArgsDict(TypedDict):
+        """
+        Spec to control the desired behavior of rolling update.
+        """
+        max_surge: NotRequired[pulumi.Input[Union[int, str]]]
+        """
+        The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 25%. Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new ReplicaSet can be scaled up further, ensuring that total number of pods running at any time during the update is at most 130% of desired pods.
+        """
+        max_unavailable: NotRequired[pulumi.Input[Union[int, str]]]
+        """
+        The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 25%. Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods immediately when the rolling update starts. Once new pods are ready, old ReplicaSet can be scaled down further, followed by scaling up the new ReplicaSet, ensuring that the total number of pods available at all times during the update is at least 70% of desired pods.
+        """
+elif False:
+    RollingUpdateDeploymentPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class RollingUpdateDeploymentPatchArgs:
     def __init__(__self__, *,
@@ -1967,6 +2649,22 @@ class RollingUpdateDeploymentPatchArgs:
     def max_unavailable(self, value: Optional[pulumi.Input[Union[int, str]]]):
         pulumi.set(self, "max_unavailable", value)
 
+
+if not MYPY:
+    class RollingUpdateDeploymentArgsDict(TypedDict):
+        """
+        Spec to control the desired behavior of rolling update.
+        """
+        max_surge: NotRequired[pulumi.Input[Union[int, str]]]
+        """
+        The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 25%. Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new ReplicaSet can be scaled up further, ensuring that total number of pods running at any time during the update is at most 130% of desired pods.
+        """
+        max_unavailable: NotRequired[pulumi.Input[Union[int, str]]]
+        """
+        The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 25%. Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods immediately when the rolling update starts. Once new pods are ready, old ReplicaSet can be scaled down further, followed by scaling up the new ReplicaSet, ensuring that the total number of pods available at all times during the update is at least 70% of desired pods.
+        """
+elif False:
+    RollingUpdateDeploymentArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class RollingUpdateDeploymentArgs:
@@ -2008,6 +2706,22 @@ class RollingUpdateDeploymentArgs:
         pulumi.set(self, "max_unavailable", value)
 
 
+if not MYPY:
+    class RollingUpdateStatefulSetStrategyPatchArgsDict(TypedDict):
+        """
+        RollingUpdateStatefulSetStrategy is used to communicate parameter for RollingUpdateStatefulSetStrategyType.
+        """
+        max_unavailable: NotRequired[pulumi.Input[Union[int, str]]]
+        """
+        The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding up. This can not be 0. Defaults to 1. This field is alpha-level and is only honored by servers that enable the MaxUnavailableStatefulSet feature. The field applies to all pods in the range 0 to Replicas-1. That means if there is any unavailable pod in the range 0 to Replicas-1, it will be counted towards MaxUnavailable.
+        """
+        partition: NotRequired[pulumi.Input[int]]
+        """
+        Partition indicates the ordinal at which the StatefulSet should be partitioned for updates. During a rolling update, all pods from ordinal Replicas-1 to Partition are updated. All pods from ordinal Partition-1 to 0 remain untouched. This is helpful in being able to do a canary based deployment. The default value is 0.
+        """
+elif False:
+    RollingUpdateStatefulSetStrategyPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class RollingUpdateStatefulSetStrategyPatchArgs:
     def __init__(__self__, *,
@@ -2048,6 +2762,22 @@ class RollingUpdateStatefulSetStrategyPatchArgs:
         pulumi.set(self, "partition", value)
 
 
+if not MYPY:
+    class RollingUpdateStatefulSetStrategyArgsDict(TypedDict):
+        """
+        RollingUpdateStatefulSetStrategy is used to communicate parameter for RollingUpdateStatefulSetStrategyType.
+        """
+        max_unavailable: NotRequired[pulumi.Input[Union[int, str]]]
+        """
+        The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding up. This can not be 0. Defaults to 1. This field is alpha-level and is only honored by servers that enable the MaxUnavailableStatefulSet feature. The field applies to all pods in the range 0 to Replicas-1. That means if there is any unavailable pod in the range 0 to Replicas-1, it will be counted towards MaxUnavailable.
+        """
+        partition: NotRequired[pulumi.Input[int]]
+        """
+        Partition indicates the ordinal at which the StatefulSet should be partitioned for updates. During a rolling update, all pods from ordinal Replicas-1 to Partition are updated. All pods from ordinal Partition-1 to 0 remain untouched. This is helpful in being able to do a canary based deployment. The default value is 0.
+        """
+elif False:
+    RollingUpdateStatefulSetStrategyArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class RollingUpdateStatefulSetStrategyArgs:
     def __init__(__self__, *,
@@ -2087,6 +2817,34 @@ class RollingUpdateStatefulSetStrategyArgs:
     def partition(self, value: Optional[pulumi.Input[int]]):
         pulumi.set(self, "partition", value)
 
+
+if not MYPY:
+    class StatefulSetConditionArgsDict(TypedDict):
+        """
+        StatefulSetCondition describes the state of a statefulset at a certain point.
+        """
+        status: pulumi.Input[str]
+        """
+        Status of the condition, one of True, False, Unknown.
+        """
+        type: pulumi.Input[str]
+        """
+        Type of statefulset condition.
+        """
+        last_transition_time: NotRequired[pulumi.Input[str]]
+        """
+        Last time the condition transitioned from one status to another.
+        """
+        message: NotRequired[pulumi.Input[str]]
+        """
+        A human readable message indicating details about the transition.
+        """
+        reason: NotRequired[pulumi.Input[str]]
+        """
+        The reason for the condition's last transition.
+        """
+elif False:
+    StatefulSetConditionArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class StatefulSetConditionArgs:
@@ -2174,6 +2932,21 @@ class StatefulSetConditionArgs:
         pulumi.set(self, "reason", value)
 
 
+if not MYPY:
+    class StatefulSetOrdinalsPatchArgsDict(TypedDict):
+        """
+        StatefulSetOrdinals describes the policy used for replica ordinal assignment in this StatefulSet.
+        """
+        start: NotRequired[pulumi.Input[int]]
+        """
+        start is the number representing the first replica's index. It may be used to number replicas from an alternate index (eg: 1-indexed) over the default 0-indexed names, or to orchestrate progressive movement of replicas from one StatefulSet to another. If set, replica indices will be in the range:
+          [.spec.ordinals.start, .spec.ordinals.start + .spec.replicas).
+        If unset, defaults to 0. Replica indices will be in the range:
+          [0, .spec.replicas).
+        """
+elif False:
+    StatefulSetOrdinalsPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class StatefulSetOrdinalsPatchArgs:
     def __init__(__self__, *,
@@ -2204,6 +2977,21 @@ class StatefulSetOrdinalsPatchArgs:
         pulumi.set(self, "start", value)
 
 
+if not MYPY:
+    class StatefulSetOrdinalsArgsDict(TypedDict):
+        """
+        StatefulSetOrdinals describes the policy used for replica ordinal assignment in this StatefulSet.
+        """
+        start: NotRequired[pulumi.Input[int]]
+        """
+        start is the number representing the first replica's index. It may be used to number replicas from an alternate index (eg: 1-indexed) over the default 0-indexed names, or to orchestrate progressive movement of replicas from one StatefulSet to another. If set, replica indices will be in the range:
+          [.spec.ordinals.start, .spec.ordinals.start + .spec.replicas).
+        If unset, defaults to 0. Replica indices will be in the range:
+          [0, .spec.replicas).
+        """
+elif False:
+    StatefulSetOrdinalsArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class StatefulSetOrdinalsArgs:
     def __init__(__self__, *,
@@ -2233,6 +3021,22 @@ class StatefulSetOrdinalsArgs:
     def start(self, value: Optional[pulumi.Input[int]]):
         pulumi.set(self, "start", value)
 
+
+if not MYPY:
+    class StatefulSetPersistentVolumeClaimRetentionPolicyPatchArgsDict(TypedDict):
+        """
+        StatefulSetPersistentVolumeClaimRetentionPolicy describes the policy used for PVCs created from the StatefulSet VolumeClaimTemplates.
+        """
+        when_deleted: NotRequired[pulumi.Input[str]]
+        """
+        WhenDeleted specifies what happens to PVCs created from StatefulSet VolumeClaimTemplates when the StatefulSet is deleted. The default policy of `Retain` causes PVCs to not be affected by StatefulSet deletion. The `Delete` policy causes those PVCs to be deleted.
+        """
+        when_scaled: NotRequired[pulumi.Input[str]]
+        """
+        WhenScaled specifies what happens to PVCs created from StatefulSet VolumeClaimTemplates when the StatefulSet is scaled down. The default policy of `Retain` causes PVCs to not be affected by a scaledown. The `Delete` policy causes the associated PVCs for any excess pods above the replica count to be deleted.
+        """
+elif False:
+    StatefulSetPersistentVolumeClaimRetentionPolicyPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class StatefulSetPersistentVolumeClaimRetentionPolicyPatchArgs:
@@ -2274,6 +3078,22 @@ class StatefulSetPersistentVolumeClaimRetentionPolicyPatchArgs:
         pulumi.set(self, "when_scaled", value)
 
 
+if not MYPY:
+    class StatefulSetPersistentVolumeClaimRetentionPolicyArgsDict(TypedDict):
+        """
+        StatefulSetPersistentVolumeClaimRetentionPolicy describes the policy used for PVCs created from the StatefulSet VolumeClaimTemplates.
+        """
+        when_deleted: NotRequired[pulumi.Input[str]]
+        """
+        WhenDeleted specifies what happens to PVCs created from StatefulSet VolumeClaimTemplates when the StatefulSet is deleted. The default policy of `Retain` causes PVCs to not be affected by StatefulSet deletion. The `Delete` policy causes those PVCs to be deleted.
+        """
+        when_scaled: NotRequired[pulumi.Input[str]]
+        """
+        WhenScaled specifies what happens to PVCs created from StatefulSet VolumeClaimTemplates when the StatefulSet is scaled down. The default policy of `Retain` causes PVCs to not be affected by a scaledown. The `Delete` policy causes the associated PVCs for any excess pods above the replica count to be deleted.
+        """
+elif False:
+    StatefulSetPersistentVolumeClaimRetentionPolicyArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class StatefulSetPersistentVolumeClaimRetentionPolicyArgs:
     def __init__(__self__, *,
@@ -2313,6 +3133,58 @@ class StatefulSetPersistentVolumeClaimRetentionPolicyArgs:
     def when_scaled(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "when_scaled", value)
 
+
+if not MYPY:
+    class StatefulSetSpecPatchArgsDict(TypedDict):
+        """
+        A StatefulSetSpec is the specification of a StatefulSet.
+        """
+        min_ready_seconds: NotRequired[pulumi.Input[int]]
+        """
+        Minimum number of seconds for which a newly created pod should be ready without any of its container crashing for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)
+        """
+        ordinals: NotRequired[pulumi.Input['StatefulSetOrdinalsPatchArgsDict']]
+        """
+        ordinals controls the numbering of replica indices in a StatefulSet. The default ordinals behavior assigns a "0" index to the first replica and increments the index by one for each additional replica requested. Using the ordinals field requires the StatefulSetStartOrdinal feature gate to be enabled, which is beta.
+        """
+        persistent_volume_claim_retention_policy: NotRequired[pulumi.Input['StatefulSetPersistentVolumeClaimRetentionPolicyPatchArgsDict']]
+        """
+        persistentVolumeClaimRetentionPolicy describes the lifecycle of persistent volume claims created from volumeClaimTemplates. By default, all persistent volume claims are created as needed and retained until manually deleted. This policy allows the lifecycle to be altered, for example by deleting persistent volume claims when their stateful set is deleted, or when their pod is scaled down. This requires the StatefulSetAutoDeletePVC feature gate to be enabled, which is alpha.  +optional
+        """
+        pod_management_policy: NotRequired[pulumi.Input[str]]
+        """
+        podManagementPolicy controls how pods are created during initial scale up, when replacing pods on nodes, or when scaling down. The default policy is `OrderedReady`, where pods are created in increasing order (pod-0, then pod-1, etc) and the controller will wait until each pod is ready before continuing. When scaling down, the pods are removed in the opposite order. The alternative policy is `Parallel` which will create pods in parallel to match the desired scale without waiting, and on scale down will delete all pods at once.
+        """
+        replicas: NotRequired[pulumi.Input[int]]
+        """
+        replicas is the desired number of replicas of the given Template. These are replicas in the sense that they are instantiations of the same Template, but individual replicas also have a consistent identity. If unspecified, defaults to 1.
+        """
+        revision_history_limit: NotRequired[pulumi.Input[int]]
+        """
+        revisionHistoryLimit is the maximum number of revisions that will be maintained in the StatefulSet's revision history. The revision history consists of all revisions not represented by a currently applied StatefulSetSpec version. The default value is 10.
+        """
+        selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorPatchArgsDict']]
+        """
+        selector is a label query over pods that should match the replica count. It must match the pod template's labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+        """
+        service_name: NotRequired[pulumi.Input[str]]
+        """
+        serviceName is the name of the service that governs this StatefulSet. This service must exist before the StatefulSet, and is responsible for the network identity of the set. Pods get DNS/hostnames that follow the pattern: pod-specific-string.serviceName.default.svc.cluster.local where "pod-specific-string" is managed by the StatefulSet controller.
+        """
+        template: NotRequired[pulumi.Input['_core.v1.PodTemplateSpecPatchArgsDict']]
+        """
+        template is the object that describes the pod that will be created if insufficient replicas are detected. Each pod stamped out by the StatefulSet will fulfill this Template, but have a unique identity from the rest of the StatefulSet. Each pod will be named with the format <statefulsetname>-<podindex>. For example, a pod in a StatefulSet named "web" with index number "3" would be named "web-3". The only allowed template.spec.restartPolicy value is "Always".
+        """
+        update_strategy: NotRequired[pulumi.Input['StatefulSetUpdateStrategyPatchArgsDict']]
+        """
+        updateStrategy indicates the StatefulSetUpdateStrategy that will be employed to update Pods in the StatefulSet when a revision is made to Template.
+        """
+        volume_claim_templates: NotRequired[pulumi.Input[Sequence[pulumi.Input['_core.v1.PersistentVolumeClaimPatchArgsDict']]]]
+        """
+        volumeClaimTemplates is a list of claims that pods are allowed to reference. The StatefulSet controller is responsible for mapping network identities to claims in a way that maintains the identity of a pod. Every claim in this list must have at least one matching (by name) volumeMount in one container in the template. A claim in this list takes precedence over any volumes in the template, with the same name.
+        """
+elif False:
+    StatefulSetSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class StatefulSetSpecPatchArgs:
@@ -2498,6 +3370,58 @@ class StatefulSetSpecPatchArgs:
         pulumi.set(self, "volume_claim_templates", value)
 
 
+if not MYPY:
+    class StatefulSetSpecArgsDict(TypedDict):
+        """
+        A StatefulSetSpec is the specification of a StatefulSet.
+        """
+        selector: pulumi.Input['_meta.v1.LabelSelectorArgsDict']
+        """
+        selector is a label query over pods that should match the replica count. It must match the pod template's labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+        """
+        service_name: pulumi.Input[str]
+        """
+        serviceName is the name of the service that governs this StatefulSet. This service must exist before the StatefulSet, and is responsible for the network identity of the set. Pods get DNS/hostnames that follow the pattern: pod-specific-string.serviceName.default.svc.cluster.local where "pod-specific-string" is managed by the StatefulSet controller.
+        """
+        template: pulumi.Input['_core.v1.PodTemplateSpecArgsDict']
+        """
+        template is the object that describes the pod that will be created if insufficient replicas are detected. Each pod stamped out by the StatefulSet will fulfill this Template, but have a unique identity from the rest of the StatefulSet. Each pod will be named with the format <statefulsetname>-<podindex>. For example, a pod in a StatefulSet named "web" with index number "3" would be named "web-3". The only allowed template.spec.restartPolicy value is "Always".
+        """
+        min_ready_seconds: NotRequired[pulumi.Input[int]]
+        """
+        Minimum number of seconds for which a newly created pod should be ready without any of its container crashing for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)
+        """
+        ordinals: NotRequired[pulumi.Input['StatefulSetOrdinalsArgsDict']]
+        """
+        ordinals controls the numbering of replica indices in a StatefulSet. The default ordinals behavior assigns a "0" index to the first replica and increments the index by one for each additional replica requested. Using the ordinals field requires the StatefulSetStartOrdinal feature gate to be enabled, which is beta.
+        """
+        persistent_volume_claim_retention_policy: NotRequired[pulumi.Input['StatefulSetPersistentVolumeClaimRetentionPolicyArgsDict']]
+        """
+        persistentVolumeClaimRetentionPolicy describes the lifecycle of persistent volume claims created from volumeClaimTemplates. By default, all persistent volume claims are created as needed and retained until manually deleted. This policy allows the lifecycle to be altered, for example by deleting persistent volume claims when their stateful set is deleted, or when their pod is scaled down. This requires the StatefulSetAutoDeletePVC feature gate to be enabled, which is alpha.  +optional
+        """
+        pod_management_policy: NotRequired[pulumi.Input[str]]
+        """
+        podManagementPolicy controls how pods are created during initial scale up, when replacing pods on nodes, or when scaling down. The default policy is `OrderedReady`, where pods are created in increasing order (pod-0, then pod-1, etc) and the controller will wait until each pod is ready before continuing. When scaling down, the pods are removed in the opposite order. The alternative policy is `Parallel` which will create pods in parallel to match the desired scale without waiting, and on scale down will delete all pods at once.
+        """
+        replicas: NotRequired[pulumi.Input[int]]
+        """
+        replicas is the desired number of replicas of the given Template. These are replicas in the sense that they are instantiations of the same Template, but individual replicas also have a consistent identity. If unspecified, defaults to 1.
+        """
+        revision_history_limit: NotRequired[pulumi.Input[int]]
+        """
+        revisionHistoryLimit is the maximum number of revisions that will be maintained in the StatefulSet's revision history. The revision history consists of all revisions not represented by a currently applied StatefulSetSpec version. The default value is 10.
+        """
+        update_strategy: NotRequired[pulumi.Input['StatefulSetUpdateStrategyArgsDict']]
+        """
+        updateStrategy indicates the StatefulSetUpdateStrategy that will be employed to update Pods in the StatefulSet when a revision is made to Template.
+        """
+        volume_claim_templates: NotRequired[pulumi.Input[Sequence[pulumi.Input['_core.v1.PersistentVolumeClaimArgsDict']]]]
+        """
+        volumeClaimTemplates is a list of claims that pods are allowed to reference. The StatefulSet controller is responsible for mapping network identities to claims in a way that maintains the identity of a pod. Every claim in this list must have at least one matching (by name) volumeMount in one container in the template. A claim in this list takes precedence over any volumes in the template, with the same name.
+        """
+elif False:
+    StatefulSetSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class StatefulSetSpecArgs:
     def __init__(__self__, *,
@@ -2679,6 +3603,54 @@ class StatefulSetSpecArgs:
         pulumi.set(self, "volume_claim_templates", value)
 
 
+if not MYPY:
+    class StatefulSetStatusArgsDict(TypedDict):
+        """
+        StatefulSetStatus represents the current state of a StatefulSet.
+        """
+        replicas: pulumi.Input[int]
+        """
+        replicas is the number of Pods created by the StatefulSet controller.
+        """
+        available_replicas: NotRequired[pulumi.Input[int]]
+        """
+        Total number of available pods (ready for at least minReadySeconds) targeted by this statefulset.
+        """
+        collision_count: NotRequired[pulumi.Input[int]]
+        """
+        collisionCount is the count of hash collisions for the StatefulSet. The StatefulSet controller uses this field as a collision avoidance mechanism when it needs to create the name for the newest ControllerRevision.
+        """
+        conditions: NotRequired[pulumi.Input[Sequence[pulumi.Input['StatefulSetConditionArgsDict']]]]
+        """
+        Represents the latest available observations of a statefulset's current state.
+        """
+        current_replicas: NotRequired[pulumi.Input[int]]
+        """
+        currentReplicas is the number of Pods created by the StatefulSet controller from the StatefulSet version indicated by currentRevision.
+        """
+        current_revision: NotRequired[pulumi.Input[str]]
+        """
+        currentRevision, if not empty, indicates the version of the StatefulSet used to generate Pods in the sequence [0,currentReplicas).
+        """
+        observed_generation: NotRequired[pulumi.Input[int]]
+        """
+        observedGeneration is the most recent generation observed for this StatefulSet. It corresponds to the StatefulSet's generation, which is updated on mutation by the API Server.
+        """
+        ready_replicas: NotRequired[pulumi.Input[int]]
+        """
+        readyReplicas is the number of pods created for this StatefulSet with a Ready Condition.
+        """
+        update_revision: NotRequired[pulumi.Input[str]]
+        """
+        updateRevision, if not empty, indicates the version of the StatefulSet used to generate Pods in the sequence [replicas-updatedReplicas,replicas)
+        """
+        updated_replicas: NotRequired[pulumi.Input[int]]
+        """
+        updatedReplicas is the number of Pods created by the StatefulSet controller from the StatefulSet version indicated by updateRevision.
+        """
+elif False:
+    StatefulSetStatusArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class StatefulSetStatusArgs:
     def __init__(__self__, *,
@@ -2846,6 +3818,22 @@ class StatefulSetStatusArgs:
         pulumi.set(self, "updated_replicas", value)
 
 
+if not MYPY:
+    class StatefulSetUpdateStrategyPatchArgsDict(TypedDict):
+        """
+        StatefulSetUpdateStrategy indicates the strategy that the StatefulSet controller will use to perform updates. It includes any additional parameters necessary to perform the update for the indicated strategy.
+        """
+        rolling_update: NotRequired[pulumi.Input['RollingUpdateStatefulSetStrategyPatchArgsDict']]
+        """
+        RollingUpdate is used to communicate parameters when Type is RollingUpdateStatefulSetStrategyType.
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        Type indicates the type of the StatefulSetUpdateStrategy. Default is RollingUpdate.
+        """
+elif False:
+    StatefulSetUpdateStrategyPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class StatefulSetUpdateStrategyPatchArgs:
     def __init__(__self__, *,
@@ -2886,6 +3874,22 @@ class StatefulSetUpdateStrategyPatchArgs:
         pulumi.set(self, "type", value)
 
 
+if not MYPY:
+    class StatefulSetUpdateStrategyArgsDict(TypedDict):
+        """
+        StatefulSetUpdateStrategy indicates the strategy that the StatefulSet controller will use to perform updates. It includes any additional parameters necessary to perform the update for the indicated strategy.
+        """
+        rolling_update: NotRequired[pulumi.Input['RollingUpdateStatefulSetStrategyArgsDict']]
+        """
+        RollingUpdate is used to communicate parameters when Type is RollingUpdateStatefulSetStrategyType.
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        Type indicates the type of the StatefulSetUpdateStrategy. Default is RollingUpdate.
+        """
+elif False:
+    StatefulSetUpdateStrategyArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class StatefulSetUpdateStrategyArgs:
     def __init__(__self__, *,
@@ -2925,6 +3929,51 @@ class StatefulSetUpdateStrategyArgs:
     def type(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "type", value)
 
+
+if not MYPY:
+    class StatefulSetArgsDict(TypedDict):
+        """
+        StatefulSet represents a set of pods with consistent identities. Identities are defined as:
+          - Network: A single stable DNS and hostname.
+          - Storage: As many VolumeClaims as requested.
+
+        The StatefulSet guarantees that a given network identity will always map to the same storage identity.
+
+        This resource waits until its status is ready before registering success
+        for create/update, and populating output properties from the current state of the resource.
+        The following conditions are used to determine whether the resource creation has
+        succeeded or failed:
+
+        1. The value of 'spec.replicas' matches '.status.replicas', '.status.currentReplicas',
+           and '.status.readyReplicas'.
+        2. The value of '.status.updateRevision' matches '.status.currentRevision'.
+
+        If the StatefulSet has not reached a Ready state after 10 minutes, it will
+        time out and mark the resource update as Failed. You can override the default timeout value
+        by setting the 'customTimeouts' option on the resource.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['StatefulSetSpecArgsDict']]
+        """
+        Spec defines the desired identities of pods in this set.
+        """
+        status: NotRequired[pulumi.Input['StatefulSetStatusArgsDict']]
+        """
+        Status is the current status of Pods in this StatefulSet. This data may be out of date by some window of time.
+        """
+elif False:
+    StatefulSetArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class StatefulSetArgs:

--- a/sdk/python/pulumi_kubernetes/apps/v1/outputs.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1/outputs.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core

--- a/sdk/python/pulumi_kubernetes/apps/v1beta1/ControllerRevision.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta1/ControllerRevision.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import meta as _meta
 
@@ -107,7 +112,7 @@ class ControllerRevision(pulumi.CustomResource):
                  api_version: Optional[pulumi.Input[str]] = None,
                  data: Optional[Any] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
                  revision: Optional[pulumi.Input[int]] = None,
                  __props__=None):
         """
@@ -118,7 +123,7 @@ class ControllerRevision(pulumi.CustomResource):
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param Any data: Data is the serialized representation of the state.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         :param pulumi.Input[int] revision: Revision indicates the revision of the state represented by Data.
         """
         ...
@@ -148,7 +153,7 @@ class ControllerRevision(pulumi.CustomResource):
                  api_version: Optional[pulumi.Input[str]] = None,
                  data: Optional[Any] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
                  revision: Optional[pulumi.Input[int]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)

--- a/sdk/python/pulumi_kubernetes/apps/v1beta1/ControllerRevisionList.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta1/ControllerRevisionList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class ControllerRevisionList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ControllerRevisionArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ControllerRevisionArgs', 'ControllerRevisionArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         ControllerRevisionList is a resource containing a list of ControllerRevision objects.
@@ -101,9 +106,9 @@ class ControllerRevisionList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ControllerRevisionArgs']]]] items: Items is the list of ControllerRevisions
+        :param pulumi.Input[Sequence[pulumi.Input[Union['ControllerRevisionArgs', 'ControllerRevisionArgsDict']]]] items: Items is the list of ControllerRevisions
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class ControllerRevisionList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ControllerRevisionArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ControllerRevisionArgs', 'ControllerRevisionArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/apps/v1beta1/ControllerRevisionPatch.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta1/ControllerRevisionPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import meta as _meta
 
@@ -108,7 +113,7 @@ class ControllerRevisionPatch(pulumi.CustomResource):
                  api_version: Optional[pulumi.Input[str]] = None,
                  data: Optional[Any] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
                  revision: Optional[pulumi.Input[int]] = None,
                  __props__=None):
         """
@@ -125,7 +130,7 @@ class ControllerRevisionPatch(pulumi.CustomResource):
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param Any data: Data is the serialized representation of the state.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         :param pulumi.Input[int] revision: Revision indicates the revision of the state represented by Data.
         """
         ...
@@ -161,7 +166,7 @@ class ControllerRevisionPatch(pulumi.CustomResource):
                  api_version: Optional[pulumi.Input[str]] = None,
                  data: Optional[Any] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
                  revision: Optional[pulumi.Input[int]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)

--- a/sdk/python/pulumi_kubernetes/apps/v1beta1/Deployment.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta1/Deployment.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -94,8 +99,8 @@ class Deployment(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['DeploymentSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['DeploymentSpecArgs', 'DeploymentSpecArgsDict']]] = None,
                  __props__=None):
         """
         Deployment enables declarative updates for Pods and ReplicaSets.
@@ -126,8 +131,8 @@ class Deployment(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object metadata.
-        :param pulumi.Input[pulumi.InputType['DeploymentSpecArgs']] spec: Specification of the desired behavior of the Deployment.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object metadata.
+        :param pulumi.Input[Union['DeploymentSpecArgs', 'DeploymentSpecArgsDict']] spec: Specification of the desired behavior of the Deployment.
         """
         ...
     @overload
@@ -177,8 +182,8 @@ class Deployment(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['DeploymentSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['DeploymentSpecArgs', 'DeploymentSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/apps/v1beta1/DeploymentList.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta1/DeploymentList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -92,9 +97,9 @@ class DeploymentList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['DeploymentArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['DeploymentArgs', 'DeploymentArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         DeploymentList is a list of Deployments.
@@ -102,9 +107,9 @@ class DeploymentList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['DeploymentArgs']]]] items: Items is the list of Deployments.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['DeploymentArgs', 'DeploymentArgsDict']]]] items: Items is the list of Deployments.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata.
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata.
         """
         ...
     @overload
@@ -131,9 +136,9 @@ class DeploymentList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['DeploymentArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['DeploymentArgs', 'DeploymentArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/apps/v1beta1/DeploymentPatch.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta1/DeploymentPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -94,8 +99,8 @@ class DeploymentPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['DeploymentSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['DeploymentSpecPatchArgs', 'DeploymentSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -132,8 +137,8 @@ class DeploymentPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object metadata.
-        :param pulumi.Input[pulumi.InputType['DeploymentSpecPatchArgs']] spec: Specification of the desired behavior of the Deployment.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object metadata.
+        :param pulumi.Input[Union['DeploymentSpecPatchArgs', 'DeploymentSpecPatchArgsDict']] spec: Specification of the desired behavior of the Deployment.
         """
         ...
     @overload
@@ -189,8 +194,8 @@ class DeploymentPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['DeploymentSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['DeploymentSpecPatchArgs', 'DeploymentSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/apps/v1beta1/StatefulSet.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta1/StatefulSet.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -90,8 +95,8 @@ class StatefulSet(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['StatefulSetSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['StatefulSetSpecArgs', 'StatefulSetSpecArgsDict']]] = None,
                  __props__=None):
         """
         StatefulSet represents a set of pods with consistent identities. Identities are defined as:
@@ -116,7 +121,7 @@ class StatefulSet(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['StatefulSetSpecArgs']] spec: Spec defines the desired identities of pods in this set.
+        :param pulumi.Input[Union['StatefulSetSpecArgs', 'StatefulSetSpecArgsDict']] spec: Spec defines the desired identities of pods in this set.
         """
         ...
     @overload
@@ -160,8 +165,8 @@ class StatefulSet(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['StatefulSetSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['StatefulSetSpecArgs', 'StatefulSetSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/apps/v1beta1/StatefulSetList.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta1/StatefulSetList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -84,9 +89,9 @@ class StatefulSetList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['StatefulSetArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['StatefulSetArgs', 'StatefulSetArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         StatefulSetList is a collection of StatefulSets.
@@ -121,9 +126,9 @@ class StatefulSetList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['StatefulSetArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['StatefulSetArgs', 'StatefulSetArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/apps/v1beta1/StatefulSetPatch.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta1/StatefulSetPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -90,8 +95,8 @@ class StatefulSetPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['StatefulSetSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['StatefulSetSpecPatchArgs', 'StatefulSetSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -122,7 +127,7 @@ class StatefulSetPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['StatefulSetSpecPatchArgs']] spec: Spec defines the desired identities of pods in this set.
+        :param pulumi.Input[Union['StatefulSetSpecPatchArgs', 'StatefulSetSpecPatchArgsDict']] spec: Spec defines the desired identities of pods in this set.
         """
         ...
     @overload
@@ -172,8 +177,8 @@ class StatefulSetPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['StatefulSetSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['StatefulSetSpecPatchArgs', 'StatefulSetSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/apps/v1beta1/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta1/_inputs.py
@@ -4,36 +4,92 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import core as _core
 from ... import meta as _meta
 
 __all__ = [
     'ControllerRevisionArgs',
+    'ControllerRevisionArgsDict',
     'DeploymentConditionArgs',
+    'DeploymentConditionArgsDict',
     'DeploymentSpecPatchArgs',
+    'DeploymentSpecPatchArgsDict',
     'DeploymentSpecArgs',
+    'DeploymentSpecArgsDict',
     'DeploymentStatusArgs',
+    'DeploymentStatusArgsDict',
     'DeploymentStrategyPatchArgs',
+    'DeploymentStrategyPatchArgsDict',
     'DeploymentStrategyArgs',
+    'DeploymentStrategyArgsDict',
     'DeploymentArgs',
+    'DeploymentArgsDict',
     'RollbackConfigPatchArgs',
+    'RollbackConfigPatchArgsDict',
     'RollbackConfigArgs',
+    'RollbackConfigArgsDict',
     'RollingUpdateDeploymentPatchArgs',
+    'RollingUpdateDeploymentPatchArgsDict',
     'RollingUpdateDeploymentArgs',
+    'RollingUpdateDeploymentArgsDict',
     'RollingUpdateStatefulSetStrategyPatchArgs',
+    'RollingUpdateStatefulSetStrategyPatchArgsDict',
     'RollingUpdateStatefulSetStrategyArgs',
+    'RollingUpdateStatefulSetStrategyArgsDict',
     'StatefulSetConditionArgs',
+    'StatefulSetConditionArgsDict',
     'StatefulSetSpecPatchArgs',
+    'StatefulSetSpecPatchArgsDict',
     'StatefulSetSpecArgs',
+    'StatefulSetSpecArgsDict',
     'StatefulSetStatusArgs',
+    'StatefulSetStatusArgsDict',
     'StatefulSetUpdateStrategyPatchArgs',
+    'StatefulSetUpdateStrategyPatchArgsDict',
     'StatefulSetUpdateStrategyArgs',
+    'StatefulSetUpdateStrategyArgsDict',
     'StatefulSetArgs',
+    'StatefulSetArgsDict',
 ]
+
+MYPY = False
+
+if not MYPY:
+    class ControllerRevisionArgsDict(TypedDict):
+        """
+        ControllerRevision implements an immutable snapshot of state data. Clients are responsible for serializing and deserializing the objects that contain their internal state. Once a ControllerRevision has been successfully created, it can not be updated. The API Server will fail validation of all requests that attempt to mutate the Data field. ControllerRevisions may, however, be deleted. Note that, due to its use by both the DaemonSet and StatefulSet controllers for update and rollback, this object is beta. However, it may be subject to name and representation changes in future releases, and clients should not depend on its stability. It is primarily for internal use by controllers.
+        """
+        revision: pulumi.Input[int]
+        """
+        Revision indicates the revision of the state represented by Data.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        data: NotRequired[Any]
+        """
+        Data is the serialized representation of the state.
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+elif False:
+    ControllerRevisionArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ControllerRevisionArgs:
@@ -121,6 +177,38 @@ class ControllerRevisionArgs:
     def metadata(self, value: Optional[pulumi.Input['_meta.v1.ObjectMetaArgs']]):
         pulumi.set(self, "metadata", value)
 
+
+if not MYPY:
+    class DeploymentConditionArgsDict(TypedDict):
+        """
+        DeploymentCondition describes the state of a deployment at a certain point.
+        """
+        status: pulumi.Input[str]
+        """
+        Status of the condition, one of True, False, Unknown.
+        """
+        type: pulumi.Input[str]
+        """
+        Type of deployment condition.
+        """
+        last_transition_time: NotRequired[pulumi.Input[str]]
+        """
+        Last time the condition transitioned from one status to another.
+        """
+        last_update_time: NotRequired[pulumi.Input[str]]
+        """
+        The last time this condition was updated.
+        """
+        message: NotRequired[pulumi.Input[str]]
+        """
+        A human readable message indicating details about the transition.
+        """
+        reason: NotRequired[pulumi.Input[str]]
+        """
+        The reason for the condition's last transition.
+        """
+elif False:
+    DeploymentConditionArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class DeploymentConditionArgs:
@@ -223,6 +311,50 @@ class DeploymentConditionArgs:
     def reason(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "reason", value)
 
+
+if not MYPY:
+    class DeploymentSpecPatchArgsDict(TypedDict):
+        """
+        DeploymentSpec is the specification of the desired behavior of the Deployment.
+        """
+        min_ready_seconds: NotRequired[pulumi.Input[int]]
+        """
+        Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)
+        """
+        paused: NotRequired[pulumi.Input[bool]]
+        """
+        Indicates that the deployment is paused.
+        """
+        progress_deadline_seconds: NotRequired[pulumi.Input[int]]
+        """
+        The maximum time in seconds for a deployment to make progress before it is considered to be failed. The deployment controller will continue to process failed deployments and a condition with a ProgressDeadlineExceeded reason will be surfaced in the deployment status. Note that progress will not be estimated during the time a deployment is paused. Defaults to 600s.
+        """
+        replicas: NotRequired[pulumi.Input[int]]
+        """
+        Number of desired pods. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1.
+        """
+        revision_history_limit: NotRequired[pulumi.Input[int]]
+        """
+        The number of old ReplicaSets to retain to allow rollback. This is a pointer to distinguish between explicit zero and not specified. Defaults to 2.
+        """
+        rollback_to: NotRequired[pulumi.Input['RollbackConfigPatchArgsDict']]
+        """
+        DEPRECATED. The config this deployment is rolling back to. Will be cleared after rollback is done.
+        """
+        selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorPatchArgsDict']]
+        """
+        Label selector for pods. Existing ReplicaSets whose pods are selected by this will be the ones affected by this deployment.
+        """
+        strategy: NotRequired[pulumi.Input['DeploymentStrategyPatchArgsDict']]
+        """
+        The deployment strategy to use to replace existing pods with new ones.
+        """
+        template: NotRequired[pulumi.Input['_core.v1.PodTemplateSpecPatchArgsDict']]
+        """
+        Template describes the pods that will be created.
+        """
+elif False:
+    DeploymentSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class DeploymentSpecPatchArgs:
@@ -376,6 +508,50 @@ class DeploymentSpecPatchArgs:
         pulumi.set(self, "template", value)
 
 
+if not MYPY:
+    class DeploymentSpecArgsDict(TypedDict):
+        """
+        DeploymentSpec is the specification of the desired behavior of the Deployment.
+        """
+        template: pulumi.Input['_core.v1.PodTemplateSpecArgsDict']
+        """
+        Template describes the pods that will be created.
+        """
+        min_ready_seconds: NotRequired[pulumi.Input[int]]
+        """
+        Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)
+        """
+        paused: NotRequired[pulumi.Input[bool]]
+        """
+        Indicates that the deployment is paused.
+        """
+        progress_deadline_seconds: NotRequired[pulumi.Input[int]]
+        """
+        The maximum time in seconds for a deployment to make progress before it is considered to be failed. The deployment controller will continue to process failed deployments and a condition with a ProgressDeadlineExceeded reason will be surfaced in the deployment status. Note that progress will not be estimated during the time a deployment is paused. Defaults to 600s.
+        """
+        replicas: NotRequired[pulumi.Input[int]]
+        """
+        Number of desired pods. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1.
+        """
+        revision_history_limit: NotRequired[pulumi.Input[int]]
+        """
+        The number of old ReplicaSets to retain to allow rollback. This is a pointer to distinguish between explicit zero and not specified. Defaults to 2.
+        """
+        rollback_to: NotRequired[pulumi.Input['RollbackConfigArgsDict']]
+        """
+        DEPRECATED. The config this deployment is rolling back to. Will be cleared after rollback is done.
+        """
+        selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorArgsDict']]
+        """
+        Label selector for pods. Existing ReplicaSets whose pods are selected by this will be the ones affected by this deployment.
+        """
+        strategy: NotRequired[pulumi.Input['DeploymentStrategyArgsDict']]
+        """
+        The deployment strategy to use to replace existing pods with new ones.
+        """
+elif False:
+    DeploymentSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class DeploymentSpecArgs:
     def __init__(__self__, *,
@@ -527,6 +703,46 @@ class DeploymentSpecArgs:
         pulumi.set(self, "strategy", value)
 
 
+if not MYPY:
+    class DeploymentStatusArgsDict(TypedDict):
+        """
+        DeploymentStatus is the most recently observed status of the Deployment.
+        """
+        available_replicas: NotRequired[pulumi.Input[int]]
+        """
+        Total number of available pods (ready for at least minReadySeconds) targeted by this deployment.
+        """
+        collision_count: NotRequired[pulumi.Input[int]]
+        """
+        Count of hash collisions for the Deployment. The Deployment controller uses this field as a collision avoidance mechanism when it needs to create the name for the newest ReplicaSet.
+        """
+        conditions: NotRequired[pulumi.Input[Sequence[pulumi.Input['DeploymentConditionArgsDict']]]]
+        """
+        Represents the latest available observations of a deployment's current state.
+        """
+        observed_generation: NotRequired[pulumi.Input[int]]
+        """
+        The generation observed by the deployment controller.
+        """
+        ready_replicas: NotRequired[pulumi.Input[int]]
+        """
+        Total number of ready pods targeted by this deployment.
+        """
+        replicas: NotRequired[pulumi.Input[int]]
+        """
+        Total number of non-terminated pods targeted by this deployment (their labels match the selector).
+        """
+        unavailable_replicas: NotRequired[pulumi.Input[int]]
+        """
+        Total number of unavailable pods targeted by this deployment. This is the total number of pods that are still required for the deployment to have 100% available capacity. They may either be pods that are running but not yet available or pods that still have not been created.
+        """
+        updated_replicas: NotRequired[pulumi.Input[int]]
+        """
+        Total number of non-terminated pods targeted by this deployment that have the desired template spec.
+        """
+elif False:
+    DeploymentStatusArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class DeploymentStatusArgs:
     def __init__(__self__, *,
@@ -663,6 +879,22 @@ class DeploymentStatusArgs:
         pulumi.set(self, "updated_replicas", value)
 
 
+if not MYPY:
+    class DeploymentStrategyPatchArgsDict(TypedDict):
+        """
+        DeploymentStrategy describes how to replace existing pods with new ones.
+        """
+        rolling_update: NotRequired[pulumi.Input['RollingUpdateDeploymentPatchArgsDict']]
+        """
+        Rolling update config params. Present only if DeploymentStrategyType = RollingUpdate.
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        Type of deployment. Can be "Recreate" or "RollingUpdate". Default is RollingUpdate.
+        """
+elif False:
+    DeploymentStrategyPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class DeploymentStrategyPatchArgs:
     def __init__(__self__, *,
@@ -703,6 +935,22 @@ class DeploymentStrategyPatchArgs:
         pulumi.set(self, "type", value)
 
 
+if not MYPY:
+    class DeploymentStrategyArgsDict(TypedDict):
+        """
+        DeploymentStrategy describes how to replace existing pods with new ones.
+        """
+        rolling_update: NotRequired[pulumi.Input['RollingUpdateDeploymentArgsDict']]
+        """
+        Rolling update config params. Present only if DeploymentStrategyType = RollingUpdate.
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        Type of deployment. Can be "Recreate" or "RollingUpdate". Default is RollingUpdate.
+        """
+elif False:
+    DeploymentStrategyArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class DeploymentStrategyArgs:
     def __init__(__self__, *,
@@ -742,6 +990,56 @@ class DeploymentStrategyArgs:
     def type(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "type", value)
 
+
+if not MYPY:
+    class DeploymentArgsDict(TypedDict):
+        """
+        Deployment enables declarative updates for Pods and ReplicaSets.
+
+        This resource waits until its status is ready before registering success
+        for create/update, and populating output properties from the current state of the resource.
+        The following conditions are used to determine whether the resource creation has
+        succeeded or failed:
+
+        1. The Deployment has begun to be updated by the Deployment controller. If the current
+           generation of the Deployment is > 1, then this means that the current generation must
+           be different from the generation reported by the last outputs.
+        2. There exists a ReplicaSet whose revision is equal to the current revision of the
+           Deployment.
+        3. The Deployment's '.status.conditions' has a status of type 'Available' whose 'status'
+           member is set to 'True'.
+        4. If the Deployment has generation > 1, then '.status.conditions' has a status of type
+           'Progressing', whose 'status' member is set to 'True', and whose 'reason' is
+           'NewReplicaSetAvailable'. For generation <= 1, this status field does not exist,
+           because it doesn't do a rollout (i.e., it simply creates the Deployment and
+           corresponding ReplicaSet), and therefore there is no rollout to mark as 'Progressing'.
+
+        If the Deployment has not reached a Ready state after 10 minutes, it will
+        time out and mark the resource update as Failed. You can override the default timeout value
+        by setting the 'customTimeouts' option on the resource.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object metadata.
+        """
+        spec: NotRequired[pulumi.Input['DeploymentSpecArgsDict']]
+        """
+        Specification of the desired behavior of the Deployment.
+        """
+        status: NotRequired[pulumi.Input['DeploymentStatusArgsDict']]
+        """
+        Most recently observed status of the Deployment.
+        """
+elif False:
+    DeploymentArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class DeploymentArgs:
@@ -853,6 +1151,18 @@ class DeploymentArgs:
         pulumi.set(self, "status", value)
 
 
+if not MYPY:
+    class RollbackConfigPatchArgsDict(TypedDict):
+        """
+        DEPRECATED.
+        """
+        revision: NotRequired[pulumi.Input[int]]
+        """
+        The revision to rollback to. If set to 0, rollback to the last revision.
+        """
+elif False:
+    RollbackConfigPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class RollbackConfigPatchArgs:
     def __init__(__self__, *,
@@ -877,6 +1187,18 @@ class RollbackConfigPatchArgs:
         pulumi.set(self, "revision", value)
 
 
+if not MYPY:
+    class RollbackConfigArgsDict(TypedDict):
+        """
+        DEPRECATED.
+        """
+        revision: NotRequired[pulumi.Input[int]]
+        """
+        The revision to rollback to. If set to 0, rollback to the last revision.
+        """
+elif False:
+    RollbackConfigArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class RollbackConfigArgs:
     def __init__(__self__, *,
@@ -900,6 +1222,22 @@ class RollbackConfigArgs:
     def revision(self, value: Optional[pulumi.Input[int]]):
         pulumi.set(self, "revision", value)
 
+
+if not MYPY:
+    class RollingUpdateDeploymentPatchArgsDict(TypedDict):
+        """
+        Spec to control the desired behavior of rolling update.
+        """
+        max_surge: NotRequired[pulumi.Input[Union[int, str]]]
+        """
+        The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 25%. Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new ReplicaSet can be scaled up further, ensuring that total number of pods running at any time during the update is at most 130% of desired pods.
+        """
+        max_unavailable: NotRequired[pulumi.Input[Union[int, str]]]
+        """
+        The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 25%. Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods immediately when the rolling update starts. Once new pods are ready, old ReplicaSet can be scaled down further, followed by scaling up the new ReplicaSet, ensuring that the total number of pods available at all times during the update is at least 70% of desired pods.
+        """
+elif False:
+    RollingUpdateDeploymentPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class RollingUpdateDeploymentPatchArgs:
@@ -941,6 +1279,22 @@ class RollingUpdateDeploymentPatchArgs:
         pulumi.set(self, "max_unavailable", value)
 
 
+if not MYPY:
+    class RollingUpdateDeploymentArgsDict(TypedDict):
+        """
+        Spec to control the desired behavior of rolling update.
+        """
+        max_surge: NotRequired[pulumi.Input[Union[int, str]]]
+        """
+        The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 25%. Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new ReplicaSet can be scaled up further, ensuring that total number of pods running at any time during the update is at most 130% of desired pods.
+        """
+        max_unavailable: NotRequired[pulumi.Input[Union[int, str]]]
+        """
+        The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 25%. Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods immediately when the rolling update starts. Once new pods are ready, old ReplicaSet can be scaled down further, followed by scaling up the new ReplicaSet, ensuring that the total number of pods available at all times during the update is at least 70% of desired pods.
+        """
+elif False:
+    RollingUpdateDeploymentArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class RollingUpdateDeploymentArgs:
     def __init__(__self__, *,
@@ -981,6 +1335,18 @@ class RollingUpdateDeploymentArgs:
         pulumi.set(self, "max_unavailable", value)
 
 
+if not MYPY:
+    class RollingUpdateStatefulSetStrategyPatchArgsDict(TypedDict):
+        """
+        RollingUpdateStatefulSetStrategy is used to communicate parameter for RollingUpdateStatefulSetStrategyType.
+        """
+        partition: NotRequired[pulumi.Input[int]]
+        """
+        Partition indicates the ordinal at which the StatefulSet should be partitioned.
+        """
+elif False:
+    RollingUpdateStatefulSetStrategyPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class RollingUpdateStatefulSetStrategyPatchArgs:
     def __init__(__self__, *,
@@ -1005,6 +1371,18 @@ class RollingUpdateStatefulSetStrategyPatchArgs:
         pulumi.set(self, "partition", value)
 
 
+if not MYPY:
+    class RollingUpdateStatefulSetStrategyArgsDict(TypedDict):
+        """
+        RollingUpdateStatefulSetStrategy is used to communicate parameter for RollingUpdateStatefulSetStrategyType.
+        """
+        partition: NotRequired[pulumi.Input[int]]
+        """
+        Partition indicates the ordinal at which the StatefulSet should be partitioned.
+        """
+elif False:
+    RollingUpdateStatefulSetStrategyArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class RollingUpdateStatefulSetStrategyArgs:
     def __init__(__self__, *,
@@ -1028,6 +1406,34 @@ class RollingUpdateStatefulSetStrategyArgs:
     def partition(self, value: Optional[pulumi.Input[int]]):
         pulumi.set(self, "partition", value)
 
+
+if not MYPY:
+    class StatefulSetConditionArgsDict(TypedDict):
+        """
+        StatefulSetCondition describes the state of a statefulset at a certain point.
+        """
+        status: pulumi.Input[str]
+        """
+        Status of the condition, one of True, False, Unknown.
+        """
+        type: pulumi.Input[str]
+        """
+        Type of statefulset condition.
+        """
+        last_transition_time: NotRequired[pulumi.Input[str]]
+        """
+        Last time the condition transitioned from one status to another.
+        """
+        message: NotRequired[pulumi.Input[str]]
+        """
+        A human readable message indicating details about the transition.
+        """
+        reason: NotRequired[pulumi.Input[str]]
+        """
+        The reason for the condition's last transition.
+        """
+elif False:
+    StatefulSetConditionArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class StatefulSetConditionArgs:
@@ -1114,6 +1520,46 @@ class StatefulSetConditionArgs:
     def reason(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "reason", value)
 
+
+if not MYPY:
+    class StatefulSetSpecPatchArgsDict(TypedDict):
+        """
+        A StatefulSetSpec is the specification of a StatefulSet.
+        """
+        pod_management_policy: NotRequired[pulumi.Input[str]]
+        """
+        podManagementPolicy controls how pods are created during initial scale up, when replacing pods on nodes, or when scaling down. The default policy is `OrderedReady`, where pods are created in increasing order (pod-0, then pod-1, etc) and the controller will wait until each pod is ready before continuing. When scaling down, the pods are removed in the opposite order. The alternative policy is `Parallel` which will create pods in parallel to match the desired scale without waiting, and on scale down will delete all pods at once.
+        """
+        replicas: NotRequired[pulumi.Input[int]]
+        """
+        replicas is the desired number of replicas of the given Template. These are replicas in the sense that they are instantiations of the same Template, but individual replicas also have a consistent identity. If unspecified, defaults to 1.
+        """
+        revision_history_limit: NotRequired[pulumi.Input[int]]
+        """
+        revisionHistoryLimit is the maximum number of revisions that will be maintained in the StatefulSet's revision history. The revision history consists of all revisions not represented by a currently applied StatefulSetSpec version. The default value is 10.
+        """
+        selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorPatchArgsDict']]
+        """
+        selector is a label query over pods that should match the replica count. If empty, defaulted to labels on the pod template. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+        """
+        service_name: NotRequired[pulumi.Input[str]]
+        """
+        serviceName is the name of the service that governs this StatefulSet. This service must exist before the StatefulSet, and is responsible for the network identity of the set. Pods get DNS/hostnames that follow the pattern: pod-specific-string.serviceName.default.svc.cluster.local where "pod-specific-string" is managed by the StatefulSet controller.
+        """
+        template: NotRequired[pulumi.Input['_core.v1.PodTemplateSpecPatchArgsDict']]
+        """
+        template is the object that describes the pod that will be created if insufficient replicas are detected. Each pod stamped out by the StatefulSet will fulfill this Template, but have a unique identity from the rest of the StatefulSet.
+        """
+        update_strategy: NotRequired[pulumi.Input['StatefulSetUpdateStrategyPatchArgsDict']]
+        """
+        updateStrategy indicates the StatefulSetUpdateStrategy that will be employed to update Pods in the StatefulSet when a revision is made to Template.
+        """
+        volume_claim_templates: NotRequired[pulumi.Input[Sequence[pulumi.Input['_core.v1.PersistentVolumeClaimPatchArgsDict']]]]
+        """
+        volumeClaimTemplates is a list of claims that pods are allowed to reference. The StatefulSet controller is responsible for mapping network identities to claims in a way that maintains the identity of a pod. Every claim in this list must have at least one matching (by name) volumeMount in one container in the template. A claim in this list takes precedence over any volumes in the template, with the same name.
+        """
+elif False:
+    StatefulSetSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class StatefulSetSpecPatchArgs:
@@ -1251,6 +1697,46 @@ class StatefulSetSpecPatchArgs:
         pulumi.set(self, "volume_claim_templates", value)
 
 
+if not MYPY:
+    class StatefulSetSpecArgsDict(TypedDict):
+        """
+        A StatefulSetSpec is the specification of a StatefulSet.
+        """
+        service_name: pulumi.Input[str]
+        """
+        serviceName is the name of the service that governs this StatefulSet. This service must exist before the StatefulSet, and is responsible for the network identity of the set. Pods get DNS/hostnames that follow the pattern: pod-specific-string.serviceName.default.svc.cluster.local where "pod-specific-string" is managed by the StatefulSet controller.
+        """
+        template: pulumi.Input['_core.v1.PodTemplateSpecArgsDict']
+        """
+        template is the object that describes the pod that will be created if insufficient replicas are detected. Each pod stamped out by the StatefulSet will fulfill this Template, but have a unique identity from the rest of the StatefulSet.
+        """
+        pod_management_policy: NotRequired[pulumi.Input[str]]
+        """
+        podManagementPolicy controls how pods are created during initial scale up, when replacing pods on nodes, or when scaling down. The default policy is `OrderedReady`, where pods are created in increasing order (pod-0, then pod-1, etc) and the controller will wait until each pod is ready before continuing. When scaling down, the pods are removed in the opposite order. The alternative policy is `Parallel` which will create pods in parallel to match the desired scale without waiting, and on scale down will delete all pods at once.
+        """
+        replicas: NotRequired[pulumi.Input[int]]
+        """
+        replicas is the desired number of replicas of the given Template. These are replicas in the sense that they are instantiations of the same Template, but individual replicas also have a consistent identity. If unspecified, defaults to 1.
+        """
+        revision_history_limit: NotRequired[pulumi.Input[int]]
+        """
+        revisionHistoryLimit is the maximum number of revisions that will be maintained in the StatefulSet's revision history. The revision history consists of all revisions not represented by a currently applied StatefulSetSpec version. The default value is 10.
+        """
+        selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorArgsDict']]
+        """
+        selector is a label query over pods that should match the replica count. If empty, defaulted to labels on the pod template. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+        """
+        update_strategy: NotRequired[pulumi.Input['StatefulSetUpdateStrategyArgsDict']]
+        """
+        updateStrategy indicates the StatefulSetUpdateStrategy that will be employed to update Pods in the StatefulSet when a revision is made to Template.
+        """
+        volume_claim_templates: NotRequired[pulumi.Input[Sequence[pulumi.Input['_core.v1.PersistentVolumeClaimArgsDict']]]]
+        """
+        volumeClaimTemplates is a list of claims that pods are allowed to reference. The StatefulSet controller is responsible for mapping network identities to claims in a way that maintains the identity of a pod. Every claim in this list must have at least one matching (by name) volumeMount in one container in the template. A claim in this list takes precedence over any volumes in the template, with the same name.
+        """
+elif False:
+    StatefulSetSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class StatefulSetSpecArgs:
     def __init__(__self__, *,
@@ -1384,6 +1870,50 @@ class StatefulSetSpecArgs:
     def volume_claim_templates(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['_core.v1.PersistentVolumeClaimArgs']]]]):
         pulumi.set(self, "volume_claim_templates", value)
 
+
+if not MYPY:
+    class StatefulSetStatusArgsDict(TypedDict):
+        """
+        StatefulSetStatus represents the current state of a StatefulSet.
+        """
+        replicas: pulumi.Input[int]
+        """
+        replicas is the number of Pods created by the StatefulSet controller.
+        """
+        collision_count: NotRequired[pulumi.Input[int]]
+        """
+        collisionCount is the count of hash collisions for the StatefulSet. The StatefulSet controller uses this field as a collision avoidance mechanism when it needs to create the name for the newest ControllerRevision.
+        """
+        conditions: NotRequired[pulumi.Input[Sequence[pulumi.Input['StatefulSetConditionArgsDict']]]]
+        """
+        Represents the latest available observations of a statefulset's current state.
+        """
+        current_replicas: NotRequired[pulumi.Input[int]]
+        """
+        currentReplicas is the number of Pods created by the StatefulSet controller from the StatefulSet version indicated by currentRevision.
+        """
+        current_revision: NotRequired[pulumi.Input[str]]
+        """
+        currentRevision, if not empty, indicates the version of the StatefulSet used to generate Pods in the sequence [0,currentReplicas).
+        """
+        observed_generation: NotRequired[pulumi.Input[int]]
+        """
+        observedGeneration is the most recent generation observed for this StatefulSet. It corresponds to the StatefulSet's generation, which is updated on mutation by the API Server.
+        """
+        ready_replicas: NotRequired[pulumi.Input[int]]
+        """
+        readyReplicas is the number of Pods created by the StatefulSet controller that have a Ready Condition.
+        """
+        update_revision: NotRequired[pulumi.Input[str]]
+        """
+        updateRevision, if not empty, indicates the version of the StatefulSet used to generate Pods in the sequence [replicas-updatedReplicas,replicas)
+        """
+        updated_replicas: NotRequired[pulumi.Input[int]]
+        """
+        updatedReplicas is the number of Pods created by the StatefulSet controller from the StatefulSet version indicated by updateRevision.
+        """
+elif False:
+    StatefulSetStatusArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class StatefulSetStatusArgs:
@@ -1536,6 +2066,22 @@ class StatefulSetStatusArgs:
         pulumi.set(self, "updated_replicas", value)
 
 
+if not MYPY:
+    class StatefulSetUpdateStrategyPatchArgsDict(TypedDict):
+        """
+        StatefulSetUpdateStrategy indicates the strategy that the StatefulSet controller will use to perform updates. It includes any additional parameters necessary to perform the update for the indicated strategy.
+        """
+        rolling_update: NotRequired[pulumi.Input['RollingUpdateStatefulSetStrategyPatchArgsDict']]
+        """
+        RollingUpdate is used to communicate parameters when Type is RollingUpdateStatefulSetStrategyType.
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        Type indicates the type of the StatefulSetUpdateStrategy.
+        """
+elif False:
+    StatefulSetUpdateStrategyPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class StatefulSetUpdateStrategyPatchArgs:
     def __init__(__self__, *,
@@ -1576,6 +2122,22 @@ class StatefulSetUpdateStrategyPatchArgs:
         pulumi.set(self, "type", value)
 
 
+if not MYPY:
+    class StatefulSetUpdateStrategyArgsDict(TypedDict):
+        """
+        StatefulSetUpdateStrategy indicates the strategy that the StatefulSet controller will use to perform updates. It includes any additional parameters necessary to perform the update for the indicated strategy.
+        """
+        rolling_update: NotRequired[pulumi.Input['RollingUpdateStatefulSetStrategyArgsDict']]
+        """
+        RollingUpdate is used to communicate parameters when Type is RollingUpdateStatefulSetStrategyType.
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        Type indicates the type of the StatefulSetUpdateStrategy.
+        """
+elif False:
+    StatefulSetUpdateStrategyArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class StatefulSetUpdateStrategyArgs:
     def __init__(__self__, *,
@@ -1615,6 +2177,47 @@ class StatefulSetUpdateStrategyArgs:
     def type(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "type", value)
 
+
+if not MYPY:
+    class StatefulSetArgsDict(TypedDict):
+        """
+        StatefulSet represents a set of pods with consistent identities. Identities are defined as:
+         - Network: A single stable DNS and hostname.
+         - Storage: As many VolumeClaims as requested.
+        The StatefulSet guarantees that a given network identity will always map to the same storage identity.
+
+        This resource waits until its status is ready before registering success
+        for create/update, and populating output properties from the current state of the resource.
+        The following conditions are used to determine whether the resource creation has
+        succeeded or failed:
+
+        1. The value of 'spec.replicas' matches '.status.replicas', '.status.currentReplicas',
+           and '.status.readyReplicas'.
+        2. The value of '.status.updateRevision' matches '.status.currentRevision'.
+
+        If the StatefulSet has not reached a Ready state after 10 minutes, it will
+        time out and mark the resource update as Failed. You can override the default timeout value
+        by setting the 'customTimeouts' option on the resource.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        spec: NotRequired[pulumi.Input['StatefulSetSpecArgsDict']]
+        """
+        Spec defines the desired identities of pods in this set.
+        """
+        status: NotRequired[pulumi.Input['StatefulSetStatusArgsDict']]
+        """
+        Status is the current status of Pods in this StatefulSet. This data may be out of date by some window of time.
+        """
+elif False:
+    StatefulSetArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class StatefulSetArgs:

--- a/sdk/python/pulumi_kubernetes/apps/v1beta1/outputs.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta1/outputs.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core

--- a/sdk/python/pulumi_kubernetes/apps/v1beta2/ControllerRevision.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta2/ControllerRevision.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import meta as _meta
 
@@ -107,7 +112,7 @@ class ControllerRevision(pulumi.CustomResource):
                  api_version: Optional[pulumi.Input[str]] = None,
                  data: Optional[Any] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
                  revision: Optional[pulumi.Input[int]] = None,
                  __props__=None):
         """
@@ -118,7 +123,7 @@ class ControllerRevision(pulumi.CustomResource):
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param Any data: Data is the serialized representation of the state.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         :param pulumi.Input[int] revision: Revision indicates the revision of the state represented by Data.
         """
         ...
@@ -148,7 +153,7 @@ class ControllerRevision(pulumi.CustomResource):
                  api_version: Optional[pulumi.Input[str]] = None,
                  data: Optional[Any] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
                  revision: Optional[pulumi.Input[int]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)

--- a/sdk/python/pulumi_kubernetes/apps/v1beta2/ControllerRevisionList.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta2/ControllerRevisionList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class ControllerRevisionList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ControllerRevisionArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ControllerRevisionArgs', 'ControllerRevisionArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         ControllerRevisionList is a resource containing a list of ControllerRevision objects.
@@ -101,9 +106,9 @@ class ControllerRevisionList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ControllerRevisionArgs']]]] items: Items is the list of ControllerRevisions
+        :param pulumi.Input[Sequence[pulumi.Input[Union['ControllerRevisionArgs', 'ControllerRevisionArgsDict']]]] items: Items is the list of ControllerRevisions
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class ControllerRevisionList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ControllerRevisionArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ControllerRevisionArgs', 'ControllerRevisionArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/apps/v1beta2/ControllerRevisionPatch.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta2/ControllerRevisionPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import meta as _meta
 
@@ -108,7 +113,7 @@ class ControllerRevisionPatch(pulumi.CustomResource):
                  api_version: Optional[pulumi.Input[str]] = None,
                  data: Optional[Any] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
                  revision: Optional[pulumi.Input[int]] = None,
                  __props__=None):
         """
@@ -125,7 +130,7 @@ class ControllerRevisionPatch(pulumi.CustomResource):
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param Any data: Data is the serialized representation of the state.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         :param pulumi.Input[int] revision: Revision indicates the revision of the state represented by Data.
         """
         ...
@@ -161,7 +166,7 @@ class ControllerRevisionPatch(pulumi.CustomResource):
                  api_version: Optional[pulumi.Input[str]] = None,
                  data: Optional[Any] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
                  revision: Optional[pulumi.Input[int]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)

--- a/sdk/python/pulumi_kubernetes/apps/v1beta2/DaemonSet.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta2/DaemonSet.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -94,8 +99,8 @@ class DaemonSet(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['DaemonSetSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['DaemonSetSpecArgs', 'DaemonSetSpecArgsDict']]] = None,
                  __props__=None):
         """
         DaemonSet represents the configuration of a daemon set.
@@ -104,8 +109,8 @@ class DaemonSet(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['DaemonSetSpecArgs']] spec: The desired behavior of this daemon set. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['DaemonSetSpecArgs', 'DaemonSetSpecArgsDict']] spec: The desired behavior of this daemon set. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -133,8 +138,8 @@ class DaemonSet(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['DaemonSetSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['DaemonSetSpecArgs', 'DaemonSetSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/apps/v1beta2/DaemonSetList.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta2/DaemonSetList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -92,9 +97,9 @@ class DaemonSetList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['DaemonSetArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['DaemonSetArgs', 'DaemonSetArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         DaemonSetList is a collection of daemon sets.
@@ -102,9 +107,9 @@ class DaemonSetList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['DaemonSetArgs']]]] items: A list of daemon sets.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['DaemonSetArgs', 'DaemonSetArgsDict']]]] items: A list of daemon sets.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -131,9 +136,9 @@ class DaemonSetList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['DaemonSetArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['DaemonSetArgs', 'DaemonSetArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/apps/v1beta2/DaemonSetPatch.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta2/DaemonSetPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -94,8 +99,8 @@ class DaemonSetPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['DaemonSetSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['DaemonSetSpecPatchArgs', 'DaemonSetSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -110,8 +115,8 @@ class DaemonSetPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['DaemonSetSpecPatchArgs']] spec: The desired behavior of this daemon set. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['DaemonSetSpecPatchArgs', 'DaemonSetSpecPatchArgsDict']] spec: The desired behavior of this daemon set. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -145,8 +150,8 @@ class DaemonSetPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['DaemonSetSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['DaemonSetSpecPatchArgs', 'DaemonSetSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/apps/v1beta2/Deployment.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta2/Deployment.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -94,8 +99,8 @@ class Deployment(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['DeploymentSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['DeploymentSpecArgs', 'DeploymentSpecArgsDict']]] = None,
                  __props__=None):
         """
         Deployment enables declarative updates for Pods and ReplicaSets.
@@ -126,8 +131,8 @@ class Deployment(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object metadata.
-        :param pulumi.Input[pulumi.InputType['DeploymentSpecArgs']] spec: Specification of the desired behavior of the Deployment.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object metadata.
+        :param pulumi.Input[Union['DeploymentSpecArgs', 'DeploymentSpecArgsDict']] spec: Specification of the desired behavior of the Deployment.
         """
         ...
     @overload
@@ -177,8 +182,8 @@ class Deployment(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['DeploymentSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['DeploymentSpecArgs', 'DeploymentSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/apps/v1beta2/DeploymentList.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta2/DeploymentList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -92,9 +97,9 @@ class DeploymentList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['DeploymentArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['DeploymentArgs', 'DeploymentArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         DeploymentList is a list of Deployments.
@@ -102,9 +107,9 @@ class DeploymentList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['DeploymentArgs']]]] items: Items is the list of Deployments.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['DeploymentArgs', 'DeploymentArgsDict']]]] items: Items is the list of Deployments.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata.
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata.
         """
         ...
     @overload
@@ -131,9 +136,9 @@ class DeploymentList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['DeploymentArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['DeploymentArgs', 'DeploymentArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/apps/v1beta2/DeploymentPatch.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta2/DeploymentPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -94,8 +99,8 @@ class DeploymentPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['DeploymentSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['DeploymentSpecPatchArgs', 'DeploymentSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -132,8 +137,8 @@ class DeploymentPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object metadata.
-        :param pulumi.Input[pulumi.InputType['DeploymentSpecPatchArgs']] spec: Specification of the desired behavior of the Deployment.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object metadata.
+        :param pulumi.Input[Union['DeploymentSpecPatchArgs', 'DeploymentSpecPatchArgsDict']] spec: Specification of the desired behavior of the Deployment.
         """
         ...
     @overload
@@ -189,8 +194,8 @@ class DeploymentPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['DeploymentSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['DeploymentSpecPatchArgs', 'DeploymentSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/apps/v1beta2/ReplicaSet.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta2/ReplicaSet.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -94,8 +99,8 @@ class ReplicaSet(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ReplicaSetSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ReplicaSetSpecArgs', 'ReplicaSetSpecArgsDict']]] = None,
                  __props__=None):
         """
         ReplicaSet ensures that a specified number of pod replicas are running at any given time.
@@ -104,8 +109,8 @@ class ReplicaSet(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: If the Labels of a ReplicaSet are empty, they are defaulted to be the same as the Pod(s) that the ReplicaSet manages. Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['ReplicaSetSpecArgs']] spec: Spec defines the specification of the desired behavior of the ReplicaSet. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: If the Labels of a ReplicaSet are empty, they are defaulted to be the same as the Pod(s) that the ReplicaSet manages. Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['ReplicaSetSpecArgs', 'ReplicaSetSpecArgsDict']] spec: Spec defines the specification of the desired behavior of the ReplicaSet. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -133,8 +138,8 @@ class ReplicaSet(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ReplicaSetSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ReplicaSetSpecArgs', 'ReplicaSetSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/apps/v1beta2/ReplicaSetList.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta2/ReplicaSetList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -92,9 +97,9 @@ class ReplicaSetList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ReplicaSetArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ReplicaSetArgs', 'ReplicaSetArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         ReplicaSetList is a collection of ReplicaSets.
@@ -102,9 +107,9 @@ class ReplicaSetList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ReplicaSetArgs']]]] items: List of ReplicaSets. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller
+        :param pulumi.Input[Sequence[pulumi.Input[Union['ReplicaSetArgs', 'ReplicaSetArgsDict']]]] items: List of ReplicaSets. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
         """
         ...
     @overload
@@ -131,9 +136,9 @@ class ReplicaSetList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ReplicaSetArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ReplicaSetArgs', 'ReplicaSetArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/apps/v1beta2/ReplicaSetPatch.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta2/ReplicaSetPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -94,8 +99,8 @@ class ReplicaSetPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ReplicaSetSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ReplicaSetSpecPatchArgs', 'ReplicaSetSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -110,8 +115,8 @@ class ReplicaSetPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: If the Labels of a ReplicaSet are empty, they are defaulted to be the same as the Pod(s) that the ReplicaSet manages. Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['ReplicaSetSpecPatchArgs']] spec: Spec defines the specification of the desired behavior of the ReplicaSet. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: If the Labels of a ReplicaSet are empty, they are defaulted to be the same as the Pod(s) that the ReplicaSet manages. Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['ReplicaSetSpecPatchArgs', 'ReplicaSetSpecPatchArgsDict']] spec: Spec defines the specification of the desired behavior of the ReplicaSet. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -145,8 +150,8 @@ class ReplicaSetPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ReplicaSetSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ReplicaSetSpecPatchArgs', 'ReplicaSetSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/apps/v1beta2/StatefulSet.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta2/StatefulSet.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -90,8 +95,8 @@ class StatefulSet(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['StatefulSetSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['StatefulSetSpecArgs', 'StatefulSetSpecArgsDict']]] = None,
                  __props__=None):
         """
         StatefulSet represents a set of pods with consistent identities. Identities are defined as:
@@ -116,7 +121,7 @@ class StatefulSet(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['StatefulSetSpecArgs']] spec: Spec defines the desired identities of pods in this set.
+        :param pulumi.Input[Union['StatefulSetSpecArgs', 'StatefulSetSpecArgsDict']] spec: Spec defines the desired identities of pods in this set.
         """
         ...
     @overload
@@ -160,8 +165,8 @@ class StatefulSet(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['StatefulSetSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['StatefulSetSpecArgs', 'StatefulSetSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/apps/v1beta2/StatefulSetList.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta2/StatefulSetList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -84,9 +89,9 @@ class StatefulSetList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['StatefulSetArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['StatefulSetArgs', 'StatefulSetArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         StatefulSetList is a collection of StatefulSets.
@@ -121,9 +126,9 @@ class StatefulSetList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['StatefulSetArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['StatefulSetArgs', 'StatefulSetArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/apps/v1beta2/StatefulSetPatch.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta2/StatefulSetPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -90,8 +95,8 @@ class StatefulSetPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['StatefulSetSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['StatefulSetSpecPatchArgs', 'StatefulSetSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -122,7 +127,7 @@ class StatefulSetPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['StatefulSetSpecPatchArgs']] spec: Spec defines the desired identities of pods in this set.
+        :param pulumi.Input[Union['StatefulSetSpecPatchArgs', 'StatefulSetSpecPatchArgsDict']] spec: Spec defines the desired identities of pods in this set.
         """
         ...
     @overload
@@ -172,8 +177,8 @@ class StatefulSetPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['StatefulSetSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['StatefulSetSpecPatchArgs', 'StatefulSetSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/apps/v1beta2/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta2/_inputs.py
@@ -4,48 +4,116 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import core as _core
 from ... import meta as _meta
 
 __all__ = [
     'ControllerRevisionArgs',
+    'ControllerRevisionArgsDict',
     'DaemonSetConditionArgs',
+    'DaemonSetConditionArgsDict',
     'DaemonSetSpecPatchArgs',
+    'DaemonSetSpecPatchArgsDict',
     'DaemonSetSpecArgs',
+    'DaemonSetSpecArgsDict',
     'DaemonSetStatusArgs',
+    'DaemonSetStatusArgsDict',
     'DaemonSetUpdateStrategyPatchArgs',
+    'DaemonSetUpdateStrategyPatchArgsDict',
     'DaemonSetUpdateStrategyArgs',
+    'DaemonSetUpdateStrategyArgsDict',
     'DaemonSetArgs',
+    'DaemonSetArgsDict',
     'DeploymentConditionArgs',
+    'DeploymentConditionArgsDict',
     'DeploymentSpecPatchArgs',
+    'DeploymentSpecPatchArgsDict',
     'DeploymentSpecArgs',
+    'DeploymentSpecArgsDict',
     'DeploymentStatusArgs',
+    'DeploymentStatusArgsDict',
     'DeploymentStrategyPatchArgs',
+    'DeploymentStrategyPatchArgsDict',
     'DeploymentStrategyArgs',
+    'DeploymentStrategyArgsDict',
     'DeploymentArgs',
+    'DeploymentArgsDict',
     'ReplicaSetConditionArgs',
+    'ReplicaSetConditionArgsDict',
     'ReplicaSetSpecPatchArgs',
+    'ReplicaSetSpecPatchArgsDict',
     'ReplicaSetSpecArgs',
+    'ReplicaSetSpecArgsDict',
     'ReplicaSetStatusArgs',
+    'ReplicaSetStatusArgsDict',
     'ReplicaSetArgs',
+    'ReplicaSetArgsDict',
     'RollingUpdateDaemonSetPatchArgs',
+    'RollingUpdateDaemonSetPatchArgsDict',
     'RollingUpdateDaemonSetArgs',
+    'RollingUpdateDaemonSetArgsDict',
     'RollingUpdateDeploymentPatchArgs',
+    'RollingUpdateDeploymentPatchArgsDict',
     'RollingUpdateDeploymentArgs',
+    'RollingUpdateDeploymentArgsDict',
     'RollingUpdateStatefulSetStrategyPatchArgs',
+    'RollingUpdateStatefulSetStrategyPatchArgsDict',
     'RollingUpdateStatefulSetStrategyArgs',
+    'RollingUpdateStatefulSetStrategyArgsDict',
     'StatefulSetConditionArgs',
+    'StatefulSetConditionArgsDict',
     'StatefulSetSpecPatchArgs',
+    'StatefulSetSpecPatchArgsDict',
     'StatefulSetSpecArgs',
+    'StatefulSetSpecArgsDict',
     'StatefulSetStatusArgs',
+    'StatefulSetStatusArgsDict',
     'StatefulSetUpdateStrategyPatchArgs',
+    'StatefulSetUpdateStrategyPatchArgsDict',
     'StatefulSetUpdateStrategyArgs',
+    'StatefulSetUpdateStrategyArgsDict',
     'StatefulSetArgs',
+    'StatefulSetArgsDict',
 ]
+
+MYPY = False
+
+if not MYPY:
+    class ControllerRevisionArgsDict(TypedDict):
+        """
+        ControllerRevision implements an immutable snapshot of state data. Clients are responsible for serializing and deserializing the objects that contain their internal state. Once a ControllerRevision has been successfully created, it can not be updated. The API Server will fail validation of all requests that attempt to mutate the Data field. ControllerRevisions may, however, be deleted. Note that, due to its use by both the DaemonSet and StatefulSet controllers for update and rollback, this object is beta. However, it may be subject to name and representation changes in future releases, and clients should not depend on its stability. It is primarily for internal use by controllers.
+        """
+        revision: pulumi.Input[int]
+        """
+        Revision indicates the revision of the state represented by Data.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        data: NotRequired[Any]
+        """
+        Data is the serialized representation of the state.
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+elif False:
+    ControllerRevisionArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ControllerRevisionArgs:
@@ -134,6 +202,34 @@ class ControllerRevisionArgs:
         pulumi.set(self, "metadata", value)
 
 
+if not MYPY:
+    class DaemonSetConditionArgsDict(TypedDict):
+        """
+        DaemonSetCondition describes the state of a DaemonSet at a certain point.
+        """
+        status: pulumi.Input[str]
+        """
+        Status of the condition, one of True, False, Unknown.
+        """
+        type: pulumi.Input[str]
+        """
+        Type of DaemonSet condition.
+        """
+        last_transition_time: NotRequired[pulumi.Input[str]]
+        """
+        Last time the condition transitioned from one status to another.
+        """
+        message: NotRequired[pulumi.Input[str]]
+        """
+        A human readable message indicating details about the transition.
+        """
+        reason: NotRequired[pulumi.Input[str]]
+        """
+        The reason for the condition's last transition.
+        """
+elif False:
+    DaemonSetConditionArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class DaemonSetConditionArgs:
     def __init__(__self__, *,
@@ -219,6 +315,34 @@ class DaemonSetConditionArgs:
     def reason(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "reason", value)
 
+
+if not MYPY:
+    class DaemonSetSpecPatchArgsDict(TypedDict):
+        """
+        DaemonSetSpec is the specification of a daemon set.
+        """
+        min_ready_seconds: NotRequired[pulumi.Input[int]]
+        """
+        The minimum number of seconds for which a newly created DaemonSet pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready).
+        """
+        revision_history_limit: NotRequired[pulumi.Input[int]]
+        """
+        The number of old history to retain to allow rollback. This is a pointer to distinguish between explicit zero and not specified. Defaults to 10.
+        """
+        selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorPatchArgsDict']]
+        """
+        A label query over pods that are managed by the daemon set. Must match in order to be controlled. It must match the pod template's labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+        """
+        template: NotRequired[pulumi.Input['_core.v1.PodTemplateSpecPatchArgsDict']]
+        """
+        An object that describes the pod that will be created. The DaemonSet will create exactly one copy of this pod on every node that matches the template's node selector (or on every node if no node selector is specified). More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template
+        """
+        update_strategy: NotRequired[pulumi.Input['DaemonSetUpdateStrategyPatchArgsDict']]
+        """
+        An update strategy to replace existing DaemonSet pods with new pods.
+        """
+elif False:
+    DaemonSetSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class DaemonSetSpecPatchArgs:
@@ -308,6 +432,34 @@ class DaemonSetSpecPatchArgs:
         pulumi.set(self, "update_strategy", value)
 
 
+if not MYPY:
+    class DaemonSetSpecArgsDict(TypedDict):
+        """
+        DaemonSetSpec is the specification of a daemon set.
+        """
+        selector: pulumi.Input['_meta.v1.LabelSelectorArgsDict']
+        """
+        A label query over pods that are managed by the daemon set. Must match in order to be controlled. It must match the pod template's labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+        """
+        template: pulumi.Input['_core.v1.PodTemplateSpecArgsDict']
+        """
+        An object that describes the pod that will be created. The DaemonSet will create exactly one copy of this pod on every node that matches the template's node selector (or on every node if no node selector is specified). More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template
+        """
+        min_ready_seconds: NotRequired[pulumi.Input[int]]
+        """
+        The minimum number of seconds for which a newly created DaemonSet pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready).
+        """
+        revision_history_limit: NotRequired[pulumi.Input[int]]
+        """
+        The number of old history to retain to allow rollback. This is a pointer to distinguish between explicit zero and not specified. Defaults to 10.
+        """
+        update_strategy: NotRequired[pulumi.Input['DaemonSetUpdateStrategyArgsDict']]
+        """
+        An update strategy to replace existing DaemonSet pods with new pods.
+        """
+elif False:
+    DaemonSetSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class DaemonSetSpecArgs:
     def __init__(__self__, *,
@@ -393,6 +545,54 @@ class DaemonSetSpecArgs:
     def update_strategy(self, value: Optional[pulumi.Input['DaemonSetUpdateStrategyArgs']]):
         pulumi.set(self, "update_strategy", value)
 
+
+if not MYPY:
+    class DaemonSetStatusArgsDict(TypedDict):
+        """
+        DaemonSetStatus represents the current status of a daemon set.
+        """
+        current_number_scheduled: pulumi.Input[int]
+        """
+        The number of nodes that are running at least 1 daemon pod and are supposed to run the daemon pod. More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
+        """
+        desired_number_scheduled: pulumi.Input[int]
+        """
+        The total number of nodes that should be running the daemon pod (including nodes correctly running the daemon pod). More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
+        """
+        number_misscheduled: pulumi.Input[int]
+        """
+        The number of nodes that are running the daemon pod, but are not supposed to run the daemon pod. More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
+        """
+        number_ready: pulumi.Input[int]
+        """
+        The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready.
+        """
+        collision_count: NotRequired[pulumi.Input[int]]
+        """
+        Count of hash collisions for the DaemonSet. The DaemonSet controller uses this field as a collision avoidance mechanism when it needs to create the name for the newest ControllerRevision.
+        """
+        conditions: NotRequired[pulumi.Input[Sequence[pulumi.Input['DaemonSetConditionArgsDict']]]]
+        """
+        Represents the latest available observations of a DaemonSet's current state.
+        """
+        number_available: NotRequired[pulumi.Input[int]]
+        """
+        The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and available (ready for at least spec.minReadySeconds)
+        """
+        number_unavailable: NotRequired[pulumi.Input[int]]
+        """
+        The number of nodes that should be running the daemon pod and have none of the daemon pod running and available (ready for at least spec.minReadySeconds)
+        """
+        observed_generation: NotRequired[pulumi.Input[int]]
+        """
+        The most recent generation observed by the daemon set controller.
+        """
+        updated_number_scheduled: NotRequired[pulumi.Input[int]]
+        """
+        The total number of nodes that are running updated daemon pod
+        """
+elif False:
+    DaemonSetStatusArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class DaemonSetStatusArgs:
@@ -558,6 +758,22 @@ class DaemonSetStatusArgs:
         pulumi.set(self, "updated_number_scheduled", value)
 
 
+if not MYPY:
+    class DaemonSetUpdateStrategyPatchArgsDict(TypedDict):
+        """
+        DaemonSetUpdateStrategy is a struct used to control the update strategy for a DaemonSet.
+        """
+        rolling_update: NotRequired[pulumi.Input['RollingUpdateDaemonSetPatchArgsDict']]
+        """
+        Rolling update config params. Present only if type = "RollingUpdate".
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        Type of daemon set update. Can be "RollingUpdate" or "OnDelete". Default is RollingUpdate.
+        """
+elif False:
+    DaemonSetUpdateStrategyPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class DaemonSetUpdateStrategyPatchArgs:
     def __init__(__self__, *,
@@ -598,6 +814,22 @@ class DaemonSetUpdateStrategyPatchArgs:
         pulumi.set(self, "type", value)
 
 
+if not MYPY:
+    class DaemonSetUpdateStrategyArgsDict(TypedDict):
+        """
+        DaemonSetUpdateStrategy is a struct used to control the update strategy for a DaemonSet.
+        """
+        rolling_update: NotRequired[pulumi.Input['RollingUpdateDaemonSetArgsDict']]
+        """
+        Rolling update config params. Present only if type = "RollingUpdate".
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        Type of daemon set update. Can be "RollingUpdate" or "OnDelete". Default is RollingUpdate.
+        """
+elif False:
+    DaemonSetUpdateStrategyArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class DaemonSetUpdateStrategyArgs:
     def __init__(__self__, *,
@@ -637,6 +869,34 @@ class DaemonSetUpdateStrategyArgs:
     def type(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "type", value)
 
+
+if not MYPY:
+    class DaemonSetArgsDict(TypedDict):
+        """
+        DaemonSet represents the configuration of a daemon set.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['DaemonSetSpecArgsDict']]
+        """
+        The desired behavior of this daemon set. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+        status: NotRequired[pulumi.Input['DaemonSetStatusArgsDict']]
+        """
+        The current status of this daemon set. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+elif False:
+    DaemonSetArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class DaemonSetArgs:
@@ -725,6 +985,38 @@ class DaemonSetArgs:
     def status(self, value: Optional[pulumi.Input['DaemonSetStatusArgs']]):
         pulumi.set(self, "status", value)
 
+
+if not MYPY:
+    class DeploymentConditionArgsDict(TypedDict):
+        """
+        DeploymentCondition describes the state of a deployment at a certain point.
+        """
+        status: pulumi.Input[str]
+        """
+        Status of the condition, one of True, False, Unknown.
+        """
+        type: pulumi.Input[str]
+        """
+        Type of deployment condition.
+        """
+        last_transition_time: NotRequired[pulumi.Input[str]]
+        """
+        Last time the condition transitioned from one status to another.
+        """
+        last_update_time: NotRequired[pulumi.Input[str]]
+        """
+        The last time this condition was updated.
+        """
+        message: NotRequired[pulumi.Input[str]]
+        """
+        A human readable message indicating details about the transition.
+        """
+        reason: NotRequired[pulumi.Input[str]]
+        """
+        The reason for the condition's last transition.
+        """
+elif False:
+    DeploymentConditionArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class DeploymentConditionArgs:
@@ -827,6 +1119,46 @@ class DeploymentConditionArgs:
     def reason(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "reason", value)
 
+
+if not MYPY:
+    class DeploymentSpecPatchArgsDict(TypedDict):
+        """
+        DeploymentSpec is the specification of the desired behavior of the Deployment.
+        """
+        min_ready_seconds: NotRequired[pulumi.Input[int]]
+        """
+        Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)
+        """
+        paused: NotRequired[pulumi.Input[bool]]
+        """
+        Indicates that the deployment is paused.
+        """
+        progress_deadline_seconds: NotRequired[pulumi.Input[int]]
+        """
+        The maximum time in seconds for a deployment to make progress before it is considered to be failed. The deployment controller will continue to process failed deployments and a condition with a ProgressDeadlineExceeded reason will be surfaced in the deployment status. Note that progress will not be estimated during the time a deployment is paused. Defaults to 600s.
+        """
+        replicas: NotRequired[pulumi.Input[int]]
+        """
+        Number of desired pods. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1.
+        """
+        revision_history_limit: NotRequired[pulumi.Input[int]]
+        """
+        The number of old ReplicaSets to retain to allow rollback. This is a pointer to distinguish between explicit zero and not specified. Defaults to 10.
+        """
+        selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorPatchArgsDict']]
+        """
+        Label selector for pods. Existing ReplicaSets whose pods are selected by this will be the ones affected by this deployment. It must match the pod template's labels.
+        """
+        strategy: NotRequired[pulumi.Input['DeploymentStrategyPatchArgsDict']]
+        """
+        The deployment strategy to use to replace existing pods with new ones.
+        """
+        template: NotRequired[pulumi.Input['_core.v1.PodTemplateSpecPatchArgsDict']]
+        """
+        Template describes the pods that will be created.
+        """
+elif False:
+    DeploymentSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class DeploymentSpecPatchArgs:
@@ -964,6 +1296,46 @@ class DeploymentSpecPatchArgs:
         pulumi.set(self, "template", value)
 
 
+if not MYPY:
+    class DeploymentSpecArgsDict(TypedDict):
+        """
+        DeploymentSpec is the specification of the desired behavior of the Deployment.
+        """
+        selector: pulumi.Input['_meta.v1.LabelSelectorArgsDict']
+        """
+        Label selector for pods. Existing ReplicaSets whose pods are selected by this will be the ones affected by this deployment. It must match the pod template's labels.
+        """
+        template: pulumi.Input['_core.v1.PodTemplateSpecArgsDict']
+        """
+        Template describes the pods that will be created.
+        """
+        min_ready_seconds: NotRequired[pulumi.Input[int]]
+        """
+        Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)
+        """
+        paused: NotRequired[pulumi.Input[bool]]
+        """
+        Indicates that the deployment is paused.
+        """
+        progress_deadline_seconds: NotRequired[pulumi.Input[int]]
+        """
+        The maximum time in seconds for a deployment to make progress before it is considered to be failed. The deployment controller will continue to process failed deployments and a condition with a ProgressDeadlineExceeded reason will be surfaced in the deployment status. Note that progress will not be estimated during the time a deployment is paused. Defaults to 600s.
+        """
+        replicas: NotRequired[pulumi.Input[int]]
+        """
+        Number of desired pods. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1.
+        """
+        revision_history_limit: NotRequired[pulumi.Input[int]]
+        """
+        The number of old ReplicaSets to retain to allow rollback. This is a pointer to distinguish between explicit zero and not specified. Defaults to 10.
+        """
+        strategy: NotRequired[pulumi.Input['DeploymentStrategyArgsDict']]
+        """
+        The deployment strategy to use to replace existing pods with new ones.
+        """
+elif False:
+    DeploymentSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class DeploymentSpecArgs:
     def __init__(__self__, *,
@@ -1097,6 +1469,46 @@ class DeploymentSpecArgs:
     def strategy(self, value: Optional[pulumi.Input['DeploymentStrategyArgs']]):
         pulumi.set(self, "strategy", value)
 
+
+if not MYPY:
+    class DeploymentStatusArgsDict(TypedDict):
+        """
+        DeploymentStatus is the most recently observed status of the Deployment.
+        """
+        available_replicas: NotRequired[pulumi.Input[int]]
+        """
+        Total number of available pods (ready for at least minReadySeconds) targeted by this deployment.
+        """
+        collision_count: NotRequired[pulumi.Input[int]]
+        """
+        Count of hash collisions for the Deployment. The Deployment controller uses this field as a collision avoidance mechanism when it needs to create the name for the newest ReplicaSet.
+        """
+        conditions: NotRequired[pulumi.Input[Sequence[pulumi.Input['DeploymentConditionArgsDict']]]]
+        """
+        Represents the latest available observations of a deployment's current state.
+        """
+        observed_generation: NotRequired[pulumi.Input[int]]
+        """
+        The generation observed by the deployment controller.
+        """
+        ready_replicas: NotRequired[pulumi.Input[int]]
+        """
+        Total number of ready pods targeted by this deployment.
+        """
+        replicas: NotRequired[pulumi.Input[int]]
+        """
+        Total number of non-terminated pods targeted by this deployment (their labels match the selector).
+        """
+        unavailable_replicas: NotRequired[pulumi.Input[int]]
+        """
+        Total number of unavailable pods targeted by this deployment. This is the total number of pods that are still required for the deployment to have 100% available capacity. They may either be pods that are running but not yet available or pods that still have not been created.
+        """
+        updated_replicas: NotRequired[pulumi.Input[int]]
+        """
+        Total number of non-terminated pods targeted by this deployment that have the desired template spec.
+        """
+elif False:
+    DeploymentStatusArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class DeploymentStatusArgs:
@@ -1234,6 +1646,22 @@ class DeploymentStatusArgs:
         pulumi.set(self, "updated_replicas", value)
 
 
+if not MYPY:
+    class DeploymentStrategyPatchArgsDict(TypedDict):
+        """
+        DeploymentStrategy describes how to replace existing pods with new ones.
+        """
+        rolling_update: NotRequired[pulumi.Input['RollingUpdateDeploymentPatchArgsDict']]
+        """
+        Rolling update config params. Present only if DeploymentStrategyType = RollingUpdate.
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        Type of deployment. Can be "Recreate" or "RollingUpdate". Default is RollingUpdate.
+        """
+elif False:
+    DeploymentStrategyPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class DeploymentStrategyPatchArgs:
     def __init__(__self__, *,
@@ -1274,6 +1702,22 @@ class DeploymentStrategyPatchArgs:
         pulumi.set(self, "type", value)
 
 
+if not MYPY:
+    class DeploymentStrategyArgsDict(TypedDict):
+        """
+        DeploymentStrategy describes how to replace existing pods with new ones.
+        """
+        rolling_update: NotRequired[pulumi.Input['RollingUpdateDeploymentArgsDict']]
+        """
+        Rolling update config params. Present only if DeploymentStrategyType = RollingUpdate.
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        Type of deployment. Can be "Recreate" or "RollingUpdate". Default is RollingUpdate.
+        """
+elif False:
+    DeploymentStrategyArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class DeploymentStrategyArgs:
     def __init__(__self__, *,
@@ -1313,6 +1757,56 @@ class DeploymentStrategyArgs:
     def type(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "type", value)
 
+
+if not MYPY:
+    class DeploymentArgsDict(TypedDict):
+        """
+        Deployment enables declarative updates for Pods and ReplicaSets.
+
+        This resource waits until its status is ready before registering success
+        for create/update, and populating output properties from the current state of the resource.
+        The following conditions are used to determine whether the resource creation has
+        succeeded or failed:
+
+        1. The Deployment has begun to be updated by the Deployment controller. If the current
+           generation of the Deployment is > 1, then this means that the current generation must
+           be different from the generation reported by the last outputs.
+        2. There exists a ReplicaSet whose revision is equal to the current revision of the
+           Deployment.
+        3. The Deployment's '.status.conditions' has a status of type 'Available' whose 'status'
+           member is set to 'True'.
+        4. If the Deployment has generation > 1, then '.status.conditions' has a status of type
+           'Progressing', whose 'status' member is set to 'True', and whose 'reason' is
+           'NewReplicaSetAvailable'. For generation <= 1, this status field does not exist,
+           because it doesn't do a rollout (i.e., it simply creates the Deployment and
+           corresponding ReplicaSet), and therefore there is no rollout to mark as 'Progressing'.
+
+        If the Deployment has not reached a Ready state after 10 minutes, it will
+        time out and mark the resource update as Failed. You can override the default timeout value
+        by setting the 'customTimeouts' option on the resource.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object metadata.
+        """
+        spec: NotRequired[pulumi.Input['DeploymentSpecArgsDict']]
+        """
+        Specification of the desired behavior of the Deployment.
+        """
+        status: NotRequired[pulumi.Input['DeploymentStatusArgsDict']]
+        """
+        Most recently observed status of the Deployment.
+        """
+elif False:
+    DeploymentArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class DeploymentArgs:
@@ -1424,6 +1918,34 @@ class DeploymentArgs:
         pulumi.set(self, "status", value)
 
 
+if not MYPY:
+    class ReplicaSetConditionArgsDict(TypedDict):
+        """
+        ReplicaSetCondition describes the state of a replica set at a certain point.
+        """
+        status: pulumi.Input[str]
+        """
+        Status of the condition, one of True, False, Unknown.
+        """
+        type: pulumi.Input[str]
+        """
+        Type of replica set condition.
+        """
+        last_transition_time: NotRequired[pulumi.Input[str]]
+        """
+        The last time the condition transitioned from one status to another.
+        """
+        message: NotRequired[pulumi.Input[str]]
+        """
+        A human readable message indicating details about the transition.
+        """
+        reason: NotRequired[pulumi.Input[str]]
+        """
+        The reason for the condition's last transition.
+        """
+elif False:
+    ReplicaSetConditionArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ReplicaSetConditionArgs:
     def __init__(__self__, *,
@@ -1510,6 +2032,30 @@ class ReplicaSetConditionArgs:
         pulumi.set(self, "reason", value)
 
 
+if not MYPY:
+    class ReplicaSetSpecPatchArgsDict(TypedDict):
+        """
+        ReplicaSetSpec is the specification of a ReplicaSet.
+        """
+        min_ready_seconds: NotRequired[pulumi.Input[int]]
+        """
+        Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)
+        """
+        replicas: NotRequired[pulumi.Input[int]]
+        """
+        Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller
+        """
+        selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorPatchArgsDict']]
+        """
+        Selector is a label query over pods that should match the replica count. Label keys and values that must match in order to be controlled by this replica set. It must match the pod template's labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+        """
+        template: NotRequired[pulumi.Input['_core.v1.PodTemplateSpecPatchArgsDict']]
+        """
+        Template is the object that describes the pod that will be created if insufficient replicas are detected. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template
+        """
+elif False:
+    ReplicaSetSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ReplicaSetSpecPatchArgs:
     def __init__(__self__, *,
@@ -1582,6 +2128,30 @@ class ReplicaSetSpecPatchArgs:
         pulumi.set(self, "template", value)
 
 
+if not MYPY:
+    class ReplicaSetSpecArgsDict(TypedDict):
+        """
+        ReplicaSetSpec is the specification of a ReplicaSet.
+        """
+        selector: pulumi.Input['_meta.v1.LabelSelectorArgsDict']
+        """
+        Selector is a label query over pods that should match the replica count. Label keys and values that must match in order to be controlled by this replica set. It must match the pod template's labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+        """
+        min_ready_seconds: NotRequired[pulumi.Input[int]]
+        """
+        Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)
+        """
+        replicas: NotRequired[pulumi.Input[int]]
+        """
+        Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller
+        """
+        template: NotRequired[pulumi.Input['_core.v1.PodTemplateSpecArgsDict']]
+        """
+        Template is the object that describes the pod that will be created if insufficient replicas are detected. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template
+        """
+elif False:
+    ReplicaSetSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ReplicaSetSpecArgs:
     def __init__(__self__, *,
@@ -1652,6 +2222,38 @@ class ReplicaSetSpecArgs:
     def template(self, value: Optional[pulumi.Input['_core.v1.PodTemplateSpecArgs']]):
         pulumi.set(self, "template", value)
 
+
+if not MYPY:
+    class ReplicaSetStatusArgsDict(TypedDict):
+        """
+        ReplicaSetStatus represents the current status of a ReplicaSet.
+        """
+        replicas: pulumi.Input[int]
+        """
+        Replicas is the most recently oberved number of replicas. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller
+        """
+        available_replicas: NotRequired[pulumi.Input[int]]
+        """
+        The number of available replicas (ready for at least minReadySeconds) for this replica set.
+        """
+        conditions: NotRequired[pulumi.Input[Sequence[pulumi.Input['ReplicaSetConditionArgsDict']]]]
+        """
+        Represents the latest available observations of a replica set's current state.
+        """
+        fully_labeled_replicas: NotRequired[pulumi.Input[int]]
+        """
+        The number of pods that have labels matching the labels of the pod template of the replicaset.
+        """
+        observed_generation: NotRequired[pulumi.Input[int]]
+        """
+        ObservedGeneration reflects the generation of the most recently observed ReplicaSet.
+        """
+        ready_replicas: NotRequired[pulumi.Input[int]]
+        """
+        The number of ready replicas for this replica set.
+        """
+elif False:
+    ReplicaSetStatusArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ReplicaSetStatusArgs:
@@ -1756,6 +2358,34 @@ class ReplicaSetStatusArgs:
         pulumi.set(self, "ready_replicas", value)
 
 
+if not MYPY:
+    class ReplicaSetArgsDict(TypedDict):
+        """
+        ReplicaSet ensures that a specified number of pod replicas are running at any given time.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        If the Labels of a ReplicaSet are empty, they are defaulted to be the same as the Pod(s) that the ReplicaSet manages. Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['ReplicaSetSpecArgsDict']]
+        """
+        Spec defines the specification of the desired behavior of the ReplicaSet. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+        status: NotRequired[pulumi.Input['ReplicaSetStatusArgsDict']]
+        """
+        Status is the most recently observed status of the ReplicaSet. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+elif False:
+    ReplicaSetArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ReplicaSetArgs:
     def __init__(__self__, *,
@@ -1844,6 +2474,18 @@ class ReplicaSetArgs:
         pulumi.set(self, "status", value)
 
 
+if not MYPY:
+    class RollingUpdateDaemonSetPatchArgsDict(TypedDict):
+        """
+        Spec to control the desired behavior of daemon set rolling update.
+        """
+        max_unavailable: NotRequired[pulumi.Input[Union[int, str]]]
+        """
+        The maximum number of DaemonSet pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of total number of DaemonSet pods at the start of the update (ex: 10%). Absolute number is calculated from percentage by rounding up. This cannot be 0. Default value is 1. Example: when this is set to 30%, at most 30% of the total number of nodes that should be running the daemon pod (i.e. status.desiredNumberScheduled) can have their pods stopped for an update at any given time. The update starts by stopping at most 30% of those DaemonSet pods and then brings up new DaemonSet pods in their place. Once the new pods are available, it then proceeds onto other DaemonSet pods, thus ensuring that at least 70% of original number of DaemonSet pods are available at all times during the update.
+        """
+elif False:
+    RollingUpdateDaemonSetPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class RollingUpdateDaemonSetPatchArgs:
     def __init__(__self__, *,
@@ -1868,6 +2510,18 @@ class RollingUpdateDaemonSetPatchArgs:
         pulumi.set(self, "max_unavailable", value)
 
 
+if not MYPY:
+    class RollingUpdateDaemonSetArgsDict(TypedDict):
+        """
+        Spec to control the desired behavior of daemon set rolling update.
+        """
+        max_unavailable: NotRequired[pulumi.Input[Union[int, str]]]
+        """
+        The maximum number of DaemonSet pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of total number of DaemonSet pods at the start of the update (ex: 10%). Absolute number is calculated from percentage by rounding up. This cannot be 0. Default value is 1. Example: when this is set to 30%, at most 30% of the total number of nodes that should be running the daemon pod (i.e. status.desiredNumberScheduled) can have their pods stopped for an update at any given time. The update starts by stopping at most 30% of those DaemonSet pods and then brings up new DaemonSet pods in their place. Once the new pods are available, it then proceeds onto other DaemonSet pods, thus ensuring that at least 70% of original number of DaemonSet pods are available at all times during the update.
+        """
+elif False:
+    RollingUpdateDaemonSetArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class RollingUpdateDaemonSetArgs:
     def __init__(__self__, *,
@@ -1891,6 +2545,22 @@ class RollingUpdateDaemonSetArgs:
     def max_unavailable(self, value: Optional[pulumi.Input[Union[int, str]]]):
         pulumi.set(self, "max_unavailable", value)
 
+
+if not MYPY:
+    class RollingUpdateDeploymentPatchArgsDict(TypedDict):
+        """
+        Spec to control the desired behavior of rolling update.
+        """
+        max_surge: NotRequired[pulumi.Input[Union[int, str]]]
+        """
+        The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 25%. Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new ReplicaSet can be scaled up further, ensuring that total number of pods running at any time during the update is at most 130% of desired pods.
+        """
+        max_unavailable: NotRequired[pulumi.Input[Union[int, str]]]
+        """
+        The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 25%. Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods immediately when the rolling update starts. Once new pods are ready, old ReplicaSet can be scaled down further, followed by scaling up the new ReplicaSet, ensuring that the total number of pods available at all times during the update is at least 70% of desired pods.
+        """
+elif False:
+    RollingUpdateDeploymentPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class RollingUpdateDeploymentPatchArgs:
@@ -1932,6 +2602,22 @@ class RollingUpdateDeploymentPatchArgs:
         pulumi.set(self, "max_unavailable", value)
 
 
+if not MYPY:
+    class RollingUpdateDeploymentArgsDict(TypedDict):
+        """
+        Spec to control the desired behavior of rolling update.
+        """
+        max_surge: NotRequired[pulumi.Input[Union[int, str]]]
+        """
+        The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 25%. Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new ReplicaSet can be scaled up further, ensuring that total number of pods running at any time during the update is at most 130% of desired pods.
+        """
+        max_unavailable: NotRequired[pulumi.Input[Union[int, str]]]
+        """
+        The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 25%. Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods immediately when the rolling update starts. Once new pods are ready, old ReplicaSet can be scaled down further, followed by scaling up the new ReplicaSet, ensuring that the total number of pods available at all times during the update is at least 70% of desired pods.
+        """
+elif False:
+    RollingUpdateDeploymentArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class RollingUpdateDeploymentArgs:
     def __init__(__self__, *,
@@ -1972,6 +2658,18 @@ class RollingUpdateDeploymentArgs:
         pulumi.set(self, "max_unavailable", value)
 
 
+if not MYPY:
+    class RollingUpdateStatefulSetStrategyPatchArgsDict(TypedDict):
+        """
+        RollingUpdateStatefulSetStrategy is used to communicate parameter for RollingUpdateStatefulSetStrategyType.
+        """
+        partition: NotRequired[pulumi.Input[int]]
+        """
+        Partition indicates the ordinal at which the StatefulSet should be partitioned. Default value is 0.
+        """
+elif False:
+    RollingUpdateStatefulSetStrategyPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class RollingUpdateStatefulSetStrategyPatchArgs:
     def __init__(__self__, *,
@@ -1996,6 +2694,18 @@ class RollingUpdateStatefulSetStrategyPatchArgs:
         pulumi.set(self, "partition", value)
 
 
+if not MYPY:
+    class RollingUpdateStatefulSetStrategyArgsDict(TypedDict):
+        """
+        RollingUpdateStatefulSetStrategy is used to communicate parameter for RollingUpdateStatefulSetStrategyType.
+        """
+        partition: NotRequired[pulumi.Input[int]]
+        """
+        Partition indicates the ordinal at which the StatefulSet should be partitioned. Default value is 0.
+        """
+elif False:
+    RollingUpdateStatefulSetStrategyArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class RollingUpdateStatefulSetStrategyArgs:
     def __init__(__self__, *,
@@ -2019,6 +2729,34 @@ class RollingUpdateStatefulSetStrategyArgs:
     def partition(self, value: Optional[pulumi.Input[int]]):
         pulumi.set(self, "partition", value)
 
+
+if not MYPY:
+    class StatefulSetConditionArgsDict(TypedDict):
+        """
+        StatefulSetCondition describes the state of a statefulset at a certain point.
+        """
+        status: pulumi.Input[str]
+        """
+        Status of the condition, one of True, False, Unknown.
+        """
+        type: pulumi.Input[str]
+        """
+        Type of statefulset condition.
+        """
+        last_transition_time: NotRequired[pulumi.Input[str]]
+        """
+        Last time the condition transitioned from one status to another.
+        """
+        message: NotRequired[pulumi.Input[str]]
+        """
+        A human readable message indicating details about the transition.
+        """
+        reason: NotRequired[pulumi.Input[str]]
+        """
+        The reason for the condition's last transition.
+        """
+elif False:
+    StatefulSetConditionArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class StatefulSetConditionArgs:
@@ -2105,6 +2843,46 @@ class StatefulSetConditionArgs:
     def reason(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "reason", value)
 
+
+if not MYPY:
+    class StatefulSetSpecPatchArgsDict(TypedDict):
+        """
+        A StatefulSetSpec is the specification of a StatefulSet.
+        """
+        pod_management_policy: NotRequired[pulumi.Input[str]]
+        """
+        podManagementPolicy controls how pods are created during initial scale up, when replacing pods on nodes, or when scaling down. The default policy is `OrderedReady`, where pods are created in increasing order (pod-0, then pod-1, etc) and the controller will wait until each pod is ready before continuing. When scaling down, the pods are removed in the opposite order. The alternative policy is `Parallel` which will create pods in parallel to match the desired scale without waiting, and on scale down will delete all pods at once.
+        """
+        replicas: NotRequired[pulumi.Input[int]]
+        """
+        replicas is the desired number of replicas of the given Template. These are replicas in the sense that they are instantiations of the same Template, but individual replicas also have a consistent identity. If unspecified, defaults to 1.
+        """
+        revision_history_limit: NotRequired[pulumi.Input[int]]
+        """
+        revisionHistoryLimit is the maximum number of revisions that will be maintained in the StatefulSet's revision history. The revision history consists of all revisions not represented by a currently applied StatefulSetSpec version. The default value is 10.
+        """
+        selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorPatchArgsDict']]
+        """
+        selector is a label query over pods that should match the replica count. It must match the pod template's labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+        """
+        service_name: NotRequired[pulumi.Input[str]]
+        """
+        serviceName is the name of the service that governs this StatefulSet. This service must exist before the StatefulSet, and is responsible for the network identity of the set. Pods get DNS/hostnames that follow the pattern: pod-specific-string.serviceName.default.svc.cluster.local where "pod-specific-string" is managed by the StatefulSet controller.
+        """
+        template: NotRequired[pulumi.Input['_core.v1.PodTemplateSpecPatchArgsDict']]
+        """
+        template is the object that describes the pod that will be created if insufficient replicas are detected. Each pod stamped out by the StatefulSet will fulfill this Template, but have a unique identity from the rest of the StatefulSet.
+        """
+        update_strategy: NotRequired[pulumi.Input['StatefulSetUpdateStrategyPatchArgsDict']]
+        """
+        updateStrategy indicates the StatefulSetUpdateStrategy that will be employed to update Pods in the StatefulSet when a revision is made to Template.
+        """
+        volume_claim_templates: NotRequired[pulumi.Input[Sequence[pulumi.Input['_core.v1.PersistentVolumeClaimPatchArgsDict']]]]
+        """
+        volumeClaimTemplates is a list of claims that pods are allowed to reference. The StatefulSet controller is responsible for mapping network identities to claims in a way that maintains the identity of a pod. Every claim in this list must have at least one matching (by name) volumeMount in one container in the template. A claim in this list takes precedence over any volumes in the template, with the same name.
+        """
+elif False:
+    StatefulSetSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class StatefulSetSpecPatchArgs:
@@ -2242,6 +3020,46 @@ class StatefulSetSpecPatchArgs:
         pulumi.set(self, "volume_claim_templates", value)
 
 
+if not MYPY:
+    class StatefulSetSpecArgsDict(TypedDict):
+        """
+        A StatefulSetSpec is the specification of a StatefulSet.
+        """
+        selector: pulumi.Input['_meta.v1.LabelSelectorArgsDict']
+        """
+        selector is a label query over pods that should match the replica count. It must match the pod template's labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+        """
+        service_name: pulumi.Input[str]
+        """
+        serviceName is the name of the service that governs this StatefulSet. This service must exist before the StatefulSet, and is responsible for the network identity of the set. Pods get DNS/hostnames that follow the pattern: pod-specific-string.serviceName.default.svc.cluster.local where "pod-specific-string" is managed by the StatefulSet controller.
+        """
+        template: pulumi.Input['_core.v1.PodTemplateSpecArgsDict']
+        """
+        template is the object that describes the pod that will be created if insufficient replicas are detected. Each pod stamped out by the StatefulSet will fulfill this Template, but have a unique identity from the rest of the StatefulSet.
+        """
+        pod_management_policy: NotRequired[pulumi.Input[str]]
+        """
+        podManagementPolicy controls how pods are created during initial scale up, when replacing pods on nodes, or when scaling down. The default policy is `OrderedReady`, where pods are created in increasing order (pod-0, then pod-1, etc) and the controller will wait until each pod is ready before continuing. When scaling down, the pods are removed in the opposite order. The alternative policy is `Parallel` which will create pods in parallel to match the desired scale without waiting, and on scale down will delete all pods at once.
+        """
+        replicas: NotRequired[pulumi.Input[int]]
+        """
+        replicas is the desired number of replicas of the given Template. These are replicas in the sense that they are instantiations of the same Template, but individual replicas also have a consistent identity. If unspecified, defaults to 1.
+        """
+        revision_history_limit: NotRequired[pulumi.Input[int]]
+        """
+        revisionHistoryLimit is the maximum number of revisions that will be maintained in the StatefulSet's revision history. The revision history consists of all revisions not represented by a currently applied StatefulSetSpec version. The default value is 10.
+        """
+        update_strategy: NotRequired[pulumi.Input['StatefulSetUpdateStrategyArgsDict']]
+        """
+        updateStrategy indicates the StatefulSetUpdateStrategy that will be employed to update Pods in the StatefulSet when a revision is made to Template.
+        """
+        volume_claim_templates: NotRequired[pulumi.Input[Sequence[pulumi.Input['_core.v1.PersistentVolumeClaimArgsDict']]]]
+        """
+        volumeClaimTemplates is a list of claims that pods are allowed to reference. The StatefulSet controller is responsible for mapping network identities to claims in a way that maintains the identity of a pod. Every claim in this list must have at least one matching (by name) volumeMount in one container in the template. A claim in this list takes precedence over any volumes in the template, with the same name.
+        """
+elif False:
+    StatefulSetSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class StatefulSetSpecArgs:
     def __init__(__self__, *,
@@ -2374,6 +3192,50 @@ class StatefulSetSpecArgs:
     def volume_claim_templates(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['_core.v1.PersistentVolumeClaimArgs']]]]):
         pulumi.set(self, "volume_claim_templates", value)
 
+
+if not MYPY:
+    class StatefulSetStatusArgsDict(TypedDict):
+        """
+        StatefulSetStatus represents the current state of a StatefulSet.
+        """
+        replicas: pulumi.Input[int]
+        """
+        replicas is the number of Pods created by the StatefulSet controller.
+        """
+        collision_count: NotRequired[pulumi.Input[int]]
+        """
+        collisionCount is the count of hash collisions for the StatefulSet. The StatefulSet controller uses this field as a collision avoidance mechanism when it needs to create the name for the newest ControllerRevision.
+        """
+        conditions: NotRequired[pulumi.Input[Sequence[pulumi.Input['StatefulSetConditionArgsDict']]]]
+        """
+        Represents the latest available observations of a statefulset's current state.
+        """
+        current_replicas: NotRequired[pulumi.Input[int]]
+        """
+        currentReplicas is the number of Pods created by the StatefulSet controller from the StatefulSet version indicated by currentRevision.
+        """
+        current_revision: NotRequired[pulumi.Input[str]]
+        """
+        currentRevision, if not empty, indicates the version of the StatefulSet used to generate Pods in the sequence [0,currentReplicas).
+        """
+        observed_generation: NotRequired[pulumi.Input[int]]
+        """
+        observedGeneration is the most recent generation observed for this StatefulSet. It corresponds to the StatefulSet's generation, which is updated on mutation by the API Server.
+        """
+        ready_replicas: NotRequired[pulumi.Input[int]]
+        """
+        readyReplicas is the number of Pods created by the StatefulSet controller that have a Ready Condition.
+        """
+        update_revision: NotRequired[pulumi.Input[str]]
+        """
+        updateRevision, if not empty, indicates the version of the StatefulSet used to generate Pods in the sequence [replicas-updatedReplicas,replicas)
+        """
+        updated_replicas: NotRequired[pulumi.Input[int]]
+        """
+        updatedReplicas is the number of Pods created by the StatefulSet controller from the StatefulSet version indicated by updateRevision.
+        """
+elif False:
+    StatefulSetStatusArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class StatefulSetStatusArgs:
@@ -2526,6 +3388,22 @@ class StatefulSetStatusArgs:
         pulumi.set(self, "updated_replicas", value)
 
 
+if not MYPY:
+    class StatefulSetUpdateStrategyPatchArgsDict(TypedDict):
+        """
+        StatefulSetUpdateStrategy indicates the strategy that the StatefulSet controller will use to perform updates. It includes any additional parameters necessary to perform the update for the indicated strategy.
+        """
+        rolling_update: NotRequired[pulumi.Input['RollingUpdateStatefulSetStrategyPatchArgsDict']]
+        """
+        RollingUpdate is used to communicate parameters when Type is RollingUpdateStatefulSetStrategyType.
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        Type indicates the type of the StatefulSetUpdateStrategy. Default is RollingUpdate.
+        """
+elif False:
+    StatefulSetUpdateStrategyPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class StatefulSetUpdateStrategyPatchArgs:
     def __init__(__self__, *,
@@ -2566,6 +3444,22 @@ class StatefulSetUpdateStrategyPatchArgs:
         pulumi.set(self, "type", value)
 
 
+if not MYPY:
+    class StatefulSetUpdateStrategyArgsDict(TypedDict):
+        """
+        StatefulSetUpdateStrategy indicates the strategy that the StatefulSet controller will use to perform updates. It includes any additional parameters necessary to perform the update for the indicated strategy.
+        """
+        rolling_update: NotRequired[pulumi.Input['RollingUpdateStatefulSetStrategyArgsDict']]
+        """
+        RollingUpdate is used to communicate parameters when Type is RollingUpdateStatefulSetStrategyType.
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        Type indicates the type of the StatefulSetUpdateStrategy. Default is RollingUpdate.
+        """
+elif False:
+    StatefulSetUpdateStrategyArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class StatefulSetUpdateStrategyArgs:
     def __init__(__self__, *,
@@ -2605,6 +3499,47 @@ class StatefulSetUpdateStrategyArgs:
     def type(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "type", value)
 
+
+if not MYPY:
+    class StatefulSetArgsDict(TypedDict):
+        """
+        StatefulSet represents a set of pods with consistent identities. Identities are defined as:
+         - Network: A single stable DNS and hostname.
+         - Storage: As many VolumeClaims as requested.
+        The StatefulSet guarantees that a given network identity will always map to the same storage identity.
+
+        This resource waits until its status is ready before registering success
+        for create/update, and populating output properties from the current state of the resource.
+        The following conditions are used to determine whether the resource creation has
+        succeeded or failed:
+
+        1. The value of 'spec.replicas' matches '.status.replicas', '.status.currentReplicas',
+           and '.status.readyReplicas'.
+        2. The value of '.status.updateRevision' matches '.status.currentRevision'.
+
+        If the StatefulSet has not reached a Ready state after 10 minutes, it will
+        time out and mark the resource update as Failed. You can override the default timeout value
+        by setting the 'customTimeouts' option on the resource.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        spec: NotRequired[pulumi.Input['StatefulSetSpecArgsDict']]
+        """
+        Spec defines the desired identities of pods in this set.
+        """
+        status: NotRequired[pulumi.Input['StatefulSetStatusArgsDict']]
+        """
+        Status is the current status of Pods in this StatefulSet. This data may be out of date by some window of time.
+        """
+elif False:
+    StatefulSetArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class StatefulSetArgs:

--- a/sdk/python/pulumi_kubernetes/apps/v1beta2/outputs.py
+++ b/sdk/python/pulumi_kubernetes/apps/v1beta2/outputs.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core

--- a/sdk/python/pulumi_kubernetes/auditregistration/v1alpha1/AuditSink.py
+++ b/sdk/python/pulumi_kubernetes/auditregistration/v1alpha1/AuditSink.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -89,8 +94,8 @@ class AuditSink(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['AuditSinkSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['AuditSinkSpecArgs', 'AuditSinkSpecArgsDict']]] = None,
                  __props__=None):
         """
         AuditSink represents a cluster level audit sink
@@ -99,7 +104,7 @@ class AuditSink(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['AuditSinkSpecArgs']] spec: Spec defines the audit configuration spec
+        :param pulumi.Input[Union['AuditSinkSpecArgs', 'AuditSinkSpecArgsDict']] spec: Spec defines the audit configuration spec
         """
         ...
     @overload
@@ -127,8 +132,8 @@ class AuditSink(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['AuditSinkSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['AuditSinkSpecArgs', 'AuditSinkSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/auditregistration/v1alpha1/AuditSinkList.py
+++ b/sdk/python/pulumi_kubernetes/auditregistration/v1alpha1/AuditSinkList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -87,9 +92,9 @@ class AuditSinkList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['AuditSinkArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['AuditSinkArgs', 'AuditSinkArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         AuditSinkList is a list of AuditSink items.
@@ -97,7 +102,7 @@ class AuditSinkList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['AuditSinkArgs']]]] items: List of audit configurations.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['AuditSinkArgs', 'AuditSinkArgsDict']]]] items: List of audit configurations.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
         """
         ...
@@ -125,9 +130,9 @@ class AuditSinkList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['AuditSinkArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['AuditSinkArgs', 'AuditSinkArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/auditregistration/v1alpha1/AuditSinkPatch.py
+++ b/sdk/python/pulumi_kubernetes/auditregistration/v1alpha1/AuditSinkPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -89,8 +94,8 @@ class AuditSinkPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['AuditSinkSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['AuditSinkSpecPatchArgs', 'AuditSinkSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -105,7 +110,7 @@ class AuditSinkPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['AuditSinkSpecPatchArgs']] spec: Spec defines the audit configuration spec
+        :param pulumi.Input[Union['AuditSinkSpecPatchArgs', 'AuditSinkSpecPatchArgsDict']] spec: Spec defines the audit configuration spec
         """
         ...
     @overload
@@ -139,8 +144,8 @@ class AuditSinkPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['AuditSinkSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['AuditSinkSpecPatchArgs', 'AuditSinkSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/auditregistration/v1alpha1/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/auditregistration/v1alpha1/_inputs.py
@@ -4,27 +4,63 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import meta as _meta
 
 __all__ = [
     'AuditSinkSpecPatchArgs',
+    'AuditSinkSpecPatchArgsDict',
     'AuditSinkSpecArgs',
+    'AuditSinkSpecArgsDict',
     'AuditSinkArgs',
+    'AuditSinkArgsDict',
     'PolicyPatchArgs',
+    'PolicyPatchArgsDict',
     'PolicyArgs',
+    'PolicyArgsDict',
     'ServiceReferencePatchArgs',
+    'ServiceReferencePatchArgsDict',
     'ServiceReferenceArgs',
+    'ServiceReferenceArgsDict',
     'WebhookClientConfigPatchArgs',
+    'WebhookClientConfigPatchArgsDict',
     'WebhookClientConfigArgs',
+    'WebhookClientConfigArgsDict',
     'WebhookPatchArgs',
+    'WebhookPatchArgsDict',
     'WebhookThrottleConfigPatchArgs',
+    'WebhookThrottleConfigPatchArgsDict',
     'WebhookThrottleConfigArgs',
+    'WebhookThrottleConfigArgsDict',
     'WebhookArgs',
+    'WebhookArgsDict',
 ]
+
+MYPY = False
+
+if not MYPY:
+    class AuditSinkSpecPatchArgsDict(TypedDict):
+        """
+        AuditSinkSpec holds the spec for the audit sink
+        """
+        policy: NotRequired[pulumi.Input['PolicyPatchArgsDict']]
+        """
+        Policy defines the policy for selecting which events should be sent to the webhook required
+        """
+        webhook: NotRequired[pulumi.Input['WebhookPatchArgsDict']]
+        """
+        Webhook to send events required
+        """
+elif False:
+    AuditSinkSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class AuditSinkSpecPatchArgs:
@@ -66,6 +102,22 @@ class AuditSinkSpecPatchArgs:
         pulumi.set(self, "webhook", value)
 
 
+if not MYPY:
+    class AuditSinkSpecArgsDict(TypedDict):
+        """
+        AuditSinkSpec holds the spec for the audit sink
+        """
+        policy: pulumi.Input['PolicyArgsDict']
+        """
+        Policy defines the policy for selecting which events should be sent to the webhook required
+        """
+        webhook: pulumi.Input['WebhookArgsDict']
+        """
+        Webhook to send events required
+        """
+elif False:
+    AuditSinkSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class AuditSinkSpecArgs:
     def __init__(__self__, *,
@@ -103,6 +155,27 @@ class AuditSinkSpecArgs:
     def webhook(self, value: pulumi.Input['WebhookArgs']):
         pulumi.set(self, "webhook", value)
 
+
+if not MYPY:
+    class AuditSinkArgsDict(TypedDict):
+        """
+        AuditSink represents a cluster level audit sink
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        spec: NotRequired[pulumi.Input['AuditSinkSpecArgsDict']]
+        """
+        Spec defines the audit configuration spec
+        """
+elif False:
+    AuditSinkArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class AuditSinkArgs:
@@ -172,6 +245,22 @@ class AuditSinkArgs:
         pulumi.set(self, "spec", value)
 
 
+if not MYPY:
+    class PolicyPatchArgsDict(TypedDict):
+        """
+        Policy defines the configuration of how audit events are logged
+        """
+        level: NotRequired[pulumi.Input[str]]
+        """
+        The Level that all requests are recorded at. available options: None, Metadata, Request, RequestResponse required
+        """
+        stages: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Stages is a list of stages for which events are created.
+        """
+elif False:
+    PolicyPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PolicyPatchArgs:
     def __init__(__self__, *,
@@ -212,6 +301,22 @@ class PolicyPatchArgs:
         pulumi.set(self, "stages", value)
 
 
+if not MYPY:
+    class PolicyArgsDict(TypedDict):
+        """
+        Policy defines the configuration of how audit events are logged
+        """
+        level: pulumi.Input[str]
+        """
+        The Level that all requests are recorded at. available options: None, Metadata, Request, RequestResponse required
+        """
+        stages: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Stages is a list of stages for which events are created.
+        """
+elif False:
+    PolicyArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PolicyArgs:
     def __init__(__self__, *,
@@ -250,6 +355,30 @@ class PolicyArgs:
     def stages(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]):
         pulumi.set(self, "stages", value)
 
+
+if not MYPY:
+    class ServiceReferencePatchArgsDict(TypedDict):
+        """
+        ServiceReference holds a reference to Service.legacy.k8s.io
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        `name` is the name of the service. Required
+        """
+        namespace: NotRequired[pulumi.Input[str]]
+        """
+        `namespace` is the namespace of the service. Required
+        """
+        path: NotRequired[pulumi.Input[str]]
+        """
+        `path` is an optional URL path which will be sent in any request to this service.
+        """
+        port: NotRequired[pulumi.Input[int]]
+        """
+        If specified, the port on the service that hosting webhook. Default to 443 for backward compatibility. `port` should be a valid port number (1-65535, inclusive).
+        """
+elif False:
+    ServiceReferencePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ServiceReferencePatchArgs:
@@ -323,6 +452,30 @@ class ServiceReferencePatchArgs:
         pulumi.set(self, "port", value)
 
 
+if not MYPY:
+    class ServiceReferenceArgsDict(TypedDict):
+        """
+        ServiceReference holds a reference to Service.legacy.k8s.io
+        """
+        name: pulumi.Input[str]
+        """
+        `name` is the name of the service. Required
+        """
+        namespace: pulumi.Input[str]
+        """
+        `namespace` is the namespace of the service. Required
+        """
+        path: NotRequired[pulumi.Input[str]]
+        """
+        `path` is an optional URL path which will be sent in any request to this service.
+        """
+        port: NotRequired[pulumi.Input[int]]
+        """
+        If specified, the port on the service that hosting webhook. Default to 443 for backward compatibility. `port` should be a valid port number (1-65535, inclusive).
+        """
+elif False:
+    ServiceReferenceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ServiceReferenceArgs:
     def __init__(__self__, *,
@@ -392,6 +545,38 @@ class ServiceReferenceArgs:
     def port(self, value: Optional[pulumi.Input[int]]):
         pulumi.set(self, "port", value)
 
+
+if not MYPY:
+    class WebhookClientConfigPatchArgsDict(TypedDict):
+        """
+        WebhookClientConfig contains the information to make a connection with the webhook
+        """
+        ca_bundle: NotRequired[pulumi.Input[str]]
+        """
+        `caBundle` is a PEM encoded CA bundle which will be used to validate the webhook's server certificate. If unspecified, system trust roots on the apiserver are used.
+        """
+        service: NotRequired[pulumi.Input['ServiceReferencePatchArgsDict']]
+        """
+        `service` is a reference to the service for this webhook. Either `service` or `url` must be specified.
+
+        If the webhook is running within the cluster, then you should use `service`.
+        """
+        url: NotRequired[pulumi.Input[str]]
+        """
+        `url` gives the location of the webhook, in standard URL form (`scheme://host:port/path`). Exactly one of `url` or `service` must be specified.
+
+        The `host` should not refer to a service running in the cluster; use the `service` field instead. The host might be resolved via external DNS in some apiservers (e.g., `kube-apiserver` cannot resolve in-cluster DNS as that would be a layering violation). `host` may also be an IP address.
+
+        Please note that using `localhost` or `127.0.0.1` as a `host` is risky unless you take great care to run this webhook on all hosts which run an apiserver which might need to make calls to this webhook. Such installs are likely to be non-portable, i.e., not easy to turn up in a new cluster.
+
+        The scheme must be "https"; the URL must begin with "https://".
+
+        A path is optional, and if present may be any string permissible in a URL. You may use the path to pass an arbitrary string to the webhook, for example, a cluster identifier.
+
+        Attempting to use a user or basic auth e.g. "user:password@" is not allowed. Fragments ("#...") and query parameters ("?...") are not allowed, either.
+        """
+elif False:
+    WebhookClientConfigPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class WebhookClientConfigPatchArgs:
@@ -473,6 +658,38 @@ class WebhookClientConfigPatchArgs:
         pulumi.set(self, "url", value)
 
 
+if not MYPY:
+    class WebhookClientConfigArgsDict(TypedDict):
+        """
+        WebhookClientConfig contains the information to make a connection with the webhook
+        """
+        ca_bundle: NotRequired[pulumi.Input[str]]
+        """
+        `caBundle` is a PEM encoded CA bundle which will be used to validate the webhook's server certificate. If unspecified, system trust roots on the apiserver are used.
+        """
+        service: NotRequired[pulumi.Input['ServiceReferenceArgsDict']]
+        """
+        `service` is a reference to the service for this webhook. Either `service` or `url` must be specified.
+
+        If the webhook is running within the cluster, then you should use `service`.
+        """
+        url: NotRequired[pulumi.Input[str]]
+        """
+        `url` gives the location of the webhook, in standard URL form (`scheme://host:port/path`). Exactly one of `url` or `service` must be specified.
+
+        The `host` should not refer to a service running in the cluster; use the `service` field instead. The host might be resolved via external DNS in some apiservers (e.g., `kube-apiserver` cannot resolve in-cluster DNS as that would be a layering violation). `host` may also be an IP address.
+
+        Please note that using `localhost` or `127.0.0.1` as a `host` is risky unless you take great care to run this webhook on all hosts which run an apiserver which might need to make calls to this webhook. Such installs are likely to be non-portable, i.e., not easy to turn up in a new cluster.
+
+        The scheme must be "https"; the URL must begin with "https://".
+
+        A path is optional, and if present may be any string permissible in a URL. You may use the path to pass an arbitrary string to the webhook, for example, a cluster identifier.
+
+        Attempting to use a user or basic auth e.g. "user:password@" is not allowed. Fragments ("#...") and query parameters ("?...") are not allowed, either.
+        """
+elif False:
+    WebhookClientConfigArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class WebhookClientConfigArgs:
     def __init__(__self__, *,
@@ -553,6 +770,22 @@ class WebhookClientConfigArgs:
         pulumi.set(self, "url", value)
 
 
+if not MYPY:
+    class WebhookPatchArgsDict(TypedDict):
+        """
+        Webhook holds the configuration of the webhook
+        """
+        client_config: NotRequired[pulumi.Input['WebhookClientConfigPatchArgsDict']]
+        """
+        ClientConfig holds the connection parameters for the webhook required
+        """
+        throttle: NotRequired[pulumi.Input['WebhookThrottleConfigPatchArgsDict']]
+        """
+        Throttle holds the options for throttling the webhook
+        """
+elif False:
+    WebhookPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class WebhookPatchArgs:
     def __init__(__self__, *,
@@ -592,6 +825,22 @@ class WebhookPatchArgs:
     def throttle(self, value: Optional[pulumi.Input['WebhookThrottleConfigPatchArgs']]):
         pulumi.set(self, "throttle", value)
 
+
+if not MYPY:
+    class WebhookThrottleConfigPatchArgsDict(TypedDict):
+        """
+        WebhookThrottleConfig holds the configuration for throttling events
+        """
+        burst: NotRequired[pulumi.Input[int]]
+        """
+        ThrottleBurst is the maximum number of events sent at the same moment default 15 QPS
+        """
+        qps: NotRequired[pulumi.Input[int]]
+        """
+        ThrottleQPS maximum number of batches per second default 10 QPS
+        """
+elif False:
+    WebhookThrottleConfigPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class WebhookThrottleConfigPatchArgs:
@@ -633,6 +882,22 @@ class WebhookThrottleConfigPatchArgs:
         pulumi.set(self, "qps", value)
 
 
+if not MYPY:
+    class WebhookThrottleConfigArgsDict(TypedDict):
+        """
+        WebhookThrottleConfig holds the configuration for throttling events
+        """
+        burst: NotRequired[pulumi.Input[int]]
+        """
+        ThrottleBurst is the maximum number of events sent at the same moment default 15 QPS
+        """
+        qps: NotRequired[pulumi.Input[int]]
+        """
+        ThrottleQPS maximum number of batches per second default 10 QPS
+        """
+elif False:
+    WebhookThrottleConfigArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class WebhookThrottleConfigArgs:
     def __init__(__self__, *,
@@ -672,6 +937,22 @@ class WebhookThrottleConfigArgs:
     def qps(self, value: Optional[pulumi.Input[int]]):
         pulumi.set(self, "qps", value)
 
+
+if not MYPY:
+    class WebhookArgsDict(TypedDict):
+        """
+        Webhook holds the configuration of the webhook
+        """
+        client_config: pulumi.Input['WebhookClientConfigArgsDict']
+        """
+        ClientConfig holds the connection parameters for the webhook required
+        """
+        throttle: NotRequired[pulumi.Input['WebhookThrottleConfigArgsDict']]
+        """
+        Throttle holds the options for throttling the webhook
+        """
+elif False:
+    WebhookArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class WebhookArgs:

--- a/sdk/python/pulumi_kubernetes/auditregistration/v1alpha1/outputs.py
+++ b/sdk/python/pulumi_kubernetes/auditregistration/v1alpha1/outputs.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta

--- a/sdk/python/pulumi_kubernetes/autoscaling/v1/HorizontalPodAutoscaler.py
+++ b/sdk/python/pulumi_kubernetes/autoscaling/v1/HorizontalPodAutoscaler.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class HorizontalPodAutoscaler(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['HorizontalPodAutoscalerSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['HorizontalPodAutoscalerSpecArgs', 'HorizontalPodAutoscalerSpecArgsDict']]] = None,
                  __props__=None):
         """
         configuration of a horizontal pod autoscaler.
@@ -103,8 +108,8 @@ class HorizontalPodAutoscaler(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['HorizontalPodAutoscalerSpecArgs']] spec: spec defines the behaviour of autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['HorizontalPodAutoscalerSpecArgs', 'HorizontalPodAutoscalerSpecArgsDict']] spec: spec defines the behaviour of autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
         """
         ...
     @overload
@@ -132,8 +137,8 @@ class HorizontalPodAutoscaler(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['HorizontalPodAutoscalerSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['HorizontalPodAutoscalerSpecArgs', 'HorizontalPodAutoscalerSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/autoscaling/v1/HorizontalPodAutoscalerList.py
+++ b/sdk/python/pulumi_kubernetes/autoscaling/v1/HorizontalPodAutoscalerList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class HorizontalPodAutoscalerList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['HorizontalPodAutoscalerArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['HorizontalPodAutoscalerArgs', 'HorizontalPodAutoscalerArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         list of horizontal pod autoscaler objects.
@@ -101,9 +106,9 @@ class HorizontalPodAutoscalerList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['HorizontalPodAutoscalerArgs']]]] items: items is the list of horizontal pod autoscaler objects.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['HorizontalPodAutoscalerArgs', 'HorizontalPodAutoscalerArgsDict']]]] items: items is the list of horizontal pod autoscaler objects.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata.
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata.
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class HorizontalPodAutoscalerList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['HorizontalPodAutoscalerArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['HorizontalPodAutoscalerArgs', 'HorizontalPodAutoscalerArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/autoscaling/v1/HorizontalPodAutoscalerPatch.py
+++ b/sdk/python/pulumi_kubernetes/autoscaling/v1/HorizontalPodAutoscalerPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class HorizontalPodAutoscalerPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['HorizontalPodAutoscalerSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['HorizontalPodAutoscalerSpecPatchArgs', 'HorizontalPodAutoscalerSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -109,8 +114,8 @@ class HorizontalPodAutoscalerPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['HorizontalPodAutoscalerSpecPatchArgs']] spec: spec defines the behaviour of autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['HorizontalPodAutoscalerSpecPatchArgs', 'HorizontalPodAutoscalerSpecPatchArgsDict']] spec: spec defines the behaviour of autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
         """
         ...
     @overload
@@ -144,8 +149,8 @@ class HorizontalPodAutoscalerPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['HorizontalPodAutoscalerSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['HorizontalPodAutoscalerSpecPatchArgs', 'HorizontalPodAutoscalerSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/autoscaling/v1/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/autoscaling/v1/_inputs.py
@@ -4,20 +4,53 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import meta as _meta
 
 __all__ = [
     'CrossVersionObjectReferencePatchArgs',
+    'CrossVersionObjectReferencePatchArgsDict',
     'CrossVersionObjectReferenceArgs',
+    'CrossVersionObjectReferenceArgsDict',
     'HorizontalPodAutoscalerSpecPatchArgs',
+    'HorizontalPodAutoscalerSpecPatchArgsDict',
     'HorizontalPodAutoscalerSpecArgs',
+    'HorizontalPodAutoscalerSpecArgsDict',
     'HorizontalPodAutoscalerStatusArgs',
+    'HorizontalPodAutoscalerStatusArgsDict',
     'HorizontalPodAutoscalerArgs',
+    'HorizontalPodAutoscalerArgsDict',
 ]
+
+MYPY = False
+
+if not MYPY:
+    class CrossVersionObjectReferencePatchArgsDict(TypedDict):
+        """
+        CrossVersionObjectReference contains enough information to let you identify the referred resource.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        apiVersion is the API version of the referent
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        kind is the kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        name is the name of the referent; More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+        """
+elif False:
+    CrossVersionObjectReferencePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class CrossVersionObjectReferencePatchArgs:
@@ -75,6 +108,26 @@ class CrossVersionObjectReferencePatchArgs:
         pulumi.set(self, "name", value)
 
 
+if not MYPY:
+    class CrossVersionObjectReferenceArgsDict(TypedDict):
+        """
+        CrossVersionObjectReference contains enough information to let you identify the referred resource.
+        """
+        kind: pulumi.Input[str]
+        """
+        kind is the kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        name: pulumi.Input[str]
+        """
+        name is the name of the referent; More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        apiVersion is the API version of the referent
+        """
+elif False:
+    CrossVersionObjectReferenceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CrossVersionObjectReferenceArgs:
     def __init__(__self__, *,
@@ -128,6 +181,30 @@ class CrossVersionObjectReferenceArgs:
     def api_version(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "api_version", value)
 
+
+if not MYPY:
+    class HorizontalPodAutoscalerSpecPatchArgsDict(TypedDict):
+        """
+        specification of a horizontal pod autoscaler.
+        """
+        max_replicas: NotRequired[pulumi.Input[int]]
+        """
+        maxReplicas is the upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.
+        """
+        min_replicas: NotRequired[pulumi.Input[int]]
+        """
+        minReplicas is the lower limit for the number of replicas to which the autoscaler can scale down.  It defaults to 1 pod.  minReplicas is allowed to be 0 if the alpha feature gate HPAScaleToZero is enabled and at least one Object or External metric is configured.  Scaling is active as long as at least one metric value is available.
+        """
+        scale_target_ref: NotRequired[pulumi.Input['CrossVersionObjectReferencePatchArgsDict']]
+        """
+        reference to scaled resource; horizontal pod autoscaler will learn the current resource consumption and will set the desired number of pods by using its Scale subresource.
+        """
+        target_cpu_utilization_percentage: NotRequired[pulumi.Input[int]]
+        """
+        targetCPUUtilizationPercentage is the target average CPU utilization (represented as a percentage of requested CPU) over all the pods; if not specified the default autoscaling policy will be used.
+        """
+elif False:
+    HorizontalPodAutoscalerSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class HorizontalPodAutoscalerSpecPatchArgs:
@@ -201,6 +278,30 @@ class HorizontalPodAutoscalerSpecPatchArgs:
         pulumi.set(self, "target_cpu_utilization_percentage", value)
 
 
+if not MYPY:
+    class HorizontalPodAutoscalerSpecArgsDict(TypedDict):
+        """
+        specification of a horizontal pod autoscaler.
+        """
+        max_replicas: pulumi.Input[int]
+        """
+        maxReplicas is the upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.
+        """
+        scale_target_ref: pulumi.Input['CrossVersionObjectReferenceArgsDict']
+        """
+        reference to scaled resource; horizontal pod autoscaler will learn the current resource consumption and will set the desired number of pods by using its Scale subresource.
+        """
+        min_replicas: NotRequired[pulumi.Input[int]]
+        """
+        minReplicas is the lower limit for the number of replicas to which the autoscaler can scale down.  It defaults to 1 pod.  minReplicas is allowed to be 0 if the alpha feature gate HPAScaleToZero is enabled and at least one Object or External metric is configured.  Scaling is active as long as at least one metric value is available.
+        """
+        target_cpu_utilization_percentage: NotRequired[pulumi.Input[int]]
+        """
+        targetCPUUtilizationPercentage is the target average CPU utilization (represented as a percentage of requested CPU) over all the pods; if not specified the default autoscaling policy will be used.
+        """
+elif False:
+    HorizontalPodAutoscalerSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class HorizontalPodAutoscalerSpecArgs:
     def __init__(__self__, *,
@@ -270,6 +371,34 @@ class HorizontalPodAutoscalerSpecArgs:
     def target_cpu_utilization_percentage(self, value: Optional[pulumi.Input[int]]):
         pulumi.set(self, "target_cpu_utilization_percentage", value)
 
+
+if not MYPY:
+    class HorizontalPodAutoscalerStatusArgsDict(TypedDict):
+        """
+        current status of a horizontal pod autoscaler
+        """
+        current_replicas: pulumi.Input[int]
+        """
+        currentReplicas is the current number of replicas of pods managed by this autoscaler.
+        """
+        desired_replicas: pulumi.Input[int]
+        """
+        desiredReplicas is the  desired number of replicas of pods managed by this autoscaler.
+        """
+        current_cpu_utilization_percentage: NotRequired[pulumi.Input[int]]
+        """
+        currentCPUUtilizationPercentage is the current average CPU utilization over all pods, represented as a percentage of requested CPU, e.g. 70 means that an average pod is using now 70% of its requested CPU.
+        """
+        last_scale_time: NotRequired[pulumi.Input[str]]
+        """
+        lastScaleTime is the last time the HorizontalPodAutoscaler scaled the number of pods; used by the autoscaler to control how often the number of pods is changed.
+        """
+        observed_generation: NotRequired[pulumi.Input[int]]
+        """
+        observedGeneration is the most recent generation observed by this autoscaler.
+        """
+elif False:
+    HorizontalPodAutoscalerStatusArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class HorizontalPodAutoscalerStatusArgs:
@@ -356,6 +485,34 @@ class HorizontalPodAutoscalerStatusArgs:
     def observed_generation(self, value: Optional[pulumi.Input[int]]):
         pulumi.set(self, "observed_generation", value)
 
+
+if not MYPY:
+    class HorizontalPodAutoscalerArgsDict(TypedDict):
+        """
+        configuration of a horizontal pod autoscaler.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['HorizontalPodAutoscalerSpecArgsDict']]
+        """
+        spec defines the behaviour of autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
+        """
+        status: NotRequired[pulumi.Input['HorizontalPodAutoscalerStatusArgsDict']]
+        """
+        status is the current information about the autoscaler.
+        """
+elif False:
+    HorizontalPodAutoscalerArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class HorizontalPodAutoscalerArgs:

--- a/sdk/python/pulumi_kubernetes/autoscaling/v1/outputs.py
+++ b/sdk/python/pulumi_kubernetes/autoscaling/v1/outputs.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta

--- a/sdk/python/pulumi_kubernetes/autoscaling/v2/HorizontalPodAutoscaler.py
+++ b/sdk/python/pulumi_kubernetes/autoscaling/v2/HorizontalPodAutoscaler.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class HorizontalPodAutoscaler(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['HorizontalPodAutoscalerSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['HorizontalPodAutoscalerSpecArgs', 'HorizontalPodAutoscalerSpecArgsDict']]] = None,
                  __props__=None):
         """
         HorizontalPodAutoscaler is the configuration for a horizontal pod autoscaler, which automatically manages the replica count of any resource implementing the scale subresource based on the metrics specified.
@@ -103,8 +108,8 @@ class HorizontalPodAutoscaler(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: metadata is the standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['HorizontalPodAutoscalerSpecArgs']] spec: spec is the specification for the behaviour of the autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: metadata is the standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['HorizontalPodAutoscalerSpecArgs', 'HorizontalPodAutoscalerSpecArgsDict']] spec: spec is the specification for the behaviour of the autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
         """
         ...
     @overload
@@ -132,8 +137,8 @@ class HorizontalPodAutoscaler(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['HorizontalPodAutoscalerSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['HorizontalPodAutoscalerSpecArgs', 'HorizontalPodAutoscalerSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/autoscaling/v2/HorizontalPodAutoscalerList.py
+++ b/sdk/python/pulumi_kubernetes/autoscaling/v2/HorizontalPodAutoscalerList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class HorizontalPodAutoscalerList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['HorizontalPodAutoscalerArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['HorizontalPodAutoscalerArgs', 'HorizontalPodAutoscalerArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         HorizontalPodAutoscalerList is a list of horizontal pod autoscaler objects.
@@ -101,9 +106,9 @@ class HorizontalPodAutoscalerList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['HorizontalPodAutoscalerArgs']]]] items: items is the list of horizontal pod autoscaler objects.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['HorizontalPodAutoscalerArgs', 'HorizontalPodAutoscalerArgsDict']]]] items: items is the list of horizontal pod autoscaler objects.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: metadata is the standard list metadata.
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: metadata is the standard list metadata.
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class HorizontalPodAutoscalerList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['HorizontalPodAutoscalerArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['HorizontalPodAutoscalerArgs', 'HorizontalPodAutoscalerArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/autoscaling/v2/HorizontalPodAutoscalerPatch.py
+++ b/sdk/python/pulumi_kubernetes/autoscaling/v2/HorizontalPodAutoscalerPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class HorizontalPodAutoscalerPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['HorizontalPodAutoscalerSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['HorizontalPodAutoscalerSpecPatchArgs', 'HorizontalPodAutoscalerSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -109,8 +114,8 @@ class HorizontalPodAutoscalerPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: metadata is the standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['HorizontalPodAutoscalerSpecPatchArgs']] spec: spec is the specification for the behaviour of the autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: metadata is the standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['HorizontalPodAutoscalerSpecPatchArgs', 'HorizontalPodAutoscalerSpecPatchArgsDict']] spec: spec is the specification for the behaviour of the autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
         """
         ...
     @overload
@@ -144,8 +149,8 @@ class HorizontalPodAutoscalerPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['HorizontalPodAutoscalerSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['HorizontalPodAutoscalerSpecPatchArgs', 'HorizontalPodAutoscalerSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/autoscaling/v2/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/autoscaling/v2/_inputs.py
@@ -4,50 +4,113 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import meta as _meta
 
 __all__ = [
     'ContainerResourceMetricSourcePatchArgs',
+    'ContainerResourceMetricSourcePatchArgsDict',
     'ContainerResourceMetricSourceArgs',
+    'ContainerResourceMetricSourceArgsDict',
     'ContainerResourceMetricStatusArgs',
+    'ContainerResourceMetricStatusArgsDict',
     'CrossVersionObjectReferencePatchArgs',
+    'CrossVersionObjectReferencePatchArgsDict',
     'CrossVersionObjectReferenceArgs',
+    'CrossVersionObjectReferenceArgsDict',
     'ExternalMetricSourcePatchArgs',
+    'ExternalMetricSourcePatchArgsDict',
     'ExternalMetricSourceArgs',
+    'ExternalMetricSourceArgsDict',
     'ExternalMetricStatusArgs',
+    'ExternalMetricStatusArgsDict',
     'HPAScalingPolicyPatchArgs',
+    'HPAScalingPolicyPatchArgsDict',
     'HPAScalingPolicyArgs',
+    'HPAScalingPolicyArgsDict',
     'HPAScalingRulesPatchArgs',
+    'HPAScalingRulesPatchArgsDict',
     'HPAScalingRulesArgs',
+    'HPAScalingRulesArgsDict',
     'HorizontalPodAutoscalerBehaviorPatchArgs',
+    'HorizontalPodAutoscalerBehaviorPatchArgsDict',
     'HorizontalPodAutoscalerBehaviorArgs',
+    'HorizontalPodAutoscalerBehaviorArgsDict',
     'HorizontalPodAutoscalerConditionArgs',
+    'HorizontalPodAutoscalerConditionArgsDict',
     'HorizontalPodAutoscalerSpecPatchArgs',
+    'HorizontalPodAutoscalerSpecPatchArgsDict',
     'HorizontalPodAutoscalerSpecArgs',
+    'HorizontalPodAutoscalerSpecArgsDict',
     'HorizontalPodAutoscalerStatusArgs',
+    'HorizontalPodAutoscalerStatusArgsDict',
     'HorizontalPodAutoscalerArgs',
+    'HorizontalPodAutoscalerArgsDict',
     'MetricIdentifierPatchArgs',
+    'MetricIdentifierPatchArgsDict',
     'MetricIdentifierArgs',
+    'MetricIdentifierArgsDict',
     'MetricSpecPatchArgs',
+    'MetricSpecPatchArgsDict',
     'MetricSpecArgs',
+    'MetricSpecArgsDict',
     'MetricStatusArgs',
+    'MetricStatusArgsDict',
     'MetricTargetPatchArgs',
+    'MetricTargetPatchArgsDict',
     'MetricTargetArgs',
+    'MetricTargetArgsDict',
     'MetricValueStatusArgs',
+    'MetricValueStatusArgsDict',
     'ObjectMetricSourcePatchArgs',
+    'ObjectMetricSourcePatchArgsDict',
     'ObjectMetricSourceArgs',
+    'ObjectMetricSourceArgsDict',
     'ObjectMetricStatusArgs',
+    'ObjectMetricStatusArgsDict',
     'PodsMetricSourcePatchArgs',
+    'PodsMetricSourcePatchArgsDict',
     'PodsMetricSourceArgs',
+    'PodsMetricSourceArgsDict',
     'PodsMetricStatusArgs',
+    'PodsMetricStatusArgsDict',
     'ResourceMetricSourcePatchArgs',
+    'ResourceMetricSourcePatchArgsDict',
     'ResourceMetricSourceArgs',
+    'ResourceMetricSourceArgsDict',
     'ResourceMetricStatusArgs',
+    'ResourceMetricStatusArgsDict',
 ]
+
+MYPY = False
+
+if not MYPY:
+    class ContainerResourceMetricSourcePatchArgsDict(TypedDict):
+        """
+        ContainerResourceMetricSource indicates how to scale on a resource metric known to Kubernetes, as specified in requests and limits, describing each pod in the current scale target (e.g. CPU or memory).  The values will be averaged together before being compared to the target.  Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.  Only one "target" type should be set.
+        """
+        container: NotRequired[pulumi.Input[str]]
+        """
+        container is the name of the container in the pods of the scaling target
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        name is the name of the resource in question.
+        """
+        target: NotRequired[pulumi.Input['MetricTargetPatchArgsDict']]
+        """
+        target specifies the target value for the given metric
+        """
+elif False:
+    ContainerResourceMetricSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ContainerResourceMetricSourcePatchArgs:
@@ -105,6 +168,26 @@ class ContainerResourceMetricSourcePatchArgs:
         pulumi.set(self, "target", value)
 
 
+if not MYPY:
+    class ContainerResourceMetricSourceArgsDict(TypedDict):
+        """
+        ContainerResourceMetricSource indicates how to scale on a resource metric known to Kubernetes, as specified in requests and limits, describing each pod in the current scale target (e.g. CPU or memory).  The values will be averaged together before being compared to the target.  Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.  Only one "target" type should be set.
+        """
+        container: pulumi.Input[str]
+        """
+        container is the name of the container in the pods of the scaling target
+        """
+        name: pulumi.Input[str]
+        """
+        name is the name of the resource in question.
+        """
+        target: pulumi.Input['MetricTargetArgsDict']
+        """
+        target specifies the target value for the given metric
+        """
+elif False:
+    ContainerResourceMetricSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ContainerResourceMetricSourceArgs:
     def __init__(__self__, *,
@@ -158,6 +241,26 @@ class ContainerResourceMetricSourceArgs:
         pulumi.set(self, "target", value)
 
 
+if not MYPY:
+    class ContainerResourceMetricStatusArgsDict(TypedDict):
+        """
+        ContainerResourceMetricStatus indicates the current value of a resource metric known to Kubernetes, as specified in requests and limits, describing a single container in each pod in the current scale target (e.g. CPU or memory).  Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.
+        """
+        container: pulumi.Input[str]
+        """
+        container is the name of the container in the pods of the scaling target
+        """
+        current: pulumi.Input['MetricValueStatusArgsDict']
+        """
+        current contains the current value for the given metric
+        """
+        name: pulumi.Input[str]
+        """
+        name is the name of the resource in question.
+        """
+elif False:
+    ContainerResourceMetricStatusArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ContainerResourceMetricStatusArgs:
     def __init__(__self__, *,
@@ -210,6 +313,26 @@ class ContainerResourceMetricStatusArgs:
     def name(self, value: pulumi.Input[str]):
         pulumi.set(self, "name", value)
 
+
+if not MYPY:
+    class CrossVersionObjectReferencePatchArgsDict(TypedDict):
+        """
+        CrossVersionObjectReference contains enough information to let you identify the referred resource.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        apiVersion is the API version of the referent
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        kind is the kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        name is the name of the referent; More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+        """
+elif False:
+    CrossVersionObjectReferencePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class CrossVersionObjectReferencePatchArgs:
@@ -267,6 +390,26 @@ class CrossVersionObjectReferencePatchArgs:
         pulumi.set(self, "name", value)
 
 
+if not MYPY:
+    class CrossVersionObjectReferenceArgsDict(TypedDict):
+        """
+        CrossVersionObjectReference contains enough information to let you identify the referred resource.
+        """
+        kind: pulumi.Input[str]
+        """
+        kind is the kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        name: pulumi.Input[str]
+        """
+        name is the name of the referent; More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        apiVersion is the API version of the referent
+        """
+elif False:
+    CrossVersionObjectReferenceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CrossVersionObjectReferenceArgs:
     def __init__(__self__, *,
@@ -321,6 +464,22 @@ class CrossVersionObjectReferenceArgs:
         pulumi.set(self, "api_version", value)
 
 
+if not MYPY:
+    class ExternalMetricSourcePatchArgsDict(TypedDict):
+        """
+        ExternalMetricSource indicates how to scale on a metric not associated with any Kubernetes object (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster).
+        """
+        metric: NotRequired[pulumi.Input['MetricIdentifierPatchArgsDict']]
+        """
+        metric identifies the target metric by name and selector
+        """
+        target: NotRequired[pulumi.Input['MetricTargetPatchArgsDict']]
+        """
+        target specifies the target value for the given metric
+        """
+elif False:
+    ExternalMetricSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ExternalMetricSourcePatchArgs:
     def __init__(__self__, *,
@@ -361,6 +520,22 @@ class ExternalMetricSourcePatchArgs:
         pulumi.set(self, "target", value)
 
 
+if not MYPY:
+    class ExternalMetricSourceArgsDict(TypedDict):
+        """
+        ExternalMetricSource indicates how to scale on a metric not associated with any Kubernetes object (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster).
+        """
+        metric: pulumi.Input['MetricIdentifierArgsDict']
+        """
+        metric identifies the target metric by name and selector
+        """
+        target: pulumi.Input['MetricTargetArgsDict']
+        """
+        target specifies the target value for the given metric
+        """
+elif False:
+    ExternalMetricSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ExternalMetricSourceArgs:
     def __init__(__self__, *,
@@ -399,6 +574,22 @@ class ExternalMetricSourceArgs:
         pulumi.set(self, "target", value)
 
 
+if not MYPY:
+    class ExternalMetricStatusArgsDict(TypedDict):
+        """
+        ExternalMetricStatus indicates the current value of a global metric not associated with any Kubernetes object.
+        """
+        current: pulumi.Input['MetricValueStatusArgsDict']
+        """
+        current contains the current value for the given metric
+        """
+        metric: pulumi.Input['MetricIdentifierArgsDict']
+        """
+        metric identifies the target metric by name and selector
+        """
+elif False:
+    ExternalMetricStatusArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ExternalMetricStatusArgs:
     def __init__(__self__, *,
@@ -436,6 +627,26 @@ class ExternalMetricStatusArgs:
     def metric(self, value: pulumi.Input['MetricIdentifierArgs']):
         pulumi.set(self, "metric", value)
 
+
+if not MYPY:
+    class HPAScalingPolicyPatchArgsDict(TypedDict):
+        """
+        HPAScalingPolicy is a single policy which must hold true for a specified past interval.
+        """
+        period_seconds: NotRequired[pulumi.Input[int]]
+        """
+        periodSeconds specifies the window of time for which the policy should hold true. PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        type is used to specify the scaling policy.
+        """
+        value: NotRequired[pulumi.Input[int]]
+        """
+        value contains the amount of change which is permitted by the policy. It must be greater than zero
+        """
+elif False:
+    HPAScalingPolicyPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class HPAScalingPolicyPatchArgs:
@@ -493,6 +704,26 @@ class HPAScalingPolicyPatchArgs:
         pulumi.set(self, "value", value)
 
 
+if not MYPY:
+    class HPAScalingPolicyArgsDict(TypedDict):
+        """
+        HPAScalingPolicy is a single policy which must hold true for a specified past interval.
+        """
+        period_seconds: pulumi.Input[int]
+        """
+        periodSeconds specifies the window of time for which the policy should hold true. PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).
+        """
+        type: pulumi.Input[str]
+        """
+        type is used to specify the scaling policy.
+        """
+        value: pulumi.Input[int]
+        """
+        value contains the amount of change which is permitted by the policy. It must be greater than zero
+        """
+elif False:
+    HPAScalingPolicyArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class HPAScalingPolicyArgs:
     def __init__(__self__, *,
@@ -545,6 +776,26 @@ class HPAScalingPolicyArgs:
     def value(self, value: pulumi.Input[int]):
         pulumi.set(self, "value", value)
 
+
+if not MYPY:
+    class HPAScalingRulesPatchArgsDict(TypedDict):
+        """
+        HPAScalingRules configures the scaling behavior for one direction. These Rules are applied after calculating DesiredReplicas from metrics for the HPA. They can limit the scaling velocity by specifying scaling policies. They can prevent flapping by specifying the stabilization window, so that the number of replicas is not set instantly, instead, the safest value from the stabilization window is chosen.
+        """
+        policies: NotRequired[pulumi.Input[Sequence[pulumi.Input['HPAScalingPolicyPatchArgsDict']]]]
+        """
+        policies is a list of potential scaling polices which can be used during scaling. At least one policy must be specified, otherwise the HPAScalingRules will be discarded as invalid
+        """
+        select_policy: NotRequired[pulumi.Input[str]]
+        """
+        selectPolicy is used to specify which policy should be used. If not set, the default value Max is used.
+        """
+        stabilization_window_seconds: NotRequired[pulumi.Input[int]]
+        """
+        stabilizationWindowSeconds is the number of seconds for which past recommendations should be considered while scaling up or scaling down. StabilizationWindowSeconds must be greater than or equal to zero and less than or equal to 3600 (one hour). If not set, use the default values: - For scale up: 0 (i.e. no stabilization is done). - For scale down: 300 (i.e. the stabilization window is 300 seconds long).
+        """
+elif False:
+    HPAScalingRulesPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class HPAScalingRulesPatchArgs:
@@ -602,6 +853,26 @@ class HPAScalingRulesPatchArgs:
         pulumi.set(self, "stabilization_window_seconds", value)
 
 
+if not MYPY:
+    class HPAScalingRulesArgsDict(TypedDict):
+        """
+        HPAScalingRules configures the scaling behavior for one direction. These Rules are applied after calculating DesiredReplicas from metrics for the HPA. They can limit the scaling velocity by specifying scaling policies. They can prevent flapping by specifying the stabilization window, so that the number of replicas is not set instantly, instead, the safest value from the stabilization window is chosen.
+        """
+        policies: NotRequired[pulumi.Input[Sequence[pulumi.Input['HPAScalingPolicyArgsDict']]]]
+        """
+        policies is a list of potential scaling polices which can be used during scaling. At least one policy must be specified, otherwise the HPAScalingRules will be discarded as invalid
+        """
+        select_policy: NotRequired[pulumi.Input[str]]
+        """
+        selectPolicy is used to specify which policy should be used. If not set, the default value Max is used.
+        """
+        stabilization_window_seconds: NotRequired[pulumi.Input[int]]
+        """
+        stabilizationWindowSeconds is the number of seconds for which past recommendations should be considered while scaling up or scaling down. StabilizationWindowSeconds must be greater than or equal to zero and less than or equal to 3600 (one hour). If not set, use the default values: - For scale up: 0 (i.e. no stabilization is done). - For scale down: 300 (i.e. the stabilization window is 300 seconds long).
+        """
+elif False:
+    HPAScalingRulesArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class HPAScalingRulesArgs:
     def __init__(__self__, *,
@@ -658,6 +929,25 @@ class HPAScalingRulesArgs:
         pulumi.set(self, "stabilization_window_seconds", value)
 
 
+if not MYPY:
+    class HorizontalPodAutoscalerBehaviorPatchArgsDict(TypedDict):
+        """
+        HorizontalPodAutoscalerBehavior configures the scaling behavior of the target in both Up and Down directions (scaleUp and scaleDown fields respectively).
+        """
+        scale_down: NotRequired[pulumi.Input['HPAScalingRulesPatchArgsDict']]
+        """
+        scaleDown is scaling policy for scaling Down. If not set, the default value is to allow to scale down to minReplicas pods, with a 300 second stabilization window (i.e., the highest recommendation for the last 300sec is used).
+        """
+        scale_up: NotRequired[pulumi.Input['HPAScalingRulesPatchArgsDict']]
+        """
+        scaleUp is scaling policy for scaling Up. If not set, the default value is the higher of:
+          * increase no more than 4 pods per 60 seconds
+          * double the number of pods per 60 seconds
+        No stabilization is used.
+        """
+elif False:
+    HorizontalPodAutoscalerBehaviorPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class HorizontalPodAutoscalerBehaviorPatchArgs:
     def __init__(__self__, *,
@@ -704,6 +994,25 @@ class HorizontalPodAutoscalerBehaviorPatchArgs:
         pulumi.set(self, "scale_up", value)
 
 
+if not MYPY:
+    class HorizontalPodAutoscalerBehaviorArgsDict(TypedDict):
+        """
+        HorizontalPodAutoscalerBehavior configures the scaling behavior of the target in both Up and Down directions (scaleUp and scaleDown fields respectively).
+        """
+        scale_down: NotRequired[pulumi.Input['HPAScalingRulesArgsDict']]
+        """
+        scaleDown is scaling policy for scaling Down. If not set, the default value is to allow to scale down to minReplicas pods, with a 300 second stabilization window (i.e., the highest recommendation for the last 300sec is used).
+        """
+        scale_up: NotRequired[pulumi.Input['HPAScalingRulesArgsDict']]
+        """
+        scaleUp is scaling policy for scaling Up. If not set, the default value is the higher of:
+          * increase no more than 4 pods per 60 seconds
+          * double the number of pods per 60 seconds
+        No stabilization is used.
+        """
+elif False:
+    HorizontalPodAutoscalerBehaviorArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class HorizontalPodAutoscalerBehaviorArgs:
     def __init__(__self__, *,
@@ -749,6 +1058,34 @@ class HorizontalPodAutoscalerBehaviorArgs:
     def scale_up(self, value: Optional[pulumi.Input['HPAScalingRulesArgs']]):
         pulumi.set(self, "scale_up", value)
 
+
+if not MYPY:
+    class HorizontalPodAutoscalerConditionArgsDict(TypedDict):
+        """
+        HorizontalPodAutoscalerCondition describes the state of a HorizontalPodAutoscaler at a certain point.
+        """
+        status: pulumi.Input[str]
+        """
+        status is the status of the condition (True, False, Unknown)
+        """
+        type: pulumi.Input[str]
+        """
+        type describes the current condition
+        """
+        last_transition_time: NotRequired[pulumi.Input[str]]
+        """
+        lastTransitionTime is the last time the condition transitioned from one status to another
+        """
+        message: NotRequired[pulumi.Input[str]]
+        """
+        message is a human-readable explanation containing details about the transition
+        """
+        reason: NotRequired[pulumi.Input[str]]
+        """
+        reason is the reason for the condition's last transition.
+        """
+elif False:
+    HorizontalPodAutoscalerConditionArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class HorizontalPodAutoscalerConditionArgs:
@@ -835,6 +1172,34 @@ class HorizontalPodAutoscalerConditionArgs:
     def reason(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "reason", value)
 
+
+if not MYPY:
+    class HorizontalPodAutoscalerSpecPatchArgsDict(TypedDict):
+        """
+        HorizontalPodAutoscalerSpec describes the desired functionality of the HorizontalPodAutoscaler.
+        """
+        behavior: NotRequired[pulumi.Input['HorizontalPodAutoscalerBehaviorPatchArgsDict']]
+        """
+        behavior configures the scaling behavior of the target in both Up and Down directions (scaleUp and scaleDown fields respectively). If not set, the default HPAScalingRules for scale up and scale down are used.
+        """
+        max_replicas: NotRequired[pulumi.Input[int]]
+        """
+        maxReplicas is the upper limit for the number of replicas to which the autoscaler can scale up. It cannot be less that minReplicas.
+        """
+        metrics: NotRequired[pulumi.Input[Sequence[pulumi.Input['MetricSpecPatchArgsDict']]]]
+        """
+        metrics contains the specifications for which to use to calculate the desired replica count (the maximum replica count across all metrics will be used).  The desired replica count is calculated multiplying the ratio between the target value and the current value by the current number of pods.  Ergo, metrics used must decrease as the pod count is increased, and vice-versa.  See the individual metric source types for more information about how each type of metric must respond. If not set, the default metric will be set to 80% average CPU utilization.
+        """
+        min_replicas: NotRequired[pulumi.Input[int]]
+        """
+        minReplicas is the lower limit for the number of replicas to which the autoscaler can scale down.  It defaults to 1 pod.  minReplicas is allowed to be 0 if the alpha feature gate HPAScaleToZero is enabled and at least one Object or External metric is configured.  Scaling is active as long as at least one metric value is available.
+        """
+        scale_target_ref: NotRequired[pulumi.Input['CrossVersionObjectReferencePatchArgsDict']]
+        """
+        scaleTargetRef points to the target resource to scale, and is used to the pods for which metrics should be collected, as well as to actually change the replica count.
+        """
+elif False:
+    HorizontalPodAutoscalerSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class HorizontalPodAutoscalerSpecPatchArgs:
@@ -924,6 +1289,34 @@ class HorizontalPodAutoscalerSpecPatchArgs:
         pulumi.set(self, "scale_target_ref", value)
 
 
+if not MYPY:
+    class HorizontalPodAutoscalerSpecArgsDict(TypedDict):
+        """
+        HorizontalPodAutoscalerSpec describes the desired functionality of the HorizontalPodAutoscaler.
+        """
+        max_replicas: pulumi.Input[int]
+        """
+        maxReplicas is the upper limit for the number of replicas to which the autoscaler can scale up. It cannot be less that minReplicas.
+        """
+        scale_target_ref: pulumi.Input['CrossVersionObjectReferenceArgsDict']
+        """
+        scaleTargetRef points to the target resource to scale, and is used to the pods for which metrics should be collected, as well as to actually change the replica count.
+        """
+        behavior: NotRequired[pulumi.Input['HorizontalPodAutoscalerBehaviorArgsDict']]
+        """
+        behavior configures the scaling behavior of the target in both Up and Down directions (scaleUp and scaleDown fields respectively). If not set, the default HPAScalingRules for scale up and scale down are used.
+        """
+        metrics: NotRequired[pulumi.Input[Sequence[pulumi.Input['MetricSpecArgsDict']]]]
+        """
+        metrics contains the specifications for which to use to calculate the desired replica count (the maximum replica count across all metrics will be used).  The desired replica count is calculated multiplying the ratio between the target value and the current value by the current number of pods.  Ergo, metrics used must decrease as the pod count is increased, and vice-versa.  See the individual metric source types for more information about how each type of metric must respond. If not set, the default metric will be set to 80% average CPU utilization.
+        """
+        min_replicas: NotRequired[pulumi.Input[int]]
+        """
+        minReplicas is the lower limit for the number of replicas to which the autoscaler can scale down.  It defaults to 1 pod.  minReplicas is allowed to be 0 if the alpha feature gate HPAScaleToZero is enabled and at least one Object or External metric is configured.  Scaling is active as long as at least one metric value is available.
+        """
+elif False:
+    HorizontalPodAutoscalerSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class HorizontalPodAutoscalerSpecArgs:
     def __init__(__self__, *,
@@ -1009,6 +1402,38 @@ class HorizontalPodAutoscalerSpecArgs:
     def min_replicas(self, value: Optional[pulumi.Input[int]]):
         pulumi.set(self, "min_replicas", value)
 
+
+if not MYPY:
+    class HorizontalPodAutoscalerStatusArgsDict(TypedDict):
+        """
+        HorizontalPodAutoscalerStatus describes the current status of a horizontal pod autoscaler.
+        """
+        desired_replicas: pulumi.Input[int]
+        """
+        desiredReplicas is the desired number of replicas of pods managed by this autoscaler, as last calculated by the autoscaler.
+        """
+        conditions: NotRequired[pulumi.Input[Sequence[pulumi.Input['HorizontalPodAutoscalerConditionArgsDict']]]]
+        """
+        conditions is the set of conditions required for this autoscaler to scale its target, and indicates whether or not those conditions are met.
+        """
+        current_metrics: NotRequired[pulumi.Input[Sequence[pulumi.Input['MetricStatusArgsDict']]]]
+        """
+        currentMetrics is the last read state of the metrics used by this autoscaler.
+        """
+        current_replicas: NotRequired[pulumi.Input[int]]
+        """
+        currentReplicas is current number of replicas of pods managed by this autoscaler, as last seen by the autoscaler.
+        """
+        last_scale_time: NotRequired[pulumi.Input[str]]
+        """
+        lastScaleTime is the last time the HorizontalPodAutoscaler scaled the number of pods, used by the autoscaler to control how often the number of pods is changed.
+        """
+        observed_generation: NotRequired[pulumi.Input[int]]
+        """
+        observedGeneration is the most recent generation observed by this autoscaler.
+        """
+elif False:
+    HorizontalPodAutoscalerStatusArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class HorizontalPodAutoscalerStatusArgs:
@@ -1113,6 +1538,34 @@ class HorizontalPodAutoscalerStatusArgs:
         pulumi.set(self, "observed_generation", value)
 
 
+if not MYPY:
+    class HorizontalPodAutoscalerArgsDict(TypedDict):
+        """
+        HorizontalPodAutoscaler is the configuration for a horizontal pod autoscaler, which automatically manages the replica count of any resource implementing the scale subresource based on the metrics specified.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        metadata is the standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['HorizontalPodAutoscalerSpecArgsDict']]
+        """
+        spec is the specification for the behaviour of the autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
+        """
+        status: NotRequired[pulumi.Input['HorizontalPodAutoscalerStatusArgsDict']]
+        """
+        status is the current information about the autoscaler.
+        """
+elif False:
+    HorizontalPodAutoscalerArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class HorizontalPodAutoscalerArgs:
     def __init__(__self__, *,
@@ -1201,6 +1654,22 @@ class HorizontalPodAutoscalerArgs:
         pulumi.set(self, "status", value)
 
 
+if not MYPY:
+    class MetricIdentifierPatchArgsDict(TypedDict):
+        """
+        MetricIdentifier defines the name and optionally selector for a metric
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        name is the name of the given metric
+        """
+        selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorPatchArgsDict']]
+        """
+        selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping. When unset, just the metricName will be used to gather metrics.
+        """
+elif False:
+    MetricIdentifierPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class MetricIdentifierPatchArgs:
     def __init__(__self__, *,
@@ -1241,6 +1710,22 @@ class MetricIdentifierPatchArgs:
         pulumi.set(self, "selector", value)
 
 
+if not MYPY:
+    class MetricIdentifierArgsDict(TypedDict):
+        """
+        MetricIdentifier defines the name and optionally selector for a metric
+        """
+        name: pulumi.Input[str]
+        """
+        name is the name of the given metric
+        """
+        selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorArgsDict']]
+        """
+        selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping. When unset, just the metricName will be used to gather metrics.
+        """
+elif False:
+    MetricIdentifierArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class MetricIdentifierArgs:
     def __init__(__self__, *,
@@ -1279,6 +1764,38 @@ class MetricIdentifierArgs:
     def selector(self, value: Optional[pulumi.Input['_meta.v1.LabelSelectorArgs']]):
         pulumi.set(self, "selector", value)
 
+
+if not MYPY:
+    class MetricSpecPatchArgsDict(TypedDict):
+        """
+        MetricSpec specifies how to scale based on a single metric (only `type` and one other matching field should be set at once).
+        """
+        container_resource: NotRequired[pulumi.Input['ContainerResourceMetricSourcePatchArgsDict']]
+        """
+        containerResource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing a single container in each pod of the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source. This is an alpha feature and can be enabled by the HPAContainerMetrics feature flag.
+        """
+        external: NotRequired[pulumi.Input['ExternalMetricSourcePatchArgsDict']]
+        """
+        external refers to a global metric that is not associated with any Kubernetes object. It allows autoscaling based on information coming from components running outside of cluster (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster).
+        """
+        object: NotRequired[pulumi.Input['ObjectMetricSourcePatchArgsDict']]
+        """
+        object refers to a metric describing a single kubernetes object (for example, hits-per-second on an Ingress object).
+        """
+        pods: NotRequired[pulumi.Input['PodsMetricSourcePatchArgsDict']]
+        """
+        pods refers to a metric describing each pod in the current scale target (for example, transactions-processed-per-second).  The values will be averaged together before being compared to the target value.
+        """
+        resource: NotRequired[pulumi.Input['ResourceMetricSourcePatchArgsDict']]
+        """
+        resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        type is the type of metric source.  It should be one of "ContainerResource", "External", "Object", "Pods" or "Resource", each mapping to a matching field in the object. Note: "ContainerResource" type is available on when the feature-gate HPAContainerMetrics is enabled
+        """
+elif False:
+    MetricSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class MetricSpecPatchArgs:
@@ -1384,6 +1901,38 @@ class MetricSpecPatchArgs:
         pulumi.set(self, "type", value)
 
 
+if not MYPY:
+    class MetricSpecArgsDict(TypedDict):
+        """
+        MetricSpec specifies how to scale based on a single metric (only `type` and one other matching field should be set at once).
+        """
+        type: pulumi.Input[str]
+        """
+        type is the type of metric source.  It should be one of "ContainerResource", "External", "Object", "Pods" or "Resource", each mapping to a matching field in the object. Note: "ContainerResource" type is available on when the feature-gate HPAContainerMetrics is enabled
+        """
+        container_resource: NotRequired[pulumi.Input['ContainerResourceMetricSourceArgsDict']]
+        """
+        containerResource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing a single container in each pod of the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source. This is an alpha feature and can be enabled by the HPAContainerMetrics feature flag.
+        """
+        external: NotRequired[pulumi.Input['ExternalMetricSourceArgsDict']]
+        """
+        external refers to a global metric that is not associated with any Kubernetes object. It allows autoscaling based on information coming from components running outside of cluster (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster).
+        """
+        object: NotRequired[pulumi.Input['ObjectMetricSourceArgsDict']]
+        """
+        object refers to a metric describing a single kubernetes object (for example, hits-per-second on an Ingress object).
+        """
+        pods: NotRequired[pulumi.Input['PodsMetricSourceArgsDict']]
+        """
+        pods refers to a metric describing each pod in the current scale target (for example, transactions-processed-per-second).  The values will be averaged together before being compared to the target value.
+        """
+        resource: NotRequired[pulumi.Input['ResourceMetricSourceArgsDict']]
+        """
+        resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.
+        """
+elif False:
+    MetricSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class MetricSpecArgs:
     def __init__(__self__, *,
@@ -1486,6 +2035,38 @@ class MetricSpecArgs:
     def resource(self, value: Optional[pulumi.Input['ResourceMetricSourceArgs']]):
         pulumi.set(self, "resource", value)
 
+
+if not MYPY:
+    class MetricStatusArgsDict(TypedDict):
+        """
+        MetricStatus describes the last-read state of a single metric.
+        """
+        type: pulumi.Input[str]
+        """
+        type is the type of metric source.  It will be one of "ContainerResource", "External", "Object", "Pods" or "Resource", each corresponds to a matching field in the object. Note: "ContainerResource" type is available on when the feature-gate HPAContainerMetrics is enabled
+        """
+        container_resource: NotRequired[pulumi.Input['ContainerResourceMetricStatusArgsDict']]
+        """
+        container resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing a single container in each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.
+        """
+        external: NotRequired[pulumi.Input['ExternalMetricStatusArgsDict']]
+        """
+        external refers to a global metric that is not associated with any Kubernetes object. It allows autoscaling based on information coming from components running outside of cluster (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster).
+        """
+        object: NotRequired[pulumi.Input['ObjectMetricStatusArgsDict']]
+        """
+        object refers to a metric describing a single kubernetes object (for example, hits-per-second on an Ingress object).
+        """
+        pods: NotRequired[pulumi.Input['PodsMetricStatusArgsDict']]
+        """
+        pods refers to a metric describing each pod in the current scale target (for example, transactions-processed-per-second).  The values will be averaged together before being compared to the target value.
+        """
+        resource: NotRequired[pulumi.Input['ResourceMetricStatusArgsDict']]
+        """
+        resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.
+        """
+elif False:
+    MetricStatusArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class MetricStatusArgs:
@@ -1590,6 +2171,30 @@ class MetricStatusArgs:
         pulumi.set(self, "resource", value)
 
 
+if not MYPY:
+    class MetricTargetPatchArgsDict(TypedDict):
+        """
+        MetricTarget defines the target value, average value, or average utilization of a specific metric
+        """
+        average_utilization: NotRequired[pulumi.Input[int]]
+        """
+        averageUtilization is the target value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods. Currently only valid for Resource metric source type
+        """
+        average_value: NotRequired[pulumi.Input[str]]
+        """
+        averageValue is the target value of the average of the metric across all relevant pods (as a quantity)
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        type represents whether the metric type is Utilization, Value, or AverageValue
+        """
+        value: NotRequired[pulumi.Input[str]]
+        """
+        value is the target value of the metric (as a quantity).
+        """
+elif False:
+    MetricTargetPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class MetricTargetPatchArgs:
     def __init__(__self__, *,
@@ -1662,6 +2267,30 @@ class MetricTargetPatchArgs:
         pulumi.set(self, "value", value)
 
 
+if not MYPY:
+    class MetricTargetArgsDict(TypedDict):
+        """
+        MetricTarget defines the target value, average value, or average utilization of a specific metric
+        """
+        type: pulumi.Input[str]
+        """
+        type represents whether the metric type is Utilization, Value, or AverageValue
+        """
+        average_utilization: NotRequired[pulumi.Input[int]]
+        """
+        averageUtilization is the target value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods. Currently only valid for Resource metric source type
+        """
+        average_value: NotRequired[pulumi.Input[str]]
+        """
+        averageValue is the target value of the average of the metric across all relevant pods (as a quantity)
+        """
+        value: NotRequired[pulumi.Input[str]]
+        """
+        value is the target value of the metric (as a quantity).
+        """
+elif False:
+    MetricTargetArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class MetricTargetArgs:
     def __init__(__self__, *,
@@ -1733,6 +2362,26 @@ class MetricTargetArgs:
         pulumi.set(self, "value", value)
 
 
+if not MYPY:
+    class MetricValueStatusArgsDict(TypedDict):
+        """
+        MetricValueStatus holds the current value for a metric
+        """
+        average_utilization: NotRequired[pulumi.Input[int]]
+        """
+        currentAverageUtilization is the current value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods.
+        """
+        average_value: NotRequired[pulumi.Input[str]]
+        """
+        averageValue is the current value of the average of the metric across all relevant pods (as a quantity)
+        """
+        value: NotRequired[pulumi.Input[str]]
+        """
+        value is the current value of the metric (as a quantity).
+        """
+elif False:
+    MetricValueStatusArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class MetricValueStatusArgs:
     def __init__(__self__, *,
@@ -1788,6 +2437,26 @@ class MetricValueStatusArgs:
     def value(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "value", value)
 
+
+if not MYPY:
+    class ObjectMetricSourcePatchArgsDict(TypedDict):
+        """
+        ObjectMetricSource indicates how to scale on a metric describing a kubernetes object (for example, hits-per-second on an Ingress object).
+        """
+        described_object: NotRequired[pulumi.Input['CrossVersionObjectReferencePatchArgsDict']]
+        """
+        describedObject specifies the descriptions of a object,such as kind,name apiVersion
+        """
+        metric: NotRequired[pulumi.Input['MetricIdentifierPatchArgsDict']]
+        """
+        metric identifies the target metric by name and selector
+        """
+        target: NotRequired[pulumi.Input['MetricTargetPatchArgsDict']]
+        """
+        target specifies the target value for the given metric
+        """
+elif False:
+    ObjectMetricSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ObjectMetricSourcePatchArgs:
@@ -1845,6 +2514,26 @@ class ObjectMetricSourcePatchArgs:
         pulumi.set(self, "target", value)
 
 
+if not MYPY:
+    class ObjectMetricSourceArgsDict(TypedDict):
+        """
+        ObjectMetricSource indicates how to scale on a metric describing a kubernetes object (for example, hits-per-second on an Ingress object).
+        """
+        described_object: pulumi.Input['CrossVersionObjectReferenceArgsDict']
+        """
+        describedObject specifies the descriptions of a object,such as kind,name apiVersion
+        """
+        metric: pulumi.Input['MetricIdentifierArgsDict']
+        """
+        metric identifies the target metric by name and selector
+        """
+        target: pulumi.Input['MetricTargetArgsDict']
+        """
+        target specifies the target value for the given metric
+        """
+elif False:
+    ObjectMetricSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ObjectMetricSourceArgs:
     def __init__(__self__, *,
@@ -1897,6 +2586,26 @@ class ObjectMetricSourceArgs:
     def target(self, value: pulumi.Input['MetricTargetArgs']):
         pulumi.set(self, "target", value)
 
+
+if not MYPY:
+    class ObjectMetricStatusArgsDict(TypedDict):
+        """
+        ObjectMetricStatus indicates the current value of a metric describing a kubernetes object (for example, hits-per-second on an Ingress object).
+        """
+        current: pulumi.Input['MetricValueStatusArgsDict']
+        """
+        current contains the current value for the given metric
+        """
+        described_object: pulumi.Input['CrossVersionObjectReferenceArgsDict']
+        """
+        DescribedObject specifies the descriptions of a object,such as kind,name apiVersion
+        """
+        metric: pulumi.Input['MetricIdentifierArgsDict']
+        """
+        metric identifies the target metric by name and selector
+        """
+elif False:
+    ObjectMetricStatusArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ObjectMetricStatusArgs:
@@ -1951,6 +2660,22 @@ class ObjectMetricStatusArgs:
         pulumi.set(self, "metric", value)
 
 
+if not MYPY:
+    class PodsMetricSourcePatchArgsDict(TypedDict):
+        """
+        PodsMetricSource indicates how to scale on a metric describing each pod in the current scale target (for example, transactions-processed-per-second). The values will be averaged together before being compared to the target value.
+        """
+        metric: NotRequired[pulumi.Input['MetricIdentifierPatchArgsDict']]
+        """
+        metric identifies the target metric by name and selector
+        """
+        target: NotRequired[pulumi.Input['MetricTargetPatchArgsDict']]
+        """
+        target specifies the target value for the given metric
+        """
+elif False:
+    PodsMetricSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PodsMetricSourcePatchArgs:
     def __init__(__self__, *,
@@ -1991,6 +2716,22 @@ class PodsMetricSourcePatchArgs:
         pulumi.set(self, "target", value)
 
 
+if not MYPY:
+    class PodsMetricSourceArgsDict(TypedDict):
+        """
+        PodsMetricSource indicates how to scale on a metric describing each pod in the current scale target (for example, transactions-processed-per-second). The values will be averaged together before being compared to the target value.
+        """
+        metric: pulumi.Input['MetricIdentifierArgsDict']
+        """
+        metric identifies the target metric by name and selector
+        """
+        target: pulumi.Input['MetricTargetArgsDict']
+        """
+        target specifies the target value for the given metric
+        """
+elif False:
+    PodsMetricSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PodsMetricSourceArgs:
     def __init__(__self__, *,
@@ -2029,6 +2770,22 @@ class PodsMetricSourceArgs:
         pulumi.set(self, "target", value)
 
 
+if not MYPY:
+    class PodsMetricStatusArgsDict(TypedDict):
+        """
+        PodsMetricStatus indicates the current value of a metric describing each pod in the current scale target (for example, transactions-processed-per-second).
+        """
+        current: pulumi.Input['MetricValueStatusArgsDict']
+        """
+        current contains the current value for the given metric
+        """
+        metric: pulumi.Input['MetricIdentifierArgsDict']
+        """
+        metric identifies the target metric by name and selector
+        """
+elif False:
+    PodsMetricStatusArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PodsMetricStatusArgs:
     def __init__(__self__, *,
@@ -2066,6 +2823,22 @@ class PodsMetricStatusArgs:
     def metric(self, value: pulumi.Input['MetricIdentifierArgs']):
         pulumi.set(self, "metric", value)
 
+
+if not MYPY:
+    class ResourceMetricSourcePatchArgsDict(TypedDict):
+        """
+        ResourceMetricSource indicates how to scale on a resource metric known to Kubernetes, as specified in requests and limits, describing each pod in the current scale target (e.g. CPU or memory).  The values will be averaged together before being compared to the target.  Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.  Only one "target" type should be set.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        name is the name of the resource in question.
+        """
+        target: NotRequired[pulumi.Input['MetricTargetPatchArgsDict']]
+        """
+        target specifies the target value for the given metric
+        """
+elif False:
+    ResourceMetricSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ResourceMetricSourcePatchArgs:
@@ -2107,6 +2880,22 @@ class ResourceMetricSourcePatchArgs:
         pulumi.set(self, "target", value)
 
 
+if not MYPY:
+    class ResourceMetricSourceArgsDict(TypedDict):
+        """
+        ResourceMetricSource indicates how to scale on a resource metric known to Kubernetes, as specified in requests and limits, describing each pod in the current scale target (e.g. CPU or memory).  The values will be averaged together before being compared to the target.  Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.  Only one "target" type should be set.
+        """
+        name: pulumi.Input[str]
+        """
+        name is the name of the resource in question.
+        """
+        target: pulumi.Input['MetricTargetArgsDict']
+        """
+        target specifies the target value for the given metric
+        """
+elif False:
+    ResourceMetricSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ResourceMetricSourceArgs:
     def __init__(__self__, *,
@@ -2144,6 +2933,22 @@ class ResourceMetricSourceArgs:
     def target(self, value: pulumi.Input['MetricTargetArgs']):
         pulumi.set(self, "target", value)
 
+
+if not MYPY:
+    class ResourceMetricStatusArgsDict(TypedDict):
+        """
+        ResourceMetricStatus indicates the current value of a resource metric known to Kubernetes, as specified in requests and limits, describing each pod in the current scale target (e.g. CPU or memory).  Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.
+        """
+        current: pulumi.Input['MetricValueStatusArgsDict']
+        """
+        current contains the current value for the given metric
+        """
+        name: pulumi.Input[str]
+        """
+        name is the name of the resource in question.
+        """
+elif False:
+    ResourceMetricStatusArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ResourceMetricStatusArgs:

--- a/sdk/python/pulumi_kubernetes/autoscaling/v2/outputs.py
+++ b/sdk/python/pulumi_kubernetes/autoscaling/v2/outputs.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta

--- a/sdk/python/pulumi_kubernetes/autoscaling/v2beta1/HorizontalPodAutoscaler.py
+++ b/sdk/python/pulumi_kubernetes/autoscaling/v2beta1/HorizontalPodAutoscaler.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class HorizontalPodAutoscaler(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['HorizontalPodAutoscalerSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['HorizontalPodAutoscalerSpecArgs', 'HorizontalPodAutoscalerSpecArgsDict']]] = None,
                  __props__=None):
         """
         HorizontalPodAutoscaler is the configuration for a horizontal pod autoscaler, which automatically manages the replica count of any resource implementing the scale subresource based on the metrics specified.
@@ -103,8 +108,8 @@ class HorizontalPodAutoscaler(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: metadata is the standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['HorizontalPodAutoscalerSpecArgs']] spec: spec is the specification for the behaviour of the autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: metadata is the standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['HorizontalPodAutoscalerSpecArgs', 'HorizontalPodAutoscalerSpecArgsDict']] spec: spec is the specification for the behaviour of the autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
         """
         ...
     @overload
@@ -132,8 +137,8 @@ class HorizontalPodAutoscaler(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['HorizontalPodAutoscalerSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['HorizontalPodAutoscalerSpecArgs', 'HorizontalPodAutoscalerSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/autoscaling/v2beta1/HorizontalPodAutoscalerList.py
+++ b/sdk/python/pulumi_kubernetes/autoscaling/v2beta1/HorizontalPodAutoscalerList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class HorizontalPodAutoscalerList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['HorizontalPodAutoscalerArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['HorizontalPodAutoscalerArgs', 'HorizontalPodAutoscalerArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         HorizontalPodAutoscaler is a list of horizontal pod autoscaler objects.
@@ -101,9 +106,9 @@ class HorizontalPodAutoscalerList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['HorizontalPodAutoscalerArgs']]]] items: items is the list of horizontal pod autoscaler objects.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['HorizontalPodAutoscalerArgs', 'HorizontalPodAutoscalerArgsDict']]]] items: items is the list of horizontal pod autoscaler objects.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: metadata is the standard list metadata.
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: metadata is the standard list metadata.
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class HorizontalPodAutoscalerList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['HorizontalPodAutoscalerArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['HorizontalPodAutoscalerArgs', 'HorizontalPodAutoscalerArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/autoscaling/v2beta1/HorizontalPodAutoscalerPatch.py
+++ b/sdk/python/pulumi_kubernetes/autoscaling/v2beta1/HorizontalPodAutoscalerPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class HorizontalPodAutoscalerPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['HorizontalPodAutoscalerSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['HorizontalPodAutoscalerSpecPatchArgs', 'HorizontalPodAutoscalerSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -109,8 +114,8 @@ class HorizontalPodAutoscalerPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: metadata is the standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['HorizontalPodAutoscalerSpecPatchArgs']] spec: spec is the specification for the behaviour of the autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: metadata is the standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['HorizontalPodAutoscalerSpecPatchArgs', 'HorizontalPodAutoscalerSpecPatchArgsDict']] spec: spec is the specification for the behaviour of the autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
         """
         ...
     @overload
@@ -144,8 +149,8 @@ class HorizontalPodAutoscalerPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['HorizontalPodAutoscalerSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['HorizontalPodAutoscalerSpecPatchArgs', 'HorizontalPodAutoscalerSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/autoscaling/v2beta1/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/autoscaling/v2beta1/_inputs.py
@@ -4,39 +4,95 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import meta as _meta
 
 __all__ = [
     'ContainerResourceMetricSourcePatchArgs',
+    'ContainerResourceMetricSourcePatchArgsDict',
     'ContainerResourceMetricSourceArgs',
+    'ContainerResourceMetricSourceArgsDict',
     'ContainerResourceMetricStatusArgs',
+    'ContainerResourceMetricStatusArgsDict',
     'CrossVersionObjectReferencePatchArgs',
+    'CrossVersionObjectReferencePatchArgsDict',
     'CrossVersionObjectReferenceArgs',
+    'CrossVersionObjectReferenceArgsDict',
     'ExternalMetricSourcePatchArgs',
+    'ExternalMetricSourcePatchArgsDict',
     'ExternalMetricSourceArgs',
+    'ExternalMetricSourceArgsDict',
     'ExternalMetricStatusArgs',
+    'ExternalMetricStatusArgsDict',
     'HorizontalPodAutoscalerConditionArgs',
+    'HorizontalPodAutoscalerConditionArgsDict',
     'HorizontalPodAutoscalerSpecPatchArgs',
+    'HorizontalPodAutoscalerSpecPatchArgsDict',
     'HorizontalPodAutoscalerSpecArgs',
+    'HorizontalPodAutoscalerSpecArgsDict',
     'HorizontalPodAutoscalerStatusArgs',
+    'HorizontalPodAutoscalerStatusArgsDict',
     'HorizontalPodAutoscalerArgs',
+    'HorizontalPodAutoscalerArgsDict',
     'MetricSpecPatchArgs',
+    'MetricSpecPatchArgsDict',
     'MetricSpecArgs',
+    'MetricSpecArgsDict',
     'MetricStatusArgs',
+    'MetricStatusArgsDict',
     'ObjectMetricSourcePatchArgs',
+    'ObjectMetricSourcePatchArgsDict',
     'ObjectMetricSourceArgs',
+    'ObjectMetricSourceArgsDict',
     'ObjectMetricStatusArgs',
+    'ObjectMetricStatusArgsDict',
     'PodsMetricSourcePatchArgs',
+    'PodsMetricSourcePatchArgsDict',
     'PodsMetricSourceArgs',
+    'PodsMetricSourceArgsDict',
     'PodsMetricStatusArgs',
+    'PodsMetricStatusArgsDict',
     'ResourceMetricSourcePatchArgs',
+    'ResourceMetricSourcePatchArgsDict',
     'ResourceMetricSourceArgs',
+    'ResourceMetricSourceArgsDict',
     'ResourceMetricStatusArgs',
+    'ResourceMetricStatusArgsDict',
 ]
+
+MYPY = False
+
+if not MYPY:
+    class ContainerResourceMetricSourcePatchArgsDict(TypedDict):
+        """
+        ContainerResourceMetricSource indicates how to scale on a resource metric known to Kubernetes, as specified in requests and limits, describing each pod in the current scale target (e.g. CPU or memory).  The values will be averaged together before being compared to the target.  Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.  Only one "target" type should be set.
+        """
+        container: NotRequired[pulumi.Input[str]]
+        """
+        container is the name of the container in the pods of the scaling target
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        name is the name of the resource in question.
+        """
+        target_average_utilization: NotRequired[pulumi.Input[int]]
+        """
+        targetAverageUtilization is the target value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods.
+        """
+        target_average_value: NotRequired[pulumi.Input[str]]
+        """
+        targetAverageValue is the target value of the average of the resource metric across all relevant pods, as a raw value (instead of as a percentage of the request), similar to the "pods" metric source type.
+        """
+elif False:
+    ContainerResourceMetricSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ContainerResourceMetricSourcePatchArgs:
@@ -110,6 +166,30 @@ class ContainerResourceMetricSourcePatchArgs:
         pulumi.set(self, "target_average_value", value)
 
 
+if not MYPY:
+    class ContainerResourceMetricSourceArgsDict(TypedDict):
+        """
+        ContainerResourceMetricSource indicates how to scale on a resource metric known to Kubernetes, as specified in requests and limits, describing each pod in the current scale target (e.g. CPU or memory).  The values will be averaged together before being compared to the target.  Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.  Only one "target" type should be set.
+        """
+        container: pulumi.Input[str]
+        """
+        container is the name of the container in the pods of the scaling target
+        """
+        name: pulumi.Input[str]
+        """
+        name is the name of the resource in question.
+        """
+        target_average_utilization: NotRequired[pulumi.Input[int]]
+        """
+        targetAverageUtilization is the target value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods.
+        """
+        target_average_value: NotRequired[pulumi.Input[str]]
+        """
+        targetAverageValue is the target value of the average of the resource metric across all relevant pods, as a raw value (instead of as a percentage of the request), similar to the "pods" metric source type.
+        """
+elif False:
+    ContainerResourceMetricSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ContainerResourceMetricSourceArgs:
     def __init__(__self__, *,
@@ -180,6 +260,30 @@ class ContainerResourceMetricSourceArgs:
         pulumi.set(self, "target_average_value", value)
 
 
+if not MYPY:
+    class ContainerResourceMetricStatusArgsDict(TypedDict):
+        """
+        ContainerResourceMetricStatus indicates the current value of a resource metric known to Kubernetes, as specified in requests and limits, describing a single container in each pod in the current scale target (e.g. CPU or memory).  Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.
+        """
+        container: pulumi.Input[str]
+        """
+        container is the name of the container in the pods of the scaling target
+        """
+        current_average_value: pulumi.Input[str]
+        """
+        currentAverageValue is the current value of the average of the resource metric across all relevant pods, as a raw value (instead of as a percentage of the request), similar to the "pods" metric source type. It will always be set, regardless of the corresponding metric specification.
+        """
+        name: pulumi.Input[str]
+        """
+        name is the name of the resource in question.
+        """
+        current_average_utilization: NotRequired[pulumi.Input[int]]
+        """
+        currentAverageUtilization is the current value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods.  It will only be present if `targetAverageValue` was set in the corresponding metric specification.
+        """
+elif False:
+    ContainerResourceMetricStatusArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ContainerResourceMetricStatusArgs:
     def __init__(__self__, *,
@@ -249,6 +353,26 @@ class ContainerResourceMetricStatusArgs:
         pulumi.set(self, "current_average_utilization", value)
 
 
+if not MYPY:
+    class CrossVersionObjectReferencePatchArgsDict(TypedDict):
+        """
+        CrossVersionObjectReference contains enough information to let you identify the referred resource.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        API version of the referent
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names
+        """
+elif False:
+    CrossVersionObjectReferencePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CrossVersionObjectReferencePatchArgs:
     def __init__(__self__, *,
@@ -305,6 +429,26 @@ class CrossVersionObjectReferencePatchArgs:
         pulumi.set(self, "name", value)
 
 
+if not MYPY:
+    class CrossVersionObjectReferenceArgsDict(TypedDict):
+        """
+        CrossVersionObjectReference contains enough information to let you identify the referred resource.
+        """
+        kind: pulumi.Input[str]
+        """
+        Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+        """
+        name: pulumi.Input[str]
+        """
+        Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        API version of the referent
+        """
+elif False:
+    CrossVersionObjectReferenceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CrossVersionObjectReferenceArgs:
     def __init__(__self__, *,
@@ -358,6 +502,30 @@ class CrossVersionObjectReferenceArgs:
     def api_version(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "api_version", value)
 
+
+if not MYPY:
+    class ExternalMetricSourcePatchArgsDict(TypedDict):
+        """
+        ExternalMetricSource indicates how to scale on a metric not associated with any Kubernetes object (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster). Exactly one "target" type should be set.
+        """
+        metric_name: NotRequired[pulumi.Input[str]]
+        """
+        metricName is the name of the metric in question.
+        """
+        metric_selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorPatchArgsDict']]
+        """
+        metricSelector is used to identify a specific time series within a given metric.
+        """
+        target_average_value: NotRequired[pulumi.Input[str]]
+        """
+        targetAverageValue is the target per-pod value of global metric (as a quantity). Mutually exclusive with TargetValue.
+        """
+        target_value: NotRequired[pulumi.Input[str]]
+        """
+        targetValue is the target value of the metric (as a quantity). Mutually exclusive with TargetAverageValue.
+        """
+elif False:
+    ExternalMetricSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ExternalMetricSourcePatchArgs:
@@ -431,6 +599,30 @@ class ExternalMetricSourcePatchArgs:
         pulumi.set(self, "target_value", value)
 
 
+if not MYPY:
+    class ExternalMetricSourceArgsDict(TypedDict):
+        """
+        ExternalMetricSource indicates how to scale on a metric not associated with any Kubernetes object (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster). Exactly one "target" type should be set.
+        """
+        metric_name: pulumi.Input[str]
+        """
+        metricName is the name of the metric in question.
+        """
+        metric_selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorArgsDict']]
+        """
+        metricSelector is used to identify a specific time series within a given metric.
+        """
+        target_average_value: NotRequired[pulumi.Input[str]]
+        """
+        targetAverageValue is the target per-pod value of global metric (as a quantity). Mutually exclusive with TargetValue.
+        """
+        target_value: NotRequired[pulumi.Input[str]]
+        """
+        targetValue is the target value of the metric (as a quantity). Mutually exclusive with TargetAverageValue.
+        """
+elif False:
+    ExternalMetricSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ExternalMetricSourceArgs:
     def __init__(__self__, *,
@@ -502,6 +694,30 @@ class ExternalMetricSourceArgs:
         pulumi.set(self, "target_value", value)
 
 
+if not MYPY:
+    class ExternalMetricStatusArgsDict(TypedDict):
+        """
+        ExternalMetricStatus indicates the current value of a global metric not associated with any Kubernetes object.
+        """
+        current_value: pulumi.Input[str]
+        """
+        currentValue is the current value of the metric (as a quantity)
+        """
+        metric_name: pulumi.Input[str]
+        """
+        metricName is the name of a metric used for autoscaling in metric system.
+        """
+        current_average_value: NotRequired[pulumi.Input[str]]
+        """
+        currentAverageValue is the current value of metric averaged over autoscaled pods.
+        """
+        metric_selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorArgsDict']]
+        """
+        metricSelector is used to identify a specific time series within a given metric.
+        """
+elif False:
+    ExternalMetricStatusArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ExternalMetricStatusArgs:
     def __init__(__self__, *,
@@ -571,6 +787,34 @@ class ExternalMetricStatusArgs:
     def metric_selector(self, value: Optional[pulumi.Input['_meta.v1.LabelSelectorArgs']]):
         pulumi.set(self, "metric_selector", value)
 
+
+if not MYPY:
+    class HorizontalPodAutoscalerConditionArgsDict(TypedDict):
+        """
+        HorizontalPodAutoscalerCondition describes the state of a HorizontalPodAutoscaler at a certain point.
+        """
+        status: pulumi.Input[str]
+        """
+        status is the status of the condition (True, False, Unknown)
+        """
+        type: pulumi.Input[str]
+        """
+        type describes the current condition
+        """
+        last_transition_time: NotRequired[pulumi.Input[str]]
+        """
+        lastTransitionTime is the last time the condition transitioned from one status to another
+        """
+        message: NotRequired[pulumi.Input[str]]
+        """
+        message is a human-readable explanation containing details about the transition
+        """
+        reason: NotRequired[pulumi.Input[str]]
+        """
+        reason is the reason for the condition's last transition.
+        """
+elif False:
+    HorizontalPodAutoscalerConditionArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class HorizontalPodAutoscalerConditionArgs:
@@ -658,6 +902,30 @@ class HorizontalPodAutoscalerConditionArgs:
         pulumi.set(self, "reason", value)
 
 
+if not MYPY:
+    class HorizontalPodAutoscalerSpecPatchArgsDict(TypedDict):
+        """
+        HorizontalPodAutoscalerSpec describes the desired functionality of the HorizontalPodAutoscaler.
+        """
+        max_replicas: NotRequired[pulumi.Input[int]]
+        """
+        maxReplicas is the upper limit for the number of replicas to which the autoscaler can scale up. It cannot be less that minReplicas.
+        """
+        metrics: NotRequired[pulumi.Input[Sequence[pulumi.Input['MetricSpecPatchArgsDict']]]]
+        """
+        metrics contains the specifications for which to use to calculate the desired replica count (the maximum replica count across all metrics will be used).  The desired replica count is calculated multiplying the ratio between the target value and the current value by the current number of pods.  Ergo, metrics used must decrease as the pod count is increased, and vice-versa.  See the individual metric source types for more information about how each type of metric must respond.
+        """
+        min_replicas: NotRequired[pulumi.Input[int]]
+        """
+        minReplicas is the lower limit for the number of replicas to which the autoscaler can scale down.  It defaults to 1 pod.  minReplicas is allowed to be 0 if the alpha feature gate HPAScaleToZero is enabled and at least one Object or External metric is configured.  Scaling is active as long as at least one metric value is available.
+        """
+        scale_target_ref: NotRequired[pulumi.Input['CrossVersionObjectReferencePatchArgsDict']]
+        """
+        scaleTargetRef points to the target resource to scale, and is used to the pods for which metrics should be collected, as well as to actually change the replica count.
+        """
+elif False:
+    HorizontalPodAutoscalerSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class HorizontalPodAutoscalerSpecPatchArgs:
     def __init__(__self__, *,
@@ -730,6 +998,30 @@ class HorizontalPodAutoscalerSpecPatchArgs:
         pulumi.set(self, "scale_target_ref", value)
 
 
+if not MYPY:
+    class HorizontalPodAutoscalerSpecArgsDict(TypedDict):
+        """
+        HorizontalPodAutoscalerSpec describes the desired functionality of the HorizontalPodAutoscaler.
+        """
+        max_replicas: pulumi.Input[int]
+        """
+        maxReplicas is the upper limit for the number of replicas to which the autoscaler can scale up. It cannot be less that minReplicas.
+        """
+        scale_target_ref: pulumi.Input['CrossVersionObjectReferenceArgsDict']
+        """
+        scaleTargetRef points to the target resource to scale, and is used to the pods for which metrics should be collected, as well as to actually change the replica count.
+        """
+        metrics: NotRequired[pulumi.Input[Sequence[pulumi.Input['MetricSpecArgsDict']]]]
+        """
+        metrics contains the specifications for which to use to calculate the desired replica count (the maximum replica count across all metrics will be used).  The desired replica count is calculated multiplying the ratio between the target value and the current value by the current number of pods.  Ergo, metrics used must decrease as the pod count is increased, and vice-versa.  See the individual metric source types for more information about how each type of metric must respond.
+        """
+        min_replicas: NotRequired[pulumi.Input[int]]
+        """
+        minReplicas is the lower limit for the number of replicas to which the autoscaler can scale down.  It defaults to 1 pod.  minReplicas is allowed to be 0 if the alpha feature gate HPAScaleToZero is enabled and at least one Object or External metric is configured.  Scaling is active as long as at least one metric value is available.
+        """
+elif False:
+    HorizontalPodAutoscalerSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class HorizontalPodAutoscalerSpecArgs:
     def __init__(__self__, *,
@@ -799,6 +1091,38 @@ class HorizontalPodAutoscalerSpecArgs:
     def min_replicas(self, value: Optional[pulumi.Input[int]]):
         pulumi.set(self, "min_replicas", value)
 
+
+if not MYPY:
+    class HorizontalPodAutoscalerStatusArgsDict(TypedDict):
+        """
+        HorizontalPodAutoscalerStatus describes the current status of a horizontal pod autoscaler.
+        """
+        conditions: pulumi.Input[Sequence[pulumi.Input['HorizontalPodAutoscalerConditionArgsDict']]]
+        """
+        conditions is the set of conditions required for this autoscaler to scale its target, and indicates whether or not those conditions are met.
+        """
+        current_replicas: pulumi.Input[int]
+        """
+        currentReplicas is current number of replicas of pods managed by this autoscaler, as last seen by the autoscaler.
+        """
+        desired_replicas: pulumi.Input[int]
+        """
+        desiredReplicas is the desired number of replicas of pods managed by this autoscaler, as last calculated by the autoscaler.
+        """
+        current_metrics: NotRequired[pulumi.Input[Sequence[pulumi.Input['MetricStatusArgsDict']]]]
+        """
+        currentMetrics is the last read state of the metrics used by this autoscaler.
+        """
+        last_scale_time: NotRequired[pulumi.Input[str]]
+        """
+        lastScaleTime is the last time the HorizontalPodAutoscaler scaled the number of pods, used by the autoscaler to control how often the number of pods is changed.
+        """
+        observed_generation: NotRequired[pulumi.Input[int]]
+        """
+        observedGeneration is the most recent generation observed by this autoscaler.
+        """
+elif False:
+    HorizontalPodAutoscalerStatusArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class HorizontalPodAutoscalerStatusArgs:
@@ -901,6 +1225,34 @@ class HorizontalPodAutoscalerStatusArgs:
         pulumi.set(self, "observed_generation", value)
 
 
+if not MYPY:
+    class HorizontalPodAutoscalerArgsDict(TypedDict):
+        """
+        HorizontalPodAutoscaler is the configuration for a horizontal pod autoscaler, which automatically manages the replica count of any resource implementing the scale subresource based on the metrics specified.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        metadata is the standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['HorizontalPodAutoscalerSpecArgsDict']]
+        """
+        spec is the specification for the behaviour of the autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
+        """
+        status: NotRequired[pulumi.Input['HorizontalPodAutoscalerStatusArgsDict']]
+        """
+        status is the current information about the autoscaler.
+        """
+elif False:
+    HorizontalPodAutoscalerArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class HorizontalPodAutoscalerArgs:
     def __init__(__self__, *,
@@ -988,6 +1340,38 @@ class HorizontalPodAutoscalerArgs:
     def status(self, value: Optional[pulumi.Input['HorizontalPodAutoscalerStatusArgs']]):
         pulumi.set(self, "status", value)
 
+
+if not MYPY:
+    class MetricSpecPatchArgsDict(TypedDict):
+        """
+        MetricSpec specifies how to scale based on a single metric (only `type` and one other matching field should be set at once).
+        """
+        container_resource: NotRequired[pulumi.Input['ContainerResourceMetricSourcePatchArgsDict']]
+        """
+        container resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing a single container in each pod of the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source. This is an alpha feature and can be enabled by the HPAContainerMetrics feature flag.
+        """
+        external: NotRequired[pulumi.Input['ExternalMetricSourcePatchArgsDict']]
+        """
+        external refers to a global metric that is not associated with any Kubernetes object. It allows autoscaling based on information coming from components running outside of cluster (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster).
+        """
+        object: NotRequired[pulumi.Input['ObjectMetricSourcePatchArgsDict']]
+        """
+        object refers to a metric describing a single kubernetes object (for example, hits-per-second on an Ingress object).
+        """
+        pods: NotRequired[pulumi.Input['PodsMetricSourcePatchArgsDict']]
+        """
+        pods refers to a metric describing each pod in the current scale target (for example, transactions-processed-per-second).  The values will be averaged together before being compared to the target value.
+        """
+        resource: NotRequired[pulumi.Input['ResourceMetricSourcePatchArgsDict']]
+        """
+        resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        type is the type of metric source.  It should be one of "Object", "Pods" or "Resource", each mapping to a matching field in the object.
+        """
+elif False:
+    MetricSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class MetricSpecPatchArgs:
@@ -1093,6 +1477,38 @@ class MetricSpecPatchArgs:
         pulumi.set(self, "type", value)
 
 
+if not MYPY:
+    class MetricSpecArgsDict(TypedDict):
+        """
+        MetricSpec specifies how to scale based on a single metric (only `type` and one other matching field should be set at once).
+        """
+        type: pulumi.Input[str]
+        """
+        type is the type of metric source.  It should be one of "Object", "Pods" or "Resource", each mapping to a matching field in the object.
+        """
+        container_resource: NotRequired[pulumi.Input['ContainerResourceMetricSourceArgsDict']]
+        """
+        container resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing a single container in each pod of the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source. This is an alpha feature and can be enabled by the HPAContainerMetrics feature flag.
+        """
+        external: NotRequired[pulumi.Input['ExternalMetricSourceArgsDict']]
+        """
+        external refers to a global metric that is not associated with any Kubernetes object. It allows autoscaling based on information coming from components running outside of cluster (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster).
+        """
+        object: NotRequired[pulumi.Input['ObjectMetricSourceArgsDict']]
+        """
+        object refers to a metric describing a single kubernetes object (for example, hits-per-second on an Ingress object).
+        """
+        pods: NotRequired[pulumi.Input['PodsMetricSourceArgsDict']]
+        """
+        pods refers to a metric describing each pod in the current scale target (for example, transactions-processed-per-second).  The values will be averaged together before being compared to the target value.
+        """
+        resource: NotRequired[pulumi.Input['ResourceMetricSourceArgsDict']]
+        """
+        resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.
+        """
+elif False:
+    MetricSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class MetricSpecArgs:
     def __init__(__self__, *,
@@ -1195,6 +1611,38 @@ class MetricSpecArgs:
     def resource(self, value: Optional[pulumi.Input['ResourceMetricSourceArgs']]):
         pulumi.set(self, "resource", value)
 
+
+if not MYPY:
+    class MetricStatusArgsDict(TypedDict):
+        """
+        MetricStatus describes the last-read state of a single metric.
+        """
+        type: pulumi.Input[str]
+        """
+        type is the type of metric source.  It will be one of "Object", "Pods" or "Resource", each corresponds to a matching field in the object.
+        """
+        container_resource: NotRequired[pulumi.Input['ContainerResourceMetricStatusArgsDict']]
+        """
+        container resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing a single container in each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.
+        """
+        external: NotRequired[pulumi.Input['ExternalMetricStatusArgsDict']]
+        """
+        external refers to a global metric that is not associated with any Kubernetes object. It allows autoscaling based on information coming from components running outside of cluster (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster).
+        """
+        object: NotRequired[pulumi.Input['ObjectMetricStatusArgsDict']]
+        """
+        object refers to a metric describing a single kubernetes object (for example, hits-per-second on an Ingress object).
+        """
+        pods: NotRequired[pulumi.Input['PodsMetricStatusArgsDict']]
+        """
+        pods refers to a metric describing each pod in the current scale target (for example, transactions-processed-per-second).  The values will be averaged together before being compared to the target value.
+        """
+        resource: NotRequired[pulumi.Input['ResourceMetricStatusArgsDict']]
+        """
+        resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.
+        """
+elif False:
+    MetricStatusArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class MetricStatusArgs:
@@ -1299,6 +1747,34 @@ class MetricStatusArgs:
         pulumi.set(self, "resource", value)
 
 
+if not MYPY:
+    class ObjectMetricSourcePatchArgsDict(TypedDict):
+        """
+        ObjectMetricSource indicates how to scale on a metric describing a kubernetes object (for example, hits-per-second on an Ingress object).
+        """
+        average_value: NotRequired[pulumi.Input[str]]
+        """
+        averageValue is the target value of the average of the metric across all relevant pods (as a quantity)
+        """
+        metric_name: NotRequired[pulumi.Input[str]]
+        """
+        metricName is the name of the metric in question.
+        """
+        selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorPatchArgsDict']]
+        """
+        selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping When unset, just the metricName will be used to gather metrics.
+        """
+        target: NotRequired[pulumi.Input['CrossVersionObjectReferencePatchArgsDict']]
+        """
+        target is the described Kubernetes object.
+        """
+        target_value: NotRequired[pulumi.Input[str]]
+        """
+        targetValue is the target value of the metric (as a quantity).
+        """
+elif False:
+    ObjectMetricSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ObjectMetricSourcePatchArgs:
     def __init__(__self__, *,
@@ -1387,6 +1863,34 @@ class ObjectMetricSourcePatchArgs:
         pulumi.set(self, "target_value", value)
 
 
+if not MYPY:
+    class ObjectMetricSourceArgsDict(TypedDict):
+        """
+        ObjectMetricSource indicates how to scale on a metric describing a kubernetes object (for example, hits-per-second on an Ingress object).
+        """
+        metric_name: pulumi.Input[str]
+        """
+        metricName is the name of the metric in question.
+        """
+        target: pulumi.Input['CrossVersionObjectReferenceArgsDict']
+        """
+        target is the described Kubernetes object.
+        """
+        target_value: pulumi.Input[str]
+        """
+        targetValue is the target value of the metric (as a quantity).
+        """
+        average_value: NotRequired[pulumi.Input[str]]
+        """
+        averageValue is the target value of the average of the metric across all relevant pods (as a quantity)
+        """
+        selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorArgsDict']]
+        """
+        selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping When unset, just the metricName will be used to gather metrics.
+        """
+elif False:
+    ObjectMetricSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ObjectMetricSourceArgs:
     def __init__(__self__, *,
@@ -1471,6 +1975,34 @@ class ObjectMetricSourceArgs:
     def selector(self, value: Optional[pulumi.Input['_meta.v1.LabelSelectorArgs']]):
         pulumi.set(self, "selector", value)
 
+
+if not MYPY:
+    class ObjectMetricStatusArgsDict(TypedDict):
+        """
+        ObjectMetricStatus indicates the current value of a metric describing a kubernetes object (for example, hits-per-second on an Ingress object).
+        """
+        current_value: pulumi.Input[str]
+        """
+        currentValue is the current value of the metric (as a quantity).
+        """
+        metric_name: pulumi.Input[str]
+        """
+        metricName is the name of the metric in question.
+        """
+        target: pulumi.Input['CrossVersionObjectReferenceArgsDict']
+        """
+        target is the described Kubernetes object.
+        """
+        average_value: NotRequired[pulumi.Input[str]]
+        """
+        averageValue is the current value of the average of the metric across all relevant pods (as a quantity)
+        """
+        selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorArgsDict']]
+        """
+        selector is the string-encoded form of a standard kubernetes label selector for the given metric When set in the ObjectMetricSource, it is passed as an additional parameter to the metrics server for more specific metrics scoping. When unset, just the metricName will be used to gather metrics.
+        """
+elif False:
+    ObjectMetricStatusArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ObjectMetricStatusArgs:
@@ -1557,6 +2089,26 @@ class ObjectMetricStatusArgs:
         pulumi.set(self, "selector", value)
 
 
+if not MYPY:
+    class PodsMetricSourcePatchArgsDict(TypedDict):
+        """
+        PodsMetricSource indicates how to scale on a metric describing each pod in the current scale target (for example, transactions-processed-per-second). The values will be averaged together before being compared to the target value.
+        """
+        metric_name: NotRequired[pulumi.Input[str]]
+        """
+        metricName is the name of the metric in question
+        """
+        selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorPatchArgsDict']]
+        """
+        selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping When unset, just the metricName will be used to gather metrics.
+        """
+        target_average_value: NotRequired[pulumi.Input[str]]
+        """
+        targetAverageValue is the target value of the average of the metric across all relevant pods (as a quantity)
+        """
+elif False:
+    PodsMetricSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PodsMetricSourcePatchArgs:
     def __init__(__self__, *,
@@ -1613,6 +2165,26 @@ class PodsMetricSourcePatchArgs:
         pulumi.set(self, "target_average_value", value)
 
 
+if not MYPY:
+    class PodsMetricSourceArgsDict(TypedDict):
+        """
+        PodsMetricSource indicates how to scale on a metric describing each pod in the current scale target (for example, transactions-processed-per-second). The values will be averaged together before being compared to the target value.
+        """
+        metric_name: pulumi.Input[str]
+        """
+        metricName is the name of the metric in question
+        """
+        target_average_value: pulumi.Input[str]
+        """
+        targetAverageValue is the target value of the average of the metric across all relevant pods (as a quantity)
+        """
+        selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorArgsDict']]
+        """
+        selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping When unset, just the metricName will be used to gather metrics.
+        """
+elif False:
+    PodsMetricSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PodsMetricSourceArgs:
     def __init__(__self__, *,
@@ -1667,6 +2239,26 @@ class PodsMetricSourceArgs:
         pulumi.set(self, "selector", value)
 
 
+if not MYPY:
+    class PodsMetricStatusArgsDict(TypedDict):
+        """
+        PodsMetricStatus indicates the current value of a metric describing each pod in the current scale target (for example, transactions-processed-per-second).
+        """
+        current_average_value: pulumi.Input[str]
+        """
+        currentAverageValue is the current value of the average of the metric across all relevant pods (as a quantity)
+        """
+        metric_name: pulumi.Input[str]
+        """
+        metricName is the name of the metric in question
+        """
+        selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorArgsDict']]
+        """
+        selector is the string-encoded form of a standard kubernetes label selector for the given metric When set in the PodsMetricSource, it is passed as an additional parameter to the metrics server for more specific metrics scoping. When unset, just the metricName will be used to gather metrics.
+        """
+elif False:
+    PodsMetricStatusArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PodsMetricStatusArgs:
     def __init__(__self__, *,
@@ -1720,6 +2312,26 @@ class PodsMetricStatusArgs:
     def selector(self, value: Optional[pulumi.Input['_meta.v1.LabelSelectorArgs']]):
         pulumi.set(self, "selector", value)
 
+
+if not MYPY:
+    class ResourceMetricSourcePatchArgsDict(TypedDict):
+        """
+        ResourceMetricSource indicates how to scale on a resource metric known to Kubernetes, as specified in requests and limits, describing each pod in the current scale target (e.g. CPU or memory).  The values will be averaged together before being compared to the target.  Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.  Only one "target" type should be set.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        name is the name of the resource in question.
+        """
+        target_average_utilization: NotRequired[pulumi.Input[int]]
+        """
+        targetAverageUtilization is the target value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods.
+        """
+        target_average_value: NotRequired[pulumi.Input[str]]
+        """
+        targetAverageValue is the target value of the average of the resource metric across all relevant pods, as a raw value (instead of as a percentage of the request), similar to the "pods" metric source type.
+        """
+elif False:
+    ResourceMetricSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ResourceMetricSourcePatchArgs:
@@ -1777,6 +2389,26 @@ class ResourceMetricSourcePatchArgs:
         pulumi.set(self, "target_average_value", value)
 
 
+if not MYPY:
+    class ResourceMetricSourceArgsDict(TypedDict):
+        """
+        ResourceMetricSource indicates how to scale on a resource metric known to Kubernetes, as specified in requests and limits, describing each pod in the current scale target (e.g. CPU or memory).  The values will be averaged together before being compared to the target.  Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.  Only one "target" type should be set.
+        """
+        name: pulumi.Input[str]
+        """
+        name is the name of the resource in question.
+        """
+        target_average_utilization: NotRequired[pulumi.Input[int]]
+        """
+        targetAverageUtilization is the target value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods.
+        """
+        target_average_value: NotRequired[pulumi.Input[str]]
+        """
+        targetAverageValue is the target value of the average of the resource metric across all relevant pods, as a raw value (instead of as a percentage of the request), similar to the "pods" metric source type.
+        """
+elif False:
+    ResourceMetricSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ResourceMetricSourceArgs:
     def __init__(__self__, *,
@@ -1831,6 +2463,26 @@ class ResourceMetricSourceArgs:
     def target_average_value(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "target_average_value", value)
 
+
+if not MYPY:
+    class ResourceMetricStatusArgsDict(TypedDict):
+        """
+        ResourceMetricStatus indicates the current value of a resource metric known to Kubernetes, as specified in requests and limits, describing each pod in the current scale target (e.g. CPU or memory).  Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.
+        """
+        current_average_value: pulumi.Input[str]
+        """
+        currentAverageValue is the current value of the average of the resource metric across all relevant pods, as a raw value (instead of as a percentage of the request), similar to the "pods" metric source type. It will always be set, regardless of the corresponding metric specification.
+        """
+        name: pulumi.Input[str]
+        """
+        name is the name of the resource in question.
+        """
+        current_average_utilization: NotRequired[pulumi.Input[int]]
+        """
+        currentAverageUtilization is the current value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods.  It will only be present if `targetAverageValue` was set in the corresponding metric specification.
+        """
+elif False:
+    ResourceMetricStatusArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ResourceMetricStatusArgs:

--- a/sdk/python/pulumi_kubernetes/autoscaling/v2beta1/outputs.py
+++ b/sdk/python/pulumi_kubernetes/autoscaling/v2beta1/outputs.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta

--- a/sdk/python/pulumi_kubernetes/autoscaling/v2beta2/HorizontalPodAutoscaler.py
+++ b/sdk/python/pulumi_kubernetes/autoscaling/v2beta2/HorizontalPodAutoscaler.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class HorizontalPodAutoscaler(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['HorizontalPodAutoscalerSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['HorizontalPodAutoscalerSpecArgs', 'HorizontalPodAutoscalerSpecArgsDict']]] = None,
                  __props__=None):
         """
         HorizontalPodAutoscaler is the configuration for a horizontal pod autoscaler, which automatically manages the replica count of any resource implementing the scale subresource based on the metrics specified.
@@ -103,8 +108,8 @@ class HorizontalPodAutoscaler(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: metadata is the standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['HorizontalPodAutoscalerSpecArgs']] spec: spec is the specification for the behaviour of the autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: metadata is the standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['HorizontalPodAutoscalerSpecArgs', 'HorizontalPodAutoscalerSpecArgsDict']] spec: spec is the specification for the behaviour of the autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
         """
         ...
     @overload
@@ -132,8 +137,8 @@ class HorizontalPodAutoscaler(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['HorizontalPodAutoscalerSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['HorizontalPodAutoscalerSpecArgs', 'HorizontalPodAutoscalerSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/autoscaling/v2beta2/HorizontalPodAutoscalerList.py
+++ b/sdk/python/pulumi_kubernetes/autoscaling/v2beta2/HorizontalPodAutoscalerList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class HorizontalPodAutoscalerList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['HorizontalPodAutoscalerArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['HorizontalPodAutoscalerArgs', 'HorizontalPodAutoscalerArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         HorizontalPodAutoscalerList is a list of horizontal pod autoscaler objects.
@@ -101,9 +106,9 @@ class HorizontalPodAutoscalerList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['HorizontalPodAutoscalerArgs']]]] items: items is the list of horizontal pod autoscaler objects.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['HorizontalPodAutoscalerArgs', 'HorizontalPodAutoscalerArgsDict']]]] items: items is the list of horizontal pod autoscaler objects.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: metadata is the standard list metadata.
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: metadata is the standard list metadata.
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class HorizontalPodAutoscalerList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['HorizontalPodAutoscalerArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['HorizontalPodAutoscalerArgs', 'HorizontalPodAutoscalerArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/autoscaling/v2beta2/HorizontalPodAutoscalerPatch.py
+++ b/sdk/python/pulumi_kubernetes/autoscaling/v2beta2/HorizontalPodAutoscalerPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class HorizontalPodAutoscalerPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['HorizontalPodAutoscalerSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['HorizontalPodAutoscalerSpecPatchArgs', 'HorizontalPodAutoscalerSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -109,8 +114,8 @@ class HorizontalPodAutoscalerPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: metadata is the standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['HorizontalPodAutoscalerSpecPatchArgs']] spec: spec is the specification for the behaviour of the autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: metadata is the standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['HorizontalPodAutoscalerSpecPatchArgs', 'HorizontalPodAutoscalerSpecPatchArgsDict']] spec: spec is the specification for the behaviour of the autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
         """
         ...
     @overload
@@ -144,8 +149,8 @@ class HorizontalPodAutoscalerPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['HorizontalPodAutoscalerSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['HorizontalPodAutoscalerSpecPatchArgs', 'HorizontalPodAutoscalerSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/autoscaling/v2beta2/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/autoscaling/v2beta2/_inputs.py
@@ -4,50 +4,113 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import meta as _meta
 
 __all__ = [
     'ContainerResourceMetricSourcePatchArgs',
+    'ContainerResourceMetricSourcePatchArgsDict',
     'ContainerResourceMetricSourceArgs',
+    'ContainerResourceMetricSourceArgsDict',
     'ContainerResourceMetricStatusArgs',
+    'ContainerResourceMetricStatusArgsDict',
     'CrossVersionObjectReferencePatchArgs',
+    'CrossVersionObjectReferencePatchArgsDict',
     'CrossVersionObjectReferenceArgs',
+    'CrossVersionObjectReferenceArgsDict',
     'ExternalMetricSourcePatchArgs',
+    'ExternalMetricSourcePatchArgsDict',
     'ExternalMetricSourceArgs',
+    'ExternalMetricSourceArgsDict',
     'ExternalMetricStatusArgs',
+    'ExternalMetricStatusArgsDict',
     'HPAScalingPolicyPatchArgs',
+    'HPAScalingPolicyPatchArgsDict',
     'HPAScalingPolicyArgs',
+    'HPAScalingPolicyArgsDict',
     'HPAScalingRulesPatchArgs',
+    'HPAScalingRulesPatchArgsDict',
     'HPAScalingRulesArgs',
+    'HPAScalingRulesArgsDict',
     'HorizontalPodAutoscalerBehaviorPatchArgs',
+    'HorizontalPodAutoscalerBehaviorPatchArgsDict',
     'HorizontalPodAutoscalerBehaviorArgs',
+    'HorizontalPodAutoscalerBehaviorArgsDict',
     'HorizontalPodAutoscalerConditionArgs',
+    'HorizontalPodAutoscalerConditionArgsDict',
     'HorizontalPodAutoscalerSpecPatchArgs',
+    'HorizontalPodAutoscalerSpecPatchArgsDict',
     'HorizontalPodAutoscalerSpecArgs',
+    'HorizontalPodAutoscalerSpecArgsDict',
     'HorizontalPodAutoscalerStatusArgs',
+    'HorizontalPodAutoscalerStatusArgsDict',
     'HorizontalPodAutoscalerArgs',
+    'HorizontalPodAutoscalerArgsDict',
     'MetricIdentifierPatchArgs',
+    'MetricIdentifierPatchArgsDict',
     'MetricIdentifierArgs',
+    'MetricIdentifierArgsDict',
     'MetricSpecPatchArgs',
+    'MetricSpecPatchArgsDict',
     'MetricSpecArgs',
+    'MetricSpecArgsDict',
     'MetricStatusArgs',
+    'MetricStatusArgsDict',
     'MetricTargetPatchArgs',
+    'MetricTargetPatchArgsDict',
     'MetricTargetArgs',
+    'MetricTargetArgsDict',
     'MetricValueStatusArgs',
+    'MetricValueStatusArgsDict',
     'ObjectMetricSourcePatchArgs',
+    'ObjectMetricSourcePatchArgsDict',
     'ObjectMetricSourceArgs',
+    'ObjectMetricSourceArgsDict',
     'ObjectMetricStatusArgs',
+    'ObjectMetricStatusArgsDict',
     'PodsMetricSourcePatchArgs',
+    'PodsMetricSourcePatchArgsDict',
     'PodsMetricSourceArgs',
+    'PodsMetricSourceArgsDict',
     'PodsMetricStatusArgs',
+    'PodsMetricStatusArgsDict',
     'ResourceMetricSourcePatchArgs',
+    'ResourceMetricSourcePatchArgsDict',
     'ResourceMetricSourceArgs',
+    'ResourceMetricSourceArgsDict',
     'ResourceMetricStatusArgs',
+    'ResourceMetricStatusArgsDict',
 ]
+
+MYPY = False
+
+if not MYPY:
+    class ContainerResourceMetricSourcePatchArgsDict(TypedDict):
+        """
+        ContainerResourceMetricSource indicates how to scale on a resource metric known to Kubernetes, as specified in requests and limits, describing each pod in the current scale target (e.g. CPU or memory).  The values will be averaged together before being compared to the target.  Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.  Only one "target" type should be set.
+        """
+        container: NotRequired[pulumi.Input[str]]
+        """
+        container is the name of the container in the pods of the scaling target
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        name is the name of the resource in question.
+        """
+        target: NotRequired[pulumi.Input['MetricTargetPatchArgsDict']]
+        """
+        target specifies the target value for the given metric
+        """
+elif False:
+    ContainerResourceMetricSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ContainerResourceMetricSourcePatchArgs:
@@ -105,6 +168,26 @@ class ContainerResourceMetricSourcePatchArgs:
         pulumi.set(self, "target", value)
 
 
+if not MYPY:
+    class ContainerResourceMetricSourceArgsDict(TypedDict):
+        """
+        ContainerResourceMetricSource indicates how to scale on a resource metric known to Kubernetes, as specified in requests and limits, describing each pod in the current scale target (e.g. CPU or memory).  The values will be averaged together before being compared to the target.  Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.  Only one "target" type should be set.
+        """
+        container: pulumi.Input[str]
+        """
+        container is the name of the container in the pods of the scaling target
+        """
+        name: pulumi.Input[str]
+        """
+        name is the name of the resource in question.
+        """
+        target: pulumi.Input['MetricTargetArgsDict']
+        """
+        target specifies the target value for the given metric
+        """
+elif False:
+    ContainerResourceMetricSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ContainerResourceMetricSourceArgs:
     def __init__(__self__, *,
@@ -158,6 +241,26 @@ class ContainerResourceMetricSourceArgs:
         pulumi.set(self, "target", value)
 
 
+if not MYPY:
+    class ContainerResourceMetricStatusArgsDict(TypedDict):
+        """
+        ContainerResourceMetricStatus indicates the current value of a resource metric known to Kubernetes, as specified in requests and limits, describing a single container in each pod in the current scale target (e.g. CPU or memory).  Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.
+        """
+        container: pulumi.Input[str]
+        """
+        Container is the name of the container in the pods of the scaling target
+        """
+        current: pulumi.Input['MetricValueStatusArgsDict']
+        """
+        current contains the current value for the given metric
+        """
+        name: pulumi.Input[str]
+        """
+        Name is the name of the resource in question.
+        """
+elif False:
+    ContainerResourceMetricStatusArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ContainerResourceMetricStatusArgs:
     def __init__(__self__, *,
@@ -210,6 +313,26 @@ class ContainerResourceMetricStatusArgs:
     def name(self, value: pulumi.Input[str]):
         pulumi.set(self, "name", value)
 
+
+if not MYPY:
+    class CrossVersionObjectReferencePatchArgsDict(TypedDict):
+        """
+        CrossVersionObjectReference contains enough information to let you identify the referred resource.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        API version of the referent
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names
+        """
+elif False:
+    CrossVersionObjectReferencePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class CrossVersionObjectReferencePatchArgs:
@@ -267,6 +390,26 @@ class CrossVersionObjectReferencePatchArgs:
         pulumi.set(self, "name", value)
 
 
+if not MYPY:
+    class CrossVersionObjectReferenceArgsDict(TypedDict):
+        """
+        CrossVersionObjectReference contains enough information to let you identify the referred resource.
+        """
+        kind: pulumi.Input[str]
+        """
+        Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+        """
+        name: pulumi.Input[str]
+        """
+        Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        API version of the referent
+        """
+elif False:
+    CrossVersionObjectReferenceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CrossVersionObjectReferenceArgs:
     def __init__(__self__, *,
@@ -321,6 +464,22 @@ class CrossVersionObjectReferenceArgs:
         pulumi.set(self, "api_version", value)
 
 
+if not MYPY:
+    class ExternalMetricSourcePatchArgsDict(TypedDict):
+        """
+        ExternalMetricSource indicates how to scale on a metric not associated with any Kubernetes object (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster).
+        """
+        metric: NotRequired[pulumi.Input['MetricIdentifierPatchArgsDict']]
+        """
+        metric identifies the target metric by name and selector
+        """
+        target: NotRequired[pulumi.Input['MetricTargetPatchArgsDict']]
+        """
+        target specifies the target value for the given metric
+        """
+elif False:
+    ExternalMetricSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ExternalMetricSourcePatchArgs:
     def __init__(__self__, *,
@@ -361,6 +520,22 @@ class ExternalMetricSourcePatchArgs:
         pulumi.set(self, "target", value)
 
 
+if not MYPY:
+    class ExternalMetricSourceArgsDict(TypedDict):
+        """
+        ExternalMetricSource indicates how to scale on a metric not associated with any Kubernetes object (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster).
+        """
+        metric: pulumi.Input['MetricIdentifierArgsDict']
+        """
+        metric identifies the target metric by name and selector
+        """
+        target: pulumi.Input['MetricTargetArgsDict']
+        """
+        target specifies the target value for the given metric
+        """
+elif False:
+    ExternalMetricSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ExternalMetricSourceArgs:
     def __init__(__self__, *,
@@ -399,6 +574,22 @@ class ExternalMetricSourceArgs:
         pulumi.set(self, "target", value)
 
 
+if not MYPY:
+    class ExternalMetricStatusArgsDict(TypedDict):
+        """
+        ExternalMetricStatus indicates the current value of a global metric not associated with any Kubernetes object.
+        """
+        current: pulumi.Input['MetricValueStatusArgsDict']
+        """
+        current contains the current value for the given metric
+        """
+        metric: pulumi.Input['MetricIdentifierArgsDict']
+        """
+        metric identifies the target metric by name and selector
+        """
+elif False:
+    ExternalMetricStatusArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ExternalMetricStatusArgs:
     def __init__(__self__, *,
@@ -436,6 +627,26 @@ class ExternalMetricStatusArgs:
     def metric(self, value: pulumi.Input['MetricIdentifierArgs']):
         pulumi.set(self, "metric", value)
 
+
+if not MYPY:
+    class HPAScalingPolicyPatchArgsDict(TypedDict):
+        """
+        HPAScalingPolicy is a single policy which must hold true for a specified past interval.
+        """
+        period_seconds: NotRequired[pulumi.Input[int]]
+        """
+        PeriodSeconds specifies the window of time for which the policy should hold true. PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        Type is used to specify the scaling policy.
+        """
+        value: NotRequired[pulumi.Input[int]]
+        """
+        Value contains the amount of change which is permitted by the policy. It must be greater than zero
+        """
+elif False:
+    HPAScalingPolicyPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class HPAScalingPolicyPatchArgs:
@@ -493,6 +704,26 @@ class HPAScalingPolicyPatchArgs:
         pulumi.set(self, "value", value)
 
 
+if not MYPY:
+    class HPAScalingPolicyArgsDict(TypedDict):
+        """
+        HPAScalingPolicy is a single policy which must hold true for a specified past interval.
+        """
+        period_seconds: pulumi.Input[int]
+        """
+        PeriodSeconds specifies the window of time for which the policy should hold true. PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).
+        """
+        type: pulumi.Input[str]
+        """
+        Type is used to specify the scaling policy.
+        """
+        value: pulumi.Input[int]
+        """
+        Value contains the amount of change which is permitted by the policy. It must be greater than zero
+        """
+elif False:
+    HPAScalingPolicyArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class HPAScalingPolicyArgs:
     def __init__(__self__, *,
@@ -545,6 +776,26 @@ class HPAScalingPolicyArgs:
     def value(self, value: pulumi.Input[int]):
         pulumi.set(self, "value", value)
 
+
+if not MYPY:
+    class HPAScalingRulesPatchArgsDict(TypedDict):
+        """
+        HPAScalingRules configures the scaling behavior for one direction. These Rules are applied after calculating DesiredReplicas from metrics for the HPA. They can limit the scaling velocity by specifying scaling policies. They can prevent flapping by specifying the stabilization window, so that the number of replicas is not set instantly, instead, the safest value from the stabilization window is chosen.
+        """
+        policies: NotRequired[pulumi.Input[Sequence[pulumi.Input['HPAScalingPolicyPatchArgsDict']]]]
+        """
+        policies is a list of potential scaling polices which can be used during scaling. At least one policy must be specified, otherwise the HPAScalingRules will be discarded as invalid
+        """
+        select_policy: NotRequired[pulumi.Input[str]]
+        """
+        selectPolicy is used to specify which policy should be used. If not set, the default value MaxPolicySelect is used.
+        """
+        stabilization_window_seconds: NotRequired[pulumi.Input[int]]
+        """
+        StabilizationWindowSeconds is the number of seconds for which past recommendations should be considered while scaling up or scaling down. StabilizationWindowSeconds must be greater than or equal to zero and less than or equal to 3600 (one hour). If not set, use the default values: - For scale up: 0 (i.e. no stabilization is done). - For scale down: 300 (i.e. the stabilization window is 300 seconds long).
+        """
+elif False:
+    HPAScalingRulesPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class HPAScalingRulesPatchArgs:
@@ -602,6 +853,26 @@ class HPAScalingRulesPatchArgs:
         pulumi.set(self, "stabilization_window_seconds", value)
 
 
+if not MYPY:
+    class HPAScalingRulesArgsDict(TypedDict):
+        """
+        HPAScalingRules configures the scaling behavior for one direction. These Rules are applied after calculating DesiredReplicas from metrics for the HPA. They can limit the scaling velocity by specifying scaling policies. They can prevent flapping by specifying the stabilization window, so that the number of replicas is not set instantly, instead, the safest value from the stabilization window is chosen.
+        """
+        policies: NotRequired[pulumi.Input[Sequence[pulumi.Input['HPAScalingPolicyArgsDict']]]]
+        """
+        policies is a list of potential scaling polices which can be used during scaling. At least one policy must be specified, otherwise the HPAScalingRules will be discarded as invalid
+        """
+        select_policy: NotRequired[pulumi.Input[str]]
+        """
+        selectPolicy is used to specify which policy should be used. If not set, the default value MaxPolicySelect is used.
+        """
+        stabilization_window_seconds: NotRequired[pulumi.Input[int]]
+        """
+        StabilizationWindowSeconds is the number of seconds for which past recommendations should be considered while scaling up or scaling down. StabilizationWindowSeconds must be greater than or equal to zero and less than or equal to 3600 (one hour). If not set, use the default values: - For scale up: 0 (i.e. no stabilization is done). - For scale down: 300 (i.e. the stabilization window is 300 seconds long).
+        """
+elif False:
+    HPAScalingRulesArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class HPAScalingRulesArgs:
     def __init__(__self__, *,
@@ -658,6 +929,25 @@ class HPAScalingRulesArgs:
         pulumi.set(self, "stabilization_window_seconds", value)
 
 
+if not MYPY:
+    class HorizontalPodAutoscalerBehaviorPatchArgsDict(TypedDict):
+        """
+        HorizontalPodAutoscalerBehavior configures the scaling behavior of the target in both Up and Down directions (scaleUp and scaleDown fields respectively).
+        """
+        scale_down: NotRequired[pulumi.Input['HPAScalingRulesPatchArgsDict']]
+        """
+        scaleDown is scaling policy for scaling Down. If not set, the default value is to allow to scale down to minReplicas pods, with a 300 second stabilization window (i.e., the highest recommendation for the last 300sec is used).
+        """
+        scale_up: NotRequired[pulumi.Input['HPAScalingRulesPatchArgsDict']]
+        """
+        scaleUp is scaling policy for scaling Up. If not set, the default value is the higher of:
+          * increase no more than 4 pods per 60 seconds
+          * double the number of pods per 60 seconds
+        No stabilization is used.
+        """
+elif False:
+    HorizontalPodAutoscalerBehaviorPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class HorizontalPodAutoscalerBehaviorPatchArgs:
     def __init__(__self__, *,
@@ -704,6 +994,25 @@ class HorizontalPodAutoscalerBehaviorPatchArgs:
         pulumi.set(self, "scale_up", value)
 
 
+if not MYPY:
+    class HorizontalPodAutoscalerBehaviorArgsDict(TypedDict):
+        """
+        HorizontalPodAutoscalerBehavior configures the scaling behavior of the target in both Up and Down directions (scaleUp and scaleDown fields respectively).
+        """
+        scale_down: NotRequired[pulumi.Input['HPAScalingRulesArgsDict']]
+        """
+        scaleDown is scaling policy for scaling Down. If not set, the default value is to allow to scale down to minReplicas pods, with a 300 second stabilization window (i.e., the highest recommendation for the last 300sec is used).
+        """
+        scale_up: NotRequired[pulumi.Input['HPAScalingRulesArgsDict']]
+        """
+        scaleUp is scaling policy for scaling Up. If not set, the default value is the higher of:
+          * increase no more than 4 pods per 60 seconds
+          * double the number of pods per 60 seconds
+        No stabilization is used.
+        """
+elif False:
+    HorizontalPodAutoscalerBehaviorArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class HorizontalPodAutoscalerBehaviorArgs:
     def __init__(__self__, *,
@@ -749,6 +1058,34 @@ class HorizontalPodAutoscalerBehaviorArgs:
     def scale_up(self, value: Optional[pulumi.Input['HPAScalingRulesArgs']]):
         pulumi.set(self, "scale_up", value)
 
+
+if not MYPY:
+    class HorizontalPodAutoscalerConditionArgsDict(TypedDict):
+        """
+        HorizontalPodAutoscalerCondition describes the state of a HorizontalPodAutoscaler at a certain point.
+        """
+        status: pulumi.Input[str]
+        """
+        status is the status of the condition (True, False, Unknown)
+        """
+        type: pulumi.Input[str]
+        """
+        type describes the current condition
+        """
+        last_transition_time: NotRequired[pulumi.Input[str]]
+        """
+        lastTransitionTime is the last time the condition transitioned from one status to another
+        """
+        message: NotRequired[pulumi.Input[str]]
+        """
+        message is a human-readable explanation containing details about the transition
+        """
+        reason: NotRequired[pulumi.Input[str]]
+        """
+        reason is the reason for the condition's last transition.
+        """
+elif False:
+    HorizontalPodAutoscalerConditionArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class HorizontalPodAutoscalerConditionArgs:
@@ -835,6 +1172,34 @@ class HorizontalPodAutoscalerConditionArgs:
     def reason(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "reason", value)
 
+
+if not MYPY:
+    class HorizontalPodAutoscalerSpecPatchArgsDict(TypedDict):
+        """
+        HorizontalPodAutoscalerSpec describes the desired functionality of the HorizontalPodAutoscaler.
+        """
+        behavior: NotRequired[pulumi.Input['HorizontalPodAutoscalerBehaviorPatchArgsDict']]
+        """
+        behavior configures the scaling behavior of the target in both Up and Down directions (scaleUp and scaleDown fields respectively). If not set, the default HPAScalingRules for scale up and scale down are used.
+        """
+        max_replicas: NotRequired[pulumi.Input[int]]
+        """
+        maxReplicas is the upper limit for the number of replicas to which the autoscaler can scale up. It cannot be less that minReplicas.
+        """
+        metrics: NotRequired[pulumi.Input[Sequence[pulumi.Input['MetricSpecPatchArgsDict']]]]
+        """
+        metrics contains the specifications for which to use to calculate the desired replica count (the maximum replica count across all metrics will be used).  The desired replica count is calculated multiplying the ratio between the target value and the current value by the current number of pods.  Ergo, metrics used must decrease as the pod count is increased, and vice-versa.  See the individual metric source types for more information about how each type of metric must respond. If not set, the default metric will be set to 80% average CPU utilization.
+        """
+        min_replicas: NotRequired[pulumi.Input[int]]
+        """
+        minReplicas is the lower limit for the number of replicas to which the autoscaler can scale down.  It defaults to 1 pod.  minReplicas is allowed to be 0 if the alpha feature gate HPAScaleToZero is enabled and at least one Object or External metric is configured.  Scaling is active as long as at least one metric value is available.
+        """
+        scale_target_ref: NotRequired[pulumi.Input['CrossVersionObjectReferencePatchArgsDict']]
+        """
+        scaleTargetRef points to the target resource to scale, and is used to the pods for which metrics should be collected, as well as to actually change the replica count.
+        """
+elif False:
+    HorizontalPodAutoscalerSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class HorizontalPodAutoscalerSpecPatchArgs:
@@ -924,6 +1289,34 @@ class HorizontalPodAutoscalerSpecPatchArgs:
         pulumi.set(self, "scale_target_ref", value)
 
 
+if not MYPY:
+    class HorizontalPodAutoscalerSpecArgsDict(TypedDict):
+        """
+        HorizontalPodAutoscalerSpec describes the desired functionality of the HorizontalPodAutoscaler.
+        """
+        max_replicas: pulumi.Input[int]
+        """
+        maxReplicas is the upper limit for the number of replicas to which the autoscaler can scale up. It cannot be less that minReplicas.
+        """
+        scale_target_ref: pulumi.Input['CrossVersionObjectReferenceArgsDict']
+        """
+        scaleTargetRef points to the target resource to scale, and is used to the pods for which metrics should be collected, as well as to actually change the replica count.
+        """
+        behavior: NotRequired[pulumi.Input['HorizontalPodAutoscalerBehaviorArgsDict']]
+        """
+        behavior configures the scaling behavior of the target in both Up and Down directions (scaleUp and scaleDown fields respectively). If not set, the default HPAScalingRules for scale up and scale down are used.
+        """
+        metrics: NotRequired[pulumi.Input[Sequence[pulumi.Input['MetricSpecArgsDict']]]]
+        """
+        metrics contains the specifications for which to use to calculate the desired replica count (the maximum replica count across all metrics will be used).  The desired replica count is calculated multiplying the ratio between the target value and the current value by the current number of pods.  Ergo, metrics used must decrease as the pod count is increased, and vice-versa.  See the individual metric source types for more information about how each type of metric must respond. If not set, the default metric will be set to 80% average CPU utilization.
+        """
+        min_replicas: NotRequired[pulumi.Input[int]]
+        """
+        minReplicas is the lower limit for the number of replicas to which the autoscaler can scale down.  It defaults to 1 pod.  minReplicas is allowed to be 0 if the alpha feature gate HPAScaleToZero is enabled and at least one Object or External metric is configured.  Scaling is active as long as at least one metric value is available.
+        """
+elif False:
+    HorizontalPodAutoscalerSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class HorizontalPodAutoscalerSpecArgs:
     def __init__(__self__, *,
@@ -1009,6 +1402,38 @@ class HorizontalPodAutoscalerSpecArgs:
     def min_replicas(self, value: Optional[pulumi.Input[int]]):
         pulumi.set(self, "min_replicas", value)
 
+
+if not MYPY:
+    class HorizontalPodAutoscalerStatusArgsDict(TypedDict):
+        """
+        HorizontalPodAutoscalerStatus describes the current status of a horizontal pod autoscaler.
+        """
+        conditions: pulumi.Input[Sequence[pulumi.Input['HorizontalPodAutoscalerConditionArgsDict']]]
+        """
+        conditions is the set of conditions required for this autoscaler to scale its target, and indicates whether or not those conditions are met.
+        """
+        current_replicas: pulumi.Input[int]
+        """
+        currentReplicas is current number of replicas of pods managed by this autoscaler, as last seen by the autoscaler.
+        """
+        desired_replicas: pulumi.Input[int]
+        """
+        desiredReplicas is the desired number of replicas of pods managed by this autoscaler, as last calculated by the autoscaler.
+        """
+        current_metrics: NotRequired[pulumi.Input[Sequence[pulumi.Input['MetricStatusArgsDict']]]]
+        """
+        currentMetrics is the last read state of the metrics used by this autoscaler.
+        """
+        last_scale_time: NotRequired[pulumi.Input[str]]
+        """
+        lastScaleTime is the last time the HorizontalPodAutoscaler scaled the number of pods, used by the autoscaler to control how often the number of pods is changed.
+        """
+        observed_generation: NotRequired[pulumi.Input[int]]
+        """
+        observedGeneration is the most recent generation observed by this autoscaler.
+        """
+elif False:
+    HorizontalPodAutoscalerStatusArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class HorizontalPodAutoscalerStatusArgs:
@@ -1111,6 +1536,34 @@ class HorizontalPodAutoscalerStatusArgs:
         pulumi.set(self, "observed_generation", value)
 
 
+if not MYPY:
+    class HorizontalPodAutoscalerArgsDict(TypedDict):
+        """
+        HorizontalPodAutoscaler is the configuration for a horizontal pod autoscaler, which automatically manages the replica count of any resource implementing the scale subresource based on the metrics specified.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        metadata is the standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['HorizontalPodAutoscalerSpecArgsDict']]
+        """
+        spec is the specification for the behaviour of the autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
+        """
+        status: NotRequired[pulumi.Input['HorizontalPodAutoscalerStatusArgsDict']]
+        """
+        status is the current information about the autoscaler.
+        """
+elif False:
+    HorizontalPodAutoscalerArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class HorizontalPodAutoscalerArgs:
     def __init__(__self__, *,
@@ -1199,6 +1652,22 @@ class HorizontalPodAutoscalerArgs:
         pulumi.set(self, "status", value)
 
 
+if not MYPY:
+    class MetricIdentifierPatchArgsDict(TypedDict):
+        """
+        MetricIdentifier defines the name and optionally selector for a metric
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        name is the name of the given metric
+        """
+        selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorPatchArgsDict']]
+        """
+        selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping. When unset, just the metricName will be used to gather metrics.
+        """
+elif False:
+    MetricIdentifierPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class MetricIdentifierPatchArgs:
     def __init__(__self__, *,
@@ -1239,6 +1708,22 @@ class MetricIdentifierPatchArgs:
         pulumi.set(self, "selector", value)
 
 
+if not MYPY:
+    class MetricIdentifierArgsDict(TypedDict):
+        """
+        MetricIdentifier defines the name and optionally selector for a metric
+        """
+        name: pulumi.Input[str]
+        """
+        name is the name of the given metric
+        """
+        selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorArgsDict']]
+        """
+        selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping. When unset, just the metricName will be used to gather metrics.
+        """
+elif False:
+    MetricIdentifierArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class MetricIdentifierArgs:
     def __init__(__self__, *,
@@ -1277,6 +1762,38 @@ class MetricIdentifierArgs:
     def selector(self, value: Optional[pulumi.Input['_meta.v1.LabelSelectorArgs']]):
         pulumi.set(self, "selector", value)
 
+
+if not MYPY:
+    class MetricSpecPatchArgsDict(TypedDict):
+        """
+        MetricSpec specifies how to scale based on a single metric (only `type` and one other matching field should be set at once).
+        """
+        container_resource: NotRequired[pulumi.Input['ContainerResourceMetricSourcePatchArgsDict']]
+        """
+        container resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing a single container in each pod of the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source. This is an alpha feature and can be enabled by the HPAContainerMetrics feature flag.
+        """
+        external: NotRequired[pulumi.Input['ExternalMetricSourcePatchArgsDict']]
+        """
+        external refers to a global metric that is not associated with any Kubernetes object. It allows autoscaling based on information coming from components running outside of cluster (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster).
+        """
+        object: NotRequired[pulumi.Input['ObjectMetricSourcePatchArgsDict']]
+        """
+        object refers to a metric describing a single kubernetes object (for example, hits-per-second on an Ingress object).
+        """
+        pods: NotRequired[pulumi.Input['PodsMetricSourcePatchArgsDict']]
+        """
+        pods refers to a metric describing each pod in the current scale target (for example, transactions-processed-per-second).  The values will be averaged together before being compared to the target value.
+        """
+        resource: NotRequired[pulumi.Input['ResourceMetricSourcePatchArgsDict']]
+        """
+        resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        type is the type of metric source.  It should be one of "Object", "Pods" or "Resource", each mapping to a matching field in the object.
+        """
+elif False:
+    MetricSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class MetricSpecPatchArgs:
@@ -1382,6 +1899,38 @@ class MetricSpecPatchArgs:
         pulumi.set(self, "type", value)
 
 
+if not MYPY:
+    class MetricSpecArgsDict(TypedDict):
+        """
+        MetricSpec specifies how to scale based on a single metric (only `type` and one other matching field should be set at once).
+        """
+        type: pulumi.Input[str]
+        """
+        type is the type of metric source.  It should be one of "Object", "Pods" or "Resource", each mapping to a matching field in the object.
+        """
+        container_resource: NotRequired[pulumi.Input['ContainerResourceMetricSourceArgsDict']]
+        """
+        container resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing a single container in each pod of the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source. This is an alpha feature and can be enabled by the HPAContainerMetrics feature flag.
+        """
+        external: NotRequired[pulumi.Input['ExternalMetricSourceArgsDict']]
+        """
+        external refers to a global metric that is not associated with any Kubernetes object. It allows autoscaling based on information coming from components running outside of cluster (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster).
+        """
+        object: NotRequired[pulumi.Input['ObjectMetricSourceArgsDict']]
+        """
+        object refers to a metric describing a single kubernetes object (for example, hits-per-second on an Ingress object).
+        """
+        pods: NotRequired[pulumi.Input['PodsMetricSourceArgsDict']]
+        """
+        pods refers to a metric describing each pod in the current scale target (for example, transactions-processed-per-second).  The values will be averaged together before being compared to the target value.
+        """
+        resource: NotRequired[pulumi.Input['ResourceMetricSourceArgsDict']]
+        """
+        resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.
+        """
+elif False:
+    MetricSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class MetricSpecArgs:
     def __init__(__self__, *,
@@ -1484,6 +2033,38 @@ class MetricSpecArgs:
     def resource(self, value: Optional[pulumi.Input['ResourceMetricSourceArgs']]):
         pulumi.set(self, "resource", value)
 
+
+if not MYPY:
+    class MetricStatusArgsDict(TypedDict):
+        """
+        MetricStatus describes the last-read state of a single metric.
+        """
+        type: pulumi.Input[str]
+        """
+        type is the type of metric source.  It will be one of "Object", "Pods" or "Resource", each corresponds to a matching field in the object.
+        """
+        container_resource: NotRequired[pulumi.Input['ContainerResourceMetricStatusArgsDict']]
+        """
+        container resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing a single container in each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.
+        """
+        external: NotRequired[pulumi.Input['ExternalMetricStatusArgsDict']]
+        """
+        external refers to a global metric that is not associated with any Kubernetes object. It allows autoscaling based on information coming from components running outside of cluster (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster).
+        """
+        object: NotRequired[pulumi.Input['ObjectMetricStatusArgsDict']]
+        """
+        object refers to a metric describing a single kubernetes object (for example, hits-per-second on an Ingress object).
+        """
+        pods: NotRequired[pulumi.Input['PodsMetricStatusArgsDict']]
+        """
+        pods refers to a metric describing each pod in the current scale target (for example, transactions-processed-per-second).  The values will be averaged together before being compared to the target value.
+        """
+        resource: NotRequired[pulumi.Input['ResourceMetricStatusArgsDict']]
+        """
+        resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.
+        """
+elif False:
+    MetricStatusArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class MetricStatusArgs:
@@ -1588,6 +2169,30 @@ class MetricStatusArgs:
         pulumi.set(self, "resource", value)
 
 
+if not MYPY:
+    class MetricTargetPatchArgsDict(TypedDict):
+        """
+        MetricTarget defines the target value, average value, or average utilization of a specific metric
+        """
+        average_utilization: NotRequired[pulumi.Input[int]]
+        """
+        averageUtilization is the target value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods. Currently only valid for Resource metric source type
+        """
+        average_value: NotRequired[pulumi.Input[str]]
+        """
+        averageValue is the target value of the average of the metric across all relevant pods (as a quantity)
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        type represents whether the metric type is Utilization, Value, or AverageValue
+        """
+        value: NotRequired[pulumi.Input[str]]
+        """
+        value is the target value of the metric (as a quantity).
+        """
+elif False:
+    MetricTargetPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class MetricTargetPatchArgs:
     def __init__(__self__, *,
@@ -1660,6 +2265,30 @@ class MetricTargetPatchArgs:
         pulumi.set(self, "value", value)
 
 
+if not MYPY:
+    class MetricTargetArgsDict(TypedDict):
+        """
+        MetricTarget defines the target value, average value, or average utilization of a specific metric
+        """
+        type: pulumi.Input[str]
+        """
+        type represents whether the metric type is Utilization, Value, or AverageValue
+        """
+        average_utilization: NotRequired[pulumi.Input[int]]
+        """
+        averageUtilization is the target value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods. Currently only valid for Resource metric source type
+        """
+        average_value: NotRequired[pulumi.Input[str]]
+        """
+        averageValue is the target value of the average of the metric across all relevant pods (as a quantity)
+        """
+        value: NotRequired[pulumi.Input[str]]
+        """
+        value is the target value of the metric (as a quantity).
+        """
+elif False:
+    MetricTargetArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class MetricTargetArgs:
     def __init__(__self__, *,
@@ -1731,6 +2360,26 @@ class MetricTargetArgs:
         pulumi.set(self, "value", value)
 
 
+if not MYPY:
+    class MetricValueStatusArgsDict(TypedDict):
+        """
+        MetricValueStatus holds the current value for a metric
+        """
+        average_utilization: NotRequired[pulumi.Input[int]]
+        """
+        currentAverageUtilization is the current value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods.
+        """
+        average_value: NotRequired[pulumi.Input[str]]
+        """
+        averageValue is the current value of the average of the metric across all relevant pods (as a quantity)
+        """
+        value: NotRequired[pulumi.Input[str]]
+        """
+        value is the current value of the metric (as a quantity).
+        """
+elif False:
+    MetricValueStatusArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class MetricValueStatusArgs:
     def __init__(__self__, *,
@@ -1787,6 +2436,23 @@ class MetricValueStatusArgs:
         pulumi.set(self, "value", value)
 
 
+if not MYPY:
+    class ObjectMetricSourcePatchArgsDict(TypedDict):
+        """
+        ObjectMetricSource indicates how to scale on a metric describing a kubernetes object (for example, hits-per-second on an Ingress object).
+        """
+        described_object: NotRequired[pulumi.Input['CrossVersionObjectReferencePatchArgsDict']]
+        metric: NotRequired[pulumi.Input['MetricIdentifierPatchArgsDict']]
+        """
+        metric identifies the target metric by name and selector
+        """
+        target: NotRequired[pulumi.Input['MetricTargetPatchArgsDict']]
+        """
+        target specifies the target value for the given metric
+        """
+elif False:
+    ObjectMetricSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ObjectMetricSourcePatchArgs:
     def __init__(__self__, *,
@@ -1839,6 +2505,23 @@ class ObjectMetricSourcePatchArgs:
         pulumi.set(self, "target", value)
 
 
+if not MYPY:
+    class ObjectMetricSourceArgsDict(TypedDict):
+        """
+        ObjectMetricSource indicates how to scale on a metric describing a kubernetes object (for example, hits-per-second on an Ingress object).
+        """
+        described_object: pulumi.Input['CrossVersionObjectReferenceArgsDict']
+        metric: pulumi.Input['MetricIdentifierArgsDict']
+        """
+        metric identifies the target metric by name and selector
+        """
+        target: pulumi.Input['MetricTargetArgsDict']
+        """
+        target specifies the target value for the given metric
+        """
+elif False:
+    ObjectMetricSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ObjectMetricSourceArgs:
     def __init__(__self__, *,
@@ -1887,6 +2570,23 @@ class ObjectMetricSourceArgs:
     def target(self, value: pulumi.Input['MetricTargetArgs']):
         pulumi.set(self, "target", value)
 
+
+if not MYPY:
+    class ObjectMetricStatusArgsDict(TypedDict):
+        """
+        ObjectMetricStatus indicates the current value of a metric describing a kubernetes object (for example, hits-per-second on an Ingress object).
+        """
+        current: pulumi.Input['MetricValueStatusArgsDict']
+        """
+        current contains the current value for the given metric
+        """
+        described_object: pulumi.Input['CrossVersionObjectReferenceArgsDict']
+        metric: pulumi.Input['MetricIdentifierArgsDict']
+        """
+        metric identifies the target metric by name and selector
+        """
+elif False:
+    ObjectMetricStatusArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ObjectMetricStatusArgs:
@@ -1937,6 +2637,22 @@ class ObjectMetricStatusArgs:
         pulumi.set(self, "metric", value)
 
 
+if not MYPY:
+    class PodsMetricSourcePatchArgsDict(TypedDict):
+        """
+        PodsMetricSource indicates how to scale on a metric describing each pod in the current scale target (for example, transactions-processed-per-second). The values will be averaged together before being compared to the target value.
+        """
+        metric: NotRequired[pulumi.Input['MetricIdentifierPatchArgsDict']]
+        """
+        metric identifies the target metric by name and selector
+        """
+        target: NotRequired[pulumi.Input['MetricTargetPatchArgsDict']]
+        """
+        target specifies the target value for the given metric
+        """
+elif False:
+    PodsMetricSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PodsMetricSourcePatchArgs:
     def __init__(__self__, *,
@@ -1977,6 +2693,22 @@ class PodsMetricSourcePatchArgs:
         pulumi.set(self, "target", value)
 
 
+if not MYPY:
+    class PodsMetricSourceArgsDict(TypedDict):
+        """
+        PodsMetricSource indicates how to scale on a metric describing each pod in the current scale target (for example, transactions-processed-per-second). The values will be averaged together before being compared to the target value.
+        """
+        metric: pulumi.Input['MetricIdentifierArgsDict']
+        """
+        metric identifies the target metric by name and selector
+        """
+        target: pulumi.Input['MetricTargetArgsDict']
+        """
+        target specifies the target value for the given metric
+        """
+elif False:
+    PodsMetricSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PodsMetricSourceArgs:
     def __init__(__self__, *,
@@ -2015,6 +2747,22 @@ class PodsMetricSourceArgs:
         pulumi.set(self, "target", value)
 
 
+if not MYPY:
+    class PodsMetricStatusArgsDict(TypedDict):
+        """
+        PodsMetricStatus indicates the current value of a metric describing each pod in the current scale target (for example, transactions-processed-per-second).
+        """
+        current: pulumi.Input['MetricValueStatusArgsDict']
+        """
+        current contains the current value for the given metric
+        """
+        metric: pulumi.Input['MetricIdentifierArgsDict']
+        """
+        metric identifies the target metric by name and selector
+        """
+elif False:
+    PodsMetricStatusArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PodsMetricStatusArgs:
     def __init__(__self__, *,
@@ -2052,6 +2800,22 @@ class PodsMetricStatusArgs:
     def metric(self, value: pulumi.Input['MetricIdentifierArgs']):
         pulumi.set(self, "metric", value)
 
+
+if not MYPY:
+    class ResourceMetricSourcePatchArgsDict(TypedDict):
+        """
+        ResourceMetricSource indicates how to scale on a resource metric known to Kubernetes, as specified in requests and limits, describing each pod in the current scale target (e.g. CPU or memory).  The values will be averaged together before being compared to the target.  Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.  Only one "target" type should be set.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        name is the name of the resource in question.
+        """
+        target: NotRequired[pulumi.Input['MetricTargetPatchArgsDict']]
+        """
+        target specifies the target value for the given metric
+        """
+elif False:
+    ResourceMetricSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ResourceMetricSourcePatchArgs:
@@ -2093,6 +2857,22 @@ class ResourceMetricSourcePatchArgs:
         pulumi.set(self, "target", value)
 
 
+if not MYPY:
+    class ResourceMetricSourceArgsDict(TypedDict):
+        """
+        ResourceMetricSource indicates how to scale on a resource metric known to Kubernetes, as specified in requests and limits, describing each pod in the current scale target (e.g. CPU or memory).  The values will be averaged together before being compared to the target.  Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.  Only one "target" type should be set.
+        """
+        name: pulumi.Input[str]
+        """
+        name is the name of the resource in question.
+        """
+        target: pulumi.Input['MetricTargetArgsDict']
+        """
+        target specifies the target value for the given metric
+        """
+elif False:
+    ResourceMetricSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ResourceMetricSourceArgs:
     def __init__(__self__, *,
@@ -2130,6 +2910,22 @@ class ResourceMetricSourceArgs:
     def target(self, value: pulumi.Input['MetricTargetArgs']):
         pulumi.set(self, "target", value)
 
+
+if not MYPY:
+    class ResourceMetricStatusArgsDict(TypedDict):
+        """
+        ResourceMetricStatus indicates the current value of a resource metric known to Kubernetes, as specified in requests and limits, describing each pod in the current scale target (e.g. CPU or memory).  Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the "pods" source.
+        """
+        current: pulumi.Input['MetricValueStatusArgsDict']
+        """
+        current contains the current value for the given metric
+        """
+        name: pulumi.Input[str]
+        """
+        Name is the name of the resource in question.
+        """
+elif False:
+    ResourceMetricStatusArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ResourceMetricStatusArgs:

--- a/sdk/python/pulumi_kubernetes/autoscaling/v2beta2/outputs.py
+++ b/sdk/python/pulumi_kubernetes/autoscaling/v2beta2/outputs.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta

--- a/sdk/python/pulumi_kubernetes/batch/v1/CronJob.py
+++ b/sdk/python/pulumi_kubernetes/batch/v1/CronJob.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -94,8 +99,8 @@ class CronJob(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['CronJobSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['CronJobSpecArgs', 'CronJobSpecArgsDict']]] = None,
                  __props__=None):
         """
         CronJob represents the configuration of a single cron job.
@@ -104,8 +109,8 @@ class CronJob(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['CronJobSpecArgs']] spec: Specification of the desired behavior of a cron job, including the schedule. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['CronJobSpecArgs', 'CronJobSpecArgsDict']] spec: Specification of the desired behavior of a cron job, including the schedule. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -133,8 +138,8 @@ class CronJob(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['CronJobSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['CronJobSpecArgs', 'CronJobSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/batch/v1/CronJobList.py
+++ b/sdk/python/pulumi_kubernetes/batch/v1/CronJobList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -92,9 +97,9 @@ class CronJobList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['CronJobArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['CronJobArgs', 'CronJobArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         CronJobList is a collection of cron jobs.
@@ -102,9 +107,9 @@ class CronJobList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['CronJobArgs']]]] items: items is the list of CronJobs.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['CronJobArgs', 'CronJobArgsDict']]]] items: items is the list of CronJobs.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -131,9 +136,9 @@ class CronJobList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['CronJobArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['CronJobArgs', 'CronJobArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/batch/v1/CronJobPatch.py
+++ b/sdk/python/pulumi_kubernetes/batch/v1/CronJobPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -94,8 +99,8 @@ class CronJobPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['CronJobSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['CronJobSpecPatchArgs', 'CronJobSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -110,8 +115,8 @@ class CronJobPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['CronJobSpecPatchArgs']] spec: Specification of the desired behavior of a cron job, including the schedule. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['CronJobSpecPatchArgs', 'CronJobSpecPatchArgsDict']] spec: Specification of the desired behavior of a cron job, including the schedule. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -145,8 +150,8 @@ class CronJobPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['CronJobSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['CronJobSpecPatchArgs', 'CronJobSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/batch/v1/Job.py
+++ b/sdk/python/pulumi_kubernetes/batch/v1/Job.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -94,8 +99,8 @@ class Job(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['JobSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['JobSpecArgs', 'JobSpecArgsDict']]] = None,
                  __props__=None):
         """
         Job represents the configuration of a single job.
@@ -180,8 +185,8 @@ class Job(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['JobSpecArgs']] spec: Specification of the desired behavior of a job. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['JobSpecArgs', 'JobSpecArgsDict']] spec: Specification of the desired behavior of a job. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -285,8 +290,8 @@ class Job(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['JobSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['JobSpecArgs', 'JobSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/batch/v1/JobList.py
+++ b/sdk/python/pulumi_kubernetes/batch/v1/JobList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -92,9 +97,9 @@ class JobList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['JobArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['JobArgs', 'JobArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         JobList is a collection of jobs.
@@ -102,9 +107,9 @@ class JobList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['JobArgs']]]] items: items is the list of Jobs.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['JobArgs', 'JobArgsDict']]]] items: items is the list of Jobs.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -131,9 +136,9 @@ class JobList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['JobArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['JobArgs', 'JobArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/batch/v1/JobPatch.py
+++ b/sdk/python/pulumi_kubernetes/batch/v1/JobPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -94,8 +99,8 @@ class JobPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['JobSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['JobSpecPatchArgs', 'JobSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -130,8 +135,8 @@ class JobPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['JobSpecPatchArgs']] spec: Specification of the desired behavior of a job. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['JobSpecPatchArgs', 'JobSpecPatchArgsDict']] spec: Specification of the desired behavior of a job. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -185,8 +190,8 @@ class JobPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['JobSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['JobSpecPatchArgs', 'JobSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/batch/v1/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/batch/v1/_inputs.py
@@ -4,39 +4,112 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import core as _core
 from ... import meta as _meta
 
 __all__ = [
     'CronJobSpecPatchArgs',
+    'CronJobSpecPatchArgsDict',
     'CronJobSpecArgs',
+    'CronJobSpecArgsDict',
     'CronJobStatusArgs',
+    'CronJobStatusArgsDict',
     'CronJobArgs',
+    'CronJobArgsDict',
     'JobConditionArgs',
+    'JobConditionArgsDict',
     'JobSpecPatchArgs',
+    'JobSpecPatchArgsDict',
     'JobSpecArgs',
+    'JobSpecArgsDict',
     'JobStatusArgs',
+    'JobStatusArgsDict',
     'JobTemplateSpecPatchArgs',
+    'JobTemplateSpecPatchArgsDict',
     'JobTemplateSpecArgs',
+    'JobTemplateSpecArgsDict',
     'JobArgs',
+    'JobArgsDict',
     'PodFailurePolicyOnExitCodesRequirementPatchArgs',
+    'PodFailurePolicyOnExitCodesRequirementPatchArgsDict',
     'PodFailurePolicyOnExitCodesRequirementArgs',
+    'PodFailurePolicyOnExitCodesRequirementArgsDict',
     'PodFailurePolicyOnPodConditionsPatternPatchArgs',
+    'PodFailurePolicyOnPodConditionsPatternPatchArgsDict',
     'PodFailurePolicyOnPodConditionsPatternArgs',
+    'PodFailurePolicyOnPodConditionsPatternArgsDict',
     'PodFailurePolicyPatchArgs',
+    'PodFailurePolicyPatchArgsDict',
     'PodFailurePolicyRulePatchArgs',
+    'PodFailurePolicyRulePatchArgsDict',
     'PodFailurePolicyRuleArgs',
+    'PodFailurePolicyRuleArgsDict',
     'PodFailurePolicyArgs',
+    'PodFailurePolicyArgsDict',
     'SuccessPolicyPatchArgs',
+    'SuccessPolicyPatchArgsDict',
     'SuccessPolicyRulePatchArgs',
+    'SuccessPolicyRulePatchArgsDict',
     'SuccessPolicyRuleArgs',
+    'SuccessPolicyRuleArgsDict',
     'SuccessPolicyArgs',
+    'SuccessPolicyArgsDict',
     'UncountedTerminatedPodsArgs',
+    'UncountedTerminatedPodsArgsDict',
 ]
+
+MYPY = False
+
+if not MYPY:
+    class CronJobSpecPatchArgsDict(TypedDict):
+        """
+        CronJobSpec describes how the job execution will look like and when it will actually run.
+        """
+        concurrency_policy: NotRequired[pulumi.Input[str]]
+        """
+        Specifies how to treat concurrent executions of a Job. Valid values are:
+
+        - "Allow" (default): allows CronJobs to run concurrently; - "Forbid": forbids concurrent runs, skipping next run if previous run hasn't finished yet; - "Replace": cancels currently running job and replaces it with a new one
+        """
+        failed_jobs_history_limit: NotRequired[pulumi.Input[int]]
+        """
+        The number of failed finished jobs to retain. Value must be non-negative integer. Defaults to 1.
+        """
+        job_template: NotRequired[pulumi.Input['JobTemplateSpecPatchArgsDict']]
+        """
+        Specifies the job that will be created when executing a CronJob.
+        """
+        schedule: NotRequired[pulumi.Input[str]]
+        """
+        The schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
+        """
+        starting_deadline_seconds: NotRequired[pulumi.Input[int]]
+        """
+        Optional deadline in seconds for starting the job if it misses scheduled time for any reason.  Missed jobs executions will be counted as failed ones.
+        """
+        successful_jobs_history_limit: NotRequired[pulumi.Input[int]]
+        """
+        The number of successful finished jobs to retain. Value must be non-negative integer. Defaults to 3.
+        """
+        suspend: NotRequired[pulumi.Input[bool]]
+        """
+        This flag tells the controller to suspend subsequent executions, it does not apply to already started executions.  Defaults to false.
+        """
+        time_zone: NotRequired[pulumi.Input[str]]
+        """
+        The time zone name for the given schedule, see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones. If not specified, this will default to the time zone of the kube-controller-manager process. The set of valid time zone names and the time zone offset is loaded from the system-wide time zone database by the API server during CronJob validation and the controller manager during execution. If no system-wide time zone database can be found a bundled version of the database is used instead. If the time zone name becomes invalid during the lifetime of a CronJob or due to a change in host configuration, the controller will stop creating new new Jobs and will create a system event with the reason UnknownTimeZone. More information can be found in https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#time-zones
+        """
+elif False:
+    CronJobSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class CronJobSpecPatchArgs:
@@ -178,6 +251,48 @@ class CronJobSpecPatchArgs:
         pulumi.set(self, "time_zone", value)
 
 
+if not MYPY:
+    class CronJobSpecArgsDict(TypedDict):
+        """
+        CronJobSpec describes how the job execution will look like and when it will actually run.
+        """
+        job_template: pulumi.Input['JobTemplateSpecArgsDict']
+        """
+        Specifies the job that will be created when executing a CronJob.
+        """
+        schedule: pulumi.Input[str]
+        """
+        The schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
+        """
+        concurrency_policy: NotRequired[pulumi.Input[str]]
+        """
+        Specifies how to treat concurrent executions of a Job. Valid values are:
+
+        - "Allow" (default): allows CronJobs to run concurrently; - "Forbid": forbids concurrent runs, skipping next run if previous run hasn't finished yet; - "Replace": cancels currently running job and replaces it with a new one
+        """
+        failed_jobs_history_limit: NotRequired[pulumi.Input[int]]
+        """
+        The number of failed finished jobs to retain. Value must be non-negative integer. Defaults to 1.
+        """
+        starting_deadline_seconds: NotRequired[pulumi.Input[int]]
+        """
+        Optional deadline in seconds for starting the job if it misses scheduled time for any reason.  Missed jobs executions will be counted as failed ones.
+        """
+        successful_jobs_history_limit: NotRequired[pulumi.Input[int]]
+        """
+        The number of successful finished jobs to retain. Value must be non-negative integer. Defaults to 3.
+        """
+        suspend: NotRequired[pulumi.Input[bool]]
+        """
+        This flag tells the controller to suspend subsequent executions, it does not apply to already started executions.  Defaults to false.
+        """
+        time_zone: NotRequired[pulumi.Input[str]]
+        """
+        The time zone name for the given schedule, see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones. If not specified, this will default to the time zone of the kube-controller-manager process. The set of valid time zone names and the time zone offset is loaded from the system-wide time zone database by the API server during CronJob validation and the controller manager during execution. If no system-wide time zone database can be found a bundled version of the database is used instead. If the time zone name becomes invalid during the lifetime of a CronJob or due to a change in host configuration, the controller will stop creating new new Jobs and will create a system event with the reason UnknownTimeZone. More information can be found in https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#time-zones
+        """
+elif False:
+    CronJobSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CronJobSpecArgs:
     def __init__(__self__, *,
@@ -316,6 +431,26 @@ class CronJobSpecArgs:
         pulumi.set(self, "time_zone", value)
 
 
+if not MYPY:
+    class CronJobStatusArgsDict(TypedDict):
+        """
+        CronJobStatus represents the current state of a cron job.
+        """
+        active: NotRequired[pulumi.Input[Sequence[pulumi.Input['_core.v1.ObjectReferenceArgsDict']]]]
+        """
+        A list of pointers to currently running jobs.
+        """
+        last_schedule_time: NotRequired[pulumi.Input[str]]
+        """
+        Information when was the last time the job was successfully scheduled.
+        """
+        last_successful_time: NotRequired[pulumi.Input[str]]
+        """
+        Information when was the last time the job successfully completed.
+        """
+elif False:
+    CronJobStatusArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CronJobStatusArgs:
     def __init__(__self__, *,
@@ -371,6 +506,34 @@ class CronJobStatusArgs:
     def last_successful_time(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "last_successful_time", value)
 
+
+if not MYPY:
+    class CronJobArgsDict(TypedDict):
+        """
+        CronJob represents the configuration of a single cron job.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['CronJobSpecArgsDict']]
+        """
+        Specification of the desired behavior of a cron job, including the schedule. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+        status: NotRequired[pulumi.Input['CronJobStatusArgsDict']]
+        """
+        Current status of a cron job. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+elif False:
+    CronJobArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class CronJobArgs:
@@ -459,6 +622,38 @@ class CronJobArgs:
     def status(self, value: Optional[pulumi.Input['CronJobStatusArgs']]):
         pulumi.set(self, "status", value)
 
+
+if not MYPY:
+    class JobConditionArgsDict(TypedDict):
+        """
+        JobCondition describes current state of a job.
+        """
+        status: pulumi.Input[str]
+        """
+        Status of the condition, one of True, False, Unknown.
+        """
+        type: pulumi.Input[str]
+        """
+        Type of job condition, Complete or Failed.
+        """
+        last_probe_time: NotRequired[pulumi.Input[str]]
+        """
+        Last time the condition was checked.
+        """
+        last_transition_time: NotRequired[pulumi.Input[str]]
+        """
+        Last time the condition transit from one status to another.
+        """
+        message: NotRequired[pulumi.Input[str]]
+        """
+        Human readable message indicating details about last transition.
+        """
+        reason: NotRequired[pulumi.Input[str]]
+        """
+        (brief) reason for the condition's last transition.
+        """
+elif False:
+    JobConditionArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class JobConditionArgs:
@@ -561,6 +756,95 @@ class JobConditionArgs:
     def reason(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "reason", value)
 
+
+if not MYPY:
+    class JobSpecPatchArgsDict(TypedDict):
+        """
+        JobSpec describes how the job execution will look like.
+        """
+        active_deadline_seconds: NotRequired[pulumi.Input[int]]
+        """
+        Specifies the duration in seconds relative to the startTime that the job may be continuously active before the system tries to terminate it; value must be positive integer. If a Job is suspended (at creation or through an update), this timer will effectively be stopped and reset when the Job is resumed again.
+        """
+        backoff_limit: NotRequired[pulumi.Input[int]]
+        """
+        Specifies the number of retries before marking this job failed. Defaults to 6
+        """
+        backoff_limit_per_index: NotRequired[pulumi.Input[int]]
+        """
+        Specifies the limit for the number of retries within an index before marking this index as failed. When enabled the number of failures per index is kept in the pod's batch.kubernetes.io/job-index-failure-count annotation. It can only be set when Job's completionMode=Indexed, and the Pod's restart policy is Never. The field is immutable. This field is beta-level. It can be used when the `JobBackoffLimitPerIndex` feature gate is enabled (enabled by default).
+        """
+        completion_mode: NotRequired[pulumi.Input[str]]
+        """
+        completionMode specifies how Pod completions are tracked. It can be `NonIndexed` (default) or `Indexed`.
+
+        `NonIndexed` means that the Job is considered complete when there have been .spec.completions successfully completed Pods. Each Pod completion is homologous to each other.
+
+        `Indexed` means that the Pods of a Job get an associated completion index from 0 to (.spec.completions - 1), available in the annotation batch.kubernetes.io/job-completion-index. The Job is considered complete when there is one successfully completed Pod for each index. When value is `Indexed`, .spec.completions must be specified and `.spec.parallelism` must be less than or equal to 10^5. In addition, The Pod name takes the form `$(job-name)-$(index)-$(random-string)`, the Pod hostname takes the form `$(job-name)-$(index)`.
+
+        More completion modes can be added in the future. If the Job controller observes a mode that it doesn't recognize, which is possible during upgrades due to version skew, the controller skips updates for the Job.
+        """
+        completions: NotRequired[pulumi.Input[int]]
+        """
+        Specifies the desired number of successfully finished pods the job should be run with.  Setting to null means that the success of any pod signals the success of all pods, and allows parallelism to have any positive value.  Setting to 1 means that parallelism is limited to 1 and the success of that pod signals the success of the job. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
+        """
+        managed_by: NotRequired[pulumi.Input[str]]
+        """
+        ManagedBy field indicates the controller that manages a Job. The k8s Job controller reconciles jobs which don't have this field at all or the field value is the reserved string `kubernetes.io/job-controller`, but skips reconciling Jobs with a custom value for this field. The value must be a valid domain-prefixed path (e.g. acme.io/foo) - all characters before the first "/" must be a valid subdomain as defined by RFC 1123. All characters trailing the first "/" must be valid HTTP Path characters as defined by RFC 3986. The value cannot exceed 64 characters.
+
+        This field is alpha-level. The job controller accepts setting the field when the feature gate JobManagedBy is enabled (disabled by default).
+        """
+        manual_selector: NotRequired[pulumi.Input[bool]]
+        """
+        manualSelector controls generation of pod labels and pod selectors. Leave `manualSelector` unset unless you are certain what you are doing. When false or unset, the system pick labels unique to this job and appends those labels to the pod template.  When true, the user is responsible for picking unique labels and specifying the selector.  Failure to pick a unique label may cause this and other jobs to not function correctly.  However, You may see `manualSelector=true` in jobs that were created with the old `extensions/v1beta1` API. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/#specifying-your-own-pod-selector
+        """
+        max_failed_indexes: NotRequired[pulumi.Input[int]]
+        """
+        Specifies the maximal number of failed indexes before marking the Job as failed, when backoffLimitPerIndex is set. Once the number of failed indexes exceeds this number the entire Job is marked as Failed and its execution is terminated. When left as null the job continues execution of all of its indexes and is marked with the `Complete` Job condition. It can only be specified when backoffLimitPerIndex is set. It can be null or up to completions. It is required and must be less than or equal to 10^4 when is completions greater than 10^5. This field is beta-level. It can be used when the `JobBackoffLimitPerIndex` feature gate is enabled (enabled by default).
+        """
+        parallelism: NotRequired[pulumi.Input[int]]
+        """
+        Specifies the maximum desired number of pods the job should run at any given time. The actual number of pods running in steady state will be less than this number when ((.spec.completions - .status.successful) < .spec.parallelism), i.e. when the work left to do is less than max parallelism. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
+        """
+        pod_failure_policy: NotRequired[pulumi.Input['PodFailurePolicyPatchArgsDict']]
+        """
+        Specifies the policy of handling failed pods. In particular, it allows to specify the set of actions and conditions which need to be satisfied to take the associated action. If empty, the default behaviour applies - the counter of failed pods, represented by the jobs's .status.failed field, is incremented and it is checked against the backoffLimit. This field cannot be used in combination with restartPolicy=OnFailure.
+
+        This field is beta-level. It can be used when the `JobPodFailurePolicy` feature gate is enabled (enabled by default).
+        """
+        pod_replacement_policy: NotRequired[pulumi.Input[str]]
+        """
+        podReplacementPolicy specifies when to create replacement Pods. Possible values are: - TerminatingOrFailed means that we recreate pods
+          when they are terminating (has a metadata.deletionTimestamp) or failed.
+        - Failed means to wait until a previously created Pod is fully terminated (has phase
+          Failed or Succeeded) before creating a replacement Pod.
+
+        When using podFailurePolicy, Failed is the the only allowed value. TerminatingOrFailed and Failed are allowed values when podFailurePolicy is not in use. This is an beta field. To use this, enable the JobPodReplacementPolicy feature toggle. This is on by default.
+        """
+        selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorPatchArgsDict']]
+        """
+        A label query over pods that should match the pod count. Normally, the system sets this field for you. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+        """
+        success_policy: NotRequired[pulumi.Input['SuccessPolicyPatchArgsDict']]
+        """
+        successPolicy specifies the policy when the Job can be declared as succeeded. If empty, the default behavior applies - the Job is declared as succeeded only when the number of succeeded pods equals to the completions. When the field is specified, it must be immutable and works only for the Indexed Jobs. Once the Job meets the SuccessPolicy, the lingering pods are terminated.
+
+        This field  is alpha-level. To use this field, you must enable the `JobSuccessPolicy` feature gate (disabled by default).
+        """
+        suspend: NotRequired[pulumi.Input[bool]]
+        """
+        suspend specifies whether the Job controller should create Pods or not. If a Job is created with suspend set to true, no Pods are created by the Job controller. If a Job is suspended after creation (i.e. the flag goes from false to true), the Job controller will delete all active Pods associated with this Job. Users must design their workload to gracefully handle this. Suspending a Job will reset the StartTime field of the Job, effectively resetting the ActiveDeadlineSeconds timer too. Defaults to false.
+        """
+        template: NotRequired[pulumi.Input['_core.v1.PodTemplateSpecPatchArgsDict']]
+        """
+        Describes the pod that will be created when executing a job. The only allowed template.spec.restartPolicy values are "Never" or "OnFailure". More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
+        """
+        ttl_seconds_after_finished: NotRequired[pulumi.Input[int]]
+        """
+        ttlSecondsAfterFinished limits the lifetime of a Job that has finished execution (either Complete or Failed). If this field is set, ttlSecondsAfterFinished after the Job finishes, it is eligible to be automatically deleted. When the Job is being deleted, its lifecycle guarantees (e.g. finalizers) will be honored. If this field is unset, the Job won't be automatically deleted. If this field is set to zero, the Job becomes eligible to be deleted immediately after it finishes.
+        """
+elif False:
+    JobSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class JobSpecPatchArgs:
@@ -860,6 +1144,95 @@ class JobSpecPatchArgs:
         pulumi.set(self, "ttl_seconds_after_finished", value)
 
 
+if not MYPY:
+    class JobSpecArgsDict(TypedDict):
+        """
+        JobSpec describes how the job execution will look like.
+        """
+        template: pulumi.Input['_core.v1.PodTemplateSpecArgsDict']
+        """
+        Describes the pod that will be created when executing a job. The only allowed template.spec.restartPolicy values are "Never" or "OnFailure". More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
+        """
+        active_deadline_seconds: NotRequired[pulumi.Input[int]]
+        """
+        Specifies the duration in seconds relative to the startTime that the job may be continuously active before the system tries to terminate it; value must be positive integer. If a Job is suspended (at creation or through an update), this timer will effectively be stopped and reset when the Job is resumed again.
+        """
+        backoff_limit: NotRequired[pulumi.Input[int]]
+        """
+        Specifies the number of retries before marking this job failed. Defaults to 6
+        """
+        backoff_limit_per_index: NotRequired[pulumi.Input[int]]
+        """
+        Specifies the limit for the number of retries within an index before marking this index as failed. When enabled the number of failures per index is kept in the pod's batch.kubernetes.io/job-index-failure-count annotation. It can only be set when Job's completionMode=Indexed, and the Pod's restart policy is Never. The field is immutable. This field is beta-level. It can be used when the `JobBackoffLimitPerIndex` feature gate is enabled (enabled by default).
+        """
+        completion_mode: NotRequired[pulumi.Input[str]]
+        """
+        completionMode specifies how Pod completions are tracked. It can be `NonIndexed` (default) or `Indexed`.
+
+        `NonIndexed` means that the Job is considered complete when there have been .spec.completions successfully completed Pods. Each Pod completion is homologous to each other.
+
+        `Indexed` means that the Pods of a Job get an associated completion index from 0 to (.spec.completions - 1), available in the annotation batch.kubernetes.io/job-completion-index. The Job is considered complete when there is one successfully completed Pod for each index. When value is `Indexed`, .spec.completions must be specified and `.spec.parallelism` must be less than or equal to 10^5. In addition, The Pod name takes the form `$(job-name)-$(index)-$(random-string)`, the Pod hostname takes the form `$(job-name)-$(index)`.
+
+        More completion modes can be added in the future. If the Job controller observes a mode that it doesn't recognize, which is possible during upgrades due to version skew, the controller skips updates for the Job.
+        """
+        completions: NotRequired[pulumi.Input[int]]
+        """
+        Specifies the desired number of successfully finished pods the job should be run with.  Setting to null means that the success of any pod signals the success of all pods, and allows parallelism to have any positive value.  Setting to 1 means that parallelism is limited to 1 and the success of that pod signals the success of the job. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
+        """
+        managed_by: NotRequired[pulumi.Input[str]]
+        """
+        ManagedBy field indicates the controller that manages a Job. The k8s Job controller reconciles jobs which don't have this field at all or the field value is the reserved string `kubernetes.io/job-controller`, but skips reconciling Jobs with a custom value for this field. The value must be a valid domain-prefixed path (e.g. acme.io/foo) - all characters before the first "/" must be a valid subdomain as defined by RFC 1123. All characters trailing the first "/" must be valid HTTP Path characters as defined by RFC 3986. The value cannot exceed 64 characters.
+
+        This field is alpha-level. The job controller accepts setting the field when the feature gate JobManagedBy is enabled (disabled by default).
+        """
+        manual_selector: NotRequired[pulumi.Input[bool]]
+        """
+        manualSelector controls generation of pod labels and pod selectors. Leave `manualSelector` unset unless you are certain what you are doing. When false or unset, the system pick labels unique to this job and appends those labels to the pod template.  When true, the user is responsible for picking unique labels and specifying the selector.  Failure to pick a unique label may cause this and other jobs to not function correctly.  However, You may see `manualSelector=true` in jobs that were created with the old `extensions/v1beta1` API. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/#specifying-your-own-pod-selector
+        """
+        max_failed_indexes: NotRequired[pulumi.Input[int]]
+        """
+        Specifies the maximal number of failed indexes before marking the Job as failed, when backoffLimitPerIndex is set. Once the number of failed indexes exceeds this number the entire Job is marked as Failed and its execution is terminated. When left as null the job continues execution of all of its indexes and is marked with the `Complete` Job condition. It can only be specified when backoffLimitPerIndex is set. It can be null or up to completions. It is required and must be less than or equal to 10^4 when is completions greater than 10^5. This field is beta-level. It can be used when the `JobBackoffLimitPerIndex` feature gate is enabled (enabled by default).
+        """
+        parallelism: NotRequired[pulumi.Input[int]]
+        """
+        Specifies the maximum desired number of pods the job should run at any given time. The actual number of pods running in steady state will be less than this number when ((.spec.completions - .status.successful) < .spec.parallelism), i.e. when the work left to do is less than max parallelism. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
+        """
+        pod_failure_policy: NotRequired[pulumi.Input['PodFailurePolicyArgsDict']]
+        """
+        Specifies the policy of handling failed pods. In particular, it allows to specify the set of actions and conditions which need to be satisfied to take the associated action. If empty, the default behaviour applies - the counter of failed pods, represented by the jobs's .status.failed field, is incremented and it is checked against the backoffLimit. This field cannot be used in combination with restartPolicy=OnFailure.
+
+        This field is beta-level. It can be used when the `JobPodFailurePolicy` feature gate is enabled (enabled by default).
+        """
+        pod_replacement_policy: NotRequired[pulumi.Input[str]]
+        """
+        podReplacementPolicy specifies when to create replacement Pods. Possible values are: - TerminatingOrFailed means that we recreate pods
+          when they are terminating (has a metadata.deletionTimestamp) or failed.
+        - Failed means to wait until a previously created Pod is fully terminated (has phase
+          Failed or Succeeded) before creating a replacement Pod.
+
+        When using podFailurePolicy, Failed is the the only allowed value. TerminatingOrFailed and Failed are allowed values when podFailurePolicy is not in use. This is an beta field. To use this, enable the JobPodReplacementPolicy feature toggle. This is on by default.
+        """
+        selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorArgsDict']]
+        """
+        A label query over pods that should match the pod count. Normally, the system sets this field for you. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+        """
+        success_policy: NotRequired[pulumi.Input['SuccessPolicyArgsDict']]
+        """
+        successPolicy specifies the policy when the Job can be declared as succeeded. If empty, the default behavior applies - the Job is declared as succeeded only when the number of succeeded pods equals to the completions. When the field is specified, it must be immutable and works only for the Indexed Jobs. Once the Job meets the SuccessPolicy, the lingering pods are terminated.
+
+        This field  is alpha-level. To use this field, you must enable the `JobSuccessPolicy` feature gate (disabled by default).
+        """
+        suspend: NotRequired[pulumi.Input[bool]]
+        """
+        suspend specifies whether the Job controller should create Pods or not. If a Job is created with suspend set to true, no Pods are created by the Job controller. If a Job is suspended after creation (i.e. the flag goes from false to true), the Job controller will delete all active Pods associated with this Job. Users must design their workload to gracefully handle this. Suspending a Job will reset the StartTime field of the Job, effectively resetting the ActiveDeadlineSeconds timer too. Defaults to false.
+        """
+        ttl_seconds_after_finished: NotRequired[pulumi.Input[int]]
+        """
+        ttlSecondsAfterFinished limits the lifetime of a Job that has finished execution (either Complete or Failed). If this field is set, ttlSecondsAfterFinished after the Job finishes, it is eligible to be automatically deleted. When the Job is being deleted, its lifecycle guarantees (e.g. finalizers) will be honored. If this field is unset, the Job won't be automatically deleted. If this field is set to zero, the Job becomes eligible to be deleted immediately after it finishes.
+        """
+elif False:
+    JobSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class JobSpecArgs:
     def __init__(__self__, *,
@@ -1157,6 +1530,75 @@ class JobSpecArgs:
         pulumi.set(self, "ttl_seconds_after_finished", value)
 
 
+if not MYPY:
+    class JobStatusArgsDict(TypedDict):
+        """
+        JobStatus represents the current state of a Job.
+        """
+        active: NotRequired[pulumi.Input[int]]
+        """
+        The number of pending and running pods which are not terminating (without a deletionTimestamp). The value is zero for finished jobs.
+        """
+        completed_indexes: NotRequired[pulumi.Input[str]]
+        """
+        completedIndexes holds the completed indexes when .spec.completionMode = "Indexed" in a text format. The indexes are represented as decimal integers separated by commas. The numbers are listed in increasing order. Three or more consecutive numbers are compressed and represented by the first and last element of the series, separated by a hyphen. For example, if the completed indexes are 1, 3, 4, 5 and 7, they are represented as "1,3-5,7".
+        """
+        completion_time: NotRequired[pulumi.Input[str]]
+        """
+        Represents time when the job was completed. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC. The completion time is set when the job finishes successfully, and only then. The value cannot be updated or removed. The value indicates the same or later point in time as the startTime field.
+        """
+        conditions: NotRequired[pulumi.Input[Sequence[pulumi.Input['JobConditionArgsDict']]]]
+        """
+        The latest available observations of an object's current state. When a Job fails, one of the conditions will have type "Failed" and status true. When a Job is suspended, one of the conditions will have type "Suspended" and status true; when the Job is resumed, the status of this condition will become false. When a Job is completed, one of the conditions will have type "Complete" and status true.
+
+        A job is considered finished when it is in a terminal condition, either "Complete" or "Failed". A Job cannot have both the "Complete" and "Failed" conditions. Additionally, it cannot be in the "Complete" and "FailureTarget" conditions. The "Complete", "Failed" and "FailureTarget" conditions cannot be disabled.
+
+        More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
+        """
+        failed: NotRequired[pulumi.Input[int]]
+        """
+        The number of pods which reached phase Failed. The value increases monotonically.
+        """
+        failed_indexes: NotRequired[pulumi.Input[str]]
+        """
+        FailedIndexes holds the failed indexes when spec.backoffLimitPerIndex is set. The indexes are represented in the text format analogous as for the `completedIndexes` field, ie. they are kept as decimal integers separated by commas. The numbers are listed in increasing order. Three or more consecutive numbers are compressed and represented by the first and last element of the series, separated by a hyphen. For example, if the failed indexes are 1, 3, 4, 5 and 7, they are represented as "1,3-5,7". The set of failed indexes cannot overlap with the set of completed indexes.
+
+        This field is beta-level. It can be used when the `JobBackoffLimitPerIndex` feature gate is enabled (enabled by default).
+        """
+        ready: NotRequired[pulumi.Input[int]]
+        """
+        The number of pods which have a Ready condition.
+        """
+        start_time: NotRequired[pulumi.Input[str]]
+        """
+        Represents time when the job controller started processing a job. When a Job is created in the suspended state, this field is not set until the first time it is resumed. This field is reset every time a Job is resumed from suspension. It is represented in RFC3339 form and is in UTC.
+
+        Once set, the field can only be removed when the job is suspended. The field cannot be modified while the job is unsuspended or finished.
+        """
+        succeeded: NotRequired[pulumi.Input[int]]
+        """
+        The number of pods which reached phase Succeeded. The value increases monotonically for a given spec. However, it may decrease in reaction to scale down of elastic indexed jobs.
+        """
+        terminating: NotRequired[pulumi.Input[int]]
+        """
+        The number of pods which are terminating (in phase Pending or Running and have a deletionTimestamp).
+
+        This field is beta-level. The job controller populates the field when the feature gate JobPodReplacementPolicy is enabled (enabled by default).
+        """
+        uncounted_terminated_pods: NotRequired[pulumi.Input['UncountedTerminatedPodsArgsDict']]
+        """
+        uncountedTerminatedPods holds the UIDs of Pods that have terminated but the job controller hasn't yet accounted for in the status counters.
+
+        The job controller creates pods with a finalizer. When a pod terminates (succeeded or failed), the controller does three steps to account for it in the job status:
+
+        1. Add the pod UID to the arrays in this field. 2. Remove the pod finalizer. 3. Remove the pod UID from the arrays while increasing the corresponding
+            counter.
+
+        Old jobs might not be tracked using this field, in which case the field remains null. The structure is empty for finished jobs.
+        """
+elif False:
+    JobStatusArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class JobStatusArgs:
     def __init__(__self__, *,
@@ -1375,6 +1817,22 @@ class JobStatusArgs:
         pulumi.set(self, "uncounted_terminated_pods", value)
 
 
+if not MYPY:
+    class JobTemplateSpecPatchArgsDict(TypedDict):
+        """
+        JobTemplateSpec describes the data a Job should have when created from a template
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaPatchArgsDict']]
+        """
+        Standard object's metadata of the jobs created from this template. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['JobSpecPatchArgsDict']]
+        """
+        Specification of the desired behavior of the job. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+elif False:
+    JobTemplateSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class JobTemplateSpecPatchArgs:
     def __init__(__self__, *,
@@ -1415,6 +1873,22 @@ class JobTemplateSpecPatchArgs:
         pulumi.set(self, "spec", value)
 
 
+if not MYPY:
+    class JobTemplateSpecArgsDict(TypedDict):
+        """
+        JobTemplateSpec describes the data a Job should have when created from a template
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata of the jobs created from this template. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['JobSpecArgsDict']]
+        """
+        Specification of the desired behavior of the job. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+elif False:
+    JobTemplateSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class JobTemplateSpecArgs:
     def __init__(__self__, *,
@@ -1454,6 +1928,54 @@ class JobTemplateSpecArgs:
     def spec(self, value: Optional[pulumi.Input['JobSpecArgs']]):
         pulumi.set(self, "spec", value)
 
+
+if not MYPY:
+    class JobArgsDict(TypedDict):
+        """
+        Job represents the configuration of a single job.
+
+        This resource waits until its status is ready before registering success
+        for create/update, and populating output properties from the current state of the resource.
+        The following conditions are used to determine whether the resource creation has
+        succeeded or failed:
+
+        1. The Job's '.status.startTime' is set, which indicates that the Job has started running.
+        2. The Job's '.status.conditions' has a status of type 'Complete', and a 'status' set
+           to 'True'.
+        3. The Job's '.status.conditions' do not have a status of type 'Failed', with a
+        	'status' set to 'True'. If this condition is set, we should fail the Job immediately.
+
+        If the Job has not reached a Ready state after 10 minutes, it will
+        time out and mark the resource update as Failed. You can override the default timeout value
+        by setting the 'customTimeouts' option on the resource.
+
+        By default, if a resource failed to become ready in a previous update, 
+        Pulumi will continue to wait for readiness on the next update. If you would prefer
+        to schedule a replacement for an unready resource on the next update, you can add the
+        "pulumi.com/replaceUnready": "true" annotation to the resource definition.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['JobSpecArgsDict']]
+        """
+        Specification of the desired behavior of a job. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+        status: NotRequired[pulumi.Input['JobStatusArgsDict']]
+        """
+        Current status of a job. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+elif False:
+    JobArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class JobArgs:
@@ -1563,6 +2085,34 @@ class JobArgs:
         pulumi.set(self, "status", value)
 
 
+if not MYPY:
+    class PodFailurePolicyOnExitCodesRequirementPatchArgsDict(TypedDict):
+        """
+        PodFailurePolicyOnExitCodesRequirement describes the requirement for handling a failed pod based on its container exit codes. In particular, it lookups the .state.terminated.exitCode for each app container and init container status, represented by the .status.containerStatuses and .status.initContainerStatuses fields in the Pod status, respectively. Containers completed with success (exit code 0) are excluded from the requirement check.
+        """
+        container_name: NotRequired[pulumi.Input[str]]
+        """
+        Restricts the check for exit codes to the container with the specified name. When null, the rule applies to all containers. When specified, it should match one the container or initContainer names in the pod template.
+        """
+        operator: NotRequired[pulumi.Input[str]]
+        """
+        Represents the relationship between the container exit code(s) and the specified values. Containers completed with success (exit code 0) are excluded from the requirement check. Possible values are:
+
+        - In: the requirement is satisfied if at least one container exit code
+          (might be multiple if there are multiple containers not restricted
+          by the 'containerName' field) is in the set of specified values.
+        - NotIn: the requirement is satisfied if at least one container exit code
+          (might be multiple if there are multiple containers not restricted
+          by the 'containerName' field) is not in the set of specified values.
+        Additional values are considered to be added in the future. Clients should react to an unknown operator by assuming the requirement is not satisfied.
+        """
+        values: NotRequired[pulumi.Input[Sequence[pulumi.Input[int]]]]
+        """
+        Specifies the set of values. Each returned container exit code (might be multiple in case of multiple containers) is checked against this set of values with respect to the operator. The list of values must be ordered and must not contain duplicates. Value '0' cannot be used for the In operator. At least one element is required. At most 255 elements are allowed.
+        """
+elif False:
+    PodFailurePolicyOnExitCodesRequirementPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PodFailurePolicyOnExitCodesRequirementPatchArgs:
     def __init__(__self__, *,
@@ -1635,6 +2185,34 @@ class PodFailurePolicyOnExitCodesRequirementPatchArgs:
         pulumi.set(self, "values", value)
 
 
+if not MYPY:
+    class PodFailurePolicyOnExitCodesRequirementArgsDict(TypedDict):
+        """
+        PodFailurePolicyOnExitCodesRequirement describes the requirement for handling a failed pod based on its container exit codes. In particular, it lookups the .state.terminated.exitCode for each app container and init container status, represented by the .status.containerStatuses and .status.initContainerStatuses fields in the Pod status, respectively. Containers completed with success (exit code 0) are excluded from the requirement check.
+        """
+        operator: pulumi.Input[str]
+        """
+        Represents the relationship between the container exit code(s) and the specified values. Containers completed with success (exit code 0) are excluded from the requirement check. Possible values are:
+
+        - In: the requirement is satisfied if at least one container exit code
+          (might be multiple if there are multiple containers not restricted
+          by the 'containerName' field) is in the set of specified values.
+        - NotIn: the requirement is satisfied if at least one container exit code
+          (might be multiple if there are multiple containers not restricted
+          by the 'containerName' field) is not in the set of specified values.
+        Additional values are considered to be added in the future. Clients should react to an unknown operator by assuming the requirement is not satisfied.
+        """
+        values: pulumi.Input[Sequence[pulumi.Input[int]]]
+        """
+        Specifies the set of values. Each returned container exit code (might be multiple in case of multiple containers) is checked against this set of values with respect to the operator. The list of values must be ordered and must not contain duplicates. Value '0' cannot be used for the In operator. At least one element is required. At most 255 elements are allowed.
+        """
+        container_name: NotRequired[pulumi.Input[str]]
+        """
+        Restricts the check for exit codes to the container with the specified name. When null, the rule applies to all containers. When specified, it should match one the container or initContainer names in the pod template.
+        """
+elif False:
+    PodFailurePolicyOnExitCodesRequirementArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PodFailurePolicyOnExitCodesRequirementArgs:
     def __init__(__self__, *,
@@ -1705,6 +2283,22 @@ class PodFailurePolicyOnExitCodesRequirementArgs:
         pulumi.set(self, "container_name", value)
 
 
+if not MYPY:
+    class PodFailurePolicyOnPodConditionsPatternPatchArgsDict(TypedDict):
+        """
+        PodFailurePolicyOnPodConditionsPattern describes a pattern for matching an actual pod condition type.
+        """
+        status: NotRequired[pulumi.Input[str]]
+        """
+        Specifies the required Pod condition status. To match a pod condition it is required that the specified status equals the pod condition status. Defaults to True.
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        Specifies the required Pod condition type. To match a pod condition it is required that specified type equals the pod condition type.
+        """
+elif False:
+    PodFailurePolicyOnPodConditionsPatternPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PodFailurePolicyOnPodConditionsPatternPatchArgs:
     def __init__(__self__, *,
@@ -1745,6 +2339,22 @@ class PodFailurePolicyOnPodConditionsPatternPatchArgs:
         pulumi.set(self, "type", value)
 
 
+if not MYPY:
+    class PodFailurePolicyOnPodConditionsPatternArgsDict(TypedDict):
+        """
+        PodFailurePolicyOnPodConditionsPattern describes a pattern for matching an actual pod condition type.
+        """
+        status: pulumi.Input[str]
+        """
+        Specifies the required Pod condition status. To match a pod condition it is required that the specified status equals the pod condition status. Defaults to True.
+        """
+        type: pulumi.Input[str]
+        """
+        Specifies the required Pod condition type. To match a pod condition it is required that specified type equals the pod condition type.
+        """
+elif False:
+    PodFailurePolicyOnPodConditionsPatternArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PodFailurePolicyOnPodConditionsPatternArgs:
     def __init__(__self__, *,
@@ -1783,6 +2393,18 @@ class PodFailurePolicyOnPodConditionsPatternArgs:
         pulumi.set(self, "type", value)
 
 
+if not MYPY:
+    class PodFailurePolicyPatchArgsDict(TypedDict):
+        """
+        PodFailurePolicy describes how failed pods influence the backoffLimit.
+        """
+        rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['PodFailurePolicyRulePatchArgsDict']]]]
+        """
+        A list of pod failure policy rules. The rules are evaluated in order. Once a rule matches a Pod failure, the remaining of the rules are ignored. When no rule matches the Pod failure, the default handling applies - the counter of pod failures is incremented and it is checked against the backoffLimit. At most 20 elements are allowed.
+        """
+elif False:
+    PodFailurePolicyPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PodFailurePolicyPatchArgs:
     def __init__(__self__, *,
@@ -1806,6 +2428,38 @@ class PodFailurePolicyPatchArgs:
     def rules(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['PodFailurePolicyRulePatchArgs']]]]):
         pulumi.set(self, "rules", value)
 
+
+if not MYPY:
+    class PodFailurePolicyRulePatchArgsDict(TypedDict):
+        """
+        PodFailurePolicyRule describes how a pod failure is handled when the requirements are met. One of onExitCodes and onPodConditions, but not both, can be used in each rule.
+        """
+        action: NotRequired[pulumi.Input[str]]
+        """
+        Specifies the action taken on a pod failure when the requirements are satisfied. Possible values are:
+
+        - FailJob: indicates that the pod's job is marked as Failed and all
+          running pods are terminated.
+        - FailIndex: indicates that the pod's index is marked as Failed and will
+          not be restarted.
+          This value is beta-level. It can be used when the
+          `JobBackoffLimitPerIndex` feature gate is enabled (enabled by default).
+        - Ignore: indicates that the counter towards the .backoffLimit is not
+          incremented and a replacement pod is created.
+        - Count: indicates that the pod is handled in the default way - the
+          counter towards the .backoffLimit is incremented.
+        Additional values are considered to be added in the future. Clients should react to an unknown action by skipping the rule.
+        """
+        on_exit_codes: NotRequired[pulumi.Input['PodFailurePolicyOnExitCodesRequirementPatchArgsDict']]
+        """
+        Represents the requirement on the container exit codes.
+        """
+        on_pod_conditions: NotRequired[pulumi.Input[Sequence[pulumi.Input['PodFailurePolicyOnPodConditionsPatternPatchArgsDict']]]]
+        """
+        Represents the requirement on the pod conditions. The requirement is represented as a list of pod condition patterns. The requirement is satisfied if at least one pattern matches an actual pod condition. At most 20 elements are allowed.
+        """
+elif False:
+    PodFailurePolicyRulePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class PodFailurePolicyRulePatchArgs:
@@ -1887,6 +2541,38 @@ class PodFailurePolicyRulePatchArgs:
         pulumi.set(self, "on_pod_conditions", value)
 
 
+if not MYPY:
+    class PodFailurePolicyRuleArgsDict(TypedDict):
+        """
+        PodFailurePolicyRule describes how a pod failure is handled when the requirements are met. One of onExitCodes and onPodConditions, but not both, can be used in each rule.
+        """
+        action: pulumi.Input[str]
+        """
+        Specifies the action taken on a pod failure when the requirements are satisfied. Possible values are:
+
+        - FailJob: indicates that the pod's job is marked as Failed and all
+          running pods are terminated.
+        - FailIndex: indicates that the pod's index is marked as Failed and will
+          not be restarted.
+          This value is beta-level. It can be used when the
+          `JobBackoffLimitPerIndex` feature gate is enabled (enabled by default).
+        - Ignore: indicates that the counter towards the .backoffLimit is not
+          incremented and a replacement pod is created.
+        - Count: indicates that the pod is handled in the default way - the
+          counter towards the .backoffLimit is incremented.
+        Additional values are considered to be added in the future. Clients should react to an unknown action by skipping the rule.
+        """
+        on_exit_codes: NotRequired[pulumi.Input['PodFailurePolicyOnExitCodesRequirementArgsDict']]
+        """
+        Represents the requirement on the container exit codes.
+        """
+        on_pod_conditions: NotRequired[pulumi.Input[Sequence[pulumi.Input['PodFailurePolicyOnPodConditionsPatternArgsDict']]]]
+        """
+        Represents the requirement on the pod conditions. The requirement is represented as a list of pod condition patterns. The requirement is satisfied if at least one pattern matches an actual pod condition. At most 20 elements are allowed.
+        """
+elif False:
+    PodFailurePolicyRuleArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PodFailurePolicyRuleArgs:
     def __init__(__self__, *,
@@ -1966,6 +2652,18 @@ class PodFailurePolicyRuleArgs:
         pulumi.set(self, "on_pod_conditions", value)
 
 
+if not MYPY:
+    class PodFailurePolicyArgsDict(TypedDict):
+        """
+        PodFailurePolicy describes how failed pods influence the backoffLimit.
+        """
+        rules: pulumi.Input[Sequence[pulumi.Input['PodFailurePolicyRuleArgsDict']]]
+        """
+        A list of pod failure policy rules. The rules are evaluated in order. Once a rule matches a Pod failure, the remaining of the rules are ignored. When no rule matches the Pod failure, the default handling applies - the counter of pod failures is incremented and it is checked against the backoffLimit. At most 20 elements are allowed.
+        """
+elif False:
+    PodFailurePolicyArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PodFailurePolicyArgs:
     def __init__(__self__, *,
@@ -1988,6 +2686,18 @@ class PodFailurePolicyArgs:
     def rules(self, value: pulumi.Input[Sequence[pulumi.Input['PodFailurePolicyRuleArgs']]]):
         pulumi.set(self, "rules", value)
 
+
+if not MYPY:
+    class SuccessPolicyPatchArgsDict(TypedDict):
+        """
+        SuccessPolicy describes when a Job can be declared as succeeded based on the success of some indexes.
+        """
+        rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['SuccessPolicyRulePatchArgsDict']]]]
+        """
+        rules represents the list of alternative rules for the declaring the Jobs as successful before `.status.succeeded >= .spec.completions`. Once any of the rules are met, the "SucceededCriteriaMet" condition is added, and the lingering pods are removed. The terminal state for such a Job has the "Complete" condition. Additionally, these rules are evaluated in order; Once the Job meets one of the rules, other rules are ignored. At most 20 elements are allowed.
+        """
+elif False:
+    SuccessPolicyPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class SuccessPolicyPatchArgs:
@@ -2012,6 +2722,22 @@ class SuccessPolicyPatchArgs:
     def rules(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['SuccessPolicyRulePatchArgs']]]]):
         pulumi.set(self, "rules", value)
 
+
+if not MYPY:
+    class SuccessPolicyRulePatchArgsDict(TypedDict):
+        """
+        SuccessPolicyRule describes rule for declaring a Job as succeeded. Each rule must have at least one of the "succeededIndexes" or "succeededCount" specified.
+        """
+        succeeded_count: NotRequired[pulumi.Input[int]]
+        """
+        succeededCount specifies the minimal required size of the actual set of the succeeded indexes for the Job. When succeededCount is used along with succeededIndexes, the check is constrained only to the set of indexes specified by succeededIndexes. For example, given that succeededIndexes is "1-4", succeededCount is "3", and completed indexes are "1", "3", and "5", the Job isn't declared as succeeded because only "1" and "3" indexes are considered in that rules. When this field is null, this doesn't default to any value and is never evaluated at any time. When specified it needs to be a positive integer.
+        """
+        succeeded_indexes: NotRequired[pulumi.Input[str]]
+        """
+        succeededIndexes specifies the set of indexes which need to be contained in the actual set of the succeeded indexes for the Job. The list of indexes must be within 0 to ".spec.completions-1" and must not contain duplicates. At least one element is required. The indexes are represented as intervals separated by commas. The intervals can be a decimal integer or a pair of decimal integers separated by a hyphen. The number are listed in represented by the first and last element of the series, separated by a hyphen. For example, if the completed indexes are 1, 3, 4, 5 and 7, they are represented as "1,3-5,7". When this field is null, this field doesn't default to any value and is never evaluated at any time.
+        """
+elif False:
+    SuccessPolicyRulePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class SuccessPolicyRulePatchArgs:
@@ -2053,6 +2779,22 @@ class SuccessPolicyRulePatchArgs:
         pulumi.set(self, "succeeded_indexes", value)
 
 
+if not MYPY:
+    class SuccessPolicyRuleArgsDict(TypedDict):
+        """
+        SuccessPolicyRule describes rule for declaring a Job as succeeded. Each rule must have at least one of the "succeededIndexes" or "succeededCount" specified.
+        """
+        succeeded_count: NotRequired[pulumi.Input[int]]
+        """
+        succeededCount specifies the minimal required size of the actual set of the succeeded indexes for the Job. When succeededCount is used along with succeededIndexes, the check is constrained only to the set of indexes specified by succeededIndexes. For example, given that succeededIndexes is "1-4", succeededCount is "3", and completed indexes are "1", "3", and "5", the Job isn't declared as succeeded because only "1" and "3" indexes are considered in that rules. When this field is null, this doesn't default to any value and is never evaluated at any time. When specified it needs to be a positive integer.
+        """
+        succeeded_indexes: NotRequired[pulumi.Input[str]]
+        """
+        succeededIndexes specifies the set of indexes which need to be contained in the actual set of the succeeded indexes for the Job. The list of indexes must be within 0 to ".spec.completions-1" and must not contain duplicates. At least one element is required. The indexes are represented as intervals separated by commas. The intervals can be a decimal integer or a pair of decimal integers separated by a hyphen. The number are listed in represented by the first and last element of the series, separated by a hyphen. For example, if the completed indexes are 1, 3, 4, 5 and 7, they are represented as "1,3-5,7". When this field is null, this field doesn't default to any value and is never evaluated at any time.
+        """
+elif False:
+    SuccessPolicyRuleArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class SuccessPolicyRuleArgs:
     def __init__(__self__, *,
@@ -2093,6 +2835,18 @@ class SuccessPolicyRuleArgs:
         pulumi.set(self, "succeeded_indexes", value)
 
 
+if not MYPY:
+    class SuccessPolicyArgsDict(TypedDict):
+        """
+        SuccessPolicy describes when a Job can be declared as succeeded based on the success of some indexes.
+        """
+        rules: pulumi.Input[Sequence[pulumi.Input['SuccessPolicyRuleArgsDict']]]
+        """
+        rules represents the list of alternative rules for the declaring the Jobs as successful before `.status.succeeded >= .spec.completions`. Once any of the rules are met, the "SucceededCriteriaMet" condition is added, and the lingering pods are removed. The terminal state for such a Job has the "Complete" condition. Additionally, these rules are evaluated in order; Once the Job meets one of the rules, other rules are ignored. At most 20 elements are allowed.
+        """
+elif False:
+    SuccessPolicyArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class SuccessPolicyArgs:
     def __init__(__self__, *,
@@ -2115,6 +2869,22 @@ class SuccessPolicyArgs:
     def rules(self, value: pulumi.Input[Sequence[pulumi.Input['SuccessPolicyRuleArgs']]]):
         pulumi.set(self, "rules", value)
 
+
+if not MYPY:
+    class UncountedTerminatedPodsArgsDict(TypedDict):
+        """
+        UncountedTerminatedPods holds UIDs of Pods that have terminated but haven't been accounted in Job status counters.
+        """
+        failed: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        failed holds UIDs of failed Pods.
+        """
+        succeeded: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        succeeded holds UIDs of succeeded Pods.
+        """
+elif False:
+    UncountedTerminatedPodsArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class UncountedTerminatedPodsArgs:

--- a/sdk/python/pulumi_kubernetes/batch/v1/outputs.py
+++ b/sdk/python/pulumi_kubernetes/batch/v1/outputs.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core

--- a/sdk/python/pulumi_kubernetes/batch/v1beta1/CronJob.py
+++ b/sdk/python/pulumi_kubernetes/batch/v1beta1/CronJob.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import batch as _batch
@@ -95,8 +100,8 @@ class CronJob(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['CronJobSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['CronJobSpecArgs', 'CronJobSpecArgsDict']]] = None,
                  __props__=None):
         """
         CronJob represents the configuration of a single cron job.
@@ -105,8 +110,8 @@ class CronJob(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['CronJobSpecArgs']] spec: Specification of the desired behavior of a cron job, including the schedule. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['CronJobSpecArgs', 'CronJobSpecArgsDict']] spec: Specification of the desired behavior of a cron job, including the schedule. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -134,8 +139,8 @@ class CronJob(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['CronJobSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['CronJobSpecArgs', 'CronJobSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/batch/v1beta1/CronJobList.py
+++ b/sdk/python/pulumi_kubernetes/batch/v1beta1/CronJobList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import batch as _batch
@@ -93,9 +98,9 @@ class CronJobList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['CronJobArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['CronJobArgs', 'CronJobArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         CronJobList is a collection of cron jobs.
@@ -103,9 +108,9 @@ class CronJobList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['CronJobArgs']]]] items: items is the list of CronJobs.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['CronJobArgs', 'CronJobArgsDict']]]] items: items is the list of CronJobs.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -132,9 +137,9 @@ class CronJobList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['CronJobArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['CronJobArgs', 'CronJobArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/batch/v1beta1/CronJobPatch.py
+++ b/sdk/python/pulumi_kubernetes/batch/v1beta1/CronJobPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import batch as _batch
@@ -95,8 +100,8 @@ class CronJobPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['CronJobSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['CronJobSpecPatchArgs', 'CronJobSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -111,8 +116,8 @@ class CronJobPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['CronJobSpecPatchArgs']] spec: Specification of the desired behavior of a cron job, including the schedule. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['CronJobSpecPatchArgs', 'CronJobSpecPatchArgsDict']] spec: Specification of the desired behavior of a cron job, including the schedule. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -146,8 +151,8 @@ class CronJobPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['CronJobSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['CronJobSpecPatchArgs', 'CronJobSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/batch/v1beta1/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/batch/v1beta1/_inputs.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import batch as _batch
 from ... import core as _core
@@ -14,12 +19,56 @@ from ... import meta as _meta
 
 __all__ = [
     'CronJobSpecPatchArgs',
+    'CronJobSpecPatchArgsDict',
     'CronJobSpecArgs',
+    'CronJobSpecArgsDict',
     'CronJobStatusArgs',
+    'CronJobStatusArgsDict',
     'CronJobArgs',
+    'CronJobArgsDict',
     'JobTemplateSpecPatchArgs',
+    'JobTemplateSpecPatchArgsDict',
     'JobTemplateSpecArgs',
+    'JobTemplateSpecArgsDict',
 ]
+
+MYPY = False
+
+if not MYPY:
+    class CronJobSpecPatchArgsDict(TypedDict):
+        """
+        CronJobSpec describes how the job execution will look like and when it will actually run.
+        """
+        concurrency_policy: NotRequired[pulumi.Input[str]]
+        """
+        Specifies how to treat concurrent executions of a Job. Valid values are: - "Allow" (default): allows CronJobs to run concurrently; - "Forbid": forbids concurrent runs, skipping next run if previous run hasn't finished yet; - "Replace": cancels currently running job and replaces it with a new one
+        """
+        failed_jobs_history_limit: NotRequired[pulumi.Input[int]]
+        """
+        The number of failed finished jobs to retain. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1.
+        """
+        job_template: NotRequired[pulumi.Input['JobTemplateSpecPatchArgsDict']]
+        """
+        Specifies the job that will be created when executing a CronJob.
+        """
+        schedule: NotRequired[pulumi.Input[str]]
+        """
+        The schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
+        """
+        starting_deadline_seconds: NotRequired[pulumi.Input[int]]
+        """
+        Optional deadline in seconds for starting the job if it misses scheduled time for any reason.  Missed jobs executions will be counted as failed ones.
+        """
+        successful_jobs_history_limit: NotRequired[pulumi.Input[int]]
+        """
+        The number of successful finished jobs to retain. This is a pointer to distinguish between explicit zero and not specified. Defaults to 3.
+        """
+        suspend: NotRequired[pulumi.Input[bool]]
+        """
+        This flag tells the controller to suspend subsequent executions, it does not apply to already started executions.  Defaults to false.
+        """
+elif False:
+    CronJobSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class CronJobSpecPatchArgs:
@@ -141,6 +190,42 @@ class CronJobSpecPatchArgs:
         pulumi.set(self, "suspend", value)
 
 
+if not MYPY:
+    class CronJobSpecArgsDict(TypedDict):
+        """
+        CronJobSpec describes how the job execution will look like and when it will actually run.
+        """
+        job_template: pulumi.Input['JobTemplateSpecArgsDict']
+        """
+        Specifies the job that will be created when executing a CronJob.
+        """
+        schedule: pulumi.Input[str]
+        """
+        The schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
+        """
+        concurrency_policy: NotRequired[pulumi.Input[str]]
+        """
+        Specifies how to treat concurrent executions of a Job. Valid values are: - "Allow" (default): allows CronJobs to run concurrently; - "Forbid": forbids concurrent runs, skipping next run if previous run hasn't finished yet; - "Replace": cancels currently running job and replaces it with a new one
+        """
+        failed_jobs_history_limit: NotRequired[pulumi.Input[int]]
+        """
+        The number of failed finished jobs to retain. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1.
+        """
+        starting_deadline_seconds: NotRequired[pulumi.Input[int]]
+        """
+        Optional deadline in seconds for starting the job if it misses scheduled time for any reason.  Missed jobs executions will be counted as failed ones.
+        """
+        successful_jobs_history_limit: NotRequired[pulumi.Input[int]]
+        """
+        The number of successful finished jobs to retain. This is a pointer to distinguish between explicit zero and not specified. Defaults to 3.
+        """
+        suspend: NotRequired[pulumi.Input[bool]]
+        """
+        This flag tells the controller to suspend subsequent executions, it does not apply to already started executions.  Defaults to false.
+        """
+elif False:
+    CronJobSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CronJobSpecArgs:
     def __init__(__self__, *,
@@ -259,6 +344,22 @@ class CronJobSpecArgs:
         pulumi.set(self, "suspend", value)
 
 
+if not MYPY:
+    class CronJobStatusArgsDict(TypedDict):
+        """
+        CronJobStatus represents the current state of a cron job.
+        """
+        active: NotRequired[pulumi.Input[Sequence[pulumi.Input['_core.v1.ObjectReferenceArgsDict']]]]
+        """
+        A list of pointers to currently running jobs.
+        """
+        last_schedule_time: NotRequired[pulumi.Input[str]]
+        """
+        Information when was the last time the job was successfully scheduled.
+        """
+elif False:
+    CronJobStatusArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CronJobStatusArgs:
     def __init__(__self__, *,
@@ -298,6 +399,34 @@ class CronJobStatusArgs:
     def last_schedule_time(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "last_schedule_time", value)
 
+
+if not MYPY:
+    class CronJobArgsDict(TypedDict):
+        """
+        CronJob represents the configuration of a single cron job.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['CronJobSpecArgsDict']]
+        """
+        Specification of the desired behavior of a cron job, including the schedule. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+        status: NotRequired[pulumi.Input['CronJobStatusArgsDict']]
+        """
+        Current status of a cron job. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+elif False:
+    CronJobArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class CronJobArgs:
@@ -387,6 +516,22 @@ class CronJobArgs:
         pulumi.set(self, "status", value)
 
 
+if not MYPY:
+    class JobTemplateSpecPatchArgsDict(TypedDict):
+        """
+        JobTemplateSpec describes the data a Job should have when created from a template
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaPatchArgsDict']]
+        """
+        Standard object's metadata of the jobs created from this template. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['_batch.v1.JobSpecPatchArgsDict']]
+        """
+        Specification of the desired behavior of the job. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+elif False:
+    JobTemplateSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class JobTemplateSpecPatchArgs:
     def __init__(__self__, *,
@@ -426,6 +571,22 @@ class JobTemplateSpecPatchArgs:
     def spec(self, value: Optional[pulumi.Input['_batch.v1.JobSpecPatchArgs']]):
         pulumi.set(self, "spec", value)
 
+
+if not MYPY:
+    class JobTemplateSpecArgsDict(TypedDict):
+        """
+        JobTemplateSpec describes the data a Job should have when created from a template
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata of the jobs created from this template. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['_batch.v1.JobSpecArgsDict']]
+        """
+        Specification of the desired behavior of the job. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+elif False:
+    JobTemplateSpecArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class JobTemplateSpecArgs:

--- a/sdk/python/pulumi_kubernetes/batch/v1beta1/outputs.py
+++ b/sdk/python/pulumi_kubernetes/batch/v1beta1/outputs.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import batch as _batch

--- a/sdk/python/pulumi_kubernetes/batch/v2alpha1/CronJob.py
+++ b/sdk/python/pulumi_kubernetes/batch/v2alpha1/CronJob.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import batch as _batch
@@ -95,8 +100,8 @@ class CronJob(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['CronJobSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['CronJobSpecArgs', 'CronJobSpecArgsDict']]] = None,
                  __props__=None):
         """
         CronJob represents the configuration of a single cron job.
@@ -105,8 +110,8 @@ class CronJob(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['CronJobSpecArgs']] spec: Specification of the desired behavior of a cron job, including the schedule. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['CronJobSpecArgs', 'CronJobSpecArgsDict']] spec: Specification of the desired behavior of a cron job, including the schedule. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -134,8 +139,8 @@ class CronJob(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['CronJobSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['CronJobSpecArgs', 'CronJobSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/batch/v2alpha1/CronJobList.py
+++ b/sdk/python/pulumi_kubernetes/batch/v2alpha1/CronJobList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import batch as _batch
@@ -93,9 +98,9 @@ class CronJobList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['CronJobArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['CronJobArgs', 'CronJobArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         CronJobList is a collection of cron jobs.
@@ -103,9 +108,9 @@ class CronJobList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['CronJobArgs']]]] items: items is the list of CronJobs.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['CronJobArgs', 'CronJobArgsDict']]]] items: items is the list of CronJobs.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -132,9 +137,9 @@ class CronJobList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['CronJobArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['CronJobArgs', 'CronJobArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/batch/v2alpha1/CronJobPatch.py
+++ b/sdk/python/pulumi_kubernetes/batch/v2alpha1/CronJobPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import batch as _batch
@@ -95,8 +100,8 @@ class CronJobPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['CronJobSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['CronJobSpecPatchArgs', 'CronJobSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -111,8 +116,8 @@ class CronJobPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['CronJobSpecPatchArgs']] spec: Specification of the desired behavior of a cron job, including the schedule. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['CronJobSpecPatchArgs', 'CronJobSpecPatchArgsDict']] spec: Specification of the desired behavior of a cron job, including the schedule. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -146,8 +151,8 @@ class CronJobPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['CronJobSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['CronJobSpecPatchArgs', 'CronJobSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/batch/v2alpha1/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/batch/v2alpha1/_inputs.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import batch as _batch
 from ... import core as _core
@@ -14,12 +19,56 @@ from ... import meta as _meta
 
 __all__ = [
     'CronJobSpecPatchArgs',
+    'CronJobSpecPatchArgsDict',
     'CronJobSpecArgs',
+    'CronJobSpecArgsDict',
     'CronJobStatusArgs',
+    'CronJobStatusArgsDict',
     'CronJobArgs',
+    'CronJobArgsDict',
     'JobTemplateSpecPatchArgs',
+    'JobTemplateSpecPatchArgsDict',
     'JobTemplateSpecArgs',
+    'JobTemplateSpecArgsDict',
 ]
+
+MYPY = False
+
+if not MYPY:
+    class CronJobSpecPatchArgsDict(TypedDict):
+        """
+        CronJobSpec describes how the job execution will look like and when it will actually run.
+        """
+        concurrency_policy: NotRequired[pulumi.Input[str]]
+        """
+        Specifies how to treat concurrent executions of a Job. Valid values are: - "Allow" (default): allows CronJobs to run concurrently; - "Forbid": forbids concurrent runs, skipping next run if previous run hasn't finished yet; - "Replace": cancels currently running job and replaces it with a new one
+        """
+        failed_jobs_history_limit: NotRequired[pulumi.Input[int]]
+        """
+        The number of failed finished jobs to retain. This is a pointer to distinguish between explicit zero and not specified.
+        """
+        job_template: NotRequired[pulumi.Input['JobTemplateSpecPatchArgsDict']]
+        """
+        Specifies the job that will be created when executing a CronJob.
+        """
+        schedule: NotRequired[pulumi.Input[str]]
+        """
+        The schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
+        """
+        starting_deadline_seconds: NotRequired[pulumi.Input[int]]
+        """
+        Optional deadline in seconds for starting the job if it misses scheduled time for any reason.  Missed jobs executions will be counted as failed ones.
+        """
+        successful_jobs_history_limit: NotRequired[pulumi.Input[int]]
+        """
+        The number of successful finished jobs to retain. This is a pointer to distinguish between explicit zero and not specified.
+        """
+        suspend: NotRequired[pulumi.Input[bool]]
+        """
+        This flag tells the controller to suspend subsequent executions, it does not apply to already started executions.  Defaults to false.
+        """
+elif False:
+    CronJobSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class CronJobSpecPatchArgs:
@@ -141,6 +190,42 @@ class CronJobSpecPatchArgs:
         pulumi.set(self, "suspend", value)
 
 
+if not MYPY:
+    class CronJobSpecArgsDict(TypedDict):
+        """
+        CronJobSpec describes how the job execution will look like and when it will actually run.
+        """
+        job_template: pulumi.Input['JobTemplateSpecArgsDict']
+        """
+        Specifies the job that will be created when executing a CronJob.
+        """
+        schedule: pulumi.Input[str]
+        """
+        The schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
+        """
+        concurrency_policy: NotRequired[pulumi.Input[str]]
+        """
+        Specifies how to treat concurrent executions of a Job. Valid values are: - "Allow" (default): allows CronJobs to run concurrently; - "Forbid": forbids concurrent runs, skipping next run if previous run hasn't finished yet; - "Replace": cancels currently running job and replaces it with a new one
+        """
+        failed_jobs_history_limit: NotRequired[pulumi.Input[int]]
+        """
+        The number of failed finished jobs to retain. This is a pointer to distinguish between explicit zero and not specified.
+        """
+        starting_deadline_seconds: NotRequired[pulumi.Input[int]]
+        """
+        Optional deadline in seconds for starting the job if it misses scheduled time for any reason.  Missed jobs executions will be counted as failed ones.
+        """
+        successful_jobs_history_limit: NotRequired[pulumi.Input[int]]
+        """
+        The number of successful finished jobs to retain. This is a pointer to distinguish between explicit zero and not specified.
+        """
+        suspend: NotRequired[pulumi.Input[bool]]
+        """
+        This flag tells the controller to suspend subsequent executions, it does not apply to already started executions.  Defaults to false.
+        """
+elif False:
+    CronJobSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CronJobSpecArgs:
     def __init__(__self__, *,
@@ -259,6 +344,22 @@ class CronJobSpecArgs:
         pulumi.set(self, "suspend", value)
 
 
+if not MYPY:
+    class CronJobStatusArgsDict(TypedDict):
+        """
+        CronJobStatus represents the current state of a cron job.
+        """
+        active: NotRequired[pulumi.Input[Sequence[pulumi.Input['_core.v1.ObjectReferenceArgsDict']]]]
+        """
+        A list of pointers to currently running jobs.
+        """
+        last_schedule_time: NotRequired[pulumi.Input[str]]
+        """
+        Information when was the last time the job was successfully scheduled.
+        """
+elif False:
+    CronJobStatusArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CronJobStatusArgs:
     def __init__(__self__, *,
@@ -298,6 +399,34 @@ class CronJobStatusArgs:
     def last_schedule_time(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "last_schedule_time", value)
 
+
+if not MYPY:
+    class CronJobArgsDict(TypedDict):
+        """
+        CronJob represents the configuration of a single cron job.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['CronJobSpecArgsDict']]
+        """
+        Specification of the desired behavior of a cron job, including the schedule. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+        status: NotRequired[pulumi.Input['CronJobStatusArgsDict']]
+        """
+        Current status of a cron job. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+elif False:
+    CronJobArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class CronJobArgs:
@@ -387,6 +516,22 @@ class CronJobArgs:
         pulumi.set(self, "status", value)
 
 
+if not MYPY:
+    class JobTemplateSpecPatchArgsDict(TypedDict):
+        """
+        JobTemplateSpec describes the data a Job should have when created from a template
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaPatchArgsDict']]
+        """
+        Standard object's metadata of the jobs created from this template. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['_batch.v1.JobSpecPatchArgsDict']]
+        """
+        Specification of the desired behavior of the job. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+elif False:
+    JobTemplateSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class JobTemplateSpecPatchArgs:
     def __init__(__self__, *,
@@ -426,6 +571,22 @@ class JobTemplateSpecPatchArgs:
     def spec(self, value: Optional[pulumi.Input['_batch.v1.JobSpecPatchArgs']]):
         pulumi.set(self, "spec", value)
 
+
+if not MYPY:
+    class JobTemplateSpecArgsDict(TypedDict):
+        """
+        JobTemplateSpec describes the data a Job should have when created from a template
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata of the jobs created from this template. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['_batch.v1.JobSpecArgsDict']]
+        """
+        Specification of the desired behavior of the job. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+elif False:
+    JobTemplateSpecArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class JobTemplateSpecArgs:

--- a/sdk/python/pulumi_kubernetes/batch/v2alpha1/outputs.py
+++ b/sdk/python/pulumi_kubernetes/batch/v2alpha1/outputs.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import batch as _batch

--- a/sdk/python/pulumi_kubernetes/certificates/v1/CertificateSigningRequest.py
+++ b/sdk/python/pulumi_kubernetes/certificates/v1/CertificateSigningRequest.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -88,8 +93,8 @@ class CertificateSigningRequest(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['CertificateSigningRequestSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['CertificateSigningRequestSpecArgs', 'CertificateSigningRequestSpecArgsDict']]] = None,
                  __props__=None):
         """
         CertificateSigningRequest objects provide a mechanism to obtain x509 certificates by submitting a certificate signing request, and having it asynchronously approved and issued.
@@ -104,7 +109,7 @@ class CertificateSigningRequest(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['CertificateSigningRequestSpecArgs']] spec: spec contains the certificate request, and is immutable after creation. Only the request, signerName, expirationSeconds, and usages fields can be set on creation. Other fields are derived by Kubernetes and cannot be modified by users.
+        :param pulumi.Input[Union['CertificateSigningRequestSpecArgs', 'CertificateSigningRequestSpecArgsDict']] spec: spec contains the certificate request, and is immutable after creation. Only the request, signerName, expirationSeconds, and usages fields can be set on creation. Other fields are derived by Kubernetes and cannot be modified by users.
         """
         ...
     @overload
@@ -138,8 +143,8 @@ class CertificateSigningRequest(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['CertificateSigningRequestSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['CertificateSigningRequestSpecArgs', 'CertificateSigningRequestSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/certificates/v1/CertificateSigningRequestList.py
+++ b/sdk/python/pulumi_kubernetes/certificates/v1/CertificateSigningRequestList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -87,9 +92,9 @@ class CertificateSigningRequestList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['CertificateSigningRequestArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['CertificateSigningRequestArgs', 'CertificateSigningRequestArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         CertificateSigningRequestList is a collection of CertificateSigningRequest objects
@@ -97,7 +102,7 @@ class CertificateSigningRequestList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['CertificateSigningRequestArgs']]]] items: items is a collection of CertificateSigningRequest objects
+        :param pulumi.Input[Sequence[pulumi.Input[Union['CertificateSigningRequestArgs', 'CertificateSigningRequestArgsDict']]]] items: items is a collection of CertificateSigningRequest objects
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
         """
         ...
@@ -125,9 +130,9 @@ class CertificateSigningRequestList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['CertificateSigningRequestArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['CertificateSigningRequestArgs', 'CertificateSigningRequestArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/certificates/v1/CertificateSigningRequestPatch.py
+++ b/sdk/python/pulumi_kubernetes/certificates/v1/CertificateSigningRequestPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -89,8 +94,8 @@ class CertificateSigningRequestPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['CertificateSigningRequestSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['CertificateSigningRequestSpecPatchArgs', 'CertificateSigningRequestSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -111,7 +116,7 @@ class CertificateSigningRequestPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['CertificateSigningRequestSpecPatchArgs']] spec: spec contains the certificate request, and is immutable after creation. Only the request, signerName, expirationSeconds, and usages fields can be set on creation. Other fields are derived by Kubernetes and cannot be modified by users.
+        :param pulumi.Input[Union['CertificateSigningRequestSpecPatchArgs', 'CertificateSigningRequestSpecPatchArgsDict']] spec: spec contains the certificate request, and is immutable after creation. Only the request, signerName, expirationSeconds, and usages fields can be set on creation. Other fields are derived by Kubernetes and cannot be modified by users.
         """
         ...
     @overload
@@ -151,8 +156,8 @@ class CertificateSigningRequestPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['CertificateSigningRequestSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['CertificateSigningRequestSpecPatchArgs', 'CertificateSigningRequestSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/certificates/v1/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/certificates/v1/_inputs.py
@@ -4,19 +4,73 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import meta as _meta
 
 __all__ = [
     'CertificateSigningRequestConditionArgs',
+    'CertificateSigningRequestConditionArgsDict',
     'CertificateSigningRequestSpecPatchArgs',
+    'CertificateSigningRequestSpecPatchArgsDict',
     'CertificateSigningRequestSpecArgs',
+    'CertificateSigningRequestSpecArgsDict',
     'CertificateSigningRequestStatusArgs',
+    'CertificateSigningRequestStatusArgsDict',
     'CertificateSigningRequestArgs',
+    'CertificateSigningRequestArgsDict',
 ]
+
+MYPY = False
+
+if not MYPY:
+    class CertificateSigningRequestConditionArgsDict(TypedDict):
+        """
+        CertificateSigningRequestCondition describes a condition of a CertificateSigningRequest object
+        """
+        status: pulumi.Input[str]
+        """
+        status of the condition, one of True, False, Unknown. Approved, Denied, and Failed conditions may not be "False" or "Unknown".
+        """
+        type: pulumi.Input[str]
+        """
+        type of the condition. Known conditions are "Approved", "Denied", and "Failed".
+
+        An "Approved" condition is added via the /approval subresource, indicating the request was approved and should be issued by the signer.
+
+        A "Denied" condition is added via the /approval subresource, indicating the request was denied and should not be issued by the signer.
+
+        A "Failed" condition is added via the /status subresource, indicating the signer failed to issue the certificate.
+
+        Approved and Denied conditions are mutually exclusive. Approved, Denied, and Failed conditions cannot be removed once added.
+
+        Only one condition of a given type is allowed.
+        """
+        last_transition_time: NotRequired[pulumi.Input[str]]
+        """
+        lastTransitionTime is the time the condition last transitioned from one status to another. If unset, when a new condition type is added or an existing condition's status is changed, the server defaults this to the current time.
+        """
+        last_update_time: NotRequired[pulumi.Input[str]]
+        """
+        lastUpdateTime is the time of the last update to this condition
+        """
+        message: NotRequired[pulumi.Input[str]]
+        """
+        message contains a human readable message with details about the request state
+        """
+        reason: NotRequired[pulumi.Input[str]]
+        """
+        reason indicates a brief reason for the request state
+        """
+elif False:
+    CertificateSigningRequestConditionArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class CertificateSigningRequestConditionArgs:
@@ -139,6 +193,90 @@ class CertificateSigningRequestConditionArgs:
     def reason(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "reason", value)
 
+
+if not MYPY:
+    class CertificateSigningRequestSpecPatchArgsDict(TypedDict):
+        """
+        CertificateSigningRequestSpec contains the certificate request.
+        """
+        expiration_seconds: NotRequired[pulumi.Input[int]]
+        """
+        expirationSeconds is the requested duration of validity of the issued certificate. The certificate signer may issue a certificate with a different validity duration so a client must check the delta between the notBefore and and notAfter fields in the issued certificate to determine the actual duration.
+
+        The v1.22+ in-tree implementations of the well-known Kubernetes signers will honor this field as long as the requested duration is not greater than the maximum duration they will honor per the --cluster-signing-duration CLI flag to the Kubernetes controller manager.
+
+        Certificate signers may not honor this field for various reasons:
+
+          1. Old signer that is unaware of the field (such as the in-tree
+             implementations prior to v1.22)
+          2. Signer whose configured maximum is shorter than the requested duration
+          3. Signer whose configured minimum is longer than the requested duration
+
+        The minimum valid value for expirationSeconds is 600, i.e. 10 minutes.
+        """
+        extra: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[Sequence[pulumi.Input[str]]]]]]
+        """
+        extra contains extra attributes of the user that created the CertificateSigningRequest. Populated by the API server on creation and immutable.
+        """
+        groups: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        groups contains group membership of the user that created the CertificateSigningRequest. Populated by the API server on creation and immutable.
+        """
+        request: NotRequired[pulumi.Input[str]]
+        """
+        request contains an x509 certificate signing request encoded in a "CERTIFICATE REQUEST" PEM block. When serialized as JSON or YAML, the data is additionally base64-encoded.
+        """
+        signer_name: NotRequired[pulumi.Input[str]]
+        """
+        signerName indicates the requested signer, and is a qualified name.
+
+        List/watch requests for CertificateSigningRequests can filter on this field using a "spec.signerName=NAME" fieldSelector.
+
+        Well-known Kubernetes signers are:
+         1. "kubernetes.io/kube-apiserver-client": issues client certificates that can be used to authenticate to kube-apiserver.
+          Requests for this signer are never auto-approved by kube-controller-manager, can be issued by the "csrsigning" controller in kube-controller-manager.
+         2. "kubernetes.io/kube-apiserver-client-kubelet": issues client certificates that kubelets use to authenticate to kube-apiserver.
+          Requests for this signer can be auto-approved by the "csrapproving" controller in kube-controller-manager, and can be issued by the "csrsigning" controller in kube-controller-manager.
+         3. "kubernetes.io/kubelet-serving" issues serving certificates that kubelets use to serve TLS endpoints, which kube-apiserver can connect to securely.
+          Requests for this signer are never auto-approved by kube-controller-manager, and can be issued by the "csrsigning" controller in kube-controller-manager.
+
+        More details are available at https://k8s.io/docs/reference/access-authn-authz/certificate-signing-requests/#kubernetes-signers
+
+        Custom signerNames can also be specified. The signer defines:
+         1. Trust distribution: how trust (CA bundles) are distributed.
+         2. Permitted subjects: and behavior when a disallowed subject is requested.
+         3. Required, permitted, or forbidden x509 extensions in the request (including whether subjectAltNames are allowed, which types, restrictions on allowed values) and behavior when a disallowed extension is requested.
+         4. Required, permitted, or forbidden key usages / extended key usages.
+         5. Expiration/certificate lifetime: whether it is fixed by the signer, configurable by the admin.
+         6. Whether or not requests for CA certificates are allowed.
+        """
+        uid: NotRequired[pulumi.Input[str]]
+        """
+        uid contains the uid of the user that created the CertificateSigningRequest. Populated by the API server on creation and immutable.
+        """
+        usages: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        usages specifies a set of key usages requested in the issued certificate.
+
+        Requests for TLS client certificates typically request: "digital signature", "key encipherment", "client auth".
+
+        Requests for TLS serving certificates typically request: "key encipherment", "digital signature", "server auth".
+
+        Valid values are:
+         "signing", "digital signature", "content commitment",
+         "key encipherment", "key agreement", "data encipherment",
+         "cert sign", "crl sign", "encipher only", "decipher only", "any",
+         "server auth", "client auth",
+         "code signing", "email protection", "s/mime",
+         "ipsec end system", "ipsec tunnel", "ipsec user",
+         "timestamping", "ocsp signing", "microsoft sgc", "netscape sgc"
+        """
+        username: NotRequired[pulumi.Input[str]]
+        """
+        username contains the name of the user that created the CertificateSigningRequest. Populated by the API server on creation and immutable.
+        """
+elif False:
+    CertificateSigningRequestSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class CertificateSigningRequestSpecPatchArgs:
@@ -364,6 +502,90 @@ class CertificateSigningRequestSpecPatchArgs:
         pulumi.set(self, "username", value)
 
 
+if not MYPY:
+    class CertificateSigningRequestSpecArgsDict(TypedDict):
+        """
+        CertificateSigningRequestSpec contains the certificate request.
+        """
+        request: pulumi.Input[str]
+        """
+        request contains an x509 certificate signing request encoded in a "CERTIFICATE REQUEST" PEM block. When serialized as JSON or YAML, the data is additionally base64-encoded.
+        """
+        signer_name: pulumi.Input[str]
+        """
+        signerName indicates the requested signer, and is a qualified name.
+
+        List/watch requests for CertificateSigningRequests can filter on this field using a "spec.signerName=NAME" fieldSelector.
+
+        Well-known Kubernetes signers are:
+         1. "kubernetes.io/kube-apiserver-client": issues client certificates that can be used to authenticate to kube-apiserver.
+          Requests for this signer are never auto-approved by kube-controller-manager, can be issued by the "csrsigning" controller in kube-controller-manager.
+         2. "kubernetes.io/kube-apiserver-client-kubelet": issues client certificates that kubelets use to authenticate to kube-apiserver.
+          Requests for this signer can be auto-approved by the "csrapproving" controller in kube-controller-manager, and can be issued by the "csrsigning" controller in kube-controller-manager.
+         3. "kubernetes.io/kubelet-serving" issues serving certificates that kubelets use to serve TLS endpoints, which kube-apiserver can connect to securely.
+          Requests for this signer are never auto-approved by kube-controller-manager, and can be issued by the "csrsigning" controller in kube-controller-manager.
+
+        More details are available at https://k8s.io/docs/reference/access-authn-authz/certificate-signing-requests/#kubernetes-signers
+
+        Custom signerNames can also be specified. The signer defines:
+         1. Trust distribution: how trust (CA bundles) are distributed.
+         2. Permitted subjects: and behavior when a disallowed subject is requested.
+         3. Required, permitted, or forbidden x509 extensions in the request (including whether subjectAltNames are allowed, which types, restrictions on allowed values) and behavior when a disallowed extension is requested.
+         4. Required, permitted, or forbidden key usages / extended key usages.
+         5. Expiration/certificate lifetime: whether it is fixed by the signer, configurable by the admin.
+         6. Whether or not requests for CA certificates are allowed.
+        """
+        expiration_seconds: NotRequired[pulumi.Input[int]]
+        """
+        expirationSeconds is the requested duration of validity of the issued certificate. The certificate signer may issue a certificate with a different validity duration so a client must check the delta between the notBefore and and notAfter fields in the issued certificate to determine the actual duration.
+
+        The v1.22+ in-tree implementations of the well-known Kubernetes signers will honor this field as long as the requested duration is not greater than the maximum duration they will honor per the --cluster-signing-duration CLI flag to the Kubernetes controller manager.
+
+        Certificate signers may not honor this field for various reasons:
+
+          1. Old signer that is unaware of the field (such as the in-tree
+             implementations prior to v1.22)
+          2. Signer whose configured maximum is shorter than the requested duration
+          3. Signer whose configured minimum is longer than the requested duration
+
+        The minimum valid value for expirationSeconds is 600, i.e. 10 minutes.
+        """
+        extra: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[Sequence[pulumi.Input[str]]]]]]
+        """
+        extra contains extra attributes of the user that created the CertificateSigningRequest. Populated by the API server on creation and immutable.
+        """
+        groups: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        groups contains group membership of the user that created the CertificateSigningRequest. Populated by the API server on creation and immutable.
+        """
+        uid: NotRequired[pulumi.Input[str]]
+        """
+        uid contains the uid of the user that created the CertificateSigningRequest. Populated by the API server on creation and immutable.
+        """
+        usages: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        usages specifies a set of key usages requested in the issued certificate.
+
+        Requests for TLS client certificates typically request: "digital signature", "key encipherment", "client auth".
+
+        Requests for TLS serving certificates typically request: "key encipherment", "digital signature", "server auth".
+
+        Valid values are:
+         "signing", "digital signature", "content commitment",
+         "key encipherment", "key agreement", "data encipherment",
+         "cert sign", "crl sign", "encipher only", "decipher only", "any",
+         "server auth", "client auth",
+         "code signing", "email protection", "s/mime",
+         "ipsec end system", "ipsec tunnel", "ipsec user",
+         "timestamping", "ocsp signing", "microsoft sgc", "netscape sgc"
+        """
+        username: NotRequired[pulumi.Input[str]]
+        """
+        username contains the name of the user that created the CertificateSigningRequest. Populated by the API server on creation and immutable.
+        """
+elif False:
+    CertificateSigningRequestSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CertificateSigningRequestSpecArgs:
     def __init__(__self__, *,
@@ -586,6 +808,43 @@ class CertificateSigningRequestSpecArgs:
         pulumi.set(self, "username", value)
 
 
+if not MYPY:
+    class CertificateSigningRequestStatusArgsDict(TypedDict):
+        """
+        CertificateSigningRequestStatus contains conditions used to indicate approved/denied/failed status of the request, and the issued certificate.
+        """
+        certificate: NotRequired[pulumi.Input[str]]
+        """
+        certificate is populated with an issued certificate by the signer after an Approved condition is present. This field is set via the /status subresource. Once populated, this field is immutable.
+
+        If the certificate signing request is denied, a condition of type "Denied" is added and this field remains empty. If the signer cannot issue the certificate, a condition of type "Failed" is added and this field remains empty.
+
+        Validation requirements:
+         1. certificate must contain one or more PEM blocks.
+         2. All PEM blocks must have the "CERTIFICATE" label, contain no headers, and the encoded data
+          must be a BER-encoded ASN.1 Certificate structure as described in section 4 of RFC5280.
+         3. Non-PEM content may appear before or after the "CERTIFICATE" PEM blocks and is unvalidated,
+          to allow for explanatory text as described in section 5.2 of RFC7468.
+
+        If more than one PEM block is present, and the definition of the requested spec.signerName does not indicate otherwise, the first block is the issued certificate, and subsequent blocks should be treated as intermediate certificates and presented in TLS handshakes.
+
+        The certificate is encoded in PEM format.
+
+        When serialized as JSON or YAML, the data is additionally base64-encoded, so it consists of:
+
+            base64(
+            -----BEGIN CERTIFICATE-----
+            ...
+            -----END CERTIFICATE-----
+            )
+        """
+        conditions: NotRequired[pulumi.Input[Sequence[pulumi.Input['CertificateSigningRequestConditionArgsDict']]]]
+        """
+        conditions applied to the request. Known conditions are "Approved", "Denied", and "Failed".
+        """
+elif False:
+    CertificateSigningRequestStatusArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CertificateSigningRequestStatusArgs:
     def __init__(__self__, *,
@@ -667,6 +926,37 @@ class CertificateSigningRequestStatusArgs:
     def conditions(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['CertificateSigningRequestConditionArgs']]]]):
         pulumi.set(self, "conditions", value)
 
+
+if not MYPY:
+    class CertificateSigningRequestArgsDict(TypedDict):
+        """
+        CertificateSigningRequest objects provide a mechanism to obtain x509 certificates by submitting a certificate signing request, and having it asynchronously approved and issued.
+
+        Kubelets use this API to obtain:
+         1. client certificates to authenticate to kube-apiserver (with the "kubernetes.io/kube-apiserver-client-kubelet" signerName).
+         2. serving certificates for TLS endpoints kube-apiserver can connect to securely (with the "kubernetes.io/kubelet-serving" signerName).
+
+        This API can be used to request client certificates to authenticate to kube-apiserver (with the "kubernetes.io/kube-apiserver-client" signerName), or to obtain certificates from custom non-Kubernetes signers.
+        """
+        spec: pulumi.Input['CertificateSigningRequestSpecArgsDict']
+        """
+        spec contains the certificate request, and is immutable after creation. Only the request, signerName, expirationSeconds, and usages fields can be set on creation. Other fields are derived by Kubernetes and cannot be modified by users.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        status: NotRequired[pulumi.Input['CertificateSigningRequestStatusArgsDict']]
+        """
+        status contains information about whether the request is approved or denied, and the certificate issued by the signer, or the failure condition indicating signer failure.
+        """
+elif False:
+    CertificateSigningRequestArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class CertificateSigningRequestArgs:

--- a/sdk/python/pulumi_kubernetes/certificates/v1/outputs.py
+++ b/sdk/python/pulumi_kubernetes/certificates/v1/outputs.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta

--- a/sdk/python/pulumi_kubernetes/certificates/v1alpha1/ClusterTrustBundle.py
+++ b/sdk/python/pulumi_kubernetes/certificates/v1alpha1/ClusterTrustBundle.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -92,8 +97,8 @@ class ClusterTrustBundle(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ClusterTrustBundleSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ClusterTrustBundleSpecArgs', 'ClusterTrustBundleSpecArgsDict']]] = None,
                  __props__=None):
         """
         ClusterTrustBundle is a cluster-scoped container for X.509 trust anchors (root certificates).
@@ -106,8 +111,8 @@ class ClusterTrustBundle(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: metadata contains the object metadata.
-        :param pulumi.Input[pulumi.InputType['ClusterTrustBundleSpecArgs']] spec: spec contains the signer (if any) and trust anchors.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: metadata contains the object metadata.
+        :param pulumi.Input[Union['ClusterTrustBundleSpecArgs', 'ClusterTrustBundleSpecArgsDict']] spec: spec contains the signer (if any) and trust anchors.
         """
         ...
     @overload
@@ -139,8 +144,8 @@ class ClusterTrustBundle(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ClusterTrustBundleSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ClusterTrustBundleSpecArgs', 'ClusterTrustBundleSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/certificates/v1alpha1/ClusterTrustBundleList.py
+++ b/sdk/python/pulumi_kubernetes/certificates/v1alpha1/ClusterTrustBundleList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class ClusterTrustBundleList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ClusterTrustBundleArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ClusterTrustBundleArgs', 'ClusterTrustBundleArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         ClusterTrustBundleList is a collection of ClusterTrustBundle objects
@@ -101,9 +106,9 @@ class ClusterTrustBundleList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ClusterTrustBundleArgs']]]] items: items is a collection of ClusterTrustBundle objects
+        :param pulumi.Input[Sequence[pulumi.Input[Union['ClusterTrustBundleArgs', 'ClusterTrustBundleArgsDict']]]] items: items is a collection of ClusterTrustBundle objects
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: metadata contains the list metadata.
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: metadata contains the list metadata.
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class ClusterTrustBundleList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ClusterTrustBundleArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ClusterTrustBundleArgs', 'ClusterTrustBundleArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/certificates/v1alpha1/ClusterTrustBundlePatch.py
+++ b/sdk/python/pulumi_kubernetes/certificates/v1alpha1/ClusterTrustBundlePatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class ClusterTrustBundlePatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ClusterTrustBundleSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ClusterTrustBundleSpecPatchArgs', 'ClusterTrustBundleSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -113,8 +118,8 @@ class ClusterTrustBundlePatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: metadata contains the object metadata.
-        :param pulumi.Input[pulumi.InputType['ClusterTrustBundleSpecPatchArgs']] spec: spec contains the signer (if any) and trust anchors.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: metadata contains the object metadata.
+        :param pulumi.Input[Union['ClusterTrustBundleSpecPatchArgs', 'ClusterTrustBundleSpecPatchArgsDict']] spec: spec contains the signer (if any) and trust anchors.
         """
         ...
     @overload
@@ -152,8 +157,8 @@ class ClusterTrustBundlePatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ClusterTrustBundleSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ClusterTrustBundleSpecPatchArgs', 'ClusterTrustBundleSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/certificates/v1alpha1/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/certificates/v1alpha1/_inputs.py
@@ -4,17 +4,55 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import meta as _meta
 
 __all__ = [
     'ClusterTrustBundleSpecPatchArgs',
+    'ClusterTrustBundleSpecPatchArgsDict',
     'ClusterTrustBundleSpecArgs',
+    'ClusterTrustBundleSpecArgsDict',
     'ClusterTrustBundleArgs',
+    'ClusterTrustBundleArgsDict',
 ]
+
+MYPY = False
+
+if not MYPY:
+    class ClusterTrustBundleSpecPatchArgsDict(TypedDict):
+        """
+        ClusterTrustBundleSpec contains the signer and trust anchors.
+        """
+        signer_name: NotRequired[pulumi.Input[str]]
+        """
+        signerName indicates the associated signer, if any.
+
+        In order to create or update a ClusterTrustBundle that sets signerName, you must have the following cluster-scoped permission: group=certificates.k8s.io resource=signers resourceName=<the signer name> verb=attest.
+
+        If signerName is not empty, then the ClusterTrustBundle object must be named with the signer name as a prefix (translating slashes to colons). For example, for the signer name `example.com/foo`, valid ClusterTrustBundle object names include `example.com:foo:abc` and `example.com:foo:v1`.
+
+        If signerName is empty, then the ClusterTrustBundle object's name must not have such a prefix.
+
+        List/watch requests for ClusterTrustBundles can filter on this field using a `spec.signerName=NAME` field selector.
+        """
+        trust_bundle: NotRequired[pulumi.Input[str]]
+        """
+        trustBundle contains the individual X.509 trust anchors for this bundle, as PEM bundle of PEM-wrapped, DER-formatted X.509 certificates.
+
+        The data must consist only of PEM certificate blocks that parse as valid X.509 certificates.  Each certificate must include a basic constraints extension with the CA bit set.  The API server will reject objects that contain duplicate certificates, or that use PEM block headers.
+
+        Users of ClusterTrustBundles, including Kubelet, are free to reorder and deduplicate certificate blocks in this file according to their own logic, as well as to drop PEM block headers and inter-block data.
+        """
+elif False:
+    ClusterTrustBundleSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ClusterTrustBundleSpecPatchArgs:
@@ -80,6 +118,34 @@ class ClusterTrustBundleSpecPatchArgs:
         pulumi.set(self, "trust_bundle", value)
 
 
+if not MYPY:
+    class ClusterTrustBundleSpecArgsDict(TypedDict):
+        """
+        ClusterTrustBundleSpec contains the signer and trust anchors.
+        """
+        trust_bundle: pulumi.Input[str]
+        """
+        trustBundle contains the individual X.509 trust anchors for this bundle, as PEM bundle of PEM-wrapped, DER-formatted X.509 certificates.
+
+        The data must consist only of PEM certificate blocks that parse as valid X.509 certificates.  Each certificate must include a basic constraints extension with the CA bit set.  The API server will reject objects that contain duplicate certificates, or that use PEM block headers.
+
+        Users of ClusterTrustBundles, including Kubelet, are free to reorder and deduplicate certificate blocks in this file according to their own logic, as well as to drop PEM block headers and inter-block data.
+        """
+        signer_name: NotRequired[pulumi.Input[str]]
+        """
+        signerName indicates the associated signer, if any.
+
+        In order to create or update a ClusterTrustBundle that sets signerName, you must have the following cluster-scoped permission: group=certificates.k8s.io resource=signers resourceName=<the signer name> verb=attest.
+
+        If signerName is not empty, then the ClusterTrustBundle object must be named with the signer name as a prefix (translating slashes to colons). For example, for the signer name `example.com/foo`, valid ClusterTrustBundle object names include `example.com:foo:abc` and `example.com:foo:v1`.
+
+        If signerName is empty, then the ClusterTrustBundle object's name must not have such a prefix.
+
+        List/watch requests for ClusterTrustBundles can filter on this field using a `spec.signerName=NAME` field selector.
+        """
+elif False:
+    ClusterTrustBundleSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ClusterTrustBundleSpecArgs:
     def __init__(__self__, *,
@@ -142,6 +208,34 @@ class ClusterTrustBundleSpecArgs:
     def signer_name(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "signer_name", value)
 
+
+if not MYPY:
+    class ClusterTrustBundleArgsDict(TypedDict):
+        """
+        ClusterTrustBundle is a cluster-scoped container for X.509 trust anchors (root certificates).
+
+        ClusterTrustBundle objects are considered to be readable by any authenticated user in the cluster, because they can be mounted by pods using the `clusterTrustBundle` projection.  All service accounts have read access to ClusterTrustBundles by default.  Users who only have namespace-level access to a cluster can read ClusterTrustBundles by impersonating a serviceaccount that they have access to.
+
+        It can be optionally associated with a particular assigner, in which case it contains one valid set of trust anchors for that signer. Signers may have multiple associated ClusterTrustBundles; each is an independent set of trust anchors for that signer. Admission control is used to enforce that only users with permissions on the signer can create or modify the corresponding bundle.
+        """
+        spec: pulumi.Input['ClusterTrustBundleSpecArgsDict']
+        """
+        spec contains the signer (if any) and trust anchors.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        metadata contains the object metadata.
+        """
+elif False:
+    ClusterTrustBundleArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ClusterTrustBundleArgs:

--- a/sdk/python/pulumi_kubernetes/certificates/v1alpha1/outputs.py
+++ b/sdk/python/pulumi_kubernetes/certificates/v1alpha1/outputs.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta

--- a/sdk/python/pulumi_kubernetes/certificates/v1beta1/CertificateSigningRequest.py
+++ b/sdk/python/pulumi_kubernetes/certificates/v1beta1/CertificateSigningRequest.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -89,8 +94,8 @@ class CertificateSigningRequest(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['CertificateSigningRequestSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['CertificateSigningRequestSpecArgs', 'CertificateSigningRequestSpecArgsDict']]] = None,
                  __props__=None):
         """
         Describes a certificate signing request
@@ -99,7 +104,7 @@ class CertificateSigningRequest(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['CertificateSigningRequestSpecArgs']] spec: The certificate request itself and any additional information.
+        :param pulumi.Input[Union['CertificateSigningRequestSpecArgs', 'CertificateSigningRequestSpecArgsDict']] spec: The certificate request itself and any additional information.
         """
         ...
     @overload
@@ -127,8 +132,8 @@ class CertificateSigningRequest(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['CertificateSigningRequestSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['CertificateSigningRequestSpecArgs', 'CertificateSigningRequestSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/certificates/v1beta1/CertificateSigningRequestList.py
+++ b/sdk/python/pulumi_kubernetes/certificates/v1beta1/CertificateSigningRequestList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -83,9 +88,9 @@ class CertificateSigningRequestList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['CertificateSigningRequestArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['CertificateSigningRequestArgs', 'CertificateSigningRequestArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         Create a CertificateSigningRequestList resource with the given unique name, props, and options.
@@ -118,9 +123,9 @@ class CertificateSigningRequestList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['CertificateSigningRequestArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['CertificateSigningRequestArgs', 'CertificateSigningRequestArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/certificates/v1beta1/CertificateSigningRequestPatch.py
+++ b/sdk/python/pulumi_kubernetes/certificates/v1beta1/CertificateSigningRequestPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -89,8 +94,8 @@ class CertificateSigningRequestPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['CertificateSigningRequestSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['CertificateSigningRequestSpecPatchArgs', 'CertificateSigningRequestSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -105,7 +110,7 @@ class CertificateSigningRequestPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['CertificateSigningRequestSpecPatchArgs']] spec: The certificate request itself and any additional information.
+        :param pulumi.Input[Union['CertificateSigningRequestSpecPatchArgs', 'CertificateSigningRequestSpecPatchArgsDict']] spec: The certificate request itself and any additional information.
         """
         ...
     @overload
@@ -139,8 +144,8 @@ class CertificateSigningRequestPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['CertificateSigningRequestSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['CertificateSigningRequestSpecPatchArgs', 'CertificateSigningRequestSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/certificates/v1beta1/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/certificates/v1beta1/_inputs.py
@@ -4,19 +4,60 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import meta as _meta
 
 __all__ = [
     'CertificateSigningRequestConditionArgs',
+    'CertificateSigningRequestConditionArgsDict',
     'CertificateSigningRequestSpecPatchArgs',
+    'CertificateSigningRequestSpecPatchArgsDict',
     'CertificateSigningRequestSpecArgs',
+    'CertificateSigningRequestSpecArgsDict',
     'CertificateSigningRequestStatusArgs',
+    'CertificateSigningRequestStatusArgsDict',
     'CertificateSigningRequestArgs',
+    'CertificateSigningRequestArgsDict',
 ]
+
+MYPY = False
+
+if not MYPY:
+    class CertificateSigningRequestConditionArgsDict(TypedDict):
+        type: pulumi.Input[str]
+        """
+        request approval state, currently Approved or Denied.
+        """
+        last_transition_time: NotRequired[pulumi.Input[str]]
+        """
+        lastTransitionTime is the time the condition last transitioned from one status to another. If unset, when a new condition type is added or an existing condition's status is changed, the server defaults this to the current time.
+        """
+        last_update_time: NotRequired[pulumi.Input[str]]
+        """
+        timestamp for the last update to this condition
+        """
+        message: NotRequired[pulumi.Input[str]]
+        """
+        human readable message with details about the request state
+        """
+        reason: NotRequired[pulumi.Input[str]]
+        """
+        brief reason for the request state
+        """
+        status: NotRequired[pulumi.Input[str]]
+        """
+        Status of the condition, one of True, False, Unknown. Approved, Denied, and Failed conditions may not be "False" or "Unknown". Defaults to "True". If unset, should be treated as "True".
+        """
+elif False:
+    CertificateSigningRequestConditionArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class CertificateSigningRequestConditionArgs:
@@ -119,6 +160,49 @@ class CertificateSigningRequestConditionArgs:
     def status(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "status", value)
 
+
+if not MYPY:
+    class CertificateSigningRequestSpecPatchArgsDict(TypedDict):
+        """
+        This information is immutable after the request is created. Only the Request and Usages fields can be set on creation, other fields are derived by Kubernetes and cannot be modified by users.
+        """
+        extra: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[Sequence[pulumi.Input[str]]]]]]
+        """
+        Extra information about the requesting user. See user.Info interface for details.
+        """
+        groups: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Group information about the requesting user. See user.Info interface for details.
+        """
+        request: NotRequired[pulumi.Input[str]]
+        """
+        Base64-encoded PKCS#10 CSR data
+        """
+        signer_name: NotRequired[pulumi.Input[str]]
+        """
+        Requested signer for the request. It is a qualified name in the form: `scope-hostname.io/name`. If empty, it will be defaulted:
+         1. If it's a kubelet client certificate, it is assigned
+            "kubernetes.io/kube-apiserver-client-kubelet".
+         2. If it's a kubelet serving certificate, it is assigned
+            "kubernetes.io/kubelet-serving".
+         3. Otherwise, it is assigned "kubernetes.io/legacy-unknown".
+        Distribution of trust for signers happens out of band. You can select on this field using `spec.signerName`.
+        """
+        uid: NotRequired[pulumi.Input[str]]
+        """
+        UID information about the requesting user. See user.Info interface for details.
+        """
+        usages: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        allowedUsages specifies a set of usage contexts the key will be valid for. See: https://tools.ietf.org/html/rfc5280#section-4.2.1.3
+             https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+        """
+        username: NotRequired[pulumi.Input[str]]
+        """
+        Information about the requesting user. See user.Info interface for details.
+        """
+elif False:
+    CertificateSigningRequestSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class CertificateSigningRequestSpecPatchArgs:
@@ -254,6 +338,49 @@ class CertificateSigningRequestSpecPatchArgs:
         pulumi.set(self, "username", value)
 
 
+if not MYPY:
+    class CertificateSigningRequestSpecArgsDict(TypedDict):
+        """
+        This information is immutable after the request is created. Only the Request and Usages fields can be set on creation, other fields are derived by Kubernetes and cannot be modified by users.
+        """
+        request: pulumi.Input[str]
+        """
+        Base64-encoded PKCS#10 CSR data
+        """
+        extra: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[Sequence[pulumi.Input[str]]]]]]
+        """
+        Extra information about the requesting user. See user.Info interface for details.
+        """
+        groups: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Group information about the requesting user. See user.Info interface for details.
+        """
+        signer_name: NotRequired[pulumi.Input[str]]
+        """
+        Requested signer for the request. It is a qualified name in the form: `scope-hostname.io/name`. If empty, it will be defaulted:
+         1. If it's a kubelet client certificate, it is assigned
+            "kubernetes.io/kube-apiserver-client-kubelet".
+         2. If it's a kubelet serving certificate, it is assigned
+            "kubernetes.io/kubelet-serving".
+         3. Otherwise, it is assigned "kubernetes.io/legacy-unknown".
+        Distribution of trust for signers happens out of band. You can select on this field using `spec.signerName`.
+        """
+        uid: NotRequired[pulumi.Input[str]]
+        """
+        UID information about the requesting user. See user.Info interface for details.
+        """
+        usages: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        allowedUsages specifies a set of usage contexts the key will be valid for. See: https://tools.ietf.org/html/rfc5280#section-4.2.1.3
+             https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+        """
+        username: NotRequired[pulumi.Input[str]]
+        """
+        Information about the requesting user. See user.Info interface for details.
+        """
+elif False:
+    CertificateSigningRequestSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CertificateSigningRequestSpecArgs:
     def __init__(__self__, *,
@@ -387,6 +514,19 @@ class CertificateSigningRequestSpecArgs:
         pulumi.set(self, "username", value)
 
 
+if not MYPY:
+    class CertificateSigningRequestStatusArgsDict(TypedDict):
+        certificate: NotRequired[pulumi.Input[str]]
+        """
+        If request was approved, the controller will place the issued certificate here.
+        """
+        conditions: NotRequired[pulumi.Input[Sequence[pulumi.Input['CertificateSigningRequestConditionArgsDict']]]]
+        """
+        Conditions applied to the request, such as approval or denial.
+        """
+elif False:
+    CertificateSigningRequestStatusArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CertificateSigningRequestStatusArgs:
     def __init__(__self__, *,
@@ -425,6 +565,31 @@ class CertificateSigningRequestStatusArgs:
     def conditions(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['CertificateSigningRequestConditionArgs']]]]):
         pulumi.set(self, "conditions", value)
 
+
+if not MYPY:
+    class CertificateSigningRequestArgsDict(TypedDict):
+        """
+        Describes a certificate signing request
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        spec: NotRequired[pulumi.Input['CertificateSigningRequestSpecArgsDict']]
+        """
+        The certificate request itself and any additional information.
+        """
+        status: NotRequired[pulumi.Input['CertificateSigningRequestStatusArgsDict']]
+        """
+        Derived information about the request.
+        """
+elif False:
+    CertificateSigningRequestArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class CertificateSigningRequestArgs:

--- a/sdk/python/pulumi_kubernetes/certificates/v1beta1/outputs.py
+++ b/sdk/python/pulumi_kubernetes/certificates/v1beta1/outputs.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta

--- a/sdk/python/pulumi_kubernetes/coordination/v1/Lease.py
+++ b/sdk/python/pulumi_kubernetes/coordination/v1/Lease.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class Lease(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['LeaseSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['LeaseSpecArgs', 'LeaseSpecArgsDict']]] = None,
                  __props__=None):
         """
         Lease defines a lease concept.
@@ -103,8 +108,8 @@ class Lease(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['LeaseSpecArgs']] spec: spec contains the specification of the Lease. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['LeaseSpecArgs', 'LeaseSpecArgsDict']] spec: spec contains the specification of the Lease. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -132,8 +137,8 @@ class Lease(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['LeaseSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['LeaseSpecArgs', 'LeaseSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/coordination/v1/LeaseList.py
+++ b/sdk/python/pulumi_kubernetes/coordination/v1/LeaseList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class LeaseList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['LeaseArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['LeaseArgs', 'LeaseArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         LeaseList is a list of Lease objects.
@@ -101,9 +106,9 @@ class LeaseList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['LeaseArgs']]]] items: items is a list of schema objects.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['LeaseArgs', 'LeaseArgsDict']]]] items: items is a list of schema objects.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class LeaseList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['LeaseArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['LeaseArgs', 'LeaseArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/coordination/v1/LeasePatch.py
+++ b/sdk/python/pulumi_kubernetes/coordination/v1/LeasePatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class LeasePatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['LeaseSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['LeaseSpecPatchArgs', 'LeaseSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -109,8 +114,8 @@ class LeasePatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['LeaseSpecPatchArgs']] spec: spec contains the specification of the Lease. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['LeaseSpecPatchArgs', 'LeaseSpecPatchArgsDict']] spec: spec contains the specification of the Lease. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -144,8 +149,8 @@ class LeasePatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['LeaseSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['LeaseSpecPatchArgs', 'LeaseSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/coordination/v1/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/coordination/v1/_inputs.py
@@ -4,17 +4,55 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import meta as _meta
 
 __all__ = [
     'LeaseSpecPatchArgs',
+    'LeaseSpecPatchArgsDict',
     'LeaseSpecArgs',
+    'LeaseSpecArgsDict',
     'LeaseArgs',
+    'LeaseArgsDict',
 ]
+
+MYPY = False
+
+if not MYPY:
+    class LeaseSpecPatchArgsDict(TypedDict):
+        """
+        LeaseSpec is a specification of a Lease.
+        """
+        acquire_time: NotRequired[pulumi.Input[str]]
+        """
+        acquireTime is a time when the current lease was acquired.
+        """
+        holder_identity: NotRequired[pulumi.Input[str]]
+        """
+        holderIdentity contains the identity of the holder of a current lease.
+        """
+        lease_duration_seconds: NotRequired[pulumi.Input[int]]
+        """
+        leaseDurationSeconds is a duration that candidates for a lease need to wait to force acquire it. This is measure against time of last observed renewTime.
+        """
+        lease_transitions: NotRequired[pulumi.Input[int]]
+        """
+        leaseTransitions is the number of transitions of a lease between holders.
+        """
+        renew_time: NotRequired[pulumi.Input[str]]
+        """
+        renewTime is a time when the current holder of a lease has last updated the lease.
+        """
+elif False:
+    LeaseSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class LeaseSpecPatchArgs:
@@ -104,6 +142,34 @@ class LeaseSpecPatchArgs:
         pulumi.set(self, "renew_time", value)
 
 
+if not MYPY:
+    class LeaseSpecArgsDict(TypedDict):
+        """
+        LeaseSpec is a specification of a Lease.
+        """
+        acquire_time: NotRequired[pulumi.Input[str]]
+        """
+        acquireTime is a time when the current lease was acquired.
+        """
+        holder_identity: NotRequired[pulumi.Input[str]]
+        """
+        holderIdentity contains the identity of the holder of a current lease.
+        """
+        lease_duration_seconds: NotRequired[pulumi.Input[int]]
+        """
+        leaseDurationSeconds is a duration that candidates for a lease need to wait to force acquire it. This is measure against time of last observed renewTime.
+        """
+        lease_transitions: NotRequired[pulumi.Input[int]]
+        """
+        leaseTransitions is the number of transitions of a lease between holders.
+        """
+        renew_time: NotRequired[pulumi.Input[str]]
+        """
+        renewTime is a time when the current holder of a lease has last updated the lease.
+        """
+elif False:
+    LeaseSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class LeaseSpecArgs:
     def __init__(__self__, *,
@@ -191,6 +257,30 @@ class LeaseSpecArgs:
     def renew_time(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "renew_time", value)
 
+
+if not MYPY:
+    class LeaseArgsDict(TypedDict):
+        """
+        Lease defines a lease concept.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['LeaseSpecArgsDict']]
+        """
+        spec contains the specification of the Lease. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+elif False:
+    LeaseArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class LeaseArgs:

--- a/sdk/python/pulumi_kubernetes/coordination/v1/outputs.py
+++ b/sdk/python/pulumi_kubernetes/coordination/v1/outputs.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta

--- a/sdk/python/pulumi_kubernetes/coordination/v1beta1/Lease.py
+++ b/sdk/python/pulumi_kubernetes/coordination/v1beta1/Lease.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class Lease(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['LeaseSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['LeaseSpecArgs', 'LeaseSpecArgsDict']]] = None,
                  __props__=None):
         """
         Lease defines a lease concept.
@@ -103,8 +108,8 @@ class Lease(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['LeaseSpecArgs']] spec: Specification of the Lease. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['LeaseSpecArgs', 'LeaseSpecArgsDict']] spec: Specification of the Lease. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -132,8 +137,8 @@ class Lease(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['LeaseSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['LeaseSpecArgs', 'LeaseSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/coordination/v1beta1/LeaseList.py
+++ b/sdk/python/pulumi_kubernetes/coordination/v1beta1/LeaseList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class LeaseList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['LeaseArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['LeaseArgs', 'LeaseArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         LeaseList is a list of Lease objects.
@@ -101,9 +106,9 @@ class LeaseList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['LeaseArgs']]]] items: Items is a list of schema objects.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['LeaseArgs', 'LeaseArgsDict']]]] items: Items is a list of schema objects.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class LeaseList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['LeaseArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['LeaseArgs', 'LeaseArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/coordination/v1beta1/LeasePatch.py
+++ b/sdk/python/pulumi_kubernetes/coordination/v1beta1/LeasePatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class LeasePatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['LeaseSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['LeaseSpecPatchArgs', 'LeaseSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -109,8 +114,8 @@ class LeasePatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['LeaseSpecPatchArgs']] spec: Specification of the Lease. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['LeaseSpecPatchArgs', 'LeaseSpecPatchArgsDict']] spec: Specification of the Lease. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -144,8 +149,8 @@ class LeasePatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['LeaseSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['LeaseSpecPatchArgs', 'LeaseSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/coordination/v1beta1/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/coordination/v1beta1/_inputs.py
@@ -4,17 +4,55 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import meta as _meta
 
 __all__ = [
     'LeaseSpecPatchArgs',
+    'LeaseSpecPatchArgsDict',
     'LeaseSpecArgs',
+    'LeaseSpecArgsDict',
     'LeaseArgs',
+    'LeaseArgsDict',
 ]
+
+MYPY = False
+
+if not MYPY:
+    class LeaseSpecPatchArgsDict(TypedDict):
+        """
+        LeaseSpec is a specification of a Lease.
+        """
+        acquire_time: NotRequired[pulumi.Input[str]]
+        """
+        acquireTime is a time when the current lease was acquired.
+        """
+        holder_identity: NotRequired[pulumi.Input[str]]
+        """
+        holderIdentity contains the identity of the holder of a current lease.
+        """
+        lease_duration_seconds: NotRequired[pulumi.Input[int]]
+        """
+        leaseDurationSeconds is a duration that candidates for a lease need to wait to force acquire it. This is measure against time of last observed RenewTime.
+        """
+        lease_transitions: NotRequired[pulumi.Input[int]]
+        """
+        leaseTransitions is the number of transitions of a lease between holders.
+        """
+        renew_time: NotRequired[pulumi.Input[str]]
+        """
+        renewTime is a time when the current holder of a lease has last updated the lease.
+        """
+elif False:
+    LeaseSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class LeaseSpecPatchArgs:
@@ -104,6 +142,34 @@ class LeaseSpecPatchArgs:
         pulumi.set(self, "renew_time", value)
 
 
+if not MYPY:
+    class LeaseSpecArgsDict(TypedDict):
+        """
+        LeaseSpec is a specification of a Lease.
+        """
+        acquire_time: NotRequired[pulumi.Input[str]]
+        """
+        acquireTime is a time when the current lease was acquired.
+        """
+        holder_identity: NotRequired[pulumi.Input[str]]
+        """
+        holderIdentity contains the identity of the holder of a current lease.
+        """
+        lease_duration_seconds: NotRequired[pulumi.Input[int]]
+        """
+        leaseDurationSeconds is a duration that candidates for a lease need to wait to force acquire it. This is measure against time of last observed RenewTime.
+        """
+        lease_transitions: NotRequired[pulumi.Input[int]]
+        """
+        leaseTransitions is the number of transitions of a lease between holders.
+        """
+        renew_time: NotRequired[pulumi.Input[str]]
+        """
+        renewTime is a time when the current holder of a lease has last updated the lease.
+        """
+elif False:
+    LeaseSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class LeaseSpecArgs:
     def __init__(__self__, *,
@@ -191,6 +257,30 @@ class LeaseSpecArgs:
     def renew_time(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "renew_time", value)
 
+
+if not MYPY:
+    class LeaseArgsDict(TypedDict):
+        """
+        Lease defines a lease concept.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['LeaseSpecArgsDict']]
+        """
+        Specification of the Lease. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+elif False:
+    LeaseArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class LeaseArgs:

--- a/sdk/python/pulumi_kubernetes/coordination/v1beta1/outputs.py
+++ b/sdk/python/pulumi_kubernetes/coordination/v1beta1/outputs.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta

--- a/sdk/python/pulumi_kubernetes/core/v1/Binding.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/Binding.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -92,8 +97,8 @@ class Binding(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 target: Optional[pulumi.Input[pulumi.InputType['ObjectReferenceArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 target: Optional[pulumi.Input[Union['ObjectReferenceArgs', 'ObjectReferenceArgsDict']]] = None,
                  __props__=None):
         """
         Binding ties one object to another; for example, a pod is bound to a node by a scheduler. Deprecated in 1.7, please use the bindings subresource of pods instead.
@@ -102,8 +107,8 @@ class Binding(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['ObjectReferenceArgs']] target: The target object that you want to bind to the standard object.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['ObjectReferenceArgs', 'ObjectReferenceArgsDict']] target: The target object that you want to bind to the standard object.
         """
         ...
     @overload
@@ -131,8 +136,8 @@ class Binding(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 target: Optional[pulumi.Input[pulumi.InputType['ObjectReferenceArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 target: Optional[pulumi.Input[Union['ObjectReferenceArgs', 'ObjectReferenceArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/core/v1/BindingPatch.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/BindingPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class BindingPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 target: Optional[pulumi.Input[pulumi.InputType['ObjectReferencePatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 target: Optional[pulumi.Input[Union['ObjectReferencePatchArgs', 'ObjectReferencePatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -109,8 +114,8 @@ class BindingPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['ObjectReferencePatchArgs']] target: The target object that you want to bind to the standard object.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['ObjectReferencePatchArgs', 'ObjectReferencePatchArgsDict']] target: The target object that you want to bind to the standard object.
         """
         ...
     @overload
@@ -144,8 +149,8 @@ class BindingPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 target: Optional[pulumi.Input[pulumi.InputType['ObjectReferencePatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 target: Optional[pulumi.Input[Union['ObjectReferencePatchArgs', 'ObjectReferencePatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/core/v1/ConfigMap.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/ConfigMap.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import meta as _meta
 
@@ -126,7 +131,7 @@ class ConfigMap(pulumi.CustomResource):
                  data: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  immutable: Optional[pulumi.Input[bool]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
                  __props__=None):
         """
         ConfigMap holds configuration data for pods to consume.
@@ -138,7 +143,7 @@ class ConfigMap(pulumi.CustomResource):
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] data: Data contains the configuration data. Each key must consist of alphanumeric characters, '-', '_' or '.'. Values with non-UTF-8 byte sequences must use the BinaryData field. The keys stored in Data must not overlap with the keys in the BinaryData field, this is enforced during validation process.
         :param pulumi.Input[bool] immutable: Immutable, if set to true, ensures that data stored in the ConfigMap cannot be updated (only object metadata can be modified). If not set to true, the field can be modified at any time. Defaulted to nil.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -169,7 +174,7 @@ class ConfigMap(pulumi.CustomResource):
                  data: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  immutable: Optional[pulumi.Input[bool]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/core/v1/ConfigMapList.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/ConfigMapList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class ConfigMapList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ConfigMapArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ConfigMapArgs', 'ConfigMapArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         ConfigMapList is a resource containing a list of ConfigMap objects.
@@ -101,9 +106,9 @@ class ConfigMapList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ConfigMapArgs']]]] items: Items is the list of ConfigMaps.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['ConfigMapArgs', 'ConfigMapArgsDict']]]] items: Items is the list of ConfigMaps.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class ConfigMapList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ConfigMapArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ConfigMapArgs', 'ConfigMapArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/core/v1/ConfigMapPatch.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/ConfigMapPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import meta as _meta
 
@@ -126,7 +131,7 @@ class ConfigMapPatch(pulumi.CustomResource):
                  data: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  immutable: Optional[pulumi.Input[bool]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -144,7 +149,7 @@ class ConfigMapPatch(pulumi.CustomResource):
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] data: Data contains the configuration data. Each key must consist of alphanumeric characters, '-', '_' or '.'. Values with non-UTF-8 byte sequences must use the BinaryData field. The keys stored in Data must not overlap with the keys in the BinaryData field, this is enforced during validation process.
         :param pulumi.Input[bool] immutable: Immutable, if set to true, ensures that data stored in the ConfigMap cannot be updated (only object metadata can be modified). If not set to true, the field can be modified at any time. Defaulted to nil.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -181,7 +186,7 @@ class ConfigMapPatch(pulumi.CustomResource):
                  data: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  immutable: Optional[pulumi.Input[bool]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/core/v1/Endpoints.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/Endpoints.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class Endpoints(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 subsets: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['EndpointSubsetArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 subsets: Optional[pulumi.Input[Sequence[pulumi.Input[Union['EndpointSubsetArgs', 'EndpointSubsetArgsDict']]]]] = None,
                  __props__=None):
         """
         Endpoints is a collection of endpoints that implement the actual service. Example:
@@ -115,8 +120,8 @@ class Endpoints(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['EndpointSubsetArgs']]]] subsets: The set of all endpoints is the union of all subsets. Addresses are placed into subsets according to the IPs they share. A single address with multiple ports, some of which are ready and some of which are not (because they come from different containers) will result in the address being displayed in different subsets for the different ports. No address will appear in both Addresses and NotReadyAddresses in the same subset. Sets of addresses and ports that comprise a service.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Sequence[pulumi.Input[Union['EndpointSubsetArgs', 'EndpointSubsetArgsDict']]]] subsets: The set of all endpoints is the union of all subsets. Addresses are placed into subsets according to the IPs they share. A single address with multiple ports, some of which are ready and some of which are not (because they come from different containers) will result in the address being displayed in different subsets for the different ports. No address will appear in both Addresses and NotReadyAddresses in the same subset. Sets of addresses and ports that comprise a service.
         """
         ...
     @overload
@@ -156,8 +161,8 @@ class Endpoints(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 subsets: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['EndpointSubsetArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 subsets: Optional[pulumi.Input[Sequence[pulumi.Input[Union['EndpointSubsetArgs', 'EndpointSubsetArgsDict']]]]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/core/v1/EndpointsList.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/EndpointsList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class EndpointsList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['EndpointsArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['EndpointsArgs', 'EndpointsArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         EndpointsList is a list of endpoints.
@@ -101,9 +106,9 @@ class EndpointsList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['EndpointsArgs']]]] items: List of endpoints.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['EndpointsArgs', 'EndpointsArgsDict']]]] items: List of endpoints.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class EndpointsList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['EndpointsArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['EndpointsArgs', 'EndpointsArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/core/v1/EndpointsPatch.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/EndpointsPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class EndpointsPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 subsets: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['EndpointSubsetPatchArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 subsets: Optional[pulumi.Input[Sequence[pulumi.Input[Union['EndpointSubsetPatchArgs', 'EndpointSubsetPatchArgsDict']]]]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -121,8 +126,8 @@ class EndpointsPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['EndpointSubsetPatchArgs']]]] subsets: The set of all endpoints is the union of all subsets. Addresses are placed into subsets according to the IPs they share. A single address with multiple ports, some of which are ready and some of which are not (because they come from different containers) will result in the address being displayed in different subsets for the different ports. No address will appear in both Addresses and NotReadyAddresses in the same subset. Sets of addresses and ports that comprise a service.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Sequence[pulumi.Input[Union['EndpointSubsetPatchArgs', 'EndpointSubsetPatchArgsDict']]]] subsets: The set of all endpoints is the union of all subsets. Addresses are placed into subsets according to the IPs they share. A single address with multiple ports, some of which are ready and some of which are not (because they come from different containers) will result in the address being displayed in different subsets for the different ports. No address will appear in both Addresses and NotReadyAddresses in the same subset. Sets of addresses and ports that comprise a service.
         """
         ...
     @overload
@@ -168,8 +173,8 @@ class EndpointsPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 subsets: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['EndpointSubsetPatchArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 subsets: Optional[pulumi.Input[Sequence[pulumi.Input[Union['EndpointSubsetPatchArgs', 'EndpointSubsetPatchArgsDict']]]]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/core/v1/Event.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/Event.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -302,17 +307,17 @@ class Event(pulumi.CustomResource):
                  count: Optional[pulumi.Input[int]] = None,
                  event_time: Optional[pulumi.Input[str]] = None,
                  first_timestamp: Optional[pulumi.Input[str]] = None,
-                 involved_object: Optional[pulumi.Input[pulumi.InputType['ObjectReferenceArgs']]] = None,
+                 involved_object: Optional[pulumi.Input[Union['ObjectReferenceArgs', 'ObjectReferenceArgsDict']]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
                  last_timestamp: Optional[pulumi.Input[str]] = None,
                  message: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
                  reason: Optional[pulumi.Input[str]] = None,
-                 related: Optional[pulumi.Input[pulumi.InputType['ObjectReferenceArgs']]] = None,
+                 related: Optional[pulumi.Input[Union['ObjectReferenceArgs', 'ObjectReferenceArgsDict']]] = None,
                  reporting_component: Optional[pulumi.Input[str]] = None,
                  reporting_instance: Optional[pulumi.Input[str]] = None,
-                 series: Optional[pulumi.Input[pulumi.InputType['EventSeriesArgs']]] = None,
-                 source: Optional[pulumi.Input[pulumi.InputType['EventSourceArgs']]] = None,
+                 series: Optional[pulumi.Input[Union['EventSeriesArgs', 'EventSeriesArgsDict']]] = None,
+                 source: Optional[pulumi.Input[Union['EventSourceArgs', 'EventSourceArgsDict']]] = None,
                  type: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         """
@@ -325,17 +330,17 @@ class Event(pulumi.CustomResource):
         :param pulumi.Input[int] count: The number of times this event has occurred.
         :param pulumi.Input[str] event_time: Time when this Event was first observed.
         :param pulumi.Input[str] first_timestamp: The time at which the event was first recorded. (Time of server receipt is in TypeMeta.)
-        :param pulumi.Input[pulumi.InputType['ObjectReferenceArgs']] involved_object: The object that this event is about.
+        :param pulumi.Input[Union['ObjectReferenceArgs', 'ObjectReferenceArgsDict']] involved_object: The object that this event is about.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
         :param pulumi.Input[str] last_timestamp: The time at which the most recent occurrence of this event was recorded.
         :param pulumi.Input[str] message: A human-readable description of the status of this operation.
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         :param pulumi.Input[str] reason: This should be a short, machine understandable string that gives the reason for the transition into the object's current status.
-        :param pulumi.Input[pulumi.InputType['ObjectReferenceArgs']] related: Optional secondary object for more complex actions.
+        :param pulumi.Input[Union['ObjectReferenceArgs', 'ObjectReferenceArgsDict']] related: Optional secondary object for more complex actions.
         :param pulumi.Input[str] reporting_component: Name of the controller that emitted this Event, e.g. `kubernetes.io/kubelet`.
         :param pulumi.Input[str] reporting_instance: ID of the controller instance, e.g. `kubelet-xyzf`.
-        :param pulumi.Input[pulumi.InputType['EventSeriesArgs']] series: Data about the Event series this event represents or nil if it's a singleton Event.
-        :param pulumi.Input[pulumi.InputType['EventSourceArgs']] source: The component reporting this event. Should be a short machine understandable string.
+        :param pulumi.Input[Union['EventSeriesArgs', 'EventSeriesArgsDict']] series: Data about the Event series this event represents or nil if it's a singleton Event.
+        :param pulumi.Input[Union['EventSourceArgs', 'EventSourceArgsDict']] source: The component reporting this event. Should be a short machine understandable string.
         :param pulumi.Input[str] type: Type of this event (Normal, Warning), new types could be added in the future
         """
         ...
@@ -367,17 +372,17 @@ class Event(pulumi.CustomResource):
                  count: Optional[pulumi.Input[int]] = None,
                  event_time: Optional[pulumi.Input[str]] = None,
                  first_timestamp: Optional[pulumi.Input[str]] = None,
-                 involved_object: Optional[pulumi.Input[pulumi.InputType['ObjectReferenceArgs']]] = None,
+                 involved_object: Optional[pulumi.Input[Union['ObjectReferenceArgs', 'ObjectReferenceArgsDict']]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
                  last_timestamp: Optional[pulumi.Input[str]] = None,
                  message: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
                  reason: Optional[pulumi.Input[str]] = None,
-                 related: Optional[pulumi.Input[pulumi.InputType['ObjectReferenceArgs']]] = None,
+                 related: Optional[pulumi.Input[Union['ObjectReferenceArgs', 'ObjectReferenceArgsDict']]] = None,
                  reporting_component: Optional[pulumi.Input[str]] = None,
                  reporting_instance: Optional[pulumi.Input[str]] = None,
-                 series: Optional[pulumi.Input[pulumi.InputType['EventSeriesArgs']]] = None,
-                 source: Optional[pulumi.Input[pulumi.InputType['EventSourceArgs']]] = None,
+                 series: Optional[pulumi.Input[Union['EventSeriesArgs', 'EventSeriesArgsDict']]] = None,
+                 source: Optional[pulumi.Input[Union['EventSourceArgs', 'EventSourceArgsDict']]] = None,
                  type: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)

--- a/sdk/python/pulumi_kubernetes/core/v1/EventList.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/EventList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class EventList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['EventArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['EventArgs', 'EventArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         EventList is a list of events.
@@ -101,9 +106,9 @@ class EventList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['EventArgs']]]] items: List of events
+        :param pulumi.Input[Sequence[pulumi.Input[Union['EventArgs', 'EventArgsDict']]]] items: List of events
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class EventList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['EventArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['EventArgs', 'EventArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/core/v1/EventPatch.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/EventPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -304,17 +309,17 @@ class EventPatch(pulumi.CustomResource):
                  count: Optional[pulumi.Input[int]] = None,
                  event_time: Optional[pulumi.Input[str]] = None,
                  first_timestamp: Optional[pulumi.Input[str]] = None,
-                 involved_object: Optional[pulumi.Input[pulumi.InputType['ObjectReferencePatchArgs']]] = None,
+                 involved_object: Optional[pulumi.Input[Union['ObjectReferencePatchArgs', 'ObjectReferencePatchArgsDict']]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
                  last_timestamp: Optional[pulumi.Input[str]] = None,
                  message: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
                  reason: Optional[pulumi.Input[str]] = None,
-                 related: Optional[pulumi.Input[pulumi.InputType['ObjectReferencePatchArgs']]] = None,
+                 related: Optional[pulumi.Input[Union['ObjectReferencePatchArgs', 'ObjectReferencePatchArgsDict']]] = None,
                  reporting_component: Optional[pulumi.Input[str]] = None,
                  reporting_instance: Optional[pulumi.Input[str]] = None,
-                 series: Optional[pulumi.Input[pulumi.InputType['EventSeriesPatchArgs']]] = None,
-                 source: Optional[pulumi.Input[pulumi.InputType['EventSourcePatchArgs']]] = None,
+                 series: Optional[pulumi.Input[Union['EventSeriesPatchArgs', 'EventSeriesPatchArgsDict']]] = None,
+                 source: Optional[pulumi.Input[Union['EventSourcePatchArgs', 'EventSourcePatchArgsDict']]] = None,
                  type: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         """
@@ -333,17 +338,17 @@ class EventPatch(pulumi.CustomResource):
         :param pulumi.Input[int] count: The number of times this event has occurred.
         :param pulumi.Input[str] event_time: Time when this Event was first observed.
         :param pulumi.Input[str] first_timestamp: The time at which the event was first recorded. (Time of server receipt is in TypeMeta.)
-        :param pulumi.Input[pulumi.InputType['ObjectReferencePatchArgs']] involved_object: The object that this event is about.
+        :param pulumi.Input[Union['ObjectReferencePatchArgs', 'ObjectReferencePatchArgsDict']] involved_object: The object that this event is about.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
         :param pulumi.Input[str] last_timestamp: The time at which the most recent occurrence of this event was recorded.
         :param pulumi.Input[str] message: A human-readable description of the status of this operation.
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         :param pulumi.Input[str] reason: This should be a short, machine understandable string that gives the reason for the transition into the object's current status.
-        :param pulumi.Input[pulumi.InputType['ObjectReferencePatchArgs']] related: Optional secondary object for more complex actions.
+        :param pulumi.Input[Union['ObjectReferencePatchArgs', 'ObjectReferencePatchArgsDict']] related: Optional secondary object for more complex actions.
         :param pulumi.Input[str] reporting_component: Name of the controller that emitted this Event, e.g. `kubernetes.io/kubelet`.
         :param pulumi.Input[str] reporting_instance: ID of the controller instance, e.g. `kubelet-xyzf`.
-        :param pulumi.Input[pulumi.InputType['EventSeriesPatchArgs']] series: Data about the Event series this event represents or nil if it's a singleton Event.
-        :param pulumi.Input[pulumi.InputType['EventSourcePatchArgs']] source: The component reporting this event. Should be a short machine understandable string.
+        :param pulumi.Input[Union['EventSeriesPatchArgs', 'EventSeriesPatchArgsDict']] series: Data about the Event series this event represents or nil if it's a singleton Event.
+        :param pulumi.Input[Union['EventSourcePatchArgs', 'EventSourcePatchArgsDict']] source: The component reporting this event. Should be a short machine understandable string.
         :param pulumi.Input[str] type: Type of this event (Normal, Warning), new types could be added in the future
         """
         ...
@@ -381,17 +386,17 @@ class EventPatch(pulumi.CustomResource):
                  count: Optional[pulumi.Input[int]] = None,
                  event_time: Optional[pulumi.Input[str]] = None,
                  first_timestamp: Optional[pulumi.Input[str]] = None,
-                 involved_object: Optional[pulumi.Input[pulumi.InputType['ObjectReferencePatchArgs']]] = None,
+                 involved_object: Optional[pulumi.Input[Union['ObjectReferencePatchArgs', 'ObjectReferencePatchArgsDict']]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
                  last_timestamp: Optional[pulumi.Input[str]] = None,
                  message: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
                  reason: Optional[pulumi.Input[str]] = None,
-                 related: Optional[pulumi.Input[pulumi.InputType['ObjectReferencePatchArgs']]] = None,
+                 related: Optional[pulumi.Input[Union['ObjectReferencePatchArgs', 'ObjectReferencePatchArgsDict']]] = None,
                  reporting_component: Optional[pulumi.Input[str]] = None,
                  reporting_instance: Optional[pulumi.Input[str]] = None,
-                 series: Optional[pulumi.Input[pulumi.InputType['EventSeriesPatchArgs']]] = None,
-                 source: Optional[pulumi.Input[pulumi.InputType['EventSourcePatchArgs']]] = None,
+                 series: Optional[pulumi.Input[Union['EventSeriesPatchArgs', 'EventSeriesPatchArgsDict']]] = None,
+                 source: Optional[pulumi.Input[Union['EventSourcePatchArgs', 'EventSourcePatchArgsDict']]] = None,
                  type: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)

--- a/sdk/python/pulumi_kubernetes/core/v1/LimitRange.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/LimitRange.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class LimitRange(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['LimitRangeSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['LimitRangeSpecArgs', 'LimitRangeSpecArgsDict']]] = None,
                  __props__=None):
         """
         LimitRange sets resource usage limits for each kind of resource in a Namespace.
@@ -103,8 +108,8 @@ class LimitRange(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['LimitRangeSpecArgs']] spec: Spec defines the limits enforced. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['LimitRangeSpecArgs', 'LimitRangeSpecArgsDict']] spec: Spec defines the limits enforced. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -132,8 +137,8 @@ class LimitRange(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['LimitRangeSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['LimitRangeSpecArgs', 'LimitRangeSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/core/v1/LimitRangeList.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/LimitRangeList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class LimitRangeList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['LimitRangeArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['LimitRangeArgs', 'LimitRangeArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         LimitRangeList is a list of LimitRange items.
@@ -101,9 +106,9 @@ class LimitRangeList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['LimitRangeArgs']]]] items: Items is a list of LimitRange objects. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+        :param pulumi.Input[Sequence[pulumi.Input[Union['LimitRangeArgs', 'LimitRangeArgsDict']]]] items: Items is a list of LimitRange objects. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class LimitRangeList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['LimitRangeArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['LimitRangeArgs', 'LimitRangeArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/core/v1/LimitRangePatch.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/LimitRangePatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class LimitRangePatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['LimitRangeSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['LimitRangeSpecPatchArgs', 'LimitRangeSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -109,8 +114,8 @@ class LimitRangePatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['LimitRangeSpecPatchArgs']] spec: Spec defines the limits enforced. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['LimitRangeSpecPatchArgs', 'LimitRangeSpecPatchArgsDict']] spec: Spec defines the limits enforced. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -144,8 +149,8 @@ class LimitRangePatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['LimitRangeSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['LimitRangeSpecPatchArgs', 'LimitRangeSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/core/v1/Namespace.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/Namespace.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class Namespace(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['NamespaceSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['NamespaceSpecArgs', 'NamespaceSpecArgsDict']]] = None,
                  __props__=None):
         """
         Namespace provides a scope for Names. Use of multiple namespaces is optional.
@@ -103,8 +108,8 @@ class Namespace(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['NamespaceSpecArgs']] spec: Spec defines the behavior of the Namespace. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['NamespaceSpecArgs', 'NamespaceSpecArgsDict']] spec: Spec defines the behavior of the Namespace. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -132,8 +137,8 @@ class Namespace(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['NamespaceSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['NamespaceSpecArgs', 'NamespaceSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/core/v1/NamespaceList.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/NamespaceList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class NamespaceList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['NamespaceArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['NamespaceArgs', 'NamespaceArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         NamespaceList is a list of Namespaces.
@@ -101,9 +106,9 @@ class NamespaceList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['NamespaceArgs']]]] items: Items is the list of Namespace objects in the list. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+        :param pulumi.Input[Sequence[pulumi.Input[Union['NamespaceArgs', 'NamespaceArgsDict']]]] items: Items is the list of Namespace objects in the list. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class NamespaceList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['NamespaceArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['NamespaceArgs', 'NamespaceArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/core/v1/NamespacePatch.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/NamespacePatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class NamespacePatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['NamespaceSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['NamespaceSpecPatchArgs', 'NamespaceSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -109,8 +114,8 @@ class NamespacePatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['NamespaceSpecPatchArgs']] spec: Spec defines the behavior of the Namespace. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['NamespaceSpecPatchArgs', 'NamespaceSpecPatchArgsDict']] spec: Spec defines the behavior of the Namespace. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -144,8 +149,8 @@ class NamespacePatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['NamespaceSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['NamespaceSpecPatchArgs', 'NamespaceSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/core/v1/Node.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/Node.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class Node(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['NodeSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['NodeSpecArgs', 'NodeSpecArgsDict']]] = None,
                  __props__=None):
         """
         Node is a worker node in Kubernetes. Each node will have a unique identifier in the cache (i.e. in etcd).
@@ -103,8 +108,8 @@ class Node(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['NodeSpecArgs']] spec: Spec defines the behavior of a node. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['NodeSpecArgs', 'NodeSpecArgsDict']] spec: Spec defines the behavior of a node. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -132,8 +137,8 @@ class Node(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['NodeSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['NodeSpecArgs', 'NodeSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/core/v1/NodeList.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/NodeList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class NodeList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['NodeArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['NodeArgs', 'NodeArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         NodeList is the whole list of all Nodes which have been registered with master.
@@ -101,9 +106,9 @@ class NodeList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['NodeArgs']]]] items: List of nodes
+        :param pulumi.Input[Sequence[pulumi.Input[Union['NodeArgs', 'NodeArgsDict']]]] items: List of nodes
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class NodeList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['NodeArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['NodeArgs', 'NodeArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/core/v1/NodePatch.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/NodePatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class NodePatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['NodeSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['NodeSpecPatchArgs', 'NodeSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -109,8 +114,8 @@ class NodePatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['NodeSpecPatchArgs']] spec: Spec defines the behavior of a node. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['NodeSpecPatchArgs', 'NodeSpecPatchArgsDict']] spec: Spec defines the behavior of a node. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -144,8 +149,8 @@ class NodePatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['NodeSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['NodeSpecPatchArgs', 'NodeSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/core/v1/PersistentVolume.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/PersistentVolume.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class PersistentVolume(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PersistentVolumeSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PersistentVolumeSpecArgs', 'PersistentVolumeSpecArgsDict']]] = None,
                  __props__=None):
         """
         PersistentVolume (PV) is a storage resource provisioned by an administrator. It is analogous to a node. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes
@@ -103,8 +108,8 @@ class PersistentVolume(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['PersistentVolumeSpecArgs']] spec: spec defines a specification of a persistent volume owned by the cluster. Provisioned by an administrator. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistent-volumes
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['PersistentVolumeSpecArgs', 'PersistentVolumeSpecArgsDict']] spec: spec defines a specification of a persistent volume owned by the cluster. Provisioned by an administrator. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistent-volumes
         """
         ...
     @overload
@@ -132,8 +137,8 @@ class PersistentVolume(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PersistentVolumeSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PersistentVolumeSpecArgs', 'PersistentVolumeSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/core/v1/PersistentVolumeClaim.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/PersistentVolumeClaim.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class PersistentVolumeClaim(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PersistentVolumeClaimSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PersistentVolumeClaimSpecArgs', 'PersistentVolumeClaimSpecArgsDict']]] = None,
                  __props__=None):
         """
         PersistentVolumeClaim is a user's request for and claim to a persistent volume
@@ -103,8 +108,8 @@ class PersistentVolumeClaim(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['PersistentVolumeClaimSpecArgs']] spec: spec defines the desired characteristics of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['PersistentVolumeClaimSpecArgs', 'PersistentVolumeClaimSpecArgsDict']] spec: spec defines the desired characteristics of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
         """
         ...
     @overload
@@ -132,8 +137,8 @@ class PersistentVolumeClaim(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PersistentVolumeClaimSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PersistentVolumeClaimSpecArgs', 'PersistentVolumeClaimSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/core/v1/PersistentVolumeClaimList.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/PersistentVolumeClaimList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class PersistentVolumeClaimList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PersistentVolumeClaimArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PersistentVolumeClaimArgs', 'PersistentVolumeClaimArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         PersistentVolumeClaimList is a list of PersistentVolumeClaim items.
@@ -101,9 +106,9 @@ class PersistentVolumeClaimList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PersistentVolumeClaimArgs']]]] items: items is a list of persistent volume claims. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+        :param pulumi.Input[Sequence[pulumi.Input[Union['PersistentVolumeClaimArgs', 'PersistentVolumeClaimArgsDict']]]] items: items is a list of persistent volume claims. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class PersistentVolumeClaimList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PersistentVolumeClaimArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PersistentVolumeClaimArgs', 'PersistentVolumeClaimArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/core/v1/PersistentVolumeClaimPatch.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/PersistentVolumeClaimPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class PersistentVolumeClaimPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PersistentVolumeClaimSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PersistentVolumeClaimSpecPatchArgs', 'PersistentVolumeClaimSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -109,8 +114,8 @@ class PersistentVolumeClaimPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['PersistentVolumeClaimSpecPatchArgs']] spec: spec defines the desired characteristics of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['PersistentVolumeClaimSpecPatchArgs', 'PersistentVolumeClaimSpecPatchArgsDict']] spec: spec defines the desired characteristics of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
         """
         ...
     @overload
@@ -144,8 +149,8 @@ class PersistentVolumeClaimPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PersistentVolumeClaimSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PersistentVolumeClaimSpecPatchArgs', 'PersistentVolumeClaimSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/core/v1/PersistentVolumeList.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/PersistentVolumeList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class PersistentVolumeList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PersistentVolumeArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PersistentVolumeArgs', 'PersistentVolumeArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         PersistentVolumeList is a list of PersistentVolume items.
@@ -101,9 +106,9 @@ class PersistentVolumeList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PersistentVolumeArgs']]]] items: items is a list of persistent volumes. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes
+        :param pulumi.Input[Sequence[pulumi.Input[Union['PersistentVolumeArgs', 'PersistentVolumeArgsDict']]]] items: items is a list of persistent volumes. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class PersistentVolumeList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PersistentVolumeArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PersistentVolumeArgs', 'PersistentVolumeArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/core/v1/PersistentVolumePatch.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/PersistentVolumePatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class PersistentVolumePatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PersistentVolumeSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PersistentVolumeSpecPatchArgs', 'PersistentVolumeSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -109,8 +114,8 @@ class PersistentVolumePatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['PersistentVolumeSpecPatchArgs']] spec: spec defines a specification of a persistent volume owned by the cluster. Provisioned by an administrator. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistent-volumes
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['PersistentVolumeSpecPatchArgs', 'PersistentVolumeSpecPatchArgsDict']] spec: spec defines a specification of a persistent volume owned by the cluster. Provisioned by an administrator. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistent-volumes
         """
         ...
     @overload
@@ -144,8 +149,8 @@ class PersistentVolumePatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PersistentVolumeSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PersistentVolumeSpecPatchArgs', 'PersistentVolumeSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/core/v1/Pod.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/Pod.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class Pod(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PodSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PodSpecArgs', 'PodSpecArgsDict']]] = None,
                  __props__=None):
         """
         Pod is a collection of containers that can run on a host. This resource is created by clients and scheduled onto hosts.
@@ -154,8 +159,8 @@ class Pod(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['PodSpecArgs']] spec: Specification of the desired behavior of the pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['PodSpecArgs', 'PodSpecArgsDict']] spec: Specification of the desired behavior of the pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -234,8 +239,8 @@ class Pod(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PodSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PodSpecArgs', 'PodSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/core/v1/PodList.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/PodList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class PodList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PodArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PodArgs', 'PodArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         PodList is a list of Pods.
@@ -101,9 +106,9 @@ class PodList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PodArgs']]]] items: List of pods. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
+        :param pulumi.Input[Sequence[pulumi.Input[Union['PodArgs', 'PodArgsDict']]]] items: List of pods. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class PodList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PodArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PodArgs', 'PodArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/core/v1/PodPatch.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/PodPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class PodPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PodSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PodSpecPatchArgs', 'PodSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -124,8 +129,8 @@ class PodPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['PodSpecPatchArgs']] spec: Specification of the desired behavior of the pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['PodSpecPatchArgs', 'PodSpecPatchArgsDict']] spec: Specification of the desired behavior of the pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -174,8 +179,8 @@ class PodPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PodSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PodSpecPatchArgs', 'PodSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/core/v1/PodTemplate.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/PodTemplate.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class PodTemplate(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 template: Optional[pulumi.Input[pulumi.InputType['PodTemplateSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 template: Optional[pulumi.Input[Union['PodTemplateSpecArgs', 'PodTemplateSpecArgsDict']]] = None,
                  __props__=None):
         """
         PodTemplate describes a template for creating copies of a predefined pod.
@@ -103,8 +108,8 @@ class PodTemplate(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['PodTemplateSpecArgs']] template: Template defines the pods that will be created from this pod template. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['PodTemplateSpecArgs', 'PodTemplateSpecArgsDict']] template: Template defines the pods that will be created from this pod template. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -132,8 +137,8 @@ class PodTemplate(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 template: Optional[pulumi.Input[pulumi.InputType['PodTemplateSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 template: Optional[pulumi.Input[Union['PodTemplateSpecArgs', 'PodTemplateSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/core/v1/PodTemplateList.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/PodTemplateList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class PodTemplateList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PodTemplateArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PodTemplateArgs', 'PodTemplateArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         PodTemplateList is a list of PodTemplates.
@@ -101,9 +106,9 @@ class PodTemplateList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PodTemplateArgs']]]] items: List of pod templates
+        :param pulumi.Input[Sequence[pulumi.Input[Union['PodTemplateArgs', 'PodTemplateArgsDict']]]] items: List of pod templates
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class PodTemplateList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PodTemplateArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PodTemplateArgs', 'PodTemplateArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/core/v1/PodTemplatePatch.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/PodTemplatePatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class PodTemplatePatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 template: Optional[pulumi.Input[pulumi.InputType['PodTemplateSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 template: Optional[pulumi.Input[Union['PodTemplateSpecPatchArgs', 'PodTemplateSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -109,8 +114,8 @@ class PodTemplatePatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['PodTemplateSpecPatchArgs']] template: Template defines the pods that will be created from this pod template. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['PodTemplateSpecPatchArgs', 'PodTemplateSpecPatchArgsDict']] template: Template defines the pods that will be created from this pod template. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -144,8 +149,8 @@ class PodTemplatePatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 template: Optional[pulumi.Input[pulumi.InputType['PodTemplateSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 template: Optional[pulumi.Input[Union['PodTemplateSpecPatchArgs', 'PodTemplateSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/core/v1/ReplicationController.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/ReplicationController.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class ReplicationController(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ReplicationControllerSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ReplicationControllerSpecArgs', 'ReplicationControllerSpecArgsDict']]] = None,
                  __props__=None):
         """
         ReplicationController represents the configuration of a replication controller.
@@ -103,8 +108,8 @@ class ReplicationController(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: If the Labels of a ReplicationController are empty, they are defaulted to be the same as the Pod(s) that the replication controller manages. Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['ReplicationControllerSpecArgs']] spec: Spec defines the specification of the desired behavior of the replication controller. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: If the Labels of a ReplicationController are empty, they are defaulted to be the same as the Pod(s) that the replication controller manages. Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['ReplicationControllerSpecArgs', 'ReplicationControllerSpecArgsDict']] spec: Spec defines the specification of the desired behavior of the replication controller. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -132,8 +137,8 @@ class ReplicationController(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ReplicationControllerSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ReplicationControllerSpecArgs', 'ReplicationControllerSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/core/v1/ReplicationControllerList.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/ReplicationControllerList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class ReplicationControllerList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ReplicationControllerArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ReplicationControllerArgs', 'ReplicationControllerArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         ReplicationControllerList is a collection of replication controllers.
@@ -101,9 +106,9 @@ class ReplicationControllerList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ReplicationControllerArgs']]]] items: List of replication controllers. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller
+        :param pulumi.Input[Sequence[pulumi.Input[Union['ReplicationControllerArgs', 'ReplicationControllerArgsDict']]]] items: List of replication controllers. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class ReplicationControllerList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ReplicationControllerArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ReplicationControllerArgs', 'ReplicationControllerArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/core/v1/ReplicationControllerPatch.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/ReplicationControllerPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class ReplicationControllerPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ReplicationControllerSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ReplicationControllerSpecPatchArgs', 'ReplicationControllerSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -109,8 +114,8 @@ class ReplicationControllerPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: If the Labels of a ReplicationController are empty, they are defaulted to be the same as the Pod(s) that the replication controller manages. Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['ReplicationControllerSpecPatchArgs']] spec: Spec defines the specification of the desired behavior of the replication controller. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: If the Labels of a ReplicationController are empty, they are defaulted to be the same as the Pod(s) that the replication controller manages. Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['ReplicationControllerSpecPatchArgs', 'ReplicationControllerSpecPatchArgsDict']] spec: Spec defines the specification of the desired behavior of the replication controller. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -144,8 +149,8 @@ class ReplicationControllerPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ReplicationControllerSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ReplicationControllerSpecPatchArgs', 'ReplicationControllerSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/core/v1/ResourceQuota.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/ResourceQuota.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class ResourceQuota(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ResourceQuotaSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ResourceQuotaSpecArgs', 'ResourceQuotaSpecArgsDict']]] = None,
                  __props__=None):
         """
         ResourceQuota sets aggregate quota restrictions enforced per namespace
@@ -103,8 +108,8 @@ class ResourceQuota(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['ResourceQuotaSpecArgs']] spec: Spec defines the desired quota. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['ResourceQuotaSpecArgs', 'ResourceQuotaSpecArgsDict']] spec: Spec defines the desired quota. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -132,8 +137,8 @@ class ResourceQuota(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ResourceQuotaSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ResourceQuotaSpecArgs', 'ResourceQuotaSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/core/v1/ResourceQuotaList.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/ResourceQuotaList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class ResourceQuotaList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ResourceQuotaArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ResourceQuotaArgs', 'ResourceQuotaArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         ResourceQuotaList is a list of ResourceQuota items.
@@ -101,9 +106,9 @@ class ResourceQuotaList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ResourceQuotaArgs']]]] items: Items is a list of ResourceQuota objects. More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/
+        :param pulumi.Input[Sequence[pulumi.Input[Union['ResourceQuotaArgs', 'ResourceQuotaArgsDict']]]] items: Items is a list of ResourceQuota objects. More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class ResourceQuotaList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ResourceQuotaArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ResourceQuotaArgs', 'ResourceQuotaArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/core/v1/ResourceQuotaPatch.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/ResourceQuotaPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class ResourceQuotaPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ResourceQuotaSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ResourceQuotaSpecPatchArgs', 'ResourceQuotaSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -109,8 +114,8 @@ class ResourceQuotaPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['ResourceQuotaSpecPatchArgs']] spec: Spec defines the desired quota. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['ResourceQuotaSpecPatchArgs', 'ResourceQuotaSpecPatchArgsDict']] spec: Spec defines the desired quota. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -144,8 +149,8 @@ class ResourceQuotaPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ResourceQuotaSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ResourceQuotaSpecPatchArgs', 'ResourceQuotaSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/core/v1/Secret.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/Secret.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import meta as _meta
 
@@ -141,7 +146,7 @@ class Secret(pulumi.CustomResource):
                  data: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  immutable: Optional[pulumi.Input[bool]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
                  string_data: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  type: Optional[pulumi.Input[str]] = None,
                  __props__=None):
@@ -164,7 +169,7 @@ class Secret(pulumi.CustomResource):
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] data: Data contains the secret data. Each key must consist of alphanumeric characters, '-', '_' or '.'. The serialized form of the secret data is a base64 encoded string, representing the arbitrary (possibly non-string) data value here. Described in https://tools.ietf.org/html/rfc4648#section-4
         :param pulumi.Input[bool] immutable: Immutable, if set to true, ensures that data stored in the Secret cannot be updated (only object metadata can be modified). If not set to true, the field can be modified at any time. Defaulted to nil.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] string_data: stringData allows specifying non-binary secret data in string form. It is provided as a write-only input field for convenience. All keys and values are merged into the data field on write, overwriting any existing values. The stringData field is never output when reading from the API.
         :param pulumi.Input[str] type: Used to facilitate programmatic handling of secret data. More info: https://kubernetes.io/docs/concepts/configuration/secret/#secret-types
         """
@@ -206,7 +211,7 @@ class Secret(pulumi.CustomResource):
                  data: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  immutable: Optional[pulumi.Input[bool]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
                  string_data: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  type: Optional[pulumi.Input[str]] = None,
                  __props__=None):

--- a/sdk/python/pulumi_kubernetes/core/v1/SecretList.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/SecretList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class SecretList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SecretArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['SecretArgs', 'SecretArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         SecretList is a list of Secret.
@@ -101,9 +106,9 @@ class SecretList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SecretArgs']]]] items: Items is a list of secret objects. More info: https://kubernetes.io/docs/concepts/configuration/secret
+        :param pulumi.Input[Sequence[pulumi.Input[Union['SecretArgs', 'SecretArgsDict']]]] items: Items is a list of secret objects. More info: https://kubernetes.io/docs/concepts/configuration/secret
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class SecretList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SecretArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['SecretArgs', 'SecretArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/core/v1/SecretPatch.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/SecretPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import meta as _meta
 
@@ -141,7 +146,7 @@ class SecretPatch(pulumi.CustomResource):
                  data: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  immutable: Optional[pulumi.Input[bool]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
                  string_data: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  type: Optional[pulumi.Input[str]] = None,
                  __props__=None):
@@ -170,7 +175,7 @@ class SecretPatch(pulumi.CustomResource):
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] data: Data contains the secret data. Each key must consist of alphanumeric characters, '-', '_' or '.'. The serialized form of the secret data is a base64 encoded string, representing the arbitrary (possibly non-string) data value here. Described in https://tools.ietf.org/html/rfc4648#section-4
         :param pulumi.Input[bool] immutable: Immutable, if set to true, ensures that data stored in the Secret cannot be updated (only object metadata can be modified). If not set to true, the field can be modified at any time. Defaulted to nil.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] string_data: stringData allows specifying non-binary secret data in string form. It is provided as a write-only input field for convenience. All keys and values are merged into the data field on write, overwriting any existing values. The stringData field is never output when reading from the API.
         :param pulumi.Input[str] type: Used to facilitate programmatic handling of secret data. More info: https://kubernetes.io/docs/concepts/configuration/secret/#secret-types
         """
@@ -218,7 +223,7 @@ class SecretPatch(pulumi.CustomResource):
                  data: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  immutable: Optional[pulumi.Input[bool]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
                  string_data: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  type: Optional[pulumi.Input[str]] = None,
                  __props__=None):

--- a/sdk/python/pulumi_kubernetes/core/v1/Service.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/Service.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -94,8 +99,8 @@ class Service(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ServiceSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ServiceSpecArgs', 'ServiceSpecArgsDict']]] = None,
                  __props__=None):
         """
         Service is a named abstraction of software service (for example, mysql) consisting of local port (for example 3306) that the proxy listens on, and the selector that determines which pods will answer requests sent through the proxy.
@@ -167,8 +172,8 @@ class Service(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['ServiceSpecArgs']] spec: Spec defines the behavior of a service. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['ServiceSpecArgs', 'ServiceSpecArgsDict']] spec: Spec defines the behavior of a service. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -259,8 +264,8 @@ class Service(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ServiceSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ServiceSpecArgs', 'ServiceSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/core/v1/ServiceAccount.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/ServiceAccount.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -125,10 +130,10 @@ class ServiceAccount(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  automount_service_account_token: Optional[pulumi.Input[bool]] = None,
-                 image_pull_secrets: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['LocalObjectReferenceArgs']]]]] = None,
+                 image_pull_secrets: Optional[pulumi.Input[Sequence[pulumi.Input[Union['LocalObjectReferenceArgs', 'LocalObjectReferenceArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 secrets: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ObjectReferenceArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 secrets: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ObjectReferenceArgs', 'ObjectReferenceArgsDict']]]]] = None,
                  __props__=None):
         """
         ServiceAccount binds together: * a name, understood by users, and perhaps by peripheral systems, for an identity * a principal that can be authenticated and authorized * a set of secrets
@@ -137,10 +142,10 @@ class ServiceAccount(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[bool] automount_service_account_token: AutomountServiceAccountToken indicates whether pods running as this service account should have an API token automatically mounted. Can be overridden at the pod level.
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['LocalObjectReferenceArgs']]]] image_pull_secrets: ImagePullSecrets is a list of references to secrets in the same namespace to use for pulling any images in pods that reference this ServiceAccount. ImagePullSecrets are distinct from Secrets because Secrets can be mounted in the pod, but ImagePullSecrets are only accessed by the kubelet. More info: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+        :param pulumi.Input[Sequence[pulumi.Input[Union['LocalObjectReferenceArgs', 'LocalObjectReferenceArgsDict']]]] image_pull_secrets: ImagePullSecrets is a list of references to secrets in the same namespace to use for pulling any images in pods that reference this ServiceAccount. ImagePullSecrets are distinct from Secrets because Secrets can be mounted in the pod, but ImagePullSecrets are only accessed by the kubelet. More info: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ObjectReferenceArgs']]]] secrets: Secrets is a list of the secrets in the same namespace that pods running using this ServiceAccount are allowed to use. Pods are only limited to this list if this service account has a "kubernetes.io/enforce-mountable-secrets" annotation set to "true". This field should not be used to find auto-generated service account token secrets for use outside of pods. Instead, tokens can be requested directly using the TokenRequest API, or service account token secrets can be manually created. More info: https://kubernetes.io/docs/concepts/configuration/secret
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Sequence[pulumi.Input[Union['ObjectReferenceArgs', 'ObjectReferenceArgsDict']]]] secrets: Secrets is a list of the secrets in the same namespace that pods running using this ServiceAccount are allowed to use. Pods are only limited to this list if this service account has a "kubernetes.io/enforce-mountable-secrets" annotation set to "true". This field should not be used to find auto-generated service account token secrets for use outside of pods. Instead, tokens can be requested directly using the TokenRequest API, or service account token secrets can be manually created. More info: https://kubernetes.io/docs/concepts/configuration/secret
         """
         ...
     @overload
@@ -168,10 +173,10 @@ class ServiceAccount(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  automount_service_account_token: Optional[pulumi.Input[bool]] = None,
-                 image_pull_secrets: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['LocalObjectReferenceArgs']]]]] = None,
+                 image_pull_secrets: Optional[pulumi.Input[Sequence[pulumi.Input[Union['LocalObjectReferenceArgs', 'LocalObjectReferenceArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 secrets: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ObjectReferenceArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 secrets: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ObjectReferenceArgs', 'ObjectReferenceArgsDict']]]]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/core/v1/ServiceAccountList.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/ServiceAccountList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class ServiceAccountList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ServiceAccountArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ServiceAccountArgs', 'ServiceAccountArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         ServiceAccountList is a list of ServiceAccount objects
@@ -101,9 +106,9 @@ class ServiceAccountList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ServiceAccountArgs']]]] items: List of ServiceAccounts. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+        :param pulumi.Input[Sequence[pulumi.Input[Union['ServiceAccountArgs', 'ServiceAccountArgsDict']]]] items: List of ServiceAccounts. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class ServiceAccountList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ServiceAccountArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ServiceAccountArgs', 'ServiceAccountArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/core/v1/ServiceAccountPatch.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/ServiceAccountPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -125,10 +130,10 @@ class ServiceAccountPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  automount_service_account_token: Optional[pulumi.Input[bool]] = None,
-                 image_pull_secrets: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['LocalObjectReferencePatchArgs']]]]] = None,
+                 image_pull_secrets: Optional[pulumi.Input[Sequence[pulumi.Input[Union['LocalObjectReferencePatchArgs', 'LocalObjectReferencePatchArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 secrets: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ObjectReferencePatchArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 secrets: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ObjectReferencePatchArgs', 'ObjectReferencePatchArgsDict']]]]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -143,10 +148,10 @@ class ServiceAccountPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[bool] automount_service_account_token: AutomountServiceAccountToken indicates whether pods running as this service account should have an API token automatically mounted. Can be overridden at the pod level.
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['LocalObjectReferencePatchArgs']]]] image_pull_secrets: ImagePullSecrets is a list of references to secrets in the same namespace to use for pulling any images in pods that reference this ServiceAccount. ImagePullSecrets are distinct from Secrets because Secrets can be mounted in the pod, but ImagePullSecrets are only accessed by the kubelet. More info: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+        :param pulumi.Input[Sequence[pulumi.Input[Union['LocalObjectReferencePatchArgs', 'LocalObjectReferencePatchArgsDict']]]] image_pull_secrets: ImagePullSecrets is a list of references to secrets in the same namespace to use for pulling any images in pods that reference this ServiceAccount. ImagePullSecrets are distinct from Secrets because Secrets can be mounted in the pod, but ImagePullSecrets are only accessed by the kubelet. More info: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ObjectReferencePatchArgs']]]] secrets: Secrets is a list of the secrets in the same namespace that pods running using this ServiceAccount are allowed to use. Pods are only limited to this list if this service account has a "kubernetes.io/enforce-mountable-secrets" annotation set to "true". This field should not be used to find auto-generated service account token secrets for use outside of pods. Instead, tokens can be requested directly using the TokenRequest API, or service account token secrets can be manually created. More info: https://kubernetes.io/docs/concepts/configuration/secret
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Sequence[pulumi.Input[Union['ObjectReferencePatchArgs', 'ObjectReferencePatchArgsDict']]]] secrets: Secrets is a list of the secrets in the same namespace that pods running using this ServiceAccount are allowed to use. Pods are only limited to this list if this service account has a "kubernetes.io/enforce-mountable-secrets" annotation set to "true". This field should not be used to find auto-generated service account token secrets for use outside of pods. Instead, tokens can be requested directly using the TokenRequest API, or service account token secrets can be manually created. More info: https://kubernetes.io/docs/concepts/configuration/secret
         """
         ...
     @overload
@@ -180,10 +185,10 @@ class ServiceAccountPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  automount_service_account_token: Optional[pulumi.Input[bool]] = None,
-                 image_pull_secrets: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['LocalObjectReferencePatchArgs']]]]] = None,
+                 image_pull_secrets: Optional[pulumi.Input[Sequence[pulumi.Input[Union['LocalObjectReferencePatchArgs', 'LocalObjectReferencePatchArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 secrets: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ObjectReferencePatchArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 secrets: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ObjectReferencePatchArgs', 'ObjectReferencePatchArgsDict']]]]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/core/v1/ServiceList.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/ServiceList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -92,9 +97,9 @@ class ServiceList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ServiceArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ServiceArgs', 'ServiceArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         ServiceList holds a list of services.
@@ -102,9 +107,9 @@ class ServiceList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ServiceArgs']]]] items: List of services
+        :param pulumi.Input[Sequence[pulumi.Input[Union['ServiceArgs', 'ServiceArgsDict']]]] items: List of services
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
         """
         ...
     @overload
@@ -131,9 +136,9 @@ class ServiceList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ServiceArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ServiceArgs', 'ServiceArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/core/v1/ServicePatch.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/ServicePatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -94,8 +99,8 @@ class ServicePatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ServiceSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ServiceSpecPatchArgs', 'ServiceSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -135,8 +140,8 @@ class ServicePatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['ServiceSpecPatchArgs']] spec: Spec defines the behavior of a service. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['ServiceSpecPatchArgs', 'ServiceSpecPatchArgsDict']] spec: Spec defines the behavior of a service. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -195,8 +200,8 @@ class ServicePatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ServiceSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ServiceSpecPatchArgs', 'ServiceSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/core/v1/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/_inputs.py
@@ -4,343 +4,704 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import meta as _meta
 from ._enums import *
 
 __all__ = [
     'AWSElasticBlockStoreVolumeSourcePatchArgs',
+    'AWSElasticBlockStoreVolumeSourcePatchArgsDict',
     'AWSElasticBlockStoreVolumeSourceArgs',
+    'AWSElasticBlockStoreVolumeSourceArgsDict',
     'AffinityPatchArgs',
+    'AffinityPatchArgsDict',
     'AffinityArgs',
+    'AffinityArgsDict',
     'AppArmorProfilePatchArgs',
+    'AppArmorProfilePatchArgsDict',
     'AppArmorProfileArgs',
+    'AppArmorProfileArgsDict',
     'AttachedVolumeArgs',
+    'AttachedVolumeArgsDict',
     'AzureDiskVolumeSourcePatchArgs',
+    'AzureDiskVolumeSourcePatchArgsDict',
     'AzureDiskVolumeSourceArgs',
+    'AzureDiskVolumeSourceArgsDict',
     'AzureFilePersistentVolumeSourcePatchArgs',
+    'AzureFilePersistentVolumeSourcePatchArgsDict',
     'AzureFilePersistentVolumeSourceArgs',
+    'AzureFilePersistentVolumeSourceArgsDict',
     'AzureFileVolumeSourcePatchArgs',
+    'AzureFileVolumeSourcePatchArgsDict',
     'AzureFileVolumeSourceArgs',
+    'AzureFileVolumeSourceArgsDict',
     'CSIPersistentVolumeSourcePatchArgs',
+    'CSIPersistentVolumeSourcePatchArgsDict',
     'CSIPersistentVolumeSourceArgs',
+    'CSIPersistentVolumeSourceArgsDict',
     'CSIVolumeSourcePatchArgs',
+    'CSIVolumeSourcePatchArgsDict',
     'CSIVolumeSourceArgs',
+    'CSIVolumeSourceArgsDict',
     'CapabilitiesPatchArgs',
+    'CapabilitiesPatchArgsDict',
     'CapabilitiesArgs',
+    'CapabilitiesArgsDict',
     'CephFSPersistentVolumeSourcePatchArgs',
+    'CephFSPersistentVolumeSourcePatchArgsDict',
     'CephFSPersistentVolumeSourceArgs',
+    'CephFSPersistentVolumeSourceArgsDict',
     'CephFSVolumeSourcePatchArgs',
+    'CephFSVolumeSourcePatchArgsDict',
     'CephFSVolumeSourceArgs',
+    'CephFSVolumeSourceArgsDict',
     'CinderPersistentVolumeSourcePatchArgs',
+    'CinderPersistentVolumeSourcePatchArgsDict',
     'CinderPersistentVolumeSourceArgs',
+    'CinderPersistentVolumeSourceArgsDict',
     'CinderVolumeSourcePatchArgs',
+    'CinderVolumeSourcePatchArgsDict',
     'CinderVolumeSourceArgs',
+    'CinderVolumeSourceArgsDict',
     'ClaimSourcePatchArgs',
+    'ClaimSourcePatchArgsDict',
     'ClaimSourceArgs',
+    'ClaimSourceArgsDict',
     'ClientIPConfigPatchArgs',
+    'ClientIPConfigPatchArgsDict',
     'ClientIPConfigArgs',
+    'ClientIPConfigArgsDict',
     'ClusterTrustBundleProjectionPatchArgs',
+    'ClusterTrustBundleProjectionPatchArgsDict',
     'ClusterTrustBundleProjectionArgs',
+    'ClusterTrustBundleProjectionArgsDict',
     'ConfigMapEnvSourcePatchArgs',
+    'ConfigMapEnvSourcePatchArgsDict',
     'ConfigMapEnvSourceArgs',
+    'ConfigMapEnvSourceArgsDict',
     'ConfigMapKeySelectorPatchArgs',
+    'ConfigMapKeySelectorPatchArgsDict',
     'ConfigMapKeySelectorArgs',
+    'ConfigMapKeySelectorArgsDict',
     'ConfigMapNodeConfigSourcePatchArgs',
+    'ConfigMapNodeConfigSourcePatchArgsDict',
     'ConfigMapNodeConfigSourceArgs',
+    'ConfigMapNodeConfigSourceArgsDict',
     'ConfigMapProjectionPatchArgs',
+    'ConfigMapProjectionPatchArgsDict',
     'ConfigMapProjectionArgs',
+    'ConfigMapProjectionArgsDict',
     'ConfigMapVolumeSourcePatchArgs',
+    'ConfigMapVolumeSourcePatchArgsDict',
     'ConfigMapVolumeSourceArgs',
+    'ConfigMapVolumeSourceArgsDict',
     'ConfigMapArgs',
+    'ConfigMapArgsDict',
     'ContainerImageArgs',
+    'ContainerImageArgsDict',
     'ContainerPatchArgs',
+    'ContainerPatchArgsDict',
     'ContainerPortPatchArgs',
+    'ContainerPortPatchArgsDict',
     'ContainerPortArgs',
+    'ContainerPortArgsDict',
     'ContainerResizePolicyPatchArgs',
+    'ContainerResizePolicyPatchArgsDict',
     'ContainerResizePolicyArgs',
+    'ContainerResizePolicyArgsDict',
     'ContainerStateRunningArgs',
+    'ContainerStateRunningArgsDict',
     'ContainerStateTerminatedArgs',
+    'ContainerStateTerminatedArgsDict',
     'ContainerStateWaitingArgs',
+    'ContainerStateWaitingArgsDict',
     'ContainerStateArgs',
+    'ContainerStateArgsDict',
     'ContainerStatusArgs',
+    'ContainerStatusArgsDict',
     'ContainerArgs',
+    'ContainerArgsDict',
     'DaemonEndpointArgs',
+    'DaemonEndpointArgsDict',
     'DownwardAPIProjectionPatchArgs',
+    'DownwardAPIProjectionPatchArgsDict',
     'DownwardAPIProjectionArgs',
+    'DownwardAPIProjectionArgsDict',
     'DownwardAPIVolumeFilePatchArgs',
+    'DownwardAPIVolumeFilePatchArgsDict',
     'DownwardAPIVolumeFileArgs',
+    'DownwardAPIVolumeFileArgsDict',
     'DownwardAPIVolumeSourcePatchArgs',
+    'DownwardAPIVolumeSourcePatchArgsDict',
     'DownwardAPIVolumeSourceArgs',
+    'DownwardAPIVolumeSourceArgsDict',
     'EmptyDirVolumeSourcePatchArgs',
+    'EmptyDirVolumeSourcePatchArgsDict',
     'EmptyDirVolumeSourceArgs',
+    'EmptyDirVolumeSourceArgsDict',
     'EndpointAddressPatchArgs',
+    'EndpointAddressPatchArgsDict',
     'EndpointAddressArgs',
+    'EndpointAddressArgsDict',
     'EndpointPortPatchArgs',
+    'EndpointPortPatchArgsDict',
     'EndpointPortArgs',
+    'EndpointPortArgsDict',
     'EndpointSubsetPatchArgs',
+    'EndpointSubsetPatchArgsDict',
     'EndpointSubsetArgs',
+    'EndpointSubsetArgsDict',
     'EndpointsArgs',
+    'EndpointsArgsDict',
     'EnvFromSourcePatchArgs',
+    'EnvFromSourcePatchArgsDict',
     'EnvFromSourceArgs',
+    'EnvFromSourceArgsDict',
     'EnvVarPatchArgs',
+    'EnvVarPatchArgsDict',
     'EnvVarSourcePatchArgs',
+    'EnvVarSourcePatchArgsDict',
     'EnvVarSourceArgs',
+    'EnvVarSourceArgsDict',
     'EnvVarArgs',
+    'EnvVarArgsDict',
     'EphemeralContainerPatchArgs',
+    'EphemeralContainerPatchArgsDict',
     'EphemeralContainerArgs',
+    'EphemeralContainerArgsDict',
     'EphemeralVolumeSourcePatchArgs',
+    'EphemeralVolumeSourcePatchArgsDict',
     'EphemeralVolumeSourceArgs',
+    'EphemeralVolumeSourceArgsDict',
     'EventSeriesPatchArgs',
+    'EventSeriesPatchArgsDict',
     'EventSeriesArgs',
+    'EventSeriesArgsDict',
     'EventSourcePatchArgs',
+    'EventSourcePatchArgsDict',
     'EventSourceArgs',
+    'EventSourceArgsDict',
     'EventArgs',
+    'EventArgsDict',
     'ExecActionPatchArgs',
+    'ExecActionPatchArgsDict',
     'ExecActionArgs',
+    'ExecActionArgsDict',
     'FCVolumeSourcePatchArgs',
+    'FCVolumeSourcePatchArgsDict',
     'FCVolumeSourceArgs',
+    'FCVolumeSourceArgsDict',
     'FlexPersistentVolumeSourcePatchArgs',
+    'FlexPersistentVolumeSourcePatchArgsDict',
     'FlexPersistentVolumeSourceArgs',
+    'FlexPersistentVolumeSourceArgsDict',
     'FlexVolumeSourcePatchArgs',
+    'FlexVolumeSourcePatchArgsDict',
     'FlexVolumeSourceArgs',
+    'FlexVolumeSourceArgsDict',
     'FlockerVolumeSourcePatchArgs',
+    'FlockerVolumeSourcePatchArgsDict',
     'FlockerVolumeSourceArgs',
+    'FlockerVolumeSourceArgsDict',
     'GCEPersistentDiskVolumeSourcePatchArgs',
+    'GCEPersistentDiskVolumeSourcePatchArgsDict',
     'GCEPersistentDiskVolumeSourceArgs',
+    'GCEPersistentDiskVolumeSourceArgsDict',
     'GRPCActionPatchArgs',
+    'GRPCActionPatchArgsDict',
     'GRPCActionArgs',
+    'GRPCActionArgsDict',
     'GitRepoVolumeSourcePatchArgs',
+    'GitRepoVolumeSourcePatchArgsDict',
     'GitRepoVolumeSourceArgs',
+    'GitRepoVolumeSourceArgsDict',
     'GlusterfsPersistentVolumeSourcePatchArgs',
+    'GlusterfsPersistentVolumeSourcePatchArgsDict',
     'GlusterfsPersistentVolumeSourceArgs',
+    'GlusterfsPersistentVolumeSourceArgsDict',
     'GlusterfsVolumeSourcePatchArgs',
+    'GlusterfsVolumeSourcePatchArgsDict',
     'GlusterfsVolumeSourceArgs',
+    'GlusterfsVolumeSourceArgsDict',
     'HTTPGetActionPatchArgs',
+    'HTTPGetActionPatchArgsDict',
     'HTTPGetActionArgs',
+    'HTTPGetActionArgsDict',
     'HTTPHeaderPatchArgs',
+    'HTTPHeaderPatchArgsDict',
     'HTTPHeaderArgs',
+    'HTTPHeaderArgsDict',
     'HostAliasPatchArgs',
+    'HostAliasPatchArgsDict',
     'HostAliasArgs',
+    'HostAliasArgsDict',
     'HostIPArgs',
+    'HostIPArgsDict',
     'HostPathVolumeSourcePatchArgs',
+    'HostPathVolumeSourcePatchArgsDict',
     'HostPathVolumeSourceArgs',
+    'HostPathVolumeSourceArgsDict',
     'ISCSIPersistentVolumeSourcePatchArgs',
+    'ISCSIPersistentVolumeSourcePatchArgsDict',
     'ISCSIPersistentVolumeSourceArgs',
+    'ISCSIPersistentVolumeSourceArgsDict',
     'ISCSIVolumeSourcePatchArgs',
+    'ISCSIVolumeSourcePatchArgsDict',
     'ISCSIVolumeSourceArgs',
+    'ISCSIVolumeSourceArgsDict',
     'KeyToPathPatchArgs',
+    'KeyToPathPatchArgsDict',
     'KeyToPathArgs',
+    'KeyToPathArgsDict',
     'LifecycleHandlerPatchArgs',
+    'LifecycleHandlerPatchArgsDict',
     'LifecycleHandlerArgs',
+    'LifecycleHandlerArgsDict',
     'LifecyclePatchArgs',
+    'LifecyclePatchArgsDict',
     'LifecycleArgs',
+    'LifecycleArgsDict',
     'LimitRangeItemPatchArgs',
+    'LimitRangeItemPatchArgsDict',
     'LimitRangeItemArgs',
+    'LimitRangeItemArgsDict',
     'LimitRangeSpecPatchArgs',
+    'LimitRangeSpecPatchArgsDict',
     'LimitRangeSpecArgs',
+    'LimitRangeSpecArgsDict',
     'LimitRangeArgs',
+    'LimitRangeArgsDict',
     'LoadBalancerIngressArgs',
+    'LoadBalancerIngressArgsDict',
     'LoadBalancerStatusArgs',
+    'LoadBalancerStatusArgsDict',
     'LocalObjectReferencePatchArgs',
+    'LocalObjectReferencePatchArgsDict',
     'LocalObjectReferenceArgs',
+    'LocalObjectReferenceArgsDict',
     'LocalVolumeSourcePatchArgs',
+    'LocalVolumeSourcePatchArgsDict',
     'LocalVolumeSourceArgs',
+    'LocalVolumeSourceArgsDict',
     'ModifyVolumeStatusPatchArgs',
+    'ModifyVolumeStatusPatchArgsDict',
     'ModifyVolumeStatusArgs',
+    'ModifyVolumeStatusArgsDict',
     'NFSVolumeSourcePatchArgs',
+    'NFSVolumeSourcePatchArgsDict',
     'NFSVolumeSourceArgs',
+    'NFSVolumeSourceArgsDict',
     'NamespaceConditionArgs',
+    'NamespaceConditionArgsDict',
     'NamespaceSpecPatchArgs',
+    'NamespaceSpecPatchArgsDict',
     'NamespaceSpecArgs',
+    'NamespaceSpecArgsDict',
     'NamespaceStatusArgs',
+    'NamespaceStatusArgsDict',
     'NamespaceArgs',
+    'NamespaceArgsDict',
     'NodeAddressArgs',
+    'NodeAddressArgsDict',
     'NodeAffinityPatchArgs',
+    'NodeAffinityPatchArgsDict',
     'NodeAffinityArgs',
+    'NodeAffinityArgsDict',
     'NodeConditionArgs',
+    'NodeConditionArgsDict',
     'NodeConfigSourcePatchArgs',
+    'NodeConfigSourcePatchArgsDict',
     'NodeConfigSourceArgs',
+    'NodeConfigSourceArgsDict',
     'NodeConfigStatusArgs',
+    'NodeConfigStatusArgsDict',
     'NodeDaemonEndpointsArgs',
+    'NodeDaemonEndpointsArgsDict',
     'NodeRuntimeHandlerFeaturesArgs',
+    'NodeRuntimeHandlerFeaturesArgsDict',
     'NodeRuntimeHandlerArgs',
+    'NodeRuntimeHandlerArgsDict',
     'NodeSelectorPatchArgs',
+    'NodeSelectorPatchArgsDict',
     'NodeSelectorRequirementPatchArgs',
+    'NodeSelectorRequirementPatchArgsDict',
     'NodeSelectorRequirementArgs',
+    'NodeSelectorRequirementArgsDict',
     'NodeSelectorTermPatchArgs',
+    'NodeSelectorTermPatchArgsDict',
     'NodeSelectorTermArgs',
+    'NodeSelectorTermArgsDict',
     'NodeSelectorArgs',
+    'NodeSelectorArgsDict',
     'NodeSpecPatchArgs',
+    'NodeSpecPatchArgsDict',
     'NodeSpecArgs',
+    'NodeSpecArgsDict',
     'NodeStatusArgs',
+    'NodeStatusArgsDict',
     'NodeSystemInfoArgs',
+    'NodeSystemInfoArgsDict',
     'NodeArgs',
+    'NodeArgsDict',
     'ObjectFieldSelectorPatchArgs',
+    'ObjectFieldSelectorPatchArgsDict',
     'ObjectFieldSelectorArgs',
+    'ObjectFieldSelectorArgsDict',
     'ObjectReferencePatchArgs',
+    'ObjectReferencePatchArgsDict',
     'ObjectReferenceArgs',
+    'ObjectReferenceArgsDict',
     'PersistentVolumeClaimConditionPatchArgs',
+    'PersistentVolumeClaimConditionPatchArgsDict',
     'PersistentVolumeClaimConditionArgs',
+    'PersistentVolumeClaimConditionArgsDict',
     'PersistentVolumeClaimPatchArgs',
+    'PersistentVolumeClaimPatchArgsDict',
     'PersistentVolumeClaimSpecPatchArgs',
+    'PersistentVolumeClaimSpecPatchArgsDict',
     'PersistentVolumeClaimSpecArgs',
+    'PersistentVolumeClaimSpecArgsDict',
     'PersistentVolumeClaimStatusPatchArgs',
+    'PersistentVolumeClaimStatusPatchArgsDict',
     'PersistentVolumeClaimStatusArgs',
+    'PersistentVolumeClaimStatusArgsDict',
     'PersistentVolumeClaimTemplatePatchArgs',
+    'PersistentVolumeClaimTemplatePatchArgsDict',
     'PersistentVolumeClaimTemplateArgs',
+    'PersistentVolumeClaimTemplateArgsDict',
     'PersistentVolumeClaimVolumeSourcePatchArgs',
+    'PersistentVolumeClaimVolumeSourcePatchArgsDict',
     'PersistentVolumeClaimVolumeSourceArgs',
+    'PersistentVolumeClaimVolumeSourceArgsDict',
     'PersistentVolumeClaimArgs',
+    'PersistentVolumeClaimArgsDict',
     'PersistentVolumeSpecPatchArgs',
+    'PersistentVolumeSpecPatchArgsDict',
     'PersistentVolumeSpecArgs',
+    'PersistentVolumeSpecArgsDict',
     'PersistentVolumeStatusArgs',
+    'PersistentVolumeStatusArgsDict',
     'PersistentVolumeArgs',
+    'PersistentVolumeArgsDict',
     'PhotonPersistentDiskVolumeSourcePatchArgs',
+    'PhotonPersistentDiskVolumeSourcePatchArgsDict',
     'PhotonPersistentDiskVolumeSourceArgs',
+    'PhotonPersistentDiskVolumeSourceArgsDict',
     'PodAffinityPatchArgs',
+    'PodAffinityPatchArgsDict',
     'PodAffinityTermPatchArgs',
+    'PodAffinityTermPatchArgsDict',
     'PodAffinityTermArgs',
+    'PodAffinityTermArgsDict',
     'PodAffinityArgs',
+    'PodAffinityArgsDict',
     'PodAntiAffinityPatchArgs',
+    'PodAntiAffinityPatchArgsDict',
     'PodAntiAffinityArgs',
+    'PodAntiAffinityArgsDict',
     'PodConditionArgs',
+    'PodConditionArgsDict',
     'PodDNSConfigOptionPatchArgs',
+    'PodDNSConfigOptionPatchArgsDict',
     'PodDNSConfigOptionArgs',
+    'PodDNSConfigOptionArgsDict',
     'PodDNSConfigPatchArgs',
+    'PodDNSConfigPatchArgsDict',
     'PodDNSConfigArgs',
+    'PodDNSConfigArgsDict',
     'PodIPArgs',
+    'PodIPArgsDict',
     'PodOSPatchArgs',
+    'PodOSPatchArgsDict',
     'PodOSArgs',
+    'PodOSArgsDict',
     'PodReadinessGatePatchArgs',
+    'PodReadinessGatePatchArgsDict',
     'PodReadinessGateArgs',
+    'PodReadinessGateArgsDict',
     'PodResourceClaimPatchArgs',
+    'PodResourceClaimPatchArgsDict',
     'PodResourceClaimStatusArgs',
+    'PodResourceClaimStatusArgsDict',
     'PodResourceClaimArgs',
+    'PodResourceClaimArgsDict',
     'PodSchedulingGatePatchArgs',
+    'PodSchedulingGatePatchArgsDict',
     'PodSchedulingGateArgs',
+    'PodSchedulingGateArgsDict',
     'PodSecurityContextPatchArgs',
+    'PodSecurityContextPatchArgsDict',
     'PodSecurityContextArgs',
+    'PodSecurityContextArgsDict',
     'PodSpecPatchArgs',
+    'PodSpecPatchArgsDict',
     'PodSpecArgs',
+    'PodSpecArgsDict',
     'PodStatusArgs',
+    'PodStatusArgsDict',
     'PodTemplateSpecPatchArgs',
+    'PodTemplateSpecPatchArgsDict',
     'PodTemplateSpecArgs',
+    'PodTemplateSpecArgsDict',
     'PodTemplateArgs',
+    'PodTemplateArgsDict',
     'PodArgs',
+    'PodArgsDict',
     'PortStatusArgs',
+    'PortStatusArgsDict',
     'PortworxVolumeSourcePatchArgs',
+    'PortworxVolumeSourcePatchArgsDict',
     'PortworxVolumeSourceArgs',
+    'PortworxVolumeSourceArgsDict',
     'PreferredSchedulingTermPatchArgs',
+    'PreferredSchedulingTermPatchArgsDict',
     'PreferredSchedulingTermArgs',
+    'PreferredSchedulingTermArgsDict',
     'ProbePatchArgs',
+    'ProbePatchArgsDict',
     'ProbeArgs',
+    'ProbeArgsDict',
     'ProjectedVolumeSourcePatchArgs',
+    'ProjectedVolumeSourcePatchArgsDict',
     'ProjectedVolumeSourceArgs',
+    'ProjectedVolumeSourceArgsDict',
     'QuobyteVolumeSourcePatchArgs',
+    'QuobyteVolumeSourcePatchArgsDict',
     'QuobyteVolumeSourceArgs',
+    'QuobyteVolumeSourceArgsDict',
     'RBDPersistentVolumeSourcePatchArgs',
+    'RBDPersistentVolumeSourcePatchArgsDict',
     'RBDPersistentVolumeSourceArgs',
+    'RBDPersistentVolumeSourceArgsDict',
     'RBDVolumeSourcePatchArgs',
+    'RBDVolumeSourcePatchArgsDict',
     'RBDVolumeSourceArgs',
+    'RBDVolumeSourceArgsDict',
     'ReplicationControllerConditionArgs',
+    'ReplicationControllerConditionArgsDict',
     'ReplicationControllerSpecPatchArgs',
+    'ReplicationControllerSpecPatchArgsDict',
     'ReplicationControllerSpecArgs',
+    'ReplicationControllerSpecArgsDict',
     'ReplicationControllerStatusArgs',
+    'ReplicationControllerStatusArgsDict',
     'ReplicationControllerArgs',
+    'ReplicationControllerArgsDict',
     'ResourceClaimPatchArgs',
+    'ResourceClaimPatchArgsDict',
     'ResourceClaimArgs',
+    'ResourceClaimArgsDict',
     'ResourceFieldSelectorPatchArgs',
+    'ResourceFieldSelectorPatchArgsDict',
     'ResourceFieldSelectorArgs',
+    'ResourceFieldSelectorArgsDict',
     'ResourceQuotaSpecPatchArgs',
+    'ResourceQuotaSpecPatchArgsDict',
     'ResourceQuotaSpecArgs',
+    'ResourceQuotaSpecArgsDict',
     'ResourceQuotaStatusArgs',
+    'ResourceQuotaStatusArgsDict',
     'ResourceQuotaArgs',
+    'ResourceQuotaArgsDict',
     'ResourceRequirementsPatchArgs',
+    'ResourceRequirementsPatchArgsDict',
     'ResourceRequirementsArgs',
+    'ResourceRequirementsArgsDict',
     'SELinuxOptionsPatchArgs',
+    'SELinuxOptionsPatchArgsDict',
     'SELinuxOptionsArgs',
+    'SELinuxOptionsArgsDict',
     'ScaleIOPersistentVolumeSourcePatchArgs',
+    'ScaleIOPersistentVolumeSourcePatchArgsDict',
     'ScaleIOPersistentVolumeSourceArgs',
+    'ScaleIOPersistentVolumeSourceArgsDict',
     'ScaleIOVolumeSourcePatchArgs',
+    'ScaleIOVolumeSourcePatchArgsDict',
     'ScaleIOVolumeSourceArgs',
+    'ScaleIOVolumeSourceArgsDict',
     'ScopeSelectorPatchArgs',
+    'ScopeSelectorPatchArgsDict',
     'ScopeSelectorArgs',
+    'ScopeSelectorArgsDict',
     'ScopedResourceSelectorRequirementPatchArgs',
+    'ScopedResourceSelectorRequirementPatchArgsDict',
     'ScopedResourceSelectorRequirementArgs',
+    'ScopedResourceSelectorRequirementArgsDict',
     'SeccompProfilePatchArgs',
+    'SeccompProfilePatchArgsDict',
     'SeccompProfileArgs',
+    'SeccompProfileArgsDict',
     'SecretEnvSourcePatchArgs',
+    'SecretEnvSourcePatchArgsDict',
     'SecretEnvSourceArgs',
+    'SecretEnvSourceArgsDict',
     'SecretKeySelectorPatchArgs',
+    'SecretKeySelectorPatchArgsDict',
     'SecretKeySelectorArgs',
+    'SecretKeySelectorArgsDict',
     'SecretProjectionPatchArgs',
+    'SecretProjectionPatchArgsDict',
     'SecretProjectionArgs',
+    'SecretProjectionArgsDict',
     'SecretReferencePatchArgs',
+    'SecretReferencePatchArgsDict',
     'SecretReferenceArgs',
+    'SecretReferenceArgsDict',
     'SecretVolumeSourcePatchArgs',
+    'SecretVolumeSourcePatchArgsDict',
     'SecretVolumeSourceArgs',
+    'SecretVolumeSourceArgsDict',
     'SecretArgs',
+    'SecretArgsDict',
     'SecurityContextPatchArgs',
+    'SecurityContextPatchArgsDict',
     'SecurityContextArgs',
+    'SecurityContextArgsDict',
     'ServiceAccountTokenProjectionPatchArgs',
+    'ServiceAccountTokenProjectionPatchArgsDict',
     'ServiceAccountTokenProjectionArgs',
+    'ServiceAccountTokenProjectionArgsDict',
     'ServiceAccountArgs',
+    'ServiceAccountArgsDict',
     'ServicePortPatchArgs',
+    'ServicePortPatchArgsDict',
     'ServicePortArgs',
+    'ServicePortArgsDict',
     'ServiceSpecPatchArgs',
+    'ServiceSpecPatchArgsDict',
     'ServiceSpecArgs',
+    'ServiceSpecArgsDict',
     'ServiceStatusArgs',
+    'ServiceStatusArgsDict',
     'ServiceArgs',
+    'ServiceArgsDict',
     'SessionAffinityConfigPatchArgs',
+    'SessionAffinityConfigPatchArgsDict',
     'SessionAffinityConfigArgs',
+    'SessionAffinityConfigArgsDict',
     'SleepActionPatchArgs',
+    'SleepActionPatchArgsDict',
     'SleepActionArgs',
+    'SleepActionArgsDict',
     'StorageOSPersistentVolumeSourcePatchArgs',
+    'StorageOSPersistentVolumeSourcePatchArgsDict',
     'StorageOSPersistentVolumeSourceArgs',
+    'StorageOSPersistentVolumeSourceArgsDict',
     'StorageOSVolumeSourcePatchArgs',
+    'StorageOSVolumeSourcePatchArgsDict',
     'StorageOSVolumeSourceArgs',
+    'StorageOSVolumeSourceArgsDict',
     'SysctlPatchArgs',
+    'SysctlPatchArgsDict',
     'SysctlArgs',
+    'SysctlArgsDict',
     'TCPSocketActionPatchArgs',
+    'TCPSocketActionPatchArgsDict',
     'TCPSocketActionArgs',
+    'TCPSocketActionArgsDict',
     'TaintPatchArgs',
+    'TaintPatchArgsDict',
     'TaintArgs',
+    'TaintArgsDict',
     'TolerationPatchArgs',
+    'TolerationPatchArgsDict',
     'TolerationArgs',
+    'TolerationArgsDict',
     'TopologySelectorLabelRequirementPatchArgs',
+    'TopologySelectorLabelRequirementPatchArgsDict',
     'TopologySelectorLabelRequirementArgs',
+    'TopologySelectorLabelRequirementArgsDict',
     'TopologySelectorTermPatchArgs',
+    'TopologySelectorTermPatchArgsDict',
     'TopologySelectorTermArgs',
+    'TopologySelectorTermArgsDict',
     'TopologySpreadConstraintPatchArgs',
+    'TopologySpreadConstraintPatchArgsDict',
     'TopologySpreadConstraintArgs',
+    'TopologySpreadConstraintArgsDict',
     'TypedLocalObjectReferencePatchArgs',
+    'TypedLocalObjectReferencePatchArgsDict',
     'TypedLocalObjectReferenceArgs',
+    'TypedLocalObjectReferenceArgsDict',
     'TypedObjectReferencePatchArgs',
+    'TypedObjectReferencePatchArgsDict',
     'TypedObjectReferenceArgs',
+    'TypedObjectReferenceArgsDict',
     'VolumeDevicePatchArgs',
+    'VolumeDevicePatchArgsDict',
     'VolumeDeviceArgs',
+    'VolumeDeviceArgsDict',
     'VolumeMountPatchArgs',
+    'VolumeMountPatchArgsDict',
     'VolumeMountStatusArgs',
+    'VolumeMountStatusArgsDict',
     'VolumeMountArgs',
+    'VolumeMountArgsDict',
     'VolumeNodeAffinityPatchArgs',
+    'VolumeNodeAffinityPatchArgsDict',
     'VolumeNodeAffinityArgs',
+    'VolumeNodeAffinityArgsDict',
     'VolumePatchArgs',
+    'VolumePatchArgsDict',
     'VolumeProjectionPatchArgs',
+    'VolumeProjectionPatchArgsDict',
     'VolumeProjectionArgs',
+    'VolumeProjectionArgsDict',
     'VolumeResourceRequirementsPatchArgs',
+    'VolumeResourceRequirementsPatchArgsDict',
     'VolumeResourceRequirementsArgs',
+    'VolumeResourceRequirementsArgsDict',
     'VolumeArgs',
+    'VolumeArgsDict',
     'VsphereVirtualDiskVolumeSourcePatchArgs',
+    'VsphereVirtualDiskVolumeSourcePatchArgsDict',
     'VsphereVirtualDiskVolumeSourceArgs',
+    'VsphereVirtualDiskVolumeSourceArgsDict',
     'WeightedPodAffinityTermPatchArgs',
+    'WeightedPodAffinityTermPatchArgsDict',
     'WeightedPodAffinityTermArgs',
+    'WeightedPodAffinityTermArgsDict',
     'WindowsSecurityContextOptionsPatchArgs',
+    'WindowsSecurityContextOptionsPatchArgsDict',
     'WindowsSecurityContextOptionsArgs',
+    'WindowsSecurityContextOptionsArgsDict',
 ]
+
+MYPY = False
+
+if not MYPY:
+    class AWSElasticBlockStoreVolumeSourcePatchArgsDict(TypedDict):
+        """
+        Represents a Persistent Disk resource in AWS.
+
+        An AWS EBS disk must exist before mounting to a container. The disk must also be in the same AWS zone as the kubelet. An AWS EBS disk can only be mounted as read/write once. AWS EBS volumes support ownership management and SELinux relabeling.
+        """
+        fs_type: NotRequired[pulumi.Input[str]]
+        """
+        fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+        """
+        partition: NotRequired[pulumi.Input[int]]
+        """
+        partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        readOnly value true will force the readOnly setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+        """
+        volume_id: NotRequired[pulumi.Input[str]]
+        """
+        volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+        """
+elif False:
+    AWSElasticBlockStoreVolumeSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class AWSElasticBlockStoreVolumeSourcePatchArgs:
@@ -416,6 +777,32 @@ class AWSElasticBlockStoreVolumeSourcePatchArgs:
         pulumi.set(self, "volume_id", value)
 
 
+if not MYPY:
+    class AWSElasticBlockStoreVolumeSourceArgsDict(TypedDict):
+        """
+        Represents a Persistent Disk resource in AWS.
+
+        An AWS EBS disk must exist before mounting to a container. The disk must also be in the same AWS zone as the kubelet. An AWS EBS disk can only be mounted as read/write once. AWS EBS volumes support ownership management and SELinux relabeling.
+        """
+        volume_id: pulumi.Input[str]
+        """
+        volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+        """
+        fs_type: NotRequired[pulumi.Input[str]]
+        """
+        fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+        """
+        partition: NotRequired[pulumi.Input[int]]
+        """
+        partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        readOnly value true will force the readOnly setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+        """
+elif False:
+    AWSElasticBlockStoreVolumeSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class AWSElasticBlockStoreVolumeSourceArgs:
     def __init__(__self__, *,
@@ -489,6 +876,26 @@ class AWSElasticBlockStoreVolumeSourceArgs:
         pulumi.set(self, "read_only", value)
 
 
+if not MYPY:
+    class AffinityPatchArgsDict(TypedDict):
+        """
+        Affinity is a group of affinity scheduling rules.
+        """
+        node_affinity: NotRequired[pulumi.Input['NodeAffinityPatchArgsDict']]
+        """
+        Describes node affinity scheduling rules for the pod.
+        """
+        pod_affinity: NotRequired[pulumi.Input['PodAffinityPatchArgsDict']]
+        """
+        Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+        """
+        pod_anti_affinity: NotRequired[pulumi.Input['PodAntiAffinityPatchArgsDict']]
+        """
+        Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+        """
+elif False:
+    AffinityPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class AffinityPatchArgs:
     def __init__(__self__, *,
@@ -544,6 +951,26 @@ class AffinityPatchArgs:
     def pod_anti_affinity(self, value: Optional[pulumi.Input['PodAntiAffinityPatchArgs']]):
         pulumi.set(self, "pod_anti_affinity", value)
 
+
+if not MYPY:
+    class AffinityArgsDict(TypedDict):
+        """
+        Affinity is a group of affinity scheduling rules.
+        """
+        node_affinity: NotRequired[pulumi.Input['NodeAffinityArgsDict']]
+        """
+        Describes node affinity scheduling rules for the pod.
+        """
+        pod_affinity: NotRequired[pulumi.Input['PodAffinityArgsDict']]
+        """
+        Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+        """
+        pod_anti_affinity: NotRequired[pulumi.Input['PodAntiAffinityArgsDict']]
+        """
+        Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+        """
+elif False:
+    AffinityArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class AffinityArgs:
@@ -601,6 +1028,25 @@ class AffinityArgs:
         pulumi.set(self, "pod_anti_affinity", value)
 
 
+if not MYPY:
+    class AppArmorProfilePatchArgsDict(TypedDict):
+        """
+        AppArmorProfile defines a pod or container's AppArmor settings.
+        """
+        localhost_profile: NotRequired[pulumi.Input[str]]
+        """
+        localhostProfile indicates a profile loaded on the node that should be used. The profile must be preconfigured on the node to work. Must match the loaded name of the profile. Must be set if and only if type is "Localhost".
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        type indicates which kind of AppArmor profile will be applied. Valid options are:
+          Localhost - a profile pre-loaded on the node.
+          RuntimeDefault - the container runtime's default profile.
+          Unconfined - no AppArmor enforcement.
+        """
+elif False:
+    AppArmorProfilePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class AppArmorProfilePatchArgs:
     def __init__(__self__, *,
@@ -647,6 +1093,25 @@ class AppArmorProfilePatchArgs:
         pulumi.set(self, "type", value)
 
 
+if not MYPY:
+    class AppArmorProfileArgsDict(TypedDict):
+        """
+        AppArmorProfile defines a pod or container's AppArmor settings.
+        """
+        type: pulumi.Input[str]
+        """
+        type indicates which kind of AppArmor profile will be applied. Valid options are:
+          Localhost - a profile pre-loaded on the node.
+          RuntimeDefault - the container runtime's default profile.
+          Unconfined - no AppArmor enforcement.
+        """
+        localhost_profile: NotRequired[pulumi.Input[str]]
+        """
+        localhostProfile indicates a profile loaded on the node that should be used. The profile must be preconfigured on the node to work. Must match the loaded name of the profile. Must be set if and only if type is "Localhost".
+        """
+elif False:
+    AppArmorProfileArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class AppArmorProfileArgs:
     def __init__(__self__, *,
@@ -692,6 +1157,22 @@ class AppArmorProfileArgs:
         pulumi.set(self, "localhost_profile", value)
 
 
+if not MYPY:
+    class AttachedVolumeArgsDict(TypedDict):
+        """
+        AttachedVolume describes a volume attached to a node
+        """
+        device_path: pulumi.Input[str]
+        """
+        DevicePath represents the device path where the volume should be available
+        """
+        name: pulumi.Input[str]
+        """
+        Name of the attached volume
+        """
+elif False:
+    AttachedVolumeArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class AttachedVolumeArgs:
     def __init__(__self__, *,
@@ -729,6 +1210,38 @@ class AttachedVolumeArgs:
     def name(self, value: pulumi.Input[str]):
         pulumi.set(self, "name", value)
 
+
+if not MYPY:
+    class AzureDiskVolumeSourcePatchArgsDict(TypedDict):
+        """
+        AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+        """
+        caching_mode: NotRequired[pulumi.Input[str]]
+        """
+        cachingMode is the Host Caching mode: None, Read Only, Read Write.
+        """
+        disk_name: NotRequired[pulumi.Input[str]]
+        """
+        diskName is the Name of the data disk in the blob storage
+        """
+        disk_uri: NotRequired[pulumi.Input[str]]
+        """
+        diskURI is the URI of data disk in the blob storage
+        """
+        fs_type: NotRequired[pulumi.Input[str]]
+        """
+        fsType is Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+        """
+elif False:
+    AzureDiskVolumeSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class AzureDiskVolumeSourcePatchArgs:
@@ -834,6 +1347,38 @@ class AzureDiskVolumeSourcePatchArgs:
         pulumi.set(self, "read_only", value)
 
 
+if not MYPY:
+    class AzureDiskVolumeSourceArgsDict(TypedDict):
+        """
+        AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+        """
+        disk_name: pulumi.Input[str]
+        """
+        diskName is the Name of the data disk in the blob storage
+        """
+        disk_uri: pulumi.Input[str]
+        """
+        diskURI is the URI of data disk in the blob storage
+        """
+        caching_mode: NotRequired[pulumi.Input[str]]
+        """
+        cachingMode is the Host Caching mode: None, Read Only, Read Write.
+        """
+        fs_type: NotRequired[pulumi.Input[str]]
+        """
+        fsType is Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+        """
+elif False:
+    AzureDiskVolumeSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class AzureDiskVolumeSourceArgs:
     def __init__(__self__, *,
@@ -936,6 +1481,30 @@ class AzureDiskVolumeSourceArgs:
         pulumi.set(self, "read_only", value)
 
 
+if not MYPY:
+    class AzureFilePersistentVolumeSourcePatchArgsDict(TypedDict):
+        """
+        AzureFile represents an Azure File Service mount on the host and bind mount to the pod.
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+        """
+        secret_name: NotRequired[pulumi.Input[str]]
+        """
+        secretName is the name of secret that contains Azure Storage Account Name and Key
+        """
+        secret_namespace: NotRequired[pulumi.Input[str]]
+        """
+        secretNamespace is the namespace of the secret that contains Azure Storage Account Name and Key default is the same as the Pod
+        """
+        share_name: NotRequired[pulumi.Input[str]]
+        """
+        shareName is the azure Share Name
+        """
+elif False:
+    AzureFilePersistentVolumeSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class AzureFilePersistentVolumeSourcePatchArgs:
     def __init__(__self__, *,
@@ -1008,6 +1577,30 @@ class AzureFilePersistentVolumeSourcePatchArgs:
         pulumi.set(self, "share_name", value)
 
 
+if not MYPY:
+    class AzureFilePersistentVolumeSourceArgsDict(TypedDict):
+        """
+        AzureFile represents an Azure File Service mount on the host and bind mount to the pod.
+        """
+        secret_name: pulumi.Input[str]
+        """
+        secretName is the name of secret that contains Azure Storage Account Name and Key
+        """
+        share_name: pulumi.Input[str]
+        """
+        shareName is the azure Share Name
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+        """
+        secret_namespace: NotRequired[pulumi.Input[str]]
+        """
+        secretNamespace is the namespace of the secret that contains Azure Storage Account Name and Key default is the same as the Pod
+        """
+elif False:
+    AzureFilePersistentVolumeSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class AzureFilePersistentVolumeSourceArgs:
     def __init__(__self__, *,
@@ -1078,6 +1671,26 @@ class AzureFilePersistentVolumeSourceArgs:
         pulumi.set(self, "secret_namespace", value)
 
 
+if not MYPY:
+    class AzureFileVolumeSourcePatchArgsDict(TypedDict):
+        """
+        AzureFile represents an Azure File Service mount on the host and bind mount to the pod.
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+        """
+        secret_name: NotRequired[pulumi.Input[str]]
+        """
+        secretName is the  name of secret that contains Azure Storage Account Name and Key
+        """
+        share_name: NotRequired[pulumi.Input[str]]
+        """
+        shareName is the azure share Name
+        """
+elif False:
+    AzureFileVolumeSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class AzureFileVolumeSourcePatchArgs:
     def __init__(__self__, *,
@@ -1134,6 +1747,26 @@ class AzureFileVolumeSourcePatchArgs:
         pulumi.set(self, "share_name", value)
 
 
+if not MYPY:
+    class AzureFileVolumeSourceArgsDict(TypedDict):
+        """
+        AzureFile represents an Azure File Service mount on the host and bind mount to the pod.
+        """
+        secret_name: pulumi.Input[str]
+        """
+        secretName is the  name of secret that contains Azure Storage Account Name and Key
+        """
+        share_name: pulumi.Input[str]
+        """
+        shareName is the azure share Name
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+        """
+elif False:
+    AzureFileVolumeSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class AzureFileVolumeSourceArgs:
     def __init__(__self__, *,
@@ -1187,6 +1820,54 @@ class AzureFileVolumeSourceArgs:
     def read_only(self, value: Optional[pulumi.Input[bool]]):
         pulumi.set(self, "read_only", value)
 
+
+if not MYPY:
+    class CSIPersistentVolumeSourcePatchArgsDict(TypedDict):
+        """
+        Represents storage that is managed by an external CSI volume driver (Beta feature)
+        """
+        controller_expand_secret_ref: NotRequired[pulumi.Input['SecretReferencePatchArgsDict']]
+        """
+        controllerExpandSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI ControllerExpandVolume call. This field is optional, and may be empty if no secret is required. If the secret object contains more than one secret, all secrets are passed.
+        """
+        controller_publish_secret_ref: NotRequired[pulumi.Input['SecretReferencePatchArgsDict']]
+        """
+        controllerPublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI ControllerPublishVolume and ControllerUnpublishVolume calls. This field is optional, and may be empty if no secret is required. If the secret object contains more than one secret, all secrets are passed.
+        """
+        driver: NotRequired[pulumi.Input[str]]
+        """
+        driver is the name of the driver to use for this volume. Required.
+        """
+        fs_type: NotRequired[pulumi.Input[str]]
+        """
+        fsType to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs".
+        """
+        node_expand_secret_ref: NotRequired[pulumi.Input['SecretReferencePatchArgsDict']]
+        """
+        nodeExpandSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodeExpandVolume call. This field is optional, may be omitted if no secret is required. If the secret object contains more than one secret, all secrets are passed.
+        """
+        node_publish_secret_ref: NotRequired[pulumi.Input['SecretReferencePatchArgsDict']]
+        """
+        nodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and may be empty if no secret is required. If the secret object contains more than one secret, all secrets are passed.
+        """
+        node_stage_secret_ref: NotRequired[pulumi.Input['SecretReferencePatchArgsDict']]
+        """
+        nodeStageSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodeStageVolume and NodeStageVolume and NodeUnstageVolume calls. This field is optional, and may be empty if no secret is required. If the secret object contains more than one secret, all secrets are passed.
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        readOnly value to pass to ControllerPublishVolumeRequest. Defaults to false (read/write).
+        """
+        volume_attributes: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        volumeAttributes of the volume to publish.
+        """
+        volume_handle: NotRequired[pulumi.Input[str]]
+        """
+        volumeHandle is the unique volume name returned by the CSI volume plugin’s CreateVolume to refer to the volume on all subsequent calls. Required.
+        """
+elif False:
+    CSIPersistentVolumeSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class CSIPersistentVolumeSourcePatchArgs:
@@ -1356,6 +2037,54 @@ class CSIPersistentVolumeSourcePatchArgs:
         pulumi.set(self, "volume_handle", value)
 
 
+if not MYPY:
+    class CSIPersistentVolumeSourceArgsDict(TypedDict):
+        """
+        Represents storage that is managed by an external CSI volume driver (Beta feature)
+        """
+        driver: pulumi.Input[str]
+        """
+        driver is the name of the driver to use for this volume. Required.
+        """
+        volume_handle: pulumi.Input[str]
+        """
+        volumeHandle is the unique volume name returned by the CSI volume plugin’s CreateVolume to refer to the volume on all subsequent calls. Required.
+        """
+        controller_expand_secret_ref: NotRequired[pulumi.Input['SecretReferenceArgsDict']]
+        """
+        controllerExpandSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI ControllerExpandVolume call. This field is optional, and may be empty if no secret is required. If the secret object contains more than one secret, all secrets are passed.
+        """
+        controller_publish_secret_ref: NotRequired[pulumi.Input['SecretReferenceArgsDict']]
+        """
+        controllerPublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI ControllerPublishVolume and ControllerUnpublishVolume calls. This field is optional, and may be empty if no secret is required. If the secret object contains more than one secret, all secrets are passed.
+        """
+        fs_type: NotRequired[pulumi.Input[str]]
+        """
+        fsType to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs".
+        """
+        node_expand_secret_ref: NotRequired[pulumi.Input['SecretReferenceArgsDict']]
+        """
+        nodeExpandSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodeExpandVolume call. This field is optional, may be omitted if no secret is required. If the secret object contains more than one secret, all secrets are passed.
+        """
+        node_publish_secret_ref: NotRequired[pulumi.Input['SecretReferenceArgsDict']]
+        """
+        nodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and may be empty if no secret is required. If the secret object contains more than one secret, all secrets are passed.
+        """
+        node_stage_secret_ref: NotRequired[pulumi.Input['SecretReferenceArgsDict']]
+        """
+        nodeStageSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodeStageVolume and NodeStageVolume and NodeUnstageVolume calls. This field is optional, and may be empty if no secret is required. If the secret object contains more than one secret, all secrets are passed.
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        readOnly value to pass to ControllerPublishVolumeRequest. Defaults to false (read/write).
+        """
+        volume_attributes: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        volumeAttributes of the volume to publish.
+        """
+elif False:
+    CSIPersistentVolumeSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CSIPersistentVolumeSourceArgs:
     def __init__(__self__, *,
@@ -1522,6 +2251,34 @@ class CSIPersistentVolumeSourceArgs:
         pulumi.set(self, "volume_attributes", value)
 
 
+if not MYPY:
+    class CSIVolumeSourcePatchArgsDict(TypedDict):
+        """
+        Represents a source location of a volume to mount, managed by an external CSI driver
+        """
+        driver: NotRequired[pulumi.Input[str]]
+        """
+        driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.
+        """
+        fs_type: NotRequired[pulumi.Input[str]]
+        """
+        fsType to mount. Ex. "ext4", "xfs", "ntfs". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.
+        """
+        node_publish_secret_ref: NotRequired[pulumi.Input['LocalObjectReferencePatchArgsDict']]
+        """
+        nodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        readOnly specifies a read-only configuration for the volume. Defaults to false (read/write).
+        """
+        volume_attributes: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        volumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.
+        """
+elif False:
+    CSIVolumeSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CSIVolumeSourcePatchArgs:
     def __init__(__self__, *,
@@ -1610,6 +2367,34 @@ class CSIVolumeSourcePatchArgs:
         pulumi.set(self, "volume_attributes", value)
 
 
+if not MYPY:
+    class CSIVolumeSourceArgsDict(TypedDict):
+        """
+        Represents a source location of a volume to mount, managed by an external CSI driver
+        """
+        driver: pulumi.Input[str]
+        """
+        driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.
+        """
+        fs_type: NotRequired[pulumi.Input[str]]
+        """
+        fsType to mount. Ex. "ext4", "xfs", "ntfs". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.
+        """
+        node_publish_secret_ref: NotRequired[pulumi.Input['LocalObjectReferenceArgsDict']]
+        """
+        nodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        readOnly specifies a read-only configuration for the volume. Defaults to false (read/write).
+        """
+        volume_attributes: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        volumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.
+        """
+elif False:
+    CSIVolumeSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CSIVolumeSourceArgs:
     def __init__(__self__, *,
@@ -1697,6 +2482,22 @@ class CSIVolumeSourceArgs:
         pulumi.set(self, "volume_attributes", value)
 
 
+if not MYPY:
+    class CapabilitiesPatchArgsDict(TypedDict):
+        """
+        Adds and removes POSIX capabilities from running containers.
+        """
+        add: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Added capabilities
+        """
+        drop: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Removed capabilities
+        """
+elif False:
+    CapabilitiesPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CapabilitiesPatchArgs:
     def __init__(__self__, *,
@@ -1737,6 +2538,22 @@ class CapabilitiesPatchArgs:
         pulumi.set(self, "drop", value)
 
 
+if not MYPY:
+    class CapabilitiesArgsDict(TypedDict):
+        """
+        Adds and removes POSIX capabilities from running containers.
+        """
+        add: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Added capabilities
+        """
+        drop: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Removed capabilities
+        """
+elif False:
+    CapabilitiesArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CapabilitiesArgs:
     def __init__(__self__, *,
@@ -1776,6 +2593,38 @@ class CapabilitiesArgs:
     def drop(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]):
         pulumi.set(self, "drop", value)
 
+
+if not MYPY:
+    class CephFSPersistentVolumeSourcePatchArgsDict(TypedDict):
+        """
+        Represents a Ceph Filesystem mount that lasts the lifetime of a pod Cephfs volumes do not support ownership management or SELinux relabeling.
+        """
+        monitors: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        monitors is Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+        """
+        path: NotRequired[pulumi.Input[str]]
+        """
+        path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+        """
+        secret_file: NotRequired[pulumi.Input[str]]
+        """
+        secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+        """
+        secret_ref: NotRequired[pulumi.Input['SecretReferencePatchArgsDict']]
+        """
+        secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+        """
+        user: NotRequired[pulumi.Input[str]]
+        """
+        user is Optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+        """
+elif False:
+    CephFSPersistentVolumeSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class CephFSPersistentVolumeSourcePatchArgs:
@@ -1881,6 +2730,38 @@ class CephFSPersistentVolumeSourcePatchArgs:
         pulumi.set(self, "user", value)
 
 
+if not MYPY:
+    class CephFSPersistentVolumeSourceArgsDict(TypedDict):
+        """
+        Represents a Ceph Filesystem mount that lasts the lifetime of a pod Cephfs volumes do not support ownership management or SELinux relabeling.
+        """
+        monitors: pulumi.Input[Sequence[pulumi.Input[str]]]
+        """
+        monitors is Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+        """
+        path: NotRequired[pulumi.Input[str]]
+        """
+        path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+        """
+        secret_file: NotRequired[pulumi.Input[str]]
+        """
+        secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+        """
+        secret_ref: NotRequired[pulumi.Input['SecretReferenceArgsDict']]
+        """
+        secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+        """
+        user: NotRequired[pulumi.Input[str]]
+        """
+        user is Optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+        """
+elif False:
+    CephFSPersistentVolumeSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CephFSPersistentVolumeSourceArgs:
     def __init__(__self__, *,
@@ -1983,6 +2864,38 @@ class CephFSPersistentVolumeSourceArgs:
     def user(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "user", value)
 
+
+if not MYPY:
+    class CephFSVolumeSourcePatchArgsDict(TypedDict):
+        """
+        Represents a Ceph Filesystem mount that lasts the lifetime of a pod Cephfs volumes do not support ownership management or SELinux relabeling.
+        """
+        monitors: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        monitors is Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+        """
+        path: NotRequired[pulumi.Input[str]]
+        """
+        path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+        """
+        secret_file: NotRequired[pulumi.Input[str]]
+        """
+        secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+        """
+        secret_ref: NotRequired[pulumi.Input['LocalObjectReferencePatchArgsDict']]
+        """
+        secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+        """
+        user: NotRequired[pulumi.Input[str]]
+        """
+        user is optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+        """
+elif False:
+    CephFSVolumeSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class CephFSVolumeSourcePatchArgs:
@@ -2088,6 +3001,38 @@ class CephFSVolumeSourcePatchArgs:
         pulumi.set(self, "user", value)
 
 
+if not MYPY:
+    class CephFSVolumeSourceArgsDict(TypedDict):
+        """
+        Represents a Ceph Filesystem mount that lasts the lifetime of a pod Cephfs volumes do not support ownership management or SELinux relabeling.
+        """
+        monitors: pulumi.Input[Sequence[pulumi.Input[str]]]
+        """
+        monitors is Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+        """
+        path: NotRequired[pulumi.Input[str]]
+        """
+        path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+        """
+        secret_file: NotRequired[pulumi.Input[str]]
+        """
+        secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+        """
+        secret_ref: NotRequired[pulumi.Input['LocalObjectReferenceArgsDict']]
+        """
+        secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+        """
+        user: NotRequired[pulumi.Input[str]]
+        """
+        user is optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+        """
+elif False:
+    CephFSVolumeSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CephFSVolumeSourceArgs:
     def __init__(__self__, *,
@@ -2191,6 +3136,30 @@ class CephFSVolumeSourceArgs:
         pulumi.set(self, "user", value)
 
 
+if not MYPY:
+    class CinderPersistentVolumeSourcePatchArgsDict(TypedDict):
+        """
+        Represents a cinder volume resource in Openstack. A Cinder volume must exist before mounting to a container. The volume must also be in the same region as the kubelet. Cinder volumes support ownership management and SELinux relabeling.
+        """
+        fs_type: NotRequired[pulumi.Input[str]]
+        """
+        fsType Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+        """
+        secret_ref: NotRequired[pulumi.Input['SecretReferencePatchArgsDict']]
+        """
+        secretRef is Optional: points to a secret object containing parameters used to connect to OpenStack.
+        """
+        volume_id: NotRequired[pulumi.Input[str]]
+        """
+        volumeID used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+        """
+elif False:
+    CinderPersistentVolumeSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CinderPersistentVolumeSourcePatchArgs:
     def __init__(__self__, *,
@@ -2263,6 +3232,30 @@ class CinderPersistentVolumeSourcePatchArgs:
         pulumi.set(self, "volume_id", value)
 
 
+if not MYPY:
+    class CinderPersistentVolumeSourceArgsDict(TypedDict):
+        """
+        Represents a cinder volume resource in Openstack. A Cinder volume must exist before mounting to a container. The volume must also be in the same region as the kubelet. Cinder volumes support ownership management and SELinux relabeling.
+        """
+        volume_id: pulumi.Input[str]
+        """
+        volumeID used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+        """
+        fs_type: NotRequired[pulumi.Input[str]]
+        """
+        fsType Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+        """
+        secret_ref: NotRequired[pulumi.Input['SecretReferenceArgsDict']]
+        """
+        secretRef is Optional: points to a secret object containing parameters used to connect to OpenStack.
+        """
+elif False:
+    CinderPersistentVolumeSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CinderPersistentVolumeSourceArgs:
     def __init__(__self__, *,
@@ -2333,6 +3326,30 @@ class CinderPersistentVolumeSourceArgs:
     def secret_ref(self, value: Optional[pulumi.Input['SecretReferenceArgs']]):
         pulumi.set(self, "secret_ref", value)
 
+
+if not MYPY:
+    class CinderVolumeSourcePatchArgsDict(TypedDict):
+        """
+        Represents a cinder volume resource in Openstack. A Cinder volume must exist before mounting to a container. The volume must also be in the same region as the kubelet. Cinder volumes support ownership management and SELinux relabeling.
+        """
+        fs_type: NotRequired[pulumi.Input[str]]
+        """
+        fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+        """
+        secret_ref: NotRequired[pulumi.Input['LocalObjectReferencePatchArgsDict']]
+        """
+        secretRef is optional: points to a secret object containing parameters used to connect to OpenStack.
+        """
+        volume_id: NotRequired[pulumi.Input[str]]
+        """
+        volumeID used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+        """
+elif False:
+    CinderVolumeSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class CinderVolumeSourcePatchArgs:
@@ -2406,6 +3423,30 @@ class CinderVolumeSourcePatchArgs:
         pulumi.set(self, "volume_id", value)
 
 
+if not MYPY:
+    class CinderVolumeSourceArgsDict(TypedDict):
+        """
+        Represents a cinder volume resource in Openstack. A Cinder volume must exist before mounting to a container. The volume must also be in the same region as the kubelet. Cinder volumes support ownership management and SELinux relabeling.
+        """
+        volume_id: pulumi.Input[str]
+        """
+        volumeID used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+        """
+        fs_type: NotRequired[pulumi.Input[str]]
+        """
+        fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+        """
+        secret_ref: NotRequired[pulumi.Input['LocalObjectReferenceArgsDict']]
+        """
+        secretRef is optional: points to a secret object containing parameters used to connect to OpenStack.
+        """
+elif False:
+    CinderVolumeSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CinderVolumeSourceArgs:
     def __init__(__self__, *,
@@ -2477,6 +3518,28 @@ class CinderVolumeSourceArgs:
         pulumi.set(self, "secret_ref", value)
 
 
+if not MYPY:
+    class ClaimSourcePatchArgsDict(TypedDict):
+        """
+        ClaimSource describes a reference to a ResourceClaim.
+
+        Exactly one of these fields should be set.  Consumers of this type must treat an empty object as if it has an unknown value.
+        """
+        resource_claim_name: NotRequired[pulumi.Input[str]]
+        """
+        ResourceClaimName is the name of a ResourceClaim object in the same namespace as this pod.
+        """
+        resource_claim_template_name: NotRequired[pulumi.Input[str]]
+        """
+        ResourceClaimTemplateName is the name of a ResourceClaimTemplate object in the same namespace as this pod.
+
+        The template will be used to create a new ResourceClaim, which will be bound to this pod. When this pod is deleted, the ResourceClaim will also be deleted. The pod name and resource name, along with a generated component, will be used to form a unique name for the ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.
+
+        This field is immutable and no changes will be made to the corresponding ResourceClaim by the control plane after creating the ResourceClaim.
+        """
+elif False:
+    ClaimSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ClaimSourcePatchArgs:
     def __init__(__self__, *,
@@ -2526,6 +3589,28 @@ class ClaimSourcePatchArgs:
     def resource_claim_template_name(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "resource_claim_template_name", value)
 
+
+if not MYPY:
+    class ClaimSourceArgsDict(TypedDict):
+        """
+        ClaimSource describes a reference to a ResourceClaim.
+
+        Exactly one of these fields should be set.  Consumers of this type must treat an empty object as if it has an unknown value.
+        """
+        resource_claim_name: NotRequired[pulumi.Input[str]]
+        """
+        ResourceClaimName is the name of a ResourceClaim object in the same namespace as this pod.
+        """
+        resource_claim_template_name: NotRequired[pulumi.Input[str]]
+        """
+        ResourceClaimTemplateName is the name of a ResourceClaimTemplate object in the same namespace as this pod.
+
+        The template will be used to create a new ResourceClaim, which will be bound to this pod. When this pod is deleted, the ResourceClaim will also be deleted. The pod name and resource name, along with a generated component, will be used to form a unique name for the ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.
+
+        This field is immutable and no changes will be made to the corresponding ResourceClaim by the control plane after creating the ResourceClaim.
+        """
+elif False:
+    ClaimSourceArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ClaimSourceArgs:
@@ -2577,6 +3662,18 @@ class ClaimSourceArgs:
         pulumi.set(self, "resource_claim_template_name", value)
 
 
+if not MYPY:
+    class ClientIPConfigPatchArgsDict(TypedDict):
+        """
+        ClientIPConfig represents the configurations of Client IP based session affinity.
+        """
+        timeout_seconds: NotRequired[pulumi.Input[int]]
+        """
+        timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP". Default value is 10800(for 3 hours).
+        """
+elif False:
+    ClientIPConfigPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ClientIPConfigPatchArgs:
     def __init__(__self__, *,
@@ -2601,6 +3698,18 @@ class ClientIPConfigPatchArgs:
         pulumi.set(self, "timeout_seconds", value)
 
 
+if not MYPY:
+    class ClientIPConfigArgsDict(TypedDict):
+        """
+        ClientIPConfig represents the configurations of Client IP based session affinity.
+        """
+        timeout_seconds: NotRequired[pulumi.Input[int]]
+        """
+        timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP". Default value is 10800(for 3 hours).
+        """
+elif False:
+    ClientIPConfigArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ClientIPConfigArgs:
     def __init__(__self__, *,
@@ -2624,6 +3733,34 @@ class ClientIPConfigArgs:
     def timeout_seconds(self, value: Optional[pulumi.Input[int]]):
         pulumi.set(self, "timeout_seconds", value)
 
+
+if not MYPY:
+    class ClusterTrustBundleProjectionPatchArgsDict(TypedDict):
+        """
+        ClusterTrustBundleProjection describes how to select a set of ClusterTrustBundle objects and project their contents into the pod filesystem.
+        """
+        label_selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorPatchArgsDict']]
+        """
+        Select all ClusterTrustBundles that match this label selector.  Only has effect if signerName is set.  Mutually-exclusive with name.  If unset, interpreted as "match nothing".  If set but empty, interpreted as "match everything".
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Select a single ClusterTrustBundle by object name.  Mutually-exclusive with signerName and labelSelector.
+        """
+        optional: NotRequired[pulumi.Input[bool]]
+        """
+        If true, don't block pod startup if the referenced ClusterTrustBundle(s) aren't available.  If using name, then the named ClusterTrustBundle is allowed not to exist.  If using signerName, then the combination of signerName and labelSelector is allowed to match zero ClusterTrustBundles.
+        """
+        path: NotRequired[pulumi.Input[str]]
+        """
+        Relative path from the volume root to write the bundle.
+        """
+        signer_name: NotRequired[pulumi.Input[str]]
+        """
+        Select all ClusterTrustBundles that match this signer name. Mutually-exclusive with name.  The contents of all selected ClusterTrustBundles will be unified and deduplicated.
+        """
+elif False:
+    ClusterTrustBundleProjectionPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ClusterTrustBundleProjectionPatchArgs:
@@ -2713,6 +3850,34 @@ class ClusterTrustBundleProjectionPatchArgs:
         pulumi.set(self, "signer_name", value)
 
 
+if not MYPY:
+    class ClusterTrustBundleProjectionArgsDict(TypedDict):
+        """
+        ClusterTrustBundleProjection describes how to select a set of ClusterTrustBundle objects and project their contents into the pod filesystem.
+        """
+        path: pulumi.Input[str]
+        """
+        Relative path from the volume root to write the bundle.
+        """
+        label_selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorArgsDict']]
+        """
+        Select all ClusterTrustBundles that match this label selector.  Only has effect if signerName is set.  Mutually-exclusive with name.  If unset, interpreted as "match nothing".  If set but empty, interpreted as "match everything".
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Select a single ClusterTrustBundle by object name.  Mutually-exclusive with signerName and labelSelector.
+        """
+        optional: NotRequired[pulumi.Input[bool]]
+        """
+        If true, don't block pod startup if the referenced ClusterTrustBundle(s) aren't available.  If using name, then the named ClusterTrustBundle is allowed not to exist.  If using signerName, then the combination of signerName and labelSelector is allowed to match zero ClusterTrustBundles.
+        """
+        signer_name: NotRequired[pulumi.Input[str]]
+        """
+        Select all ClusterTrustBundles that match this signer name. Mutually-exclusive with name.  The contents of all selected ClusterTrustBundles will be unified and deduplicated.
+        """
+elif False:
+    ClusterTrustBundleProjectionArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ClusterTrustBundleProjectionArgs:
     def __init__(__self__, *,
@@ -2800,6 +3965,24 @@ class ClusterTrustBundleProjectionArgs:
         pulumi.set(self, "signer_name", value)
 
 
+if not MYPY:
+    class ConfigMapEnvSourcePatchArgsDict(TypedDict):
+        """
+        ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.
+
+        The contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+        """
+        optional: NotRequired[pulumi.Input[bool]]
+        """
+        Specify whether the ConfigMap must be defined
+        """
+elif False:
+    ConfigMapEnvSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ConfigMapEnvSourcePatchArgs:
     def __init__(__self__, *,
@@ -2842,6 +4025,24 @@ class ConfigMapEnvSourcePatchArgs:
         pulumi.set(self, "optional", value)
 
 
+if not MYPY:
+    class ConfigMapEnvSourceArgsDict(TypedDict):
+        """
+        ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.
+
+        The contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+        """
+        optional: NotRequired[pulumi.Input[bool]]
+        """
+        Specify whether the ConfigMap must be defined
+        """
+elif False:
+    ConfigMapEnvSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ConfigMapEnvSourceArgs:
     def __init__(__self__, *,
@@ -2883,6 +4084,26 @@ class ConfigMapEnvSourceArgs:
     def optional(self, value: Optional[pulumi.Input[bool]]):
         pulumi.set(self, "optional", value)
 
+
+if not MYPY:
+    class ConfigMapKeySelectorPatchArgsDict(TypedDict):
+        """
+        Selects a key from a ConfigMap.
+        """
+        key: NotRequired[pulumi.Input[str]]
+        """
+        The key to select.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+        """
+        optional: NotRequired[pulumi.Input[bool]]
+        """
+        Specify whether the ConfigMap or its key must be defined
+        """
+elif False:
+    ConfigMapKeySelectorPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ConfigMapKeySelectorPatchArgs:
@@ -2940,6 +4161,26 @@ class ConfigMapKeySelectorPatchArgs:
         pulumi.set(self, "optional", value)
 
 
+if not MYPY:
+    class ConfigMapKeySelectorArgsDict(TypedDict):
+        """
+        Selects a key from a ConfigMap.
+        """
+        key: pulumi.Input[str]
+        """
+        The key to select.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+        """
+        optional: NotRequired[pulumi.Input[bool]]
+        """
+        Specify whether the ConfigMap or its key must be defined
+        """
+elif False:
+    ConfigMapKeySelectorArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ConfigMapKeySelectorArgs:
     def __init__(__self__, *,
@@ -2994,6 +4235,34 @@ class ConfigMapKeySelectorArgs:
     def optional(self, value: Optional[pulumi.Input[bool]]):
         pulumi.set(self, "optional", value)
 
+
+if not MYPY:
+    class ConfigMapNodeConfigSourcePatchArgsDict(TypedDict):
+        """
+        ConfigMapNodeConfigSource contains the information to reference a ConfigMap as a config source for the Node. This API is deprecated since 1.22: https://git.k8s.io/enhancements/keps/sig-node/281-dynamic-kubelet-configuration
+        """
+        kubelet_config_key: NotRequired[pulumi.Input[str]]
+        """
+        KubeletConfigKey declares which key of the referenced ConfigMap corresponds to the KubeletConfiguration structure This field is required in all cases.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name is the metadata.name of the referenced ConfigMap. This field is required in all cases.
+        """
+        namespace: NotRequired[pulumi.Input[str]]
+        """
+        Namespace is the metadata.namespace of the referenced ConfigMap. This field is required in all cases.
+        """
+        resource_version: NotRequired[pulumi.Input[str]]
+        """
+        ResourceVersion is the metadata.ResourceVersion of the referenced ConfigMap. This field is forbidden in Node.Spec, and required in Node.Status.
+        """
+        uid: NotRequired[pulumi.Input[str]]
+        """
+        UID is the metadata.UID of the referenced ConfigMap. This field is forbidden in Node.Spec, and required in Node.Status.
+        """
+elif False:
+    ConfigMapNodeConfigSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ConfigMapNodeConfigSourcePatchArgs:
@@ -3083,6 +4352,34 @@ class ConfigMapNodeConfigSourcePatchArgs:
         pulumi.set(self, "uid", value)
 
 
+if not MYPY:
+    class ConfigMapNodeConfigSourceArgsDict(TypedDict):
+        """
+        ConfigMapNodeConfigSource contains the information to reference a ConfigMap as a config source for the Node. This API is deprecated since 1.22: https://git.k8s.io/enhancements/keps/sig-node/281-dynamic-kubelet-configuration
+        """
+        kubelet_config_key: pulumi.Input[str]
+        """
+        KubeletConfigKey declares which key of the referenced ConfigMap corresponds to the KubeletConfiguration structure This field is required in all cases.
+        """
+        name: pulumi.Input[str]
+        """
+        Name is the metadata.name of the referenced ConfigMap. This field is required in all cases.
+        """
+        namespace: pulumi.Input[str]
+        """
+        Namespace is the metadata.namespace of the referenced ConfigMap. This field is required in all cases.
+        """
+        resource_version: NotRequired[pulumi.Input[str]]
+        """
+        ResourceVersion is the metadata.ResourceVersion of the referenced ConfigMap. This field is forbidden in Node.Spec, and required in Node.Status.
+        """
+        uid: NotRequired[pulumi.Input[str]]
+        """
+        UID is the metadata.UID of the referenced ConfigMap. This field is forbidden in Node.Spec, and required in Node.Status.
+        """
+elif False:
+    ConfigMapNodeConfigSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ConfigMapNodeConfigSourceArgs:
     def __init__(__self__, *,
@@ -3168,6 +4465,28 @@ class ConfigMapNodeConfigSourceArgs:
         pulumi.set(self, "uid", value)
 
 
+if not MYPY:
+    class ConfigMapProjectionPatchArgsDict(TypedDict):
+        """
+        Adapts a ConfigMap into a projected volume.
+
+        The contents of the target ConfigMap's Data field will be presented in a projected volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. Note that this is identical to a configmap volume source without the default mode.
+        """
+        items: NotRequired[pulumi.Input[Sequence[pulumi.Input['KeyToPathPatchArgsDict']]]]
+        """
+        items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+        """
+        optional: NotRequired[pulumi.Input[bool]]
+        """
+        optional specify whether the ConfigMap or its keys must be defined
+        """
+elif False:
+    ConfigMapProjectionPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ConfigMapProjectionPatchArgs:
     def __init__(__self__, *,
@@ -3226,6 +4545,28 @@ class ConfigMapProjectionPatchArgs:
         pulumi.set(self, "optional", value)
 
 
+if not MYPY:
+    class ConfigMapProjectionArgsDict(TypedDict):
+        """
+        Adapts a ConfigMap into a projected volume.
+
+        The contents of the target ConfigMap's Data field will be presented in a projected volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. Note that this is identical to a configmap volume source without the default mode.
+        """
+        items: NotRequired[pulumi.Input[Sequence[pulumi.Input['KeyToPathArgsDict']]]]
+        """
+        items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+        """
+        optional: NotRequired[pulumi.Input[bool]]
+        """
+        optional specify whether the ConfigMap or its keys must be defined
+        """
+elif False:
+    ConfigMapProjectionArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ConfigMapProjectionArgs:
     def __init__(__self__, *,
@@ -3283,6 +4624,32 @@ class ConfigMapProjectionArgs:
     def optional(self, value: Optional[pulumi.Input[bool]]):
         pulumi.set(self, "optional", value)
 
+
+if not MYPY:
+    class ConfigMapVolumeSourcePatchArgsDict(TypedDict):
+        """
+        Adapts a ConfigMap into a volume.
+
+        The contents of the target ConfigMap's Data field will be presented in a volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. ConfigMap volumes support ownership management and SELinux relabeling.
+        """
+        default_mode: NotRequired[pulumi.Input[int]]
+        """
+        defaultMode is optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+        """
+        items: NotRequired[pulumi.Input[Sequence[pulumi.Input['KeyToPathPatchArgsDict']]]]
+        """
+        items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+        """
+        optional: NotRequired[pulumi.Input[bool]]
+        """
+        optional specify whether the ConfigMap or its keys must be defined
+        """
+elif False:
+    ConfigMapVolumeSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ConfigMapVolumeSourcePatchArgs:
@@ -3358,6 +4725,32 @@ class ConfigMapVolumeSourcePatchArgs:
         pulumi.set(self, "optional", value)
 
 
+if not MYPY:
+    class ConfigMapVolumeSourceArgsDict(TypedDict):
+        """
+        Adapts a ConfigMap into a volume.
+
+        The contents of the target ConfigMap's Data field will be presented in a volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. ConfigMap volumes support ownership management and SELinux relabeling.
+        """
+        default_mode: NotRequired[pulumi.Input[int]]
+        """
+        defaultMode is optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+        """
+        items: NotRequired[pulumi.Input[Sequence[pulumi.Input['KeyToPathArgsDict']]]]
+        """
+        items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+        """
+        optional: NotRequired[pulumi.Input[bool]]
+        """
+        optional specify whether the ConfigMap or its keys must be defined
+        """
+elif False:
+    ConfigMapVolumeSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ConfigMapVolumeSourceArgs:
     def __init__(__self__, *,
@@ -3431,6 +4824,38 @@ class ConfigMapVolumeSourceArgs:
     def optional(self, value: Optional[pulumi.Input[bool]]):
         pulumi.set(self, "optional", value)
 
+
+if not MYPY:
+    class ConfigMapArgsDict(TypedDict):
+        """
+        ConfigMap holds configuration data for pods to consume.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        binary_data: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        BinaryData contains the binary data. Each key must consist of alphanumeric characters, '-', '_' or '.'. BinaryData can contain byte sequences that are not in the UTF-8 range. The keys stored in BinaryData must not overlap with the ones in the Data field, this is enforced during validation process. Using this field will require 1.10+ apiserver and kubelet.
+        """
+        data: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        Data contains the configuration data. Each key must consist of alphanumeric characters, '-', '_' or '.'. Values with non-UTF-8 byte sequences must use the BinaryData field. The keys stored in Data must not overlap with the keys in the BinaryData field, this is enforced during validation process.
+        """
+        immutable: NotRequired[pulumi.Input[bool]]
+        """
+        Immutable, if set to true, ensures that data stored in the ConfigMap cannot be updated (only object metadata can be modified). If not set to true, the field can be modified at any time. Defaulted to nil.
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+elif False:
+    ConfigMapArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ConfigMapArgs:
@@ -3536,6 +4961,22 @@ class ConfigMapArgs:
         pulumi.set(self, "metadata", value)
 
 
+if not MYPY:
+    class ContainerImageArgsDict(TypedDict):
+        """
+        Describe a container image
+        """
+        names: pulumi.Input[Sequence[pulumi.Input[str]]]
+        """
+        Names by which this image is known. e.g. ["kubernetes.example/hyperkube:v1.0.7", "cloud-vendor.registry.example/cloud-vendor/hyperkube:v1.0.7"]
+        """
+        size_bytes: NotRequired[pulumi.Input[int]]
+        """
+        The size of the image in bytes.
+        """
+elif False:
+    ContainerImageArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ContainerImageArgs:
     def __init__(__self__, *,
@@ -3574,6 +5015,110 @@ class ContainerImageArgs:
     def size_bytes(self, value: Optional[pulumi.Input[int]]):
         pulumi.set(self, "size_bytes", value)
 
+
+if not MYPY:
+    class ContainerPatchArgsDict(TypedDict):
+        """
+        A single application container that you want to run within a pod.
+        """
+        args: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Arguments to the entrypoint. The container image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+        """
+        command: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Entrypoint array. Not executed within a shell. The container image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+        """
+        env: NotRequired[pulumi.Input[Sequence[pulumi.Input['EnvVarPatchArgsDict']]]]
+        """
+        List of environment variables to set in the container. Cannot be updated.
+        """
+        env_from: NotRequired[pulumi.Input[Sequence[pulumi.Input['EnvFromSourcePatchArgsDict']]]]
+        """
+        List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
+        """
+        image: NotRequired[pulumi.Input[str]]
+        """
+        Container image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.
+        """
+        image_pull_policy: NotRequired[pulumi.Input[str]]
+        """
+        Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+        """
+        lifecycle: NotRequired[pulumi.Input['LifecyclePatchArgsDict']]
+        """
+        Actions that the management system should take in response to container lifecycle events. Cannot be updated.
+        """
+        liveness_probe: NotRequired[pulumi.Input['ProbePatchArgsDict']]
+        """
+        Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
+        """
+        ports: NotRequired[pulumi.Input[Sequence[pulumi.Input['ContainerPortPatchArgsDict']]]]
+        """
+        List of ports to expose from the container. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Modifying this array with strategic merge patch may corrupt the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255. Cannot be updated.
+        """
+        readiness_probe: NotRequired[pulumi.Input['ProbePatchArgsDict']]
+        """
+        Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+        """
+        resize_policy: NotRequired[pulumi.Input[Sequence[pulumi.Input['ContainerResizePolicyPatchArgsDict']]]]
+        """
+        Resources resize policy for the container.
+        """
+        resources: NotRequired[pulumi.Input['ResourceRequirementsPatchArgsDict']]
+        """
+        Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+        """
+        restart_policy: NotRequired[pulumi.Input[str]]
+        """
+        RestartPolicy defines the restart behavior of individual containers in a pod. This field may only be set for init containers, and the only allowed value is "Always". For non-init containers or when this field is not specified, the restart behavior is defined by the Pod's restart policy and the container type. Setting the RestartPolicy as "Always" for the init container will have the following effect: this init container will be continually restarted on exit until all regular containers have terminated. Once all regular containers have completed, all init containers with restartPolicy "Always" will be shut down. This lifecycle differs from normal init containers and is often referred to as a "sidecar" container. Although this init container still starts in the init container sequence, it does not wait for the container to complete before proceeding to the next init container. Instead, the next init container starts immediately after this init container is started, or after any startupProbe has successfully completed.
+        """
+        security_context: NotRequired[pulumi.Input['SecurityContextPatchArgsDict']]
+        """
+        SecurityContext defines the security options the container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+        """
+        startup_probe: NotRequired[pulumi.Input['ProbePatchArgsDict']]
+        """
+        StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+        """
+        stdin: NotRequired[pulumi.Input[bool]]
+        """
+        Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.
+        """
+        stdin_once: NotRequired[pulumi.Input[bool]]
+        """
+        Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false
+        """
+        termination_message_path: NotRequired[pulumi.Input[str]]
+        """
+        Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.
+        """
+        termination_message_policy: NotRequired[pulumi.Input[str]]
+        """
+        Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+        """
+        tty: NotRequired[pulumi.Input[bool]]
+        """
+        Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.
+        """
+        volume_devices: NotRequired[pulumi.Input[Sequence[pulumi.Input['VolumeDevicePatchArgsDict']]]]
+        """
+        volumeDevices is the list of block devices to be used by the container.
+        """
+        volume_mounts: NotRequired[pulumi.Input[Sequence[pulumi.Input['VolumeMountPatchArgsDict']]]]
+        """
+        Pod volumes to mount into the container's filesystem. Cannot be updated.
+        """
+        working_dir: NotRequired[pulumi.Input[str]]
+        """
+        Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
+        """
+elif False:
+    ContainerPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ContainerPatchArgs:
@@ -3967,6 +5512,34 @@ class ContainerPatchArgs:
         pulumi.set(self, "working_dir", value)
 
 
+if not MYPY:
+    class ContainerPortPatchArgsDict(TypedDict):
+        """
+        ContainerPort represents a network port in a single container.
+        """
+        container_port: NotRequired[pulumi.Input[int]]
+        """
+        Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.
+        """
+        host_ip: NotRequired[pulumi.Input[str]]
+        """
+        What host IP to bind the external port to.
+        """
+        host_port: NotRequired[pulumi.Input[int]]
+        """
+        Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.
+        """
+        protocol: NotRequired[pulumi.Input[str]]
+        """
+        Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+        """
+elif False:
+    ContainerPortPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ContainerPortPatchArgs:
     def __init__(__self__, *,
@@ -4055,6 +5628,34 @@ class ContainerPortPatchArgs:
         pulumi.set(self, "protocol", value)
 
 
+if not MYPY:
+    class ContainerPortArgsDict(TypedDict):
+        """
+        ContainerPort represents a network port in a single container.
+        """
+        container_port: pulumi.Input[int]
+        """
+        Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.
+        """
+        host_ip: NotRequired[pulumi.Input[str]]
+        """
+        What host IP to bind the external port to.
+        """
+        host_port: NotRequired[pulumi.Input[int]]
+        """
+        Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.
+        """
+        protocol: NotRequired[pulumi.Input[str]]
+        """
+        Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+        """
+elif False:
+    ContainerPortArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ContainerPortArgs:
     def __init__(__self__, *,
@@ -4142,6 +5743,22 @@ class ContainerPortArgs:
         pulumi.set(self, "protocol", value)
 
 
+if not MYPY:
+    class ContainerResizePolicyPatchArgsDict(TypedDict):
+        """
+        ContainerResizePolicy represents resource resize policy for the container.
+        """
+        resource_name: NotRequired[pulumi.Input[str]]
+        """
+        Name of the resource to which this resource resize policy applies. Supported values: cpu, memory.
+        """
+        restart_policy: NotRequired[pulumi.Input[str]]
+        """
+        Restart policy to apply when specified resource is resized. If not specified, it defaults to NotRequired.
+        """
+elif False:
+    ContainerResizePolicyPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ContainerResizePolicyPatchArgs:
     def __init__(__self__, *,
@@ -4182,6 +5799,22 @@ class ContainerResizePolicyPatchArgs:
         pulumi.set(self, "restart_policy", value)
 
 
+if not MYPY:
+    class ContainerResizePolicyArgsDict(TypedDict):
+        """
+        ContainerResizePolicy represents resource resize policy for the container.
+        """
+        resource_name: pulumi.Input[str]
+        """
+        Name of the resource to which this resource resize policy applies. Supported values: cpu, memory.
+        """
+        restart_policy: pulumi.Input[str]
+        """
+        Restart policy to apply when specified resource is resized. If not specified, it defaults to NotRequired.
+        """
+elif False:
+    ContainerResizePolicyArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ContainerResizePolicyArgs:
     def __init__(__self__, *,
@@ -4220,6 +5853,18 @@ class ContainerResizePolicyArgs:
         pulumi.set(self, "restart_policy", value)
 
 
+if not MYPY:
+    class ContainerStateRunningArgsDict(TypedDict):
+        """
+        ContainerStateRunning is a running state of a container.
+        """
+        started_at: NotRequired[pulumi.Input[str]]
+        """
+        Time at which the container was last (re-)started
+        """
+elif False:
+    ContainerStateRunningArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ContainerStateRunningArgs:
     def __init__(__self__, *,
@@ -4243,6 +5888,42 @@ class ContainerStateRunningArgs:
     def started_at(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "started_at", value)
 
+
+if not MYPY:
+    class ContainerStateTerminatedArgsDict(TypedDict):
+        """
+        ContainerStateTerminated is a terminated state of a container.
+        """
+        exit_code: pulumi.Input[int]
+        """
+        Exit status from the last termination of the container
+        """
+        container_id: NotRequired[pulumi.Input[str]]
+        """
+        Container's ID in the format '<type>://<container_id>'
+        """
+        finished_at: NotRequired[pulumi.Input[str]]
+        """
+        Time at which the container last terminated
+        """
+        message: NotRequired[pulumi.Input[str]]
+        """
+        Message regarding the last termination of the container
+        """
+        reason: NotRequired[pulumi.Input[str]]
+        """
+        (brief) reason from the last termination of the container
+        """
+        signal: NotRequired[pulumi.Input[int]]
+        """
+        Signal from the last termination of the container
+        """
+        started_at: NotRequired[pulumi.Input[str]]
+        """
+        Time at which previous execution of the container started
+        """
+elif False:
+    ContainerStateTerminatedArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ContainerStateTerminatedArgs:
@@ -4363,6 +6044,22 @@ class ContainerStateTerminatedArgs:
         pulumi.set(self, "started_at", value)
 
 
+if not MYPY:
+    class ContainerStateWaitingArgsDict(TypedDict):
+        """
+        ContainerStateWaiting is a waiting state of a container.
+        """
+        message: NotRequired[pulumi.Input[str]]
+        """
+        Message regarding why the container is not yet running.
+        """
+        reason: NotRequired[pulumi.Input[str]]
+        """
+        (brief) reason the container is not yet running.
+        """
+elif False:
+    ContainerStateWaitingArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ContainerStateWaitingArgs:
     def __init__(__self__, *,
@@ -4402,6 +6099,26 @@ class ContainerStateWaitingArgs:
     def reason(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "reason", value)
 
+
+if not MYPY:
+    class ContainerStateArgsDict(TypedDict):
+        """
+        ContainerState holds a possible state of container. Only one of its members may be specified. If none of them is specified, the default one is ContainerStateWaiting.
+        """
+        running: NotRequired[pulumi.Input['ContainerStateRunningArgsDict']]
+        """
+        Details about a running container
+        """
+        terminated: NotRequired[pulumi.Input['ContainerStateTerminatedArgsDict']]
+        """
+        Details about a terminated container
+        """
+        waiting: NotRequired[pulumi.Input['ContainerStateWaitingArgsDict']]
+        """
+        Details about a waiting container
+        """
+elif False:
+    ContainerStateArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ContainerStateArgs:
@@ -4458,6 +6175,64 @@ class ContainerStateArgs:
     def waiting(self, value: Optional[pulumi.Input['ContainerStateWaitingArgs']]):
         pulumi.set(self, "waiting", value)
 
+
+if not MYPY:
+    class ContainerStatusArgsDict(TypedDict):
+        """
+        ContainerStatus contains details for the current status of this container.
+        """
+        image: pulumi.Input[str]
+        """
+        Image is the name of container image that the container is running. The container image may not match the image used in the PodSpec, as it may have been resolved by the runtime. More info: https://kubernetes.io/docs/concepts/containers/images.
+        """
+        image_id: pulumi.Input[str]
+        """
+        ImageID is the image ID of the container's image. The image ID may not match the image ID of the image used in the PodSpec, as it may have been resolved by the runtime.
+        """
+        name: pulumi.Input[str]
+        """
+        Name is a DNS_LABEL representing the unique name of the container. Each container in a pod must have a unique name across all container types. Cannot be updated.
+        """
+        ready: pulumi.Input[bool]
+        """
+        Ready specifies whether the container is currently passing its readiness check. The value will change as readiness probes keep executing. If no readiness probes are specified, this field defaults to true once the container is fully started (see Started field).
+
+        The value is typically used to determine whether a container is ready to accept traffic.
+        """
+        restart_count: pulumi.Input[int]
+        """
+        RestartCount holds the number of times the container has been restarted. Kubelet makes an effort to always increment the value, but there are cases when the state may be lost due to node restarts and then the value may be reset to 0. The value is never negative.
+        """
+        allocated_resources: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        AllocatedResources represents the compute resources allocated for this container by the node. Kubelet sets this value to Container.Resources.Requests upon successful pod admission and after successfully admitting desired pod resize.
+        """
+        container_id: NotRequired[pulumi.Input[str]]
+        """
+        ContainerID is the ID of the container in the format '<type>://<container_id>'. Where type is a container runtime identifier, returned from Version call of CRI API (for example "containerd").
+        """
+        last_state: NotRequired[pulumi.Input['ContainerStateArgsDict']]
+        """
+        LastTerminationState holds the last termination state of the container to help debug container crashes and restarts. This field is not populated if the container is still running and RestartCount is 0.
+        """
+        resources: NotRequired[pulumi.Input['ResourceRequirementsArgsDict']]
+        """
+        Resources represents the compute resource requests and limits that have been successfully enacted on the running container after it has been started or has been successfully resized.
+        """
+        started: NotRequired[pulumi.Input[bool]]
+        """
+        Started indicates whether the container has finished its postStart lifecycle hook and passed its startup probe. Initialized as false, becomes true after startupProbe is considered successful. Resets to false when the container is restarted, or if kubelet loses state temporarily. In both cases, startup probes will run again. Is always true when no startupProbe is defined and container is running and has passed the postStart lifecycle hook. The null value must be treated the same as false.
+        """
+        state: NotRequired[pulumi.Input['ContainerStateArgsDict']]
+        """
+        State holds details about the container's current condition.
+        """
+        volume_mounts: NotRequired[pulumi.Input[Sequence[pulumi.Input['VolumeMountStatusArgsDict']]]]
+        """
+        Status of volume mounts.
+        """
+elif False:
+    ContainerStatusArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ContainerStatusArgs:
@@ -4657,6 +6432,110 @@ class ContainerStatusArgs:
     def volume_mounts(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['VolumeMountStatusArgs']]]]):
         pulumi.set(self, "volume_mounts", value)
 
+
+if not MYPY:
+    class ContainerArgsDict(TypedDict):
+        """
+        A single application container that you want to run within a pod.
+        """
+        name: pulumi.Input[str]
+        """
+        Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
+        """
+        args: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Arguments to the entrypoint. The container image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+        """
+        command: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Entrypoint array. Not executed within a shell. The container image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+        """
+        env: NotRequired[pulumi.Input[Sequence[pulumi.Input['EnvVarArgsDict']]]]
+        """
+        List of environment variables to set in the container. Cannot be updated.
+        """
+        env_from: NotRequired[pulumi.Input[Sequence[pulumi.Input['EnvFromSourceArgsDict']]]]
+        """
+        List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
+        """
+        image: NotRequired[pulumi.Input[str]]
+        """
+        Container image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.
+        """
+        image_pull_policy: NotRequired[pulumi.Input[str]]
+        """
+        Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+        """
+        lifecycle: NotRequired[pulumi.Input['LifecycleArgsDict']]
+        """
+        Actions that the management system should take in response to container lifecycle events. Cannot be updated.
+        """
+        liveness_probe: NotRequired[pulumi.Input['ProbeArgsDict']]
+        """
+        Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+        """
+        ports: NotRequired[pulumi.Input[Sequence[pulumi.Input['ContainerPortArgsDict']]]]
+        """
+        List of ports to expose from the container. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Modifying this array with strategic merge patch may corrupt the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255. Cannot be updated.
+        """
+        readiness_probe: NotRequired[pulumi.Input['ProbeArgsDict']]
+        """
+        Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+        """
+        resize_policy: NotRequired[pulumi.Input[Sequence[pulumi.Input['ContainerResizePolicyArgsDict']]]]
+        """
+        Resources resize policy for the container.
+        """
+        resources: NotRequired[pulumi.Input['ResourceRequirementsArgsDict']]
+        """
+        Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+        """
+        restart_policy: NotRequired[pulumi.Input[str]]
+        """
+        RestartPolicy defines the restart behavior of individual containers in a pod. This field may only be set for init containers, and the only allowed value is "Always". For non-init containers or when this field is not specified, the restart behavior is defined by the Pod's restart policy and the container type. Setting the RestartPolicy as "Always" for the init container will have the following effect: this init container will be continually restarted on exit until all regular containers have terminated. Once all regular containers have completed, all init containers with restartPolicy "Always" will be shut down. This lifecycle differs from normal init containers and is often referred to as a "sidecar" container. Although this init container still starts in the init container sequence, it does not wait for the container to complete before proceeding to the next init container. Instead, the next init container starts immediately after this init container is started, or after any startupProbe has successfully completed.
+        """
+        security_context: NotRequired[pulumi.Input['SecurityContextArgsDict']]
+        """
+        SecurityContext defines the security options the container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+        """
+        startup_probe: NotRequired[pulumi.Input['ProbeArgsDict']]
+        """
+        StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+        """
+        stdin: NotRequired[pulumi.Input[bool]]
+        """
+        Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.
+        """
+        stdin_once: NotRequired[pulumi.Input[bool]]
+        """
+        Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false
+        """
+        termination_message_path: NotRequired[pulumi.Input[str]]
+        """
+        Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.
+        """
+        termination_message_policy: NotRequired[pulumi.Input[str]]
+        """
+        Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+        """
+        tty: NotRequired[pulumi.Input[bool]]
+        """
+        Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.
+        """
+        volume_devices: NotRequired[pulumi.Input[Sequence[pulumi.Input['VolumeDeviceArgsDict']]]]
+        """
+        volumeDevices is the list of block devices to be used by the container.
+        """
+        volume_mounts: NotRequired[pulumi.Input[Sequence[pulumi.Input['VolumeMountArgsDict']]]]
+        """
+        Pod volumes to mount into the container's filesystem. Cannot be updated.
+        """
+        working_dir: NotRequired[pulumi.Input[str]]
+        """
+        Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
+        """
+elif False:
+    ContainerArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ContainerArgs:
@@ -5049,6 +6928,18 @@ class ContainerArgs:
         pulumi.set(self, "working_dir", value)
 
 
+if not MYPY:
+    class DaemonEndpointArgsDict(TypedDict):
+        """
+        DaemonEndpoint contains information about a single Daemon endpoint.
+        """
+        port: pulumi.Input[int]
+        """
+        Port number of the given endpoint.
+        """
+elif False:
+    DaemonEndpointArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class DaemonEndpointArgs:
     def __init__(__self__, *,
@@ -5071,6 +6962,18 @@ class DaemonEndpointArgs:
     def port(self, value: pulumi.Input[int]):
         pulumi.set(self, "port", value)
 
+
+if not MYPY:
+    class DownwardAPIProjectionPatchArgsDict(TypedDict):
+        """
+        Represents downward API info for projecting into a projected volume. Note that this is identical to a downwardAPI volume source without the default mode.
+        """
+        items: NotRequired[pulumi.Input[Sequence[pulumi.Input['DownwardAPIVolumeFilePatchArgsDict']]]]
+        """
+        Items is a list of DownwardAPIVolume file
+        """
+elif False:
+    DownwardAPIProjectionPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class DownwardAPIProjectionPatchArgs:
@@ -5096,6 +6999,18 @@ class DownwardAPIProjectionPatchArgs:
         pulumi.set(self, "items", value)
 
 
+if not MYPY:
+    class DownwardAPIProjectionArgsDict(TypedDict):
+        """
+        Represents downward API info for projecting into a projected volume. Note that this is identical to a downwardAPI volume source without the default mode.
+        """
+        items: NotRequired[pulumi.Input[Sequence[pulumi.Input['DownwardAPIVolumeFileArgsDict']]]]
+        """
+        Items is a list of DownwardAPIVolume file
+        """
+elif False:
+    DownwardAPIProjectionArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class DownwardAPIProjectionArgs:
     def __init__(__self__, *,
@@ -5119,6 +7034,30 @@ class DownwardAPIProjectionArgs:
     def items(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['DownwardAPIVolumeFileArgs']]]]):
         pulumi.set(self, "items", value)
 
+
+if not MYPY:
+    class DownwardAPIVolumeFilePatchArgsDict(TypedDict):
+        """
+        DownwardAPIVolumeFile represents information to create the file containing the pod field
+        """
+        field_ref: NotRequired[pulumi.Input['ObjectFieldSelectorPatchArgsDict']]
+        """
+        Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.
+        """
+        mode: NotRequired[pulumi.Input[int]]
+        """
+        Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+        """
+        path: NotRequired[pulumi.Input[str]]
+        """
+        Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'
+        """
+        resource_field_ref: NotRequired[pulumi.Input['ResourceFieldSelectorPatchArgsDict']]
+        """
+        Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+        """
+elif False:
+    DownwardAPIVolumeFilePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class DownwardAPIVolumeFilePatchArgs:
@@ -5192,6 +7131,30 @@ class DownwardAPIVolumeFilePatchArgs:
         pulumi.set(self, "resource_field_ref", value)
 
 
+if not MYPY:
+    class DownwardAPIVolumeFileArgsDict(TypedDict):
+        """
+        DownwardAPIVolumeFile represents information to create the file containing the pod field
+        """
+        path: pulumi.Input[str]
+        """
+        Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'
+        """
+        field_ref: NotRequired[pulumi.Input['ObjectFieldSelectorArgsDict']]
+        """
+        Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.
+        """
+        mode: NotRequired[pulumi.Input[int]]
+        """
+        Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+        """
+        resource_field_ref: NotRequired[pulumi.Input['ResourceFieldSelectorArgsDict']]
+        """
+        Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+        """
+elif False:
+    DownwardAPIVolumeFileArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class DownwardAPIVolumeFileArgs:
     def __init__(__self__, *,
@@ -5263,6 +7226,22 @@ class DownwardAPIVolumeFileArgs:
         pulumi.set(self, "resource_field_ref", value)
 
 
+if not MYPY:
+    class DownwardAPIVolumeSourcePatchArgsDict(TypedDict):
+        """
+        DownwardAPIVolumeSource represents a volume containing downward API info. Downward API volumes support ownership management and SELinux relabeling.
+        """
+        default_mode: NotRequired[pulumi.Input[int]]
+        """
+        Optional: mode bits to use on created files by default. Must be a Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+        """
+        items: NotRequired[pulumi.Input[Sequence[pulumi.Input['DownwardAPIVolumeFilePatchArgsDict']]]]
+        """
+        Items is a list of downward API volume file
+        """
+elif False:
+    DownwardAPIVolumeSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class DownwardAPIVolumeSourcePatchArgs:
     def __init__(__self__, *,
@@ -5302,6 +7281,22 @@ class DownwardAPIVolumeSourcePatchArgs:
     def items(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['DownwardAPIVolumeFilePatchArgs']]]]):
         pulumi.set(self, "items", value)
 
+
+if not MYPY:
+    class DownwardAPIVolumeSourceArgsDict(TypedDict):
+        """
+        DownwardAPIVolumeSource represents a volume containing downward API info. Downward API volumes support ownership management and SELinux relabeling.
+        """
+        default_mode: NotRequired[pulumi.Input[int]]
+        """
+        Optional: mode bits to use on created files by default. Must be a Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+        """
+        items: NotRequired[pulumi.Input[Sequence[pulumi.Input['DownwardAPIVolumeFileArgsDict']]]]
+        """
+        Items is a list of downward API volume file
+        """
+elif False:
+    DownwardAPIVolumeSourceArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class DownwardAPIVolumeSourceArgs:
@@ -5343,6 +7338,22 @@ class DownwardAPIVolumeSourceArgs:
         pulumi.set(self, "items", value)
 
 
+if not MYPY:
+    class EmptyDirVolumeSourcePatchArgsDict(TypedDict):
+        """
+        Represents an empty directory for a pod. Empty directory volumes support ownership management and SELinux relabeling.
+        """
+        medium: NotRequired[pulumi.Input[str]]
+        """
+        medium represents what type of storage medium should back this directory. The default is "" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+        """
+        size_limit: NotRequired[pulumi.Input[str]]
+        """
+        sizeLimit is the total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+        """
+elif False:
+    EmptyDirVolumeSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class EmptyDirVolumeSourcePatchArgs:
     def __init__(__self__, *,
@@ -5383,6 +7394,22 @@ class EmptyDirVolumeSourcePatchArgs:
         pulumi.set(self, "size_limit", value)
 
 
+if not MYPY:
+    class EmptyDirVolumeSourceArgsDict(TypedDict):
+        """
+        Represents an empty directory for a pod. Empty directory volumes support ownership management and SELinux relabeling.
+        """
+        medium: NotRequired[pulumi.Input[str]]
+        """
+        medium represents what type of storage medium should back this directory. The default is "" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+        """
+        size_limit: NotRequired[pulumi.Input[str]]
+        """
+        sizeLimit is the total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+        """
+elif False:
+    EmptyDirVolumeSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class EmptyDirVolumeSourceArgs:
     def __init__(__self__, *,
@@ -5422,6 +7449,30 @@ class EmptyDirVolumeSourceArgs:
     def size_limit(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "size_limit", value)
 
+
+if not MYPY:
+    class EndpointAddressPatchArgsDict(TypedDict):
+        """
+        EndpointAddress is a tuple that describes single IP address.
+        """
+        hostname: NotRequired[pulumi.Input[str]]
+        """
+        The Hostname of this endpoint
+        """
+        ip: NotRequired[pulumi.Input[str]]
+        """
+        The IP of this endpoint. May not be loopback (127.0.0.0/8 or ::1), link-local (169.254.0.0/16 or fe80::/10), or link-local multicast (224.0.0.0/24 or ff02::/16).
+        """
+        node_name: NotRequired[pulumi.Input[str]]
+        """
+        Optional: Node hosting this endpoint. This can be used to determine endpoints local to a node.
+        """
+        target_ref: NotRequired[pulumi.Input['ObjectReferencePatchArgsDict']]
+        """
+        Reference to object providing the endpoint.
+        """
+elif False:
+    EndpointAddressPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class EndpointAddressPatchArgs:
@@ -5495,6 +7546,30 @@ class EndpointAddressPatchArgs:
         pulumi.set(self, "target_ref", value)
 
 
+if not MYPY:
+    class EndpointAddressArgsDict(TypedDict):
+        """
+        EndpointAddress is a tuple that describes single IP address.
+        """
+        ip: pulumi.Input[str]
+        """
+        The IP of this endpoint. May not be loopback (127.0.0.0/8 or ::1), link-local (169.254.0.0/16 or fe80::/10), or link-local multicast (224.0.0.0/24 or ff02::/16).
+        """
+        hostname: NotRequired[pulumi.Input[str]]
+        """
+        The Hostname of this endpoint
+        """
+        node_name: NotRequired[pulumi.Input[str]]
+        """
+        Optional: Node hosting this endpoint. This can be used to determine endpoints local to a node.
+        """
+        target_ref: NotRequired[pulumi.Input['ObjectReferenceArgsDict']]
+        """
+        Reference to object providing the endpoint.
+        """
+elif False:
+    EndpointAddressArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class EndpointAddressArgs:
     def __init__(__self__, *,
@@ -5565,6 +7640,39 @@ class EndpointAddressArgs:
     def target_ref(self, value: Optional[pulumi.Input['ObjectReferenceArgs']]):
         pulumi.set(self, "target_ref", value)
 
+
+if not MYPY:
+    class EndpointPortPatchArgsDict(TypedDict):
+        """
+        EndpointPort is a tuple that describes a single port.
+        """
+        app_protocol: NotRequired[pulumi.Input[str]]
+        """
+        The application protocol for this port. This is used as a hint for implementations to offer richer behavior for protocols that they understand. This field follows standard Kubernetes label syntax. Valid values are either:
+
+        * Un-prefixed protocol names - reserved for IANA standard service names (as per RFC-6335 and https://www.iana.org/assignments/service-names).
+
+        * Kubernetes-defined prefixed names:
+          * 'kubernetes.io/h2c' - HTTP/2 prior knowledge over cleartext as described in https://www.rfc-editor.org/rfc/rfc9113.html#name-starting-http-2-with-prior-
+          * 'kubernetes.io/ws'  - WebSocket over cleartext as described in https://www.rfc-editor.org/rfc/rfc6455
+          * 'kubernetes.io/wss' - WebSocket over TLS as described in https://www.rfc-editor.org/rfc/rfc6455
+
+        * Other protocols should use implementation-defined prefixed names such as mycompany.com/my-custom-protocol.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        The name of this port.  This must match the 'name' field in the corresponding ServicePort. Must be a DNS_LABEL. Optional only if one port is defined.
+        """
+        port: NotRequired[pulumi.Input[int]]
+        """
+        The port number of the endpoint.
+        """
+        protocol: NotRequired[pulumi.Input[str]]
+        """
+        The IP protocol for this port. Must be UDP, TCP, or SCTP. Default is TCP.
+        """
+elif False:
+    EndpointPortPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class EndpointPortPatchArgs:
@@ -5656,6 +7764,39 @@ class EndpointPortPatchArgs:
         pulumi.set(self, "protocol", value)
 
 
+if not MYPY:
+    class EndpointPortArgsDict(TypedDict):
+        """
+        EndpointPort is a tuple that describes a single port.
+        """
+        port: pulumi.Input[int]
+        """
+        The port number of the endpoint.
+        """
+        app_protocol: NotRequired[pulumi.Input[str]]
+        """
+        The application protocol for this port. This is used as a hint for implementations to offer richer behavior for protocols that they understand. This field follows standard Kubernetes label syntax. Valid values are either:
+
+        * Un-prefixed protocol names - reserved for IANA standard service names (as per RFC-6335 and https://www.iana.org/assignments/service-names).
+
+        * Kubernetes-defined prefixed names:
+          * 'kubernetes.io/h2c' - HTTP/2 prior knowledge over cleartext as described in https://www.rfc-editor.org/rfc/rfc9113.html#name-starting-http-2-with-prior-
+          * 'kubernetes.io/ws'  - WebSocket over cleartext as described in https://www.rfc-editor.org/rfc/rfc6455
+          * 'kubernetes.io/wss' - WebSocket over TLS as described in https://www.rfc-editor.org/rfc/rfc6455
+
+        * Other protocols should use implementation-defined prefixed names such as mycompany.com/my-custom-protocol.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        The name of this port.  This must match the 'name' field in the corresponding ServicePort. Must be a DNS_LABEL. Optional only if one port is defined.
+        """
+        protocol: NotRequired[pulumi.Input[str]]
+        """
+        The IP protocol for this port. Must be UDP, TCP, or SCTP. Default is TCP.
+        """
+elif False:
+    EndpointPortArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class EndpointPortArgs:
     def __init__(__self__, *,
@@ -5745,6 +7886,36 @@ class EndpointPortArgs:
         pulumi.set(self, "protocol", value)
 
 
+if not MYPY:
+    class EndpointSubsetPatchArgsDict(TypedDict):
+        """
+        EndpointSubset is a group of addresses with a common set of ports. The expanded set of endpoints is the Cartesian product of Addresses x Ports. For example, given:
+
+        	{
+        	  Addresses: [{"ip": "10.10.1.1"}, {"ip": "10.10.2.2"}],
+        	  Ports:     [{"name": "a", "port": 8675}, {"name": "b", "port": 309}]
+        	}
+
+        The resulting set of endpoints can be viewed as:
+
+        	a: [ 10.10.1.1:8675, 10.10.2.2:8675 ],
+        	b: [ 10.10.1.1:309, 10.10.2.2:309 ]
+        """
+        addresses: NotRequired[pulumi.Input[Sequence[pulumi.Input['EndpointAddressPatchArgsDict']]]]
+        """
+        IP addresses which offer the related ports that are marked as ready. These endpoints should be considered safe for load balancers and clients to utilize.
+        """
+        not_ready_addresses: NotRequired[pulumi.Input[Sequence[pulumi.Input['EndpointAddressPatchArgsDict']]]]
+        """
+        IP addresses which offer the related ports but are not currently marked as ready because they have not yet finished starting, have recently failed a readiness check, or have recently failed a liveness check.
+        """
+        ports: NotRequired[pulumi.Input[Sequence[pulumi.Input['EndpointPortPatchArgsDict']]]]
+        """
+        Port numbers available on the related IP addresses.
+        """
+elif False:
+    EndpointSubsetPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class EndpointSubsetPatchArgs:
     def __init__(__self__, *,
@@ -5811,6 +7982,36 @@ class EndpointSubsetPatchArgs:
         pulumi.set(self, "ports", value)
 
 
+if not MYPY:
+    class EndpointSubsetArgsDict(TypedDict):
+        """
+        EndpointSubset is a group of addresses with a common set of ports. The expanded set of endpoints is the Cartesian product of Addresses x Ports. For example, given:
+
+        	{
+        	  Addresses: [{"ip": "10.10.1.1"}, {"ip": "10.10.2.2"}],
+        	  Ports:     [{"name": "a", "port": 8675}, {"name": "b", "port": 309}]
+        	}
+
+        The resulting set of endpoints can be viewed as:
+
+        	a: [ 10.10.1.1:8675, 10.10.2.2:8675 ],
+        	b: [ 10.10.1.1:309, 10.10.2.2:309 ]
+        """
+        addresses: NotRequired[pulumi.Input[Sequence[pulumi.Input['EndpointAddressArgsDict']]]]
+        """
+        IP addresses which offer the related ports that are marked as ready. These endpoints should be considered safe for load balancers and clients to utilize.
+        """
+        not_ready_addresses: NotRequired[pulumi.Input[Sequence[pulumi.Input['EndpointAddressArgsDict']]]]
+        """
+        IP addresses which offer the related ports but are not currently marked as ready because they have not yet finished starting, have recently failed a readiness check, or have recently failed a liveness check.
+        """
+        ports: NotRequired[pulumi.Input[Sequence[pulumi.Input['EndpointPortArgsDict']]]]
+        """
+        Port numbers available on the related IP addresses.
+        """
+elif False:
+    EndpointSubsetArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class EndpointSubsetArgs:
     def __init__(__self__, *,
@@ -5876,6 +8077,42 @@ class EndpointSubsetArgs:
     def ports(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['EndpointPortArgs']]]]):
         pulumi.set(self, "ports", value)
 
+
+if not MYPY:
+    class EndpointsArgsDict(TypedDict):
+        """
+        Endpoints is a collection of endpoints that implement the actual service. Example:
+
+        	 Name: "mysvc",
+        	 Subsets: [
+        	   {
+        	     Addresses: [{"ip": "10.10.1.1"}, {"ip": "10.10.2.2"}],
+        	     Ports: [{"name": "a", "port": 8675}, {"name": "b", "port": 309}]
+        	   },
+        	   {
+        	     Addresses: [{"ip": "10.10.3.3"}],
+        	     Ports: [{"name": "a", "port": 93}, {"name": "b", "port": 76}]
+        	   },
+        	]
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        subsets: NotRequired[pulumi.Input[Sequence[pulumi.Input['EndpointSubsetArgsDict']]]]
+        """
+        The set of all endpoints is the union of all subsets. Addresses are placed into subsets according to the IPs they share. A single address with multiple ports, some of which are ready and some of which are not (because they come from different containers) will result in the address being displayed in different subsets for the different ports. No address will appear in both Addresses and NotReadyAddresses in the same subset. Sets of addresses and ports that comprise a service.
+        """
+elif False:
+    EndpointsArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class EndpointsArgs:
@@ -5961,6 +8198,26 @@ class EndpointsArgs:
         pulumi.set(self, "subsets", value)
 
 
+if not MYPY:
+    class EnvFromSourcePatchArgsDict(TypedDict):
+        """
+        EnvFromSource represents the source of a set of ConfigMaps
+        """
+        config_map_ref: NotRequired[pulumi.Input['ConfigMapEnvSourcePatchArgsDict']]
+        """
+        The ConfigMap to select from
+        """
+        prefix: NotRequired[pulumi.Input[str]]
+        """
+        An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+        """
+        secret_ref: NotRequired[pulumi.Input['SecretEnvSourcePatchArgsDict']]
+        """
+        The Secret to select from
+        """
+elif False:
+    EnvFromSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class EnvFromSourcePatchArgs:
     def __init__(__self__, *,
@@ -6016,6 +8273,26 @@ class EnvFromSourcePatchArgs:
     def secret_ref(self, value: Optional[pulumi.Input['SecretEnvSourcePatchArgs']]):
         pulumi.set(self, "secret_ref", value)
 
+
+if not MYPY:
+    class EnvFromSourceArgsDict(TypedDict):
+        """
+        EnvFromSource represents the source of a set of ConfigMaps
+        """
+        config_map_ref: NotRequired[pulumi.Input['ConfigMapEnvSourceArgsDict']]
+        """
+        The ConfigMap to select from
+        """
+        prefix: NotRequired[pulumi.Input[str]]
+        """
+        An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+        """
+        secret_ref: NotRequired[pulumi.Input['SecretEnvSourceArgsDict']]
+        """
+        The Secret to select from
+        """
+elif False:
+    EnvFromSourceArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class EnvFromSourceArgs:
@@ -6073,6 +8350,26 @@ class EnvFromSourceArgs:
         pulumi.set(self, "secret_ref", value)
 
 
+if not MYPY:
+    class EnvVarPatchArgsDict(TypedDict):
+        """
+        EnvVar represents an environment variable present in a Container.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name of the environment variable. Must be a C_IDENTIFIER.
+        """
+        value: NotRequired[pulumi.Input[str]]
+        """
+        Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".
+        """
+        value_from: NotRequired[pulumi.Input['EnvVarSourcePatchArgsDict']]
+        """
+        Source for the environment variable's value. Cannot be used if value is not empty.
+        """
+elif False:
+    EnvVarPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class EnvVarPatchArgs:
     def __init__(__self__, *,
@@ -6128,6 +8425,30 @@ class EnvVarPatchArgs:
     def value_from(self, value: Optional[pulumi.Input['EnvVarSourcePatchArgs']]):
         pulumi.set(self, "value_from", value)
 
+
+if not MYPY:
+    class EnvVarSourcePatchArgsDict(TypedDict):
+        """
+        EnvVarSource represents a source for the value of an EnvVar.
+        """
+        config_map_key_ref: NotRequired[pulumi.Input['ConfigMapKeySelectorPatchArgsDict']]
+        """
+        Selects a key of a ConfigMap.
+        """
+        field_ref: NotRequired[pulumi.Input['ObjectFieldSelectorPatchArgsDict']]
+        """
+        Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+        """
+        resource_field_ref: NotRequired[pulumi.Input['ResourceFieldSelectorPatchArgsDict']]
+        """
+        Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+        """
+        secret_key_ref: NotRequired[pulumi.Input['SecretKeySelectorPatchArgsDict']]
+        """
+        Selects a key of a secret in the pod's namespace
+        """
+elif False:
+    EnvVarSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class EnvVarSourcePatchArgs:
@@ -6201,6 +8522,30 @@ class EnvVarSourcePatchArgs:
         pulumi.set(self, "secret_key_ref", value)
 
 
+if not MYPY:
+    class EnvVarSourceArgsDict(TypedDict):
+        """
+        EnvVarSource represents a source for the value of an EnvVar.
+        """
+        config_map_key_ref: NotRequired[pulumi.Input['ConfigMapKeySelectorArgsDict']]
+        """
+        Selects a key of a ConfigMap.
+        """
+        field_ref: NotRequired[pulumi.Input['ObjectFieldSelectorArgsDict']]
+        """
+        Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+        """
+        resource_field_ref: NotRequired[pulumi.Input['ResourceFieldSelectorArgsDict']]
+        """
+        Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+        """
+        secret_key_ref: NotRequired[pulumi.Input['SecretKeySelectorArgsDict']]
+        """
+        Selects a key of a secret in the pod's namespace
+        """
+elif False:
+    EnvVarSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class EnvVarSourceArgs:
     def __init__(__self__, *,
@@ -6273,6 +8618,26 @@ class EnvVarSourceArgs:
         pulumi.set(self, "secret_key_ref", value)
 
 
+if not MYPY:
+    class EnvVarArgsDict(TypedDict):
+        """
+        EnvVar represents an environment variable present in a Container.
+        """
+        name: pulumi.Input[str]
+        """
+        Name of the environment variable. Must be a C_IDENTIFIER.
+        """
+        value: NotRequired[pulumi.Input[str]]
+        """
+        Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".
+        """
+        value_from: NotRequired[pulumi.Input['EnvVarSourceArgsDict']]
+        """
+        Source for the environment variable's value. Cannot be used if value is not empty.
+        """
+elif False:
+    EnvVarArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class EnvVarArgs:
     def __init__(__self__, *,
@@ -6327,6 +8692,118 @@ class EnvVarArgs:
     def value_from(self, value: Optional[pulumi.Input['EnvVarSourceArgs']]):
         pulumi.set(self, "value_from", value)
 
+
+if not MYPY:
+    class EphemeralContainerPatchArgsDict(TypedDict):
+        """
+        An EphemeralContainer is a temporary container that you may add to an existing Pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a Pod is removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the Pod to exceed its resource allocation.
+
+        To add an ephemeral container, use the ephemeralcontainers subresource of an existing Pod. Ephemeral containers may not be removed or restarted.
+        """
+        args: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Arguments to the entrypoint. The image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+        """
+        command: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Entrypoint array. Not executed within a shell. The image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+        """
+        env: NotRequired[pulumi.Input[Sequence[pulumi.Input['EnvVarPatchArgsDict']]]]
+        """
+        List of environment variables to set in the container. Cannot be updated.
+        """
+        env_from: NotRequired[pulumi.Input[Sequence[pulumi.Input['EnvFromSourcePatchArgsDict']]]]
+        """
+        List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
+        """
+        image: NotRequired[pulumi.Input[str]]
+        """
+        Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
+        """
+        image_pull_policy: NotRequired[pulumi.Input[str]]
+        """
+        Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+        """
+        lifecycle: NotRequired[pulumi.Input['LifecyclePatchArgsDict']]
+        """
+        Lifecycle is not allowed for ephemeral containers.
+        """
+        liveness_probe: NotRequired[pulumi.Input['ProbePatchArgsDict']]
+        """
+        Probes are not allowed for ephemeral containers.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name of the ephemeral container specified as a DNS_LABEL. This name must be unique among all containers, init containers and ephemeral containers.
+        """
+        ports: NotRequired[pulumi.Input[Sequence[pulumi.Input['ContainerPortPatchArgsDict']]]]
+        """
+        Ports are not allowed for ephemeral containers.
+        """
+        readiness_probe: NotRequired[pulumi.Input['ProbePatchArgsDict']]
+        """
+        Probes are not allowed for ephemeral containers.
+        """
+        resize_policy: NotRequired[pulumi.Input[Sequence[pulumi.Input['ContainerResizePolicyPatchArgsDict']]]]
+        """
+        Resources resize policy for the container.
+        """
+        resources: NotRequired[pulumi.Input['ResourceRequirementsPatchArgsDict']]
+        """
+        Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources already allocated to the pod.
+        """
+        restart_policy: NotRequired[pulumi.Input[str]]
+        """
+        Restart policy for the container to manage the restart behavior of each container within a pod. This may only be set for init containers. You cannot set this field on ephemeral containers.
+        """
+        security_context: NotRequired[pulumi.Input['SecurityContextPatchArgsDict']]
+        """
+        Optional: SecurityContext defines the security options the ephemeral container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+        """
+        startup_probe: NotRequired[pulumi.Input['ProbePatchArgsDict']]
+        """
+        Probes are not allowed for ephemeral containers.
+        """
+        stdin: NotRequired[pulumi.Input[bool]]
+        """
+        Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.
+        """
+        stdin_once: NotRequired[pulumi.Input[bool]]
+        """
+        Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false
+        """
+        target_container_name: NotRequired[pulumi.Input[str]]
+        """
+        If set, the name of the container from PodSpec that this ephemeral container targets. The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container. If not set then the ephemeral container uses the namespaces configured in the Pod spec.
+
+        The container runtime must implement support for this feature. If the runtime does not support namespace targeting then the result of setting this field is undefined.
+        """
+        termination_message_path: NotRequired[pulumi.Input[str]]
+        """
+        Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.
+        """
+        termination_message_policy: NotRequired[pulumi.Input[str]]
+        """
+        Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+        """
+        tty: NotRequired[pulumi.Input[bool]]
+        """
+        Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.
+        """
+        volume_devices: NotRequired[pulumi.Input[Sequence[pulumi.Input['VolumeDevicePatchArgsDict']]]]
+        """
+        volumeDevices is the list of block devices to be used by the container.
+        """
+        volume_mounts: NotRequired[pulumi.Input[Sequence[pulumi.Input['VolumeMountPatchArgsDict']]]]
+        """
+        Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers. Cannot be updated.
+        """
+        working_dir: NotRequired[pulumi.Input[str]]
+        """
+        Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
+        """
+elif False:
+    EphemeralContainerPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class EphemeralContainerPatchArgs:
@@ -6742,6 +9219,118 @@ class EphemeralContainerPatchArgs:
         pulumi.set(self, "working_dir", value)
 
 
+if not MYPY:
+    class EphemeralContainerArgsDict(TypedDict):
+        """
+        An EphemeralContainer is a temporary container that you may add to an existing Pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a Pod is removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the Pod to exceed its resource allocation.
+
+        To add an ephemeral container, use the ephemeralcontainers subresource of an existing Pod. Ephemeral containers may not be removed or restarted.
+        """
+        name: pulumi.Input[str]
+        """
+        Name of the ephemeral container specified as a DNS_LABEL. This name must be unique among all containers, init containers and ephemeral containers.
+        """
+        args: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Arguments to the entrypoint. The image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+        """
+        command: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Entrypoint array. Not executed within a shell. The image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+        """
+        env: NotRequired[pulumi.Input[Sequence[pulumi.Input['EnvVarArgsDict']]]]
+        """
+        List of environment variables to set in the container. Cannot be updated.
+        """
+        env_from: NotRequired[pulumi.Input[Sequence[pulumi.Input['EnvFromSourceArgsDict']]]]
+        """
+        List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
+        """
+        image: NotRequired[pulumi.Input[str]]
+        """
+        Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
+        """
+        image_pull_policy: NotRequired[pulumi.Input[str]]
+        """
+        Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+        """
+        lifecycle: NotRequired[pulumi.Input['LifecycleArgsDict']]
+        """
+        Lifecycle is not allowed for ephemeral containers.
+        """
+        liveness_probe: NotRequired[pulumi.Input['ProbeArgsDict']]
+        """
+        Probes are not allowed for ephemeral containers.
+        """
+        ports: NotRequired[pulumi.Input[Sequence[pulumi.Input['ContainerPortArgsDict']]]]
+        """
+        Ports are not allowed for ephemeral containers.
+        """
+        readiness_probe: NotRequired[pulumi.Input['ProbeArgsDict']]
+        """
+        Probes are not allowed for ephemeral containers.
+        """
+        resize_policy: NotRequired[pulumi.Input[Sequence[pulumi.Input['ContainerResizePolicyArgsDict']]]]
+        """
+        Resources resize policy for the container.
+        """
+        resources: NotRequired[pulumi.Input['ResourceRequirementsArgsDict']]
+        """
+        Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources already allocated to the pod.
+        """
+        restart_policy: NotRequired[pulumi.Input[str]]
+        """
+        Restart policy for the container to manage the restart behavior of each container within a pod. This may only be set for init containers. You cannot set this field on ephemeral containers.
+        """
+        security_context: NotRequired[pulumi.Input['SecurityContextArgsDict']]
+        """
+        Optional: SecurityContext defines the security options the ephemeral container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+        """
+        startup_probe: NotRequired[pulumi.Input['ProbeArgsDict']]
+        """
+        Probes are not allowed for ephemeral containers.
+        """
+        stdin: NotRequired[pulumi.Input[bool]]
+        """
+        Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.
+        """
+        stdin_once: NotRequired[pulumi.Input[bool]]
+        """
+        Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false
+        """
+        target_container_name: NotRequired[pulumi.Input[str]]
+        """
+        If set, the name of the container from PodSpec that this ephemeral container targets. The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container. If not set then the ephemeral container uses the namespaces configured in the Pod spec.
+
+        The container runtime must implement support for this feature. If the runtime does not support namespace targeting then the result of setting this field is undefined.
+        """
+        termination_message_path: NotRequired[pulumi.Input[str]]
+        """
+        Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.
+        """
+        termination_message_policy: NotRequired[pulumi.Input[str]]
+        """
+        Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+        """
+        tty: NotRequired[pulumi.Input[bool]]
+        """
+        Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.
+        """
+        volume_devices: NotRequired[pulumi.Input[Sequence[pulumi.Input['VolumeDeviceArgsDict']]]]
+        """
+        volumeDevices is the list of block devices to be used by the container.
+        """
+        volume_mounts: NotRequired[pulumi.Input[Sequence[pulumi.Input['VolumeMountArgsDict']]]]
+        """
+        Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers. Cannot be updated.
+        """
+        working_dir: NotRequired[pulumi.Input[str]]
+        """
+        Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
+        """
+elif False:
+    EphemeralContainerArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class EphemeralContainerArgs:
     def __init__(__self__, *,
@@ -7155,6 +9744,28 @@ class EphemeralContainerArgs:
         pulumi.set(self, "working_dir", value)
 
 
+if not MYPY:
+    class EphemeralVolumeSourcePatchArgsDict(TypedDict):
+        """
+        Represents an ephemeral volume that is handled by a normal storage driver.
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        Specifies a read-only configuration for the volume. Defaults to false (read/write).
+        """
+        volume_claim_template: NotRequired[pulumi.Input['PersistentVolumeClaimTemplatePatchArgsDict']]
+        """
+        Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long).
+
+        An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster.
+
+        This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created.
+
+        Required, must not be nil.
+        """
+elif False:
+    EphemeralVolumeSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class EphemeralVolumeSourcePatchArgs:
     def __init__(__self__, *,
@@ -7207,6 +9818,28 @@ class EphemeralVolumeSourcePatchArgs:
         pulumi.set(self, "volume_claim_template", value)
 
 
+if not MYPY:
+    class EphemeralVolumeSourceArgsDict(TypedDict):
+        """
+        Represents an ephemeral volume that is handled by a normal storage driver.
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        Specifies a read-only configuration for the volume. Defaults to false (read/write).
+        """
+        volume_claim_template: NotRequired[pulumi.Input['PersistentVolumeClaimTemplateArgsDict']]
+        """
+        Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long).
+
+        An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster.
+
+        This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created.
+
+        Required, must not be nil.
+        """
+elif False:
+    EphemeralVolumeSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class EphemeralVolumeSourceArgs:
     def __init__(__self__, *,
@@ -7258,6 +9891,26 @@ class EphemeralVolumeSourceArgs:
     def volume_claim_template(self, value: Optional[pulumi.Input['PersistentVolumeClaimTemplateArgs']]):
         pulumi.set(self, "volume_claim_template", value)
 
+
+if not MYPY:
+    class EventSeriesPatchArgsDict(TypedDict):
+        """
+        EventSeries contain information on series of events, i.e. thing that was/is happening continuously for some time.
+        """
+        count: NotRequired[pulumi.Input[int]]
+        """
+        Number of occurrences in this series up to the last heartbeat time
+        """
+        last_observed_time: NotRequired[pulumi.Input[str]]
+        """
+        Time of the last occurrence observed
+        """
+        state: NotRequired[pulumi.Input[str]]
+        """
+        State of this Series: Ongoing or Finished Deprecated. Planned removal for 1.18
+        """
+elif False:
+    EventSeriesPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class EventSeriesPatchArgs:
@@ -7315,6 +9968,26 @@ class EventSeriesPatchArgs:
         pulumi.set(self, "state", value)
 
 
+if not MYPY:
+    class EventSeriesArgsDict(TypedDict):
+        """
+        EventSeries contain information on series of events, i.e. thing that was/is happening continuously for some time.
+        """
+        count: NotRequired[pulumi.Input[int]]
+        """
+        Number of occurrences in this series up to the last heartbeat time
+        """
+        last_observed_time: NotRequired[pulumi.Input[str]]
+        """
+        Time of the last occurrence observed
+        """
+        state: NotRequired[pulumi.Input[str]]
+        """
+        State of this Series: Ongoing or Finished Deprecated. Planned removal for 1.18
+        """
+elif False:
+    EventSeriesArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class EventSeriesArgs:
     def __init__(__self__, *,
@@ -7371,6 +10044,22 @@ class EventSeriesArgs:
         pulumi.set(self, "state", value)
 
 
+if not MYPY:
+    class EventSourcePatchArgsDict(TypedDict):
+        """
+        EventSource contains information for an event.
+        """
+        component: NotRequired[pulumi.Input[str]]
+        """
+        Component from which the event is generated.
+        """
+        host: NotRequired[pulumi.Input[str]]
+        """
+        Node name on which the event is generated.
+        """
+elif False:
+    EventSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class EventSourcePatchArgs:
     def __init__(__self__, *,
@@ -7411,6 +10100,22 @@ class EventSourcePatchArgs:
         pulumi.set(self, "host", value)
 
 
+if not MYPY:
+    class EventSourceArgsDict(TypedDict):
+        """
+        EventSource contains information for an event.
+        """
+        component: NotRequired[pulumi.Input[str]]
+        """
+        Component from which the event is generated.
+        """
+        host: NotRequired[pulumi.Input[str]]
+        """
+        Node name on which the event is generated.
+        """
+elif False:
+    EventSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class EventSourceArgs:
     def __init__(__self__, *,
@@ -7450,6 +10155,82 @@ class EventSourceArgs:
     def host(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "host", value)
 
+
+if not MYPY:
+    class EventArgsDict(TypedDict):
+        """
+        Event is a report of an event somewhere in the cluster.  Events have a limited retention time and triggers and messages may evolve with time.  Event consumers should not rely on the timing of an event with a given Reason reflecting a consistent underlying trigger, or the continued existence of events with that Reason.  Events should be treated as informative, best-effort, supplemental data.
+        """
+        involved_object: pulumi.Input['ObjectReferenceArgsDict']
+        """
+        The object that this event is about.
+        """
+        metadata: pulumi.Input['_meta.v1.ObjectMetaArgsDict']
+        """
+        Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        action: NotRequired[pulumi.Input[str]]
+        """
+        What action was taken/failed regarding to the Regarding object.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        count: NotRequired[pulumi.Input[int]]
+        """
+        The number of times this event has occurred.
+        """
+        event_time: NotRequired[pulumi.Input[str]]
+        """
+        Time when this Event was first observed.
+        """
+        first_timestamp: NotRequired[pulumi.Input[str]]
+        """
+        The time at which the event was first recorded. (Time of server receipt is in TypeMeta.)
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        last_timestamp: NotRequired[pulumi.Input[str]]
+        """
+        The time at which the most recent occurrence of this event was recorded.
+        """
+        message: NotRequired[pulumi.Input[str]]
+        """
+        A human-readable description of the status of this operation.
+        """
+        reason: NotRequired[pulumi.Input[str]]
+        """
+        This should be a short, machine understandable string that gives the reason for the transition into the object's current status.
+        """
+        related: NotRequired[pulumi.Input['ObjectReferenceArgsDict']]
+        """
+        Optional secondary object for more complex actions.
+        """
+        reporting_component: NotRequired[pulumi.Input[str]]
+        """
+        Name of the controller that emitted this Event, e.g. `kubernetes.io/kubelet`.
+        """
+        reporting_instance: NotRequired[pulumi.Input[str]]
+        """
+        ID of the controller instance, e.g. `kubelet-xyzf`.
+        """
+        series: NotRequired[pulumi.Input['EventSeriesArgsDict']]
+        """
+        Data about the Event series this event represents or nil if it's a singleton Event.
+        """
+        source: NotRequired[pulumi.Input['EventSourceArgsDict']]
+        """
+        The component reporting this event. Should be a short machine understandable string.
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        Type of this event (Normal, Warning), new types could be added in the future
+        """
+elif False:
+    EventArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class EventArgs:
@@ -7729,6 +10510,18 @@ class EventArgs:
         pulumi.set(self, "type", value)
 
 
+if not MYPY:
+    class ExecActionPatchArgsDict(TypedDict):
+        """
+        ExecAction describes a "run in container" action.
+        """
+        command: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+        """
+elif False:
+    ExecActionPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ExecActionPatchArgs:
     def __init__(__self__, *,
@@ -7753,6 +10546,18 @@ class ExecActionPatchArgs:
         pulumi.set(self, "command", value)
 
 
+if not MYPY:
+    class ExecActionArgsDict(TypedDict):
+        """
+        ExecAction describes a "run in container" action.
+        """
+        command: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+        """
+elif False:
+    ExecActionArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ExecActionArgs:
     def __init__(__self__, *,
@@ -7776,6 +10581,34 @@ class ExecActionArgs:
     def command(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]):
         pulumi.set(self, "command", value)
 
+
+if not MYPY:
+    class FCVolumeSourcePatchArgsDict(TypedDict):
+        """
+        Represents a Fibre Channel volume. Fibre Channel volumes can only be mounted as read/write once. Fibre Channel volumes support ownership management and SELinux relabeling.
+        """
+        fs_type: NotRequired[pulumi.Input[str]]
+        """
+        fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+        """
+        lun: NotRequired[pulumi.Input[int]]
+        """
+        lun is Optional: FC target lun number
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+        """
+        target_wwns: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        targetWWNs is Optional: FC target worldwide names (WWNs)
+        """
+        wwids: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        wwids Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
+        """
+elif False:
+    FCVolumeSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class FCVolumeSourcePatchArgs:
@@ -7865,6 +10698,34 @@ class FCVolumeSourcePatchArgs:
         pulumi.set(self, "wwids", value)
 
 
+if not MYPY:
+    class FCVolumeSourceArgsDict(TypedDict):
+        """
+        Represents a Fibre Channel volume. Fibre Channel volumes can only be mounted as read/write once. Fibre Channel volumes support ownership management and SELinux relabeling.
+        """
+        fs_type: NotRequired[pulumi.Input[str]]
+        """
+        fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+        """
+        lun: NotRequired[pulumi.Input[int]]
+        """
+        lun is Optional: FC target lun number
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+        """
+        target_wwns: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        targetWWNs is Optional: FC target worldwide names (WWNs)
+        """
+        wwids: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        wwids Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
+        """
+elif False:
+    FCVolumeSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class FCVolumeSourceArgs:
     def __init__(__self__, *,
@@ -7952,6 +10813,34 @@ class FCVolumeSourceArgs:
     def wwids(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]):
         pulumi.set(self, "wwids", value)
 
+
+if not MYPY:
+    class FlexPersistentVolumeSourcePatchArgsDict(TypedDict):
+        """
+        FlexPersistentVolumeSource represents a generic persistent volume resource that is provisioned/attached using an exec based plugin.
+        """
+        driver: NotRequired[pulumi.Input[str]]
+        """
+        driver is the name of the driver to use for this volume.
+        """
+        fs_type: NotRequired[pulumi.Input[str]]
+        """
+        fsType is the Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+        """
+        options: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        options is Optional: this field holds extra command options if any.
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        readOnly is Optional: defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+        """
+        secret_ref: NotRequired[pulumi.Input['SecretReferencePatchArgsDict']]
+        """
+        secretRef is Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.
+        """
+elif False:
+    FlexPersistentVolumeSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class FlexPersistentVolumeSourcePatchArgs:
@@ -8041,6 +10930,34 @@ class FlexPersistentVolumeSourcePatchArgs:
         pulumi.set(self, "secret_ref", value)
 
 
+if not MYPY:
+    class FlexPersistentVolumeSourceArgsDict(TypedDict):
+        """
+        FlexPersistentVolumeSource represents a generic persistent volume resource that is provisioned/attached using an exec based plugin.
+        """
+        driver: pulumi.Input[str]
+        """
+        driver is the name of the driver to use for this volume.
+        """
+        fs_type: NotRequired[pulumi.Input[str]]
+        """
+        fsType is the Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+        """
+        options: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        options is Optional: this field holds extra command options if any.
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        readOnly is Optional: defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+        """
+        secret_ref: NotRequired[pulumi.Input['SecretReferenceArgsDict']]
+        """
+        secretRef is Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.
+        """
+elif False:
+    FlexPersistentVolumeSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class FlexPersistentVolumeSourceArgs:
     def __init__(__self__, *,
@@ -8127,6 +11044,34 @@ class FlexPersistentVolumeSourceArgs:
     def secret_ref(self, value: Optional[pulumi.Input['SecretReferenceArgs']]):
         pulumi.set(self, "secret_ref", value)
 
+
+if not MYPY:
+    class FlexVolumeSourcePatchArgsDict(TypedDict):
+        """
+        FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
+        """
+        driver: NotRequired[pulumi.Input[str]]
+        """
+        driver is the name of the driver to use for this volume.
+        """
+        fs_type: NotRequired[pulumi.Input[str]]
+        """
+        fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+        """
+        options: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        options is Optional: this field holds extra command options if any.
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        readOnly is Optional: defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+        """
+        secret_ref: NotRequired[pulumi.Input['LocalObjectReferencePatchArgsDict']]
+        """
+        secretRef is Optional: secretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.
+        """
+elif False:
+    FlexVolumeSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class FlexVolumeSourcePatchArgs:
@@ -8216,6 +11161,34 @@ class FlexVolumeSourcePatchArgs:
         pulumi.set(self, "secret_ref", value)
 
 
+if not MYPY:
+    class FlexVolumeSourceArgsDict(TypedDict):
+        """
+        FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
+        """
+        driver: pulumi.Input[str]
+        """
+        driver is the name of the driver to use for this volume.
+        """
+        fs_type: NotRequired[pulumi.Input[str]]
+        """
+        fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+        """
+        options: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        options is Optional: this field holds extra command options if any.
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        readOnly is Optional: defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+        """
+        secret_ref: NotRequired[pulumi.Input['LocalObjectReferenceArgsDict']]
+        """
+        secretRef is Optional: secretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.
+        """
+elif False:
+    FlexVolumeSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class FlexVolumeSourceArgs:
     def __init__(__self__, *,
@@ -8303,6 +11276,22 @@ class FlexVolumeSourceArgs:
         pulumi.set(self, "secret_ref", value)
 
 
+if not MYPY:
+    class FlockerVolumeSourcePatchArgsDict(TypedDict):
+        """
+        Represents a Flocker volume mounted by the Flocker agent. One and only one of datasetName and datasetUUID should be set. Flocker volumes do not support ownership management or SELinux relabeling.
+        """
+        dataset_name: NotRequired[pulumi.Input[str]]
+        """
+        datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated
+        """
+        dataset_uuid: NotRequired[pulumi.Input[str]]
+        """
+        datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset
+        """
+elif False:
+    FlockerVolumeSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class FlockerVolumeSourcePatchArgs:
     def __init__(__self__, *,
@@ -8343,6 +11332,22 @@ class FlockerVolumeSourcePatchArgs:
         pulumi.set(self, "dataset_uuid", value)
 
 
+if not MYPY:
+    class FlockerVolumeSourceArgsDict(TypedDict):
+        """
+        Represents a Flocker volume mounted by the Flocker agent. One and only one of datasetName and datasetUUID should be set. Flocker volumes do not support ownership management or SELinux relabeling.
+        """
+        dataset_name: NotRequired[pulumi.Input[str]]
+        """
+        datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated
+        """
+        dataset_uuid: NotRequired[pulumi.Input[str]]
+        """
+        datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset
+        """
+elif False:
+    FlockerVolumeSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class FlockerVolumeSourceArgs:
     def __init__(__self__, *,
@@ -8382,6 +11387,32 @@ class FlockerVolumeSourceArgs:
     def dataset_uuid(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "dataset_uuid", value)
 
+
+if not MYPY:
+    class GCEPersistentDiskVolumeSourcePatchArgsDict(TypedDict):
+        """
+        Represents a Persistent Disk resource in Google Compute Engine.
+
+        A GCE PD must exist before mounting to a container. The disk must also be in the same GCE project and zone as the kubelet. A GCE PD can only be mounted as read/write once or read-only many times. GCE PDs support ownership management and SELinux relabeling.
+        """
+        fs_type: NotRequired[pulumi.Input[str]]
+        """
+        fsType is filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+        """
+        partition: NotRequired[pulumi.Input[int]]
+        """
+        partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+        """
+        pd_name: NotRequired[pulumi.Input[str]]
+        """
+        pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+        """
+elif False:
+    GCEPersistentDiskVolumeSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class GCEPersistentDiskVolumeSourcePatchArgs:
@@ -8457,6 +11488,32 @@ class GCEPersistentDiskVolumeSourcePatchArgs:
         pulumi.set(self, "read_only", value)
 
 
+if not MYPY:
+    class GCEPersistentDiskVolumeSourceArgsDict(TypedDict):
+        """
+        Represents a Persistent Disk resource in Google Compute Engine.
+
+        A GCE PD must exist before mounting to a container. The disk must also be in the same GCE project and zone as the kubelet. A GCE PD can only be mounted as read/write once or read-only many times. GCE PDs support ownership management and SELinux relabeling.
+        """
+        pd_name: pulumi.Input[str]
+        """
+        pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+        """
+        fs_type: NotRequired[pulumi.Input[str]]
+        """
+        fsType is filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+        """
+        partition: NotRequired[pulumi.Input[int]]
+        """
+        partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+        """
+elif False:
+    GCEPersistentDiskVolumeSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class GCEPersistentDiskVolumeSourceArgs:
     def __init__(__self__, *,
@@ -8530,6 +11587,21 @@ class GCEPersistentDiskVolumeSourceArgs:
         pulumi.set(self, "read_only", value)
 
 
+if not MYPY:
+    class GRPCActionPatchArgsDict(TypedDict):
+        port: NotRequired[pulumi.Input[int]]
+        """
+        Port number of the gRPC service. Number must be in the range 1 to 65535.
+        """
+        service: NotRequired[pulumi.Input[str]]
+        """
+        Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+        If this is not specified, the default behavior is defined by gRPC.
+        """
+elif False:
+    GRPCActionPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class GRPCActionPatchArgs:
     def __init__(__self__, *,
@@ -8573,6 +11645,21 @@ class GRPCActionPatchArgs:
         pulumi.set(self, "service", value)
 
 
+if not MYPY:
+    class GRPCActionArgsDict(TypedDict):
+        port: pulumi.Input[int]
+        """
+        Port number of the gRPC service. Number must be in the range 1 to 65535.
+        """
+        service: NotRequired[pulumi.Input[str]]
+        """
+        Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+        If this is not specified, the default behavior is defined by gRPC.
+        """
+elif False:
+    GRPCActionArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class GRPCActionArgs:
     def __init__(__self__, *,
@@ -8614,6 +11701,28 @@ class GRPCActionArgs:
     def service(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "service", value)
 
+
+if not MYPY:
+    class GitRepoVolumeSourcePatchArgsDict(TypedDict):
+        """
+        Represents a volume that is populated with the contents of a git repository. Git repo volumes do not support ownership management. Git repo volumes support SELinux relabeling.
+
+        DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.
+        """
+        directory: NotRequired[pulumi.Input[str]]
+        """
+        directory is the target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.
+        """
+        repository: NotRequired[pulumi.Input[str]]
+        """
+        repository is the URL
+        """
+        revision: NotRequired[pulumi.Input[str]]
+        """
+        revision is the commit hash for the specified revision.
+        """
+elif False:
+    GitRepoVolumeSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class GitRepoVolumeSourcePatchArgs:
@@ -8673,6 +11782,28 @@ class GitRepoVolumeSourcePatchArgs:
         pulumi.set(self, "revision", value)
 
 
+if not MYPY:
+    class GitRepoVolumeSourceArgsDict(TypedDict):
+        """
+        Represents a volume that is populated with the contents of a git repository. Git repo volumes do not support ownership management. Git repo volumes support SELinux relabeling.
+
+        DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.
+        """
+        repository: pulumi.Input[str]
+        """
+        repository is the URL
+        """
+        directory: NotRequired[pulumi.Input[str]]
+        """
+        directory is the target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.
+        """
+        revision: NotRequired[pulumi.Input[str]]
+        """
+        revision is the commit hash for the specified revision.
+        """
+elif False:
+    GitRepoVolumeSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class GitRepoVolumeSourceArgs:
     def __init__(__self__, *,
@@ -8729,6 +11860,30 @@ class GitRepoVolumeSourceArgs:
     def revision(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "revision", value)
 
+
+if not MYPY:
+    class GlusterfsPersistentVolumeSourcePatchArgsDict(TypedDict):
+        """
+        Represents a Glusterfs mount that lasts the lifetime of a pod. Glusterfs volumes do not support ownership management or SELinux relabeling.
+        """
+        endpoints: NotRequired[pulumi.Input[str]]
+        """
+        endpoints is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+        """
+        endpoints_namespace: NotRequired[pulumi.Input[str]]
+        """
+        endpointsNamespace is the namespace that contains Glusterfs endpoint. If this field is empty, the EndpointNamespace defaults to the same namespace as the bound PVC. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+        """
+        path: NotRequired[pulumi.Input[str]]
+        """
+        path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        readOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+        """
+elif False:
+    GlusterfsPersistentVolumeSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class GlusterfsPersistentVolumeSourcePatchArgs:
@@ -8802,6 +11957,30 @@ class GlusterfsPersistentVolumeSourcePatchArgs:
         pulumi.set(self, "read_only", value)
 
 
+if not MYPY:
+    class GlusterfsPersistentVolumeSourceArgsDict(TypedDict):
+        """
+        Represents a Glusterfs mount that lasts the lifetime of a pod. Glusterfs volumes do not support ownership management or SELinux relabeling.
+        """
+        endpoints: pulumi.Input[str]
+        """
+        endpoints is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+        """
+        path: pulumi.Input[str]
+        """
+        path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+        """
+        endpoints_namespace: NotRequired[pulumi.Input[str]]
+        """
+        endpointsNamespace is the namespace that contains Glusterfs endpoint. If this field is empty, the EndpointNamespace defaults to the same namespace as the bound PVC. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        readOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+        """
+elif False:
+    GlusterfsPersistentVolumeSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class GlusterfsPersistentVolumeSourceArgs:
     def __init__(__self__, *,
@@ -8872,6 +12051,26 @@ class GlusterfsPersistentVolumeSourceArgs:
         pulumi.set(self, "read_only", value)
 
 
+if not MYPY:
+    class GlusterfsVolumeSourcePatchArgsDict(TypedDict):
+        """
+        Represents a Glusterfs mount that lasts the lifetime of a pod. Glusterfs volumes do not support ownership management or SELinux relabeling.
+        """
+        endpoints: NotRequired[pulumi.Input[str]]
+        """
+        endpoints is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+        """
+        path: NotRequired[pulumi.Input[str]]
+        """
+        path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        readOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+        """
+elif False:
+    GlusterfsVolumeSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class GlusterfsVolumeSourcePatchArgs:
     def __init__(__self__, *,
@@ -8928,6 +12127,26 @@ class GlusterfsVolumeSourcePatchArgs:
         pulumi.set(self, "read_only", value)
 
 
+if not MYPY:
+    class GlusterfsVolumeSourceArgsDict(TypedDict):
+        """
+        Represents a Glusterfs mount that lasts the lifetime of a pod. Glusterfs volumes do not support ownership management or SELinux relabeling.
+        """
+        endpoints: pulumi.Input[str]
+        """
+        endpoints is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+        """
+        path: pulumi.Input[str]
+        """
+        path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        readOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+        """
+elif False:
+    GlusterfsVolumeSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class GlusterfsVolumeSourceArgs:
     def __init__(__self__, *,
@@ -8981,6 +12200,34 @@ class GlusterfsVolumeSourceArgs:
     def read_only(self, value: Optional[pulumi.Input[bool]]):
         pulumi.set(self, "read_only", value)
 
+
+if not MYPY:
+    class HTTPGetActionPatchArgsDict(TypedDict):
+        """
+        HTTPGetAction describes an action based on HTTP Get requests.
+        """
+        host: NotRequired[pulumi.Input[str]]
+        """
+        Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+        """
+        http_headers: NotRequired[pulumi.Input[Sequence[pulumi.Input['HTTPHeaderPatchArgsDict']]]]
+        """
+        Custom headers to set in the request. HTTP allows repeated headers.
+        """
+        path: NotRequired[pulumi.Input[str]]
+        """
+        Path to access on the HTTP server.
+        """
+        port: NotRequired[pulumi.Input[Union[int, str]]]
+        """
+        Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+        """
+        scheme: NotRequired[pulumi.Input[str]]
+        """
+        Scheme to use for connecting to the host. Defaults to HTTP.
+        """
+elif False:
+    HTTPGetActionPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class HTTPGetActionPatchArgs:
@@ -9070,6 +12317,34 @@ class HTTPGetActionPatchArgs:
         pulumi.set(self, "scheme", value)
 
 
+if not MYPY:
+    class HTTPGetActionArgsDict(TypedDict):
+        """
+        HTTPGetAction describes an action based on HTTP Get requests.
+        """
+        port: pulumi.Input[Union[int, str]]
+        """
+        Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+        """
+        host: NotRequired[pulumi.Input[str]]
+        """
+        Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+        """
+        http_headers: NotRequired[pulumi.Input[Sequence[pulumi.Input['HTTPHeaderArgsDict']]]]
+        """
+        Custom headers to set in the request. HTTP allows repeated headers.
+        """
+        path: NotRequired[pulumi.Input[str]]
+        """
+        Path to access on the HTTP server.
+        """
+        scheme: NotRequired[pulumi.Input[str]]
+        """
+        Scheme to use for connecting to the host. Defaults to HTTP.
+        """
+elif False:
+    HTTPGetActionArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class HTTPGetActionArgs:
     def __init__(__self__, *,
@@ -9157,6 +12432,22 @@ class HTTPGetActionArgs:
         pulumi.set(self, "scheme", value)
 
 
+if not MYPY:
+    class HTTPHeaderPatchArgsDict(TypedDict):
+        """
+        HTTPHeader describes a custom header to be used in HTTP probes
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.
+        """
+        value: NotRequired[pulumi.Input[str]]
+        """
+        The header field value
+        """
+elif False:
+    HTTPHeaderPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class HTTPHeaderPatchArgs:
     def __init__(__self__, *,
@@ -9197,6 +12488,22 @@ class HTTPHeaderPatchArgs:
         pulumi.set(self, "value", value)
 
 
+if not MYPY:
+    class HTTPHeaderArgsDict(TypedDict):
+        """
+        HTTPHeader describes a custom header to be used in HTTP probes
+        """
+        name: pulumi.Input[str]
+        """
+        The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.
+        """
+        value: pulumi.Input[str]
+        """
+        The header field value
+        """
+elif False:
+    HTTPHeaderArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class HTTPHeaderArgs:
     def __init__(__self__, *,
@@ -9234,6 +12541,22 @@ class HTTPHeaderArgs:
     def value(self, value: pulumi.Input[str]):
         pulumi.set(self, "value", value)
 
+
+if not MYPY:
+    class HostAliasPatchArgsDict(TypedDict):
+        """
+        HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.
+        """
+        hostnames: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Hostnames for the above IP address.
+        """
+        ip: NotRequired[pulumi.Input[str]]
+        """
+        IP address of the host file entry.
+        """
+elif False:
+    HostAliasPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class HostAliasPatchArgs:
@@ -9275,6 +12598,22 @@ class HostAliasPatchArgs:
         pulumi.set(self, "ip", value)
 
 
+if not MYPY:
+    class HostAliasArgsDict(TypedDict):
+        """
+        HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.
+        """
+        hostnames: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Hostnames for the above IP address.
+        """
+        ip: NotRequired[pulumi.Input[str]]
+        """
+        IP address of the host file entry.
+        """
+elif False:
+    HostAliasArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class HostAliasArgs:
     def __init__(__self__, *,
@@ -9315,6 +12654,18 @@ class HostAliasArgs:
         pulumi.set(self, "ip", value)
 
 
+if not MYPY:
+    class HostIPArgsDict(TypedDict):
+        """
+        HostIP represents a single IP address allocated to the host.
+        """
+        ip: NotRequired[pulumi.Input[str]]
+        """
+        IP is the IP address assigned to the host
+        """
+elif False:
+    HostIPArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class HostIPArgs:
     def __init__(__self__, *,
@@ -9338,6 +12689,22 @@ class HostIPArgs:
     def ip(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "ip", value)
 
+
+if not MYPY:
+    class HostPathVolumeSourcePatchArgsDict(TypedDict):
+        """
+        Represents a host path mapped into a pod. Host path volumes do not support ownership management or SELinux relabeling.
+        """
+        path: NotRequired[pulumi.Input[str]]
+        """
+        path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+        """
+elif False:
+    HostPathVolumeSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class HostPathVolumeSourcePatchArgs:
@@ -9379,6 +12746,22 @@ class HostPathVolumeSourcePatchArgs:
         pulumi.set(self, "type", value)
 
 
+if not MYPY:
+    class HostPathVolumeSourceArgsDict(TypedDict):
+        """
+        Represents a host path mapped into a pod. Host path volumes do not support ownership management or SELinux relabeling.
+        """
+        path: pulumi.Input[str]
+        """
+        path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+        """
+elif False:
+    HostPathVolumeSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class HostPathVolumeSourceArgs:
     def __init__(__self__, *,
@@ -9417,6 +12800,58 @@ class HostPathVolumeSourceArgs:
     def type(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "type", value)
 
+
+if not MYPY:
+    class ISCSIPersistentVolumeSourcePatchArgsDict(TypedDict):
+        """
+        ISCSIPersistentVolumeSource represents an ISCSI disk. ISCSI volumes can only be mounted as read/write once. ISCSI volumes support ownership management and SELinux relabeling.
+        """
+        chap_auth_discovery: NotRequired[pulumi.Input[bool]]
+        """
+        chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication
+        """
+        chap_auth_session: NotRequired[pulumi.Input[bool]]
+        """
+        chapAuthSession defines whether support iSCSI Session CHAP authentication
+        """
+        fs_type: NotRequired[pulumi.Input[str]]
+        """
+        fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+        """
+        initiator_name: NotRequired[pulumi.Input[str]]
+        """
+        initiatorName is the custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.
+        """
+        iqn: NotRequired[pulumi.Input[str]]
+        """
+        iqn is Target iSCSI Qualified Name.
+        """
+        iscsi_interface: NotRequired[pulumi.Input[str]]
+        """
+        iscsiInterface is the interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
+        """
+        lun: NotRequired[pulumi.Input[int]]
+        """
+        lun is iSCSI Target Lun number.
+        """
+        portals: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        portals is the iSCSI Target Portal List. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
+        """
+        secret_ref: NotRequired[pulumi.Input['SecretReferencePatchArgsDict']]
+        """
+        secretRef is the CHAP Secret for iSCSI target and initiator authentication
+        """
+        target_portal: NotRequired[pulumi.Input[str]]
+        """
+        targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+        """
+elif False:
+    ISCSIPersistentVolumeSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ISCSIPersistentVolumeSourcePatchArgs:
@@ -9602,6 +13037,58 @@ class ISCSIPersistentVolumeSourcePatchArgs:
         pulumi.set(self, "target_portal", value)
 
 
+if not MYPY:
+    class ISCSIPersistentVolumeSourceArgsDict(TypedDict):
+        """
+        ISCSIPersistentVolumeSource represents an ISCSI disk. ISCSI volumes can only be mounted as read/write once. ISCSI volumes support ownership management and SELinux relabeling.
+        """
+        iqn: pulumi.Input[str]
+        """
+        iqn is Target iSCSI Qualified Name.
+        """
+        lun: pulumi.Input[int]
+        """
+        lun is iSCSI Target Lun number.
+        """
+        target_portal: pulumi.Input[str]
+        """
+        targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+        """
+        chap_auth_discovery: NotRequired[pulumi.Input[bool]]
+        """
+        chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication
+        """
+        chap_auth_session: NotRequired[pulumi.Input[bool]]
+        """
+        chapAuthSession defines whether support iSCSI Session CHAP authentication
+        """
+        fs_type: NotRequired[pulumi.Input[str]]
+        """
+        fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+        """
+        initiator_name: NotRequired[pulumi.Input[str]]
+        """
+        initiatorName is the custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.
+        """
+        iscsi_interface: NotRequired[pulumi.Input[str]]
+        """
+        iscsiInterface is the interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
+        """
+        portals: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        portals is the iSCSI Target Portal List. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
+        """
+        secret_ref: NotRequired[pulumi.Input['SecretReferenceArgsDict']]
+        """
+        secretRef is the CHAP Secret for iSCSI target and initiator authentication
+        """
+elif False:
+    ISCSIPersistentVolumeSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ISCSIPersistentVolumeSourceArgs:
     def __init__(__self__, *,
@@ -9782,6 +13269,58 @@ class ISCSIPersistentVolumeSourceArgs:
     def secret_ref(self, value: Optional[pulumi.Input['SecretReferenceArgs']]):
         pulumi.set(self, "secret_ref", value)
 
+
+if not MYPY:
+    class ISCSIVolumeSourcePatchArgsDict(TypedDict):
+        """
+        Represents an ISCSI disk. ISCSI volumes can only be mounted as read/write once. ISCSI volumes support ownership management and SELinux relabeling.
+        """
+        chap_auth_discovery: NotRequired[pulumi.Input[bool]]
+        """
+        chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication
+        """
+        chap_auth_session: NotRequired[pulumi.Input[bool]]
+        """
+        chapAuthSession defines whether support iSCSI Session CHAP authentication
+        """
+        fs_type: NotRequired[pulumi.Input[str]]
+        """
+        fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+        """
+        initiator_name: NotRequired[pulumi.Input[str]]
+        """
+        initiatorName is the custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.
+        """
+        iqn: NotRequired[pulumi.Input[str]]
+        """
+        iqn is the target iSCSI Qualified Name.
+        """
+        iscsi_interface: NotRequired[pulumi.Input[str]]
+        """
+        iscsiInterface is the interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
+        """
+        lun: NotRequired[pulumi.Input[int]]
+        """
+        lun represents iSCSI Target Lun number.
+        """
+        portals: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
+        """
+        secret_ref: NotRequired[pulumi.Input['LocalObjectReferencePatchArgsDict']]
+        """
+        secretRef is the CHAP Secret for iSCSI target and initiator authentication
+        """
+        target_portal: NotRequired[pulumi.Input[str]]
+        """
+        targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+        """
+elif False:
+    ISCSIVolumeSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ISCSIVolumeSourcePatchArgs:
@@ -9967,6 +13506,58 @@ class ISCSIVolumeSourcePatchArgs:
         pulumi.set(self, "target_portal", value)
 
 
+if not MYPY:
+    class ISCSIVolumeSourceArgsDict(TypedDict):
+        """
+        Represents an ISCSI disk. ISCSI volumes can only be mounted as read/write once. ISCSI volumes support ownership management and SELinux relabeling.
+        """
+        iqn: pulumi.Input[str]
+        """
+        iqn is the target iSCSI Qualified Name.
+        """
+        lun: pulumi.Input[int]
+        """
+        lun represents iSCSI Target Lun number.
+        """
+        target_portal: pulumi.Input[str]
+        """
+        targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+        """
+        chap_auth_discovery: NotRequired[pulumi.Input[bool]]
+        """
+        chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication
+        """
+        chap_auth_session: NotRequired[pulumi.Input[bool]]
+        """
+        chapAuthSession defines whether support iSCSI Session CHAP authentication
+        """
+        fs_type: NotRequired[pulumi.Input[str]]
+        """
+        fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+        """
+        initiator_name: NotRequired[pulumi.Input[str]]
+        """
+        initiatorName is the custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.
+        """
+        iscsi_interface: NotRequired[pulumi.Input[str]]
+        """
+        iscsiInterface is the interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
+        """
+        portals: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
+        """
+        secret_ref: NotRequired[pulumi.Input['LocalObjectReferenceArgsDict']]
+        """
+        secretRef is the CHAP Secret for iSCSI target and initiator authentication
+        """
+elif False:
+    ISCSIVolumeSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ISCSIVolumeSourceArgs:
     def __init__(__self__, *,
@@ -10148,6 +13739,26 @@ class ISCSIVolumeSourceArgs:
         pulumi.set(self, "secret_ref", value)
 
 
+if not MYPY:
+    class KeyToPathPatchArgsDict(TypedDict):
+        """
+        Maps a string key to a path within a volume.
+        """
+        key: NotRequired[pulumi.Input[str]]
+        """
+        key is the key to project.
+        """
+        mode: NotRequired[pulumi.Input[int]]
+        """
+        mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+        """
+        path: NotRequired[pulumi.Input[str]]
+        """
+        path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+        """
+elif False:
+    KeyToPathPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class KeyToPathPatchArgs:
     def __init__(__self__, *,
@@ -10204,6 +13815,26 @@ class KeyToPathPatchArgs:
         pulumi.set(self, "path", value)
 
 
+if not MYPY:
+    class KeyToPathArgsDict(TypedDict):
+        """
+        Maps a string key to a path within a volume.
+        """
+        key: pulumi.Input[str]
+        """
+        key is the key to project.
+        """
+        path: pulumi.Input[str]
+        """
+        path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+        """
+        mode: NotRequired[pulumi.Input[int]]
+        """
+        mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+        """
+elif False:
+    KeyToPathArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class KeyToPathArgs:
     def __init__(__self__, *,
@@ -10257,6 +13888,30 @@ class KeyToPathArgs:
     def mode(self, value: Optional[pulumi.Input[int]]):
         pulumi.set(self, "mode", value)
 
+
+if not MYPY:
+    class LifecycleHandlerPatchArgsDict(TypedDict):
+        """
+        LifecycleHandler defines a specific action that should be taken in a lifecycle hook. One and only one of the fields, except TCPSocket must be specified.
+        """
+        exec_: NotRequired[pulumi.Input['ExecActionPatchArgsDict']]
+        """
+        Exec specifies the action to take.
+        """
+        http_get: NotRequired[pulumi.Input['HTTPGetActionPatchArgsDict']]
+        """
+        HTTPGet specifies the http request to perform.
+        """
+        sleep: NotRequired[pulumi.Input['SleepActionPatchArgsDict']]
+        """
+        Sleep represents the duration that the container should sleep before being terminated.
+        """
+        tcp_socket: NotRequired[pulumi.Input['TCPSocketActionPatchArgsDict']]
+        """
+        Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the backward compatibility. There are no validation of this field and lifecycle hooks will fail in runtime when tcp handler is specified.
+        """
+elif False:
+    LifecycleHandlerPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class LifecycleHandlerPatchArgs:
@@ -10330,6 +13985,30 @@ class LifecycleHandlerPatchArgs:
         pulumi.set(self, "tcp_socket", value)
 
 
+if not MYPY:
+    class LifecycleHandlerArgsDict(TypedDict):
+        """
+        LifecycleHandler defines a specific action that should be taken in a lifecycle hook. One and only one of the fields, except TCPSocket must be specified.
+        """
+        exec_: NotRequired[pulumi.Input['ExecActionArgsDict']]
+        """
+        Exec specifies the action to take.
+        """
+        http_get: NotRequired[pulumi.Input['HTTPGetActionArgsDict']]
+        """
+        HTTPGet specifies the http request to perform.
+        """
+        sleep: NotRequired[pulumi.Input['SleepActionArgsDict']]
+        """
+        Sleep represents the duration that the container should sleep before being terminated.
+        """
+        tcp_socket: NotRequired[pulumi.Input['TCPSocketActionArgsDict']]
+        """
+        Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the backward compatibility. There are no validation of this field and lifecycle hooks will fail in runtime when tcp handler is specified.
+        """
+elif False:
+    LifecycleHandlerArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class LifecycleHandlerArgs:
     def __init__(__self__, *,
@@ -10402,6 +14081,22 @@ class LifecycleHandlerArgs:
         pulumi.set(self, "tcp_socket", value)
 
 
+if not MYPY:
+    class LifecyclePatchArgsDict(TypedDict):
+        """
+        Lifecycle describes actions that the management system should take in response to container lifecycle events. For the PostStart and PreStop lifecycle handlers, management of the container blocks until the action is complete, unless the container process fails, in which case the handler is aborted.
+        """
+        post_start: NotRequired[pulumi.Input['LifecycleHandlerPatchArgsDict']]
+        """
+        PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+        """
+        pre_stop: NotRequired[pulumi.Input['LifecycleHandlerPatchArgsDict']]
+        """
+        PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The Pod's termination grace period countdown begins before the PreStop hook is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod's termination grace period (unless delayed by finalizers). Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+        """
+elif False:
+    LifecyclePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class LifecyclePatchArgs:
     def __init__(__self__, *,
@@ -10442,6 +14137,22 @@ class LifecyclePatchArgs:
         pulumi.set(self, "pre_stop", value)
 
 
+if not MYPY:
+    class LifecycleArgsDict(TypedDict):
+        """
+        Lifecycle describes actions that the management system should take in response to container lifecycle events. For the PostStart and PreStop lifecycle handlers, management of the container blocks until the action is complete, unless the container process fails, in which case the handler is aborted.
+        """
+        post_start: NotRequired[pulumi.Input['LifecycleHandlerArgsDict']]
+        """
+        PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+        """
+        pre_stop: NotRequired[pulumi.Input['LifecycleHandlerArgsDict']]
+        """
+        PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The Pod's termination grace period countdown begins before the PreStop hook is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod's termination grace period (unless delayed by finalizers). Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+        """
+elif False:
+    LifecycleArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class LifecycleArgs:
     def __init__(__self__, *,
@@ -10481,6 +14192,38 @@ class LifecycleArgs:
     def pre_stop(self, value: Optional[pulumi.Input['LifecycleHandlerArgs']]):
         pulumi.set(self, "pre_stop", value)
 
+
+if not MYPY:
+    class LimitRangeItemPatchArgsDict(TypedDict):
+        """
+        LimitRangeItem defines a min/max usage limit for any resource that matches on kind.
+        """
+        default: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        Default resource requirement limit value by resource name if resource limit is omitted.
+        """
+        default_request: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        DefaultRequest is the default resource requirement request value by resource name if resource request is omitted.
+        """
+        max: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        Max usage constraints on this kind by resource name.
+        """
+        max_limit_request_ratio: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        MaxLimitRequestRatio if specified, the named resource must have a request and limit that are both non-zero where limit divided by request is less than or equal to the enumerated value; this represents the max burst for the named resource.
+        """
+        min: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        Min usage constraints on this kind by resource name.
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        Type of resource that this limit applies to.
+        """
+elif False:
+    LimitRangeItemPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class LimitRangeItemPatchArgs:
@@ -10586,6 +14329,38 @@ class LimitRangeItemPatchArgs:
         pulumi.set(self, "type", value)
 
 
+if not MYPY:
+    class LimitRangeItemArgsDict(TypedDict):
+        """
+        LimitRangeItem defines a min/max usage limit for any resource that matches on kind.
+        """
+        type: pulumi.Input[str]
+        """
+        Type of resource that this limit applies to.
+        """
+        default: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        Default resource requirement limit value by resource name if resource limit is omitted.
+        """
+        default_request: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        DefaultRequest is the default resource requirement request value by resource name if resource request is omitted.
+        """
+        max: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        Max usage constraints on this kind by resource name.
+        """
+        max_limit_request_ratio: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        MaxLimitRequestRatio if specified, the named resource must have a request and limit that are both non-zero where limit divided by request is less than or equal to the enumerated value; this represents the max burst for the named resource.
+        """
+        min: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        Min usage constraints on this kind by resource name.
+        """
+elif False:
+    LimitRangeItemArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class LimitRangeItemArgs:
     def __init__(__self__, *,
@@ -10689,6 +14464,18 @@ class LimitRangeItemArgs:
         pulumi.set(self, "min", value)
 
 
+if not MYPY:
+    class LimitRangeSpecPatchArgsDict(TypedDict):
+        """
+        LimitRangeSpec defines a min/max usage limit for resources that match on kind.
+        """
+        limits: NotRequired[pulumi.Input[Sequence[pulumi.Input['LimitRangeItemPatchArgsDict']]]]
+        """
+        Limits is the list of LimitRangeItem objects that are enforced.
+        """
+elif False:
+    LimitRangeSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class LimitRangeSpecPatchArgs:
     def __init__(__self__, *,
@@ -10713,6 +14500,18 @@ class LimitRangeSpecPatchArgs:
         pulumi.set(self, "limits", value)
 
 
+if not MYPY:
+    class LimitRangeSpecArgsDict(TypedDict):
+        """
+        LimitRangeSpec defines a min/max usage limit for resources that match on kind.
+        """
+        limits: pulumi.Input[Sequence[pulumi.Input['LimitRangeItemArgsDict']]]
+        """
+        Limits is the list of LimitRangeItem objects that are enforced.
+        """
+elif False:
+    LimitRangeSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class LimitRangeSpecArgs:
     def __init__(__self__, *,
@@ -10735,6 +14534,30 @@ class LimitRangeSpecArgs:
     def limits(self, value: pulumi.Input[Sequence[pulumi.Input['LimitRangeItemArgs']]]):
         pulumi.set(self, "limits", value)
 
+
+if not MYPY:
+    class LimitRangeArgsDict(TypedDict):
+        """
+        LimitRange sets resource usage limits for each kind of resource in a Namespace.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['LimitRangeSpecArgsDict']]
+        """
+        Spec defines the limits enforced. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+elif False:
+    LimitRangeArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class LimitRangeArgs:
@@ -10808,6 +14631,30 @@ class LimitRangeArgs:
         pulumi.set(self, "spec", value)
 
 
+if not MYPY:
+    class LoadBalancerIngressArgsDict(TypedDict):
+        """
+        LoadBalancerIngress represents the status of a load-balancer ingress point: traffic intended for the service should be sent to an ingress point.
+        """
+        hostname: NotRequired[pulumi.Input[str]]
+        """
+        Hostname is set for load-balancer ingress points that are DNS based (typically AWS load-balancers)
+        """
+        ip: NotRequired[pulumi.Input[str]]
+        """
+        IP is set for load-balancer ingress points that are IP based (typically GCE or OpenStack load-balancers)
+        """
+        ip_mode: NotRequired[pulumi.Input[str]]
+        """
+        IPMode specifies how the load-balancer IP behaves, and may only be specified when the ip field is specified. Setting this to "VIP" indicates that traffic is delivered to the node with the destination set to the load-balancer's IP and port. Setting this to "Proxy" indicates that traffic is delivered to the node or pod with the destination set to the node's IP and node port or the pod's IP and port. Service implementations may use this information to adjust traffic routing.
+        """
+        ports: NotRequired[pulumi.Input[Sequence[pulumi.Input['PortStatusArgsDict']]]]
+        """
+        Ports is a list of records of service ports If used, every port defined in the service should have an entry in it
+        """
+elif False:
+    LoadBalancerIngressArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class LoadBalancerIngressArgs:
     def __init__(__self__, *,
@@ -10880,6 +14727,18 @@ class LoadBalancerIngressArgs:
         pulumi.set(self, "ports", value)
 
 
+if not MYPY:
+    class LoadBalancerStatusArgsDict(TypedDict):
+        """
+        LoadBalancerStatus represents the status of a load-balancer.
+        """
+        ingress: NotRequired[pulumi.Input[Sequence[pulumi.Input['LoadBalancerIngressArgsDict']]]]
+        """
+        Ingress is a list containing ingress points for the load-balancer. Traffic intended for the service should be sent to these ingress points.
+        """
+elif False:
+    LoadBalancerStatusArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class LoadBalancerStatusArgs:
     def __init__(__self__, *,
@@ -10903,6 +14762,18 @@ class LoadBalancerStatusArgs:
     def ingress(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['LoadBalancerIngressArgs']]]]):
         pulumi.set(self, "ingress", value)
 
+
+if not MYPY:
+    class LocalObjectReferencePatchArgsDict(TypedDict):
+        """
+        LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+        """
+elif False:
+    LocalObjectReferencePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class LocalObjectReferencePatchArgs:
@@ -10928,6 +14799,18 @@ class LocalObjectReferencePatchArgs:
         pulumi.set(self, "name", value)
 
 
+if not MYPY:
+    class LocalObjectReferenceArgsDict(TypedDict):
+        """
+        LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+        """
+elif False:
+    LocalObjectReferenceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class LocalObjectReferenceArgs:
     def __init__(__self__, *,
@@ -10951,6 +14834,22 @@ class LocalObjectReferenceArgs:
     def name(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "name", value)
 
+
+if not MYPY:
+    class LocalVolumeSourcePatchArgsDict(TypedDict):
+        """
+        Local represents directly-attached storage with node affinity (Beta feature)
+        """
+        fs_type: NotRequired[pulumi.Input[str]]
+        """
+        fsType is the filesystem type to mount. It applies only when the Path is a block device. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default value is to auto-select a filesystem if unspecified.
+        """
+        path: NotRequired[pulumi.Input[str]]
+        """
+        path of the full path to the volume on the node. It can be either a directory or block device (disk, partition, ...).
+        """
+elif False:
+    LocalVolumeSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class LocalVolumeSourcePatchArgs:
@@ -10992,6 +14891,22 @@ class LocalVolumeSourcePatchArgs:
         pulumi.set(self, "path", value)
 
 
+if not MYPY:
+    class LocalVolumeSourceArgsDict(TypedDict):
+        """
+        Local represents directly-attached storage with node affinity (Beta feature)
+        """
+        path: pulumi.Input[str]
+        """
+        path of the full path to the volume on the node. It can be either a directory or block device (disk, partition, ...).
+        """
+        fs_type: NotRequired[pulumi.Input[str]]
+        """
+        fsType is the filesystem type to mount. It applies only when the Path is a block device. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default value is to auto-select a filesystem if unspecified.
+        """
+elif False:
+    LocalVolumeSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class LocalVolumeSourceArgs:
     def __init__(__self__, *,
@@ -11030,6 +14945,31 @@ class LocalVolumeSourceArgs:
     def fs_type(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "fs_type", value)
 
+
+if not MYPY:
+    class ModifyVolumeStatusPatchArgsDict(TypedDict):
+        """
+        ModifyVolumeStatus represents the status object of ControllerModifyVolume operation
+        """
+        status: NotRequired[pulumi.Input[str]]
+        """
+        status is the status of the ControllerModifyVolume operation. It can be in any of following states:
+         - Pending
+           Pending indicates that the PersistentVolumeClaim cannot be modified due to unmet requirements, such as
+           the specified VolumeAttributesClass not existing.
+         - InProgress
+           InProgress indicates that the volume is being modified.
+         - Infeasible
+          Infeasible indicates that the request has been rejected as invalid by the CSI driver. To
+        	  resolve the error, a valid VolumeAttributesClass needs to be specified.
+        Note: New statuses can be added in the future. Consumers should check for unknown statuses and fail appropriately.
+        """
+        target_volume_attributes_class_name: NotRequired[pulumi.Input[str]]
+        """
+        targetVolumeAttributesClassName is the name of the VolumeAttributesClass the PVC currently being reconciled
+        """
+elif False:
+    ModifyVolumeStatusPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ModifyVolumeStatusPatchArgs:
@@ -11089,6 +15029,31 @@ class ModifyVolumeStatusPatchArgs:
         pulumi.set(self, "target_volume_attributes_class_name", value)
 
 
+if not MYPY:
+    class ModifyVolumeStatusArgsDict(TypedDict):
+        """
+        ModifyVolumeStatus represents the status object of ControllerModifyVolume operation
+        """
+        status: pulumi.Input[str]
+        """
+        status is the status of the ControllerModifyVolume operation. It can be in any of following states:
+         - Pending
+           Pending indicates that the PersistentVolumeClaim cannot be modified due to unmet requirements, such as
+           the specified VolumeAttributesClass not existing.
+         - InProgress
+           InProgress indicates that the volume is being modified.
+         - Infeasible
+          Infeasible indicates that the request has been rejected as invalid by the CSI driver. To
+        	  resolve the error, a valid VolumeAttributesClass needs to be specified.
+        Note: New statuses can be added in the future. Consumers should check for unknown statuses and fail appropriately.
+        """
+        target_volume_attributes_class_name: NotRequired[pulumi.Input[str]]
+        """
+        targetVolumeAttributesClassName is the name of the VolumeAttributesClass the PVC currently being reconciled
+        """
+elif False:
+    ModifyVolumeStatusArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ModifyVolumeStatusArgs:
     def __init__(__self__, *,
@@ -11146,6 +15111,26 @@ class ModifyVolumeStatusArgs:
         pulumi.set(self, "target_volume_attributes_class_name", value)
 
 
+if not MYPY:
+    class NFSVolumeSourcePatchArgsDict(TypedDict):
+        """
+        Represents an NFS mount that lasts the lifetime of a pod. NFS volumes do not support ownership management or SELinux relabeling.
+        """
+        path: NotRequired[pulumi.Input[str]]
+        """
+        path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        readOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+        """
+        server: NotRequired[pulumi.Input[str]]
+        """
+        server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+        """
+elif False:
+    NFSVolumeSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class NFSVolumeSourcePatchArgs:
     def __init__(__self__, *,
@@ -11202,6 +15187,26 @@ class NFSVolumeSourcePatchArgs:
         pulumi.set(self, "server", value)
 
 
+if not MYPY:
+    class NFSVolumeSourceArgsDict(TypedDict):
+        """
+        Represents an NFS mount that lasts the lifetime of a pod. NFS volumes do not support ownership management or SELinux relabeling.
+        """
+        path: pulumi.Input[str]
+        """
+        path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+        """
+        server: pulumi.Input[str]
+        """
+        server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        readOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+        """
+elif False:
+    NFSVolumeSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class NFSVolumeSourceArgs:
     def __init__(__self__, *,
@@ -11255,6 +15260,25 @@ class NFSVolumeSourceArgs:
     def read_only(self, value: Optional[pulumi.Input[bool]]):
         pulumi.set(self, "read_only", value)
 
+
+if not MYPY:
+    class NamespaceConditionArgsDict(TypedDict):
+        """
+        NamespaceCondition contains details about state of namespace.
+        """
+        status: pulumi.Input[str]
+        """
+        Status of the condition, one of True, False, Unknown.
+        """
+        type: pulumi.Input[str]
+        """
+        Type of namespace controller condition.
+        """
+        last_transition_time: NotRequired[pulumi.Input[str]]
+        message: NotRequired[pulumi.Input[str]]
+        reason: NotRequired[pulumi.Input[str]]
+elif False:
+    NamespaceConditionArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class NamespaceConditionArgs:
@@ -11330,6 +15354,18 @@ class NamespaceConditionArgs:
         pulumi.set(self, "reason", value)
 
 
+if not MYPY:
+    class NamespaceSpecPatchArgsDict(TypedDict):
+        """
+        NamespaceSpec describes the attributes on a Namespace.
+        """
+        finalizers: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Finalizers is an opaque list of values that must be empty to permanently remove object from storage. More info: https://kubernetes.io/docs/tasks/administer-cluster/namespaces/
+        """
+elif False:
+    NamespaceSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class NamespaceSpecPatchArgs:
     def __init__(__self__, *,
@@ -11354,6 +15390,18 @@ class NamespaceSpecPatchArgs:
         pulumi.set(self, "finalizers", value)
 
 
+if not MYPY:
+    class NamespaceSpecArgsDict(TypedDict):
+        """
+        NamespaceSpec describes the attributes on a Namespace.
+        """
+        finalizers: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Finalizers is an opaque list of values that must be empty to permanently remove object from storage. More info: https://kubernetes.io/docs/tasks/administer-cluster/namespaces/
+        """
+elif False:
+    NamespaceSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class NamespaceSpecArgs:
     def __init__(__self__, *,
@@ -11377,6 +15425,22 @@ class NamespaceSpecArgs:
     def finalizers(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]):
         pulumi.set(self, "finalizers", value)
 
+
+if not MYPY:
+    class NamespaceStatusArgsDict(TypedDict):
+        """
+        NamespaceStatus is information about the current status of a Namespace.
+        """
+        conditions: NotRequired[pulumi.Input[Sequence[pulumi.Input['NamespaceConditionArgsDict']]]]
+        """
+        Represents the latest available observations of a namespace's current state.
+        """
+        phase: NotRequired[pulumi.Input[str]]
+        """
+        Phase is the current lifecycle phase of the namespace. More info: https://kubernetes.io/docs/tasks/administer-cluster/namespaces/
+        """
+elif False:
+    NamespaceStatusArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class NamespaceStatusArgs:
@@ -11417,6 +15481,34 @@ class NamespaceStatusArgs:
     def phase(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "phase", value)
 
+
+if not MYPY:
+    class NamespaceArgsDict(TypedDict):
+        """
+        Namespace provides a scope for Names. Use of multiple namespaces is optional.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['NamespaceSpecArgsDict']]
+        """
+        Spec defines the behavior of the Namespace. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+        status: NotRequired[pulumi.Input['NamespaceStatusArgsDict']]
+        """
+        Status describes the current status of a Namespace. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+elif False:
+    NamespaceArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class NamespaceArgs:
@@ -11506,6 +15598,22 @@ class NamespaceArgs:
         pulumi.set(self, "status", value)
 
 
+if not MYPY:
+    class NodeAddressArgsDict(TypedDict):
+        """
+        NodeAddress contains information for the node's address.
+        """
+        address: pulumi.Input[str]
+        """
+        The node address.
+        """
+        type: pulumi.Input[str]
+        """
+        Node address type, one of Hostname, ExternalIP or InternalIP.
+        """
+elif False:
+    NodeAddressArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class NodeAddressArgs:
     def __init__(__self__, *,
@@ -11543,6 +15651,22 @@ class NodeAddressArgs:
     def type(self, value: pulumi.Input[str]):
         pulumi.set(self, "type", value)
 
+
+if not MYPY:
+    class NodeAffinityPatchArgsDict(TypedDict):
+        """
+        Node affinity is a group of node affinity scheduling rules.
+        """
+        preferred_during_scheduling_ignored_during_execution: NotRequired[pulumi.Input[Sequence[pulumi.Input['PreferredSchedulingTermPatchArgsDict']]]]
+        """
+        The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+        """
+        required_during_scheduling_ignored_during_execution: NotRequired[pulumi.Input['NodeSelectorPatchArgsDict']]
+        """
+        If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+        """
+elif False:
+    NodeAffinityPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class NodeAffinityPatchArgs:
@@ -11584,6 +15708,22 @@ class NodeAffinityPatchArgs:
         pulumi.set(self, "required_during_scheduling_ignored_during_execution", value)
 
 
+if not MYPY:
+    class NodeAffinityArgsDict(TypedDict):
+        """
+        Node affinity is a group of node affinity scheduling rules.
+        """
+        preferred_during_scheduling_ignored_during_execution: NotRequired[pulumi.Input[Sequence[pulumi.Input['PreferredSchedulingTermArgsDict']]]]
+        """
+        The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+        """
+        required_during_scheduling_ignored_during_execution: NotRequired[pulumi.Input['NodeSelectorArgsDict']]
+        """
+        If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+        """
+elif False:
+    NodeAffinityArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class NodeAffinityArgs:
     def __init__(__self__, *,
@@ -11623,6 +15763,38 @@ class NodeAffinityArgs:
     def required_during_scheduling_ignored_during_execution(self, value: Optional[pulumi.Input['NodeSelectorArgs']]):
         pulumi.set(self, "required_during_scheduling_ignored_during_execution", value)
 
+
+if not MYPY:
+    class NodeConditionArgsDict(TypedDict):
+        """
+        NodeCondition contains condition information for a node.
+        """
+        status: pulumi.Input[str]
+        """
+        Status of the condition, one of True, False, Unknown.
+        """
+        type: pulumi.Input[str]
+        """
+        Type of node condition.
+        """
+        last_heartbeat_time: NotRequired[pulumi.Input[str]]
+        """
+        Last time we got an update on a given condition.
+        """
+        last_transition_time: NotRequired[pulumi.Input[str]]
+        """
+        Last time the condition transit from one status to another.
+        """
+        message: NotRequired[pulumi.Input[str]]
+        """
+        Human readable message indicating details about last transition.
+        """
+        reason: NotRequired[pulumi.Input[str]]
+        """
+        (brief) reason for the condition's last transition.
+        """
+elif False:
+    NodeConditionArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class NodeConditionArgs:
@@ -11726,6 +15898,18 @@ class NodeConditionArgs:
         pulumi.set(self, "reason", value)
 
 
+if not MYPY:
+    class NodeConfigSourcePatchArgsDict(TypedDict):
+        """
+        NodeConfigSource specifies a source of node configuration. Exactly one subfield (excluding metadata) must be non-nil. This API is deprecated since 1.22
+        """
+        config_map: NotRequired[pulumi.Input['ConfigMapNodeConfigSourcePatchArgsDict']]
+        """
+        ConfigMap is a reference to a Node's ConfigMap
+        """
+elif False:
+    NodeConfigSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class NodeConfigSourcePatchArgs:
     def __init__(__self__, *,
@@ -11750,6 +15934,18 @@ class NodeConfigSourcePatchArgs:
         pulumi.set(self, "config_map", value)
 
 
+if not MYPY:
+    class NodeConfigSourceArgsDict(TypedDict):
+        """
+        NodeConfigSource specifies a source of node configuration. Exactly one subfield (excluding metadata) must be non-nil. This API is deprecated since 1.22
+        """
+        config_map: NotRequired[pulumi.Input['ConfigMapNodeConfigSourceArgsDict']]
+        """
+        ConfigMap is a reference to a Node's ConfigMap
+        """
+elif False:
+    NodeConfigSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class NodeConfigSourceArgs:
     def __init__(__self__, *,
@@ -11773,6 +15969,30 @@ class NodeConfigSourceArgs:
     def config_map(self, value: Optional[pulumi.Input['ConfigMapNodeConfigSourceArgs']]):
         pulumi.set(self, "config_map", value)
 
+
+if not MYPY:
+    class NodeConfigStatusArgsDict(TypedDict):
+        """
+        NodeConfigStatus describes the status of the config assigned by Node.Spec.ConfigSource.
+        """
+        active: NotRequired[pulumi.Input['NodeConfigSourceArgsDict']]
+        """
+        Active reports the checkpointed config the node is actively using. Active will represent either the current version of the Assigned config, or the current LastKnownGood config, depending on whether attempting to use the Assigned config results in an error.
+        """
+        assigned: NotRequired[pulumi.Input['NodeConfigSourceArgsDict']]
+        """
+        Assigned reports the checkpointed config the node will try to use. When Node.Spec.ConfigSource is updated, the node checkpoints the associated config payload to local disk, along with a record indicating intended config. The node refers to this record to choose its config checkpoint, and reports this record in Assigned. Assigned only updates in the status after the record has been checkpointed to disk. When the Kubelet is restarted, it tries to make the Assigned config the Active config by loading and validating the checkpointed payload identified by Assigned.
+        """
+        error: NotRequired[pulumi.Input[str]]
+        """
+        Error describes any problems reconciling the Spec.ConfigSource to the Active config. Errors may occur, for example, attempting to checkpoint Spec.ConfigSource to the local Assigned record, attempting to checkpoint the payload associated with Spec.ConfigSource, attempting to load or validate the Assigned config, etc. Errors may occur at different points while syncing config. Earlier errors (e.g. download or checkpointing errors) will not result in a rollback to LastKnownGood, and may resolve across Kubelet retries. Later errors (e.g. loading or validating a checkpointed config) will result in a rollback to LastKnownGood. In the latter case, it is usually possible to resolve the error by fixing the config assigned in Spec.ConfigSource. You can find additional information for debugging by searching the error message in the Kubelet log. Error is a human-readable description of the error state; machines can check whether or not Error is empty, but should not rely on the stability of the Error text across Kubelet versions.
+        """
+        last_known_good: NotRequired[pulumi.Input['NodeConfigSourceArgsDict']]
+        """
+        LastKnownGood reports the checkpointed config the node will fall back to when it encounters an error attempting to use the Assigned config. The Assigned config becomes the LastKnownGood config when the node determines that the Assigned config is stable and correct. This is currently implemented as a 10-minute soak period starting when the local record of Assigned config is updated. If the Assigned config is Active at the end of this period, it becomes the LastKnownGood. Note that if Spec.ConfigSource is reset to nil (use local defaults), the LastKnownGood is also immediately reset to nil, because the local default config is always assumed good. You should not make assumptions about the node's method of determining config stability and correctness, as this may change or become configurable in the future.
+        """
+elif False:
+    NodeConfigStatusArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class NodeConfigStatusArgs:
@@ -11846,6 +16066,18 @@ class NodeConfigStatusArgs:
         pulumi.set(self, "last_known_good", value)
 
 
+if not MYPY:
+    class NodeDaemonEndpointsArgsDict(TypedDict):
+        """
+        NodeDaemonEndpoints lists ports opened by daemons running on the Node.
+        """
+        kubelet_endpoint: NotRequired[pulumi.Input['DaemonEndpointArgsDict']]
+        """
+        Endpoint on which Kubelet is listening.
+        """
+elif False:
+    NodeDaemonEndpointsArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class NodeDaemonEndpointsArgs:
     def __init__(__self__, *,
@@ -11870,6 +16102,18 @@ class NodeDaemonEndpointsArgs:
         pulumi.set(self, "kubelet_endpoint", value)
 
 
+if not MYPY:
+    class NodeRuntimeHandlerFeaturesArgsDict(TypedDict):
+        """
+        NodeRuntimeHandlerFeatures is a set of runtime features.
+        """
+        recursive_read_only_mounts: NotRequired[pulumi.Input[bool]]
+        """
+        RecursiveReadOnlyMounts is set to true if the runtime handler supports RecursiveReadOnlyMounts.
+        """
+elif False:
+    NodeRuntimeHandlerFeaturesArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class NodeRuntimeHandlerFeaturesArgs:
     def __init__(__self__, *,
@@ -11893,6 +16137,22 @@ class NodeRuntimeHandlerFeaturesArgs:
     def recursive_read_only_mounts(self, value: Optional[pulumi.Input[bool]]):
         pulumi.set(self, "recursive_read_only_mounts", value)
 
+
+if not MYPY:
+    class NodeRuntimeHandlerArgsDict(TypedDict):
+        """
+        NodeRuntimeHandler is a set of runtime handler information.
+        """
+        features: NotRequired[pulumi.Input['NodeRuntimeHandlerFeaturesArgsDict']]
+        """
+        Supported features.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Runtime handler name. Empty for the default runtime handler.
+        """
+elif False:
+    NodeRuntimeHandlerArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class NodeRuntimeHandlerArgs:
@@ -11934,6 +16194,18 @@ class NodeRuntimeHandlerArgs:
         pulumi.set(self, "name", value)
 
 
+if not MYPY:
+    class NodeSelectorPatchArgsDict(TypedDict):
+        """
+        A node selector represents the union of the results of one or more label queries over a set of nodes; that is, it represents the OR of the selectors represented by the node selector terms.
+        """
+        node_selector_terms: NotRequired[pulumi.Input[Sequence[pulumi.Input['NodeSelectorTermPatchArgsDict']]]]
+        """
+        Required. A list of node selector terms. The terms are ORed.
+        """
+elif False:
+    NodeSelectorPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class NodeSelectorPatchArgs:
     def __init__(__self__, *,
@@ -11957,6 +16229,26 @@ class NodeSelectorPatchArgs:
     def node_selector_terms(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['NodeSelectorTermPatchArgs']]]]):
         pulumi.set(self, "node_selector_terms", value)
 
+
+if not MYPY:
+    class NodeSelectorRequirementPatchArgsDict(TypedDict):
+        """
+        A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+        """
+        key: NotRequired[pulumi.Input[str]]
+        """
+        The label key that the selector applies to.
+        """
+        operator: NotRequired[pulumi.Input[str]]
+        """
+        Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+        """
+        values: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+        """
+elif False:
+    NodeSelectorRequirementPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class NodeSelectorRequirementPatchArgs:
@@ -12014,6 +16306,26 @@ class NodeSelectorRequirementPatchArgs:
         pulumi.set(self, "values", value)
 
 
+if not MYPY:
+    class NodeSelectorRequirementArgsDict(TypedDict):
+        """
+        A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+        """
+        key: pulumi.Input[str]
+        """
+        The label key that the selector applies to.
+        """
+        operator: pulumi.Input[str]
+        """
+        Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+        """
+        values: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+        """
+elif False:
+    NodeSelectorRequirementArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class NodeSelectorRequirementArgs:
     def __init__(__self__, *,
@@ -12068,6 +16380,22 @@ class NodeSelectorRequirementArgs:
         pulumi.set(self, "values", value)
 
 
+if not MYPY:
+    class NodeSelectorTermPatchArgsDict(TypedDict):
+        """
+        A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+        """
+        match_expressions: NotRequired[pulumi.Input[Sequence[pulumi.Input['NodeSelectorRequirementPatchArgsDict']]]]
+        """
+        A list of node selector requirements by node's labels.
+        """
+        match_fields: NotRequired[pulumi.Input[Sequence[pulumi.Input['NodeSelectorRequirementPatchArgsDict']]]]
+        """
+        A list of node selector requirements by node's fields.
+        """
+elif False:
+    NodeSelectorTermPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class NodeSelectorTermPatchArgs:
     def __init__(__self__, *,
@@ -12107,6 +16435,22 @@ class NodeSelectorTermPatchArgs:
     def match_fields(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['NodeSelectorRequirementPatchArgs']]]]):
         pulumi.set(self, "match_fields", value)
 
+
+if not MYPY:
+    class NodeSelectorTermArgsDict(TypedDict):
+        """
+        A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+        """
+        match_expressions: NotRequired[pulumi.Input[Sequence[pulumi.Input['NodeSelectorRequirementArgsDict']]]]
+        """
+        A list of node selector requirements by node's labels.
+        """
+        match_fields: NotRequired[pulumi.Input[Sequence[pulumi.Input['NodeSelectorRequirementArgsDict']]]]
+        """
+        A list of node selector requirements by node's fields.
+        """
+elif False:
+    NodeSelectorTermArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class NodeSelectorTermArgs:
@@ -12148,6 +16492,18 @@ class NodeSelectorTermArgs:
         pulumi.set(self, "match_fields", value)
 
 
+if not MYPY:
+    class NodeSelectorArgsDict(TypedDict):
+        """
+        A node selector represents the union of the results of one or more label queries over a set of nodes; that is, it represents the OR of the selectors represented by the node selector terms.
+        """
+        node_selector_terms: pulumi.Input[Sequence[pulumi.Input['NodeSelectorTermArgsDict']]]
+        """
+        Required. A list of node selector terms. The terms are ORed.
+        """
+elif False:
+    NodeSelectorArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class NodeSelectorArgs:
     def __init__(__self__, *,
@@ -12170,6 +16526,42 @@ class NodeSelectorArgs:
     def node_selector_terms(self, value: pulumi.Input[Sequence[pulumi.Input['NodeSelectorTermArgs']]]):
         pulumi.set(self, "node_selector_terms", value)
 
+
+if not MYPY:
+    class NodeSpecPatchArgsDict(TypedDict):
+        """
+        NodeSpec describes the attributes that a node is created with.
+        """
+        config_source: NotRequired[pulumi.Input['NodeConfigSourcePatchArgsDict']]
+        """
+        Deprecated: Previously used to specify the source of the node's configuration for the DynamicKubeletConfig feature. This feature is removed.
+        """
+        external_id: NotRequired[pulumi.Input[str]]
+        """
+        Deprecated. Not all kubelets will set this field. Remove field after 1.13. see: https://issues.k8s.io/61966
+        """
+        pod_cidr: NotRequired[pulumi.Input[str]]
+        """
+        PodCIDR represents the pod IP range assigned to the node.
+        """
+        pod_cidrs: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        podCIDRs represents the IP ranges assigned to the node for usage by Pods on that node. If this field is specified, the 0th entry must match the podCIDR field. It may contain at most 1 value for each of IPv4 and IPv6.
+        """
+        provider_id: NotRequired[pulumi.Input[str]]
+        """
+        ID of the node assigned by the cloud provider in the format: <ProviderName>://<ProviderSpecificNodeID>
+        """
+        taints: NotRequired[pulumi.Input[Sequence[pulumi.Input['TaintPatchArgsDict']]]]
+        """
+        If specified, the node's taints.
+        """
+        unschedulable: NotRequired[pulumi.Input[bool]]
+        """
+        Unschedulable controls node schedulability of new pods. By default, node is schedulable. More info: https://kubernetes.io/docs/concepts/nodes/node/#manual-node-administration
+        """
+elif False:
+    NodeSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class NodeSpecPatchArgs:
@@ -12291,6 +16683,42 @@ class NodeSpecPatchArgs:
         pulumi.set(self, "unschedulable", value)
 
 
+if not MYPY:
+    class NodeSpecArgsDict(TypedDict):
+        """
+        NodeSpec describes the attributes that a node is created with.
+        """
+        config_source: NotRequired[pulumi.Input['NodeConfigSourceArgsDict']]
+        """
+        Deprecated: Previously used to specify the source of the node's configuration for the DynamicKubeletConfig feature. This feature is removed.
+        """
+        external_id: NotRequired[pulumi.Input[str]]
+        """
+        Deprecated. Not all kubelets will set this field. Remove field after 1.13. see: https://issues.k8s.io/61966
+        """
+        pod_cidr: NotRequired[pulumi.Input[str]]
+        """
+        PodCIDR represents the pod IP range assigned to the node.
+        """
+        pod_cidrs: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        podCIDRs represents the IP ranges assigned to the node for usage by Pods on that node. If this field is specified, the 0th entry must match the podCIDR field. It may contain at most 1 value for each of IPv4 and IPv6.
+        """
+        provider_id: NotRequired[pulumi.Input[str]]
+        """
+        ID of the node assigned by the cloud provider in the format: <ProviderName>://<ProviderSpecificNodeID>
+        """
+        taints: NotRequired[pulumi.Input[Sequence[pulumi.Input['TaintArgsDict']]]]
+        """
+        If specified, the node's taints.
+        """
+        unschedulable: NotRequired[pulumi.Input[bool]]
+        """
+        Unschedulable controls node schedulability of new pods. By default, node is schedulable. More info: https://kubernetes.io/docs/concepts/nodes/node/#manual-node-administration
+        """
+elif False:
+    NodeSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class NodeSpecArgs:
     def __init__(__self__, *,
@@ -12410,6 +16838,62 @@ class NodeSpecArgs:
     def unschedulable(self, value: Optional[pulumi.Input[bool]]):
         pulumi.set(self, "unschedulable", value)
 
+
+if not MYPY:
+    class NodeStatusArgsDict(TypedDict):
+        """
+        NodeStatus is information about the current status of a node.
+        """
+        addresses: NotRequired[pulumi.Input[Sequence[pulumi.Input['NodeAddressArgsDict']]]]
+        """
+        List of addresses reachable to the node. Queried from cloud provider, if available. More info: https://kubernetes.io/docs/concepts/nodes/node/#addresses Note: This field is declared as mergeable, but the merge key is not sufficiently unique, which can cause data corruption when it is merged. Callers should instead use a full-replacement patch. See https://pr.k8s.io/79391 for an example. Consumers should assume that addresses can change during the lifetime of a Node. However, there are some exceptions where this may not be possible, such as Pods that inherit a Node's address in its own status or consumers of the downward API (status.hostIP).
+        """
+        allocatable: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        Allocatable represents the resources of a node that are available for scheduling. Defaults to Capacity.
+        """
+        capacity: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        Capacity represents the total resources of a node. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#capacity
+        """
+        conditions: NotRequired[pulumi.Input[Sequence[pulumi.Input['NodeConditionArgsDict']]]]
+        """
+        Conditions is an array of current observed node conditions. More info: https://kubernetes.io/docs/concepts/nodes/node/#condition
+        """
+        config: NotRequired[pulumi.Input['NodeConfigStatusArgsDict']]
+        """
+        Status of the config assigned to the node via the dynamic Kubelet config feature.
+        """
+        daemon_endpoints: NotRequired[pulumi.Input['NodeDaemonEndpointsArgsDict']]
+        """
+        Endpoints of daemons running on the Node.
+        """
+        images: NotRequired[pulumi.Input[Sequence[pulumi.Input['ContainerImageArgsDict']]]]
+        """
+        List of container images on this node
+        """
+        node_info: NotRequired[pulumi.Input['NodeSystemInfoArgsDict']]
+        """
+        Set of ids/uuids to uniquely identify the node. More info: https://kubernetes.io/docs/concepts/nodes/node/#info
+        """
+        phase: NotRequired[pulumi.Input[str]]
+        """
+        NodePhase is the recently observed lifecycle phase of the node. More info: https://kubernetes.io/docs/concepts/nodes/node/#phase The field is never populated, and now is deprecated.
+        """
+        runtime_handlers: NotRequired[pulumi.Input[Sequence[pulumi.Input['NodeRuntimeHandlerArgsDict']]]]
+        """
+        The available runtime handlers.
+        """
+        volumes_attached: NotRequired[pulumi.Input[Sequence[pulumi.Input['AttachedVolumeArgsDict']]]]
+        """
+        List of volumes that are attached to the node.
+        """
+        volumes_in_use: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        List of attachable volumes in use (mounted) by the node.
+        """
+elif False:
+    NodeStatusArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class NodeStatusArgs:
@@ -12611,6 +17095,54 @@ class NodeStatusArgs:
         pulumi.set(self, "volumes_in_use", value)
 
 
+if not MYPY:
+    class NodeSystemInfoArgsDict(TypedDict):
+        """
+        NodeSystemInfo is a set of ids/uuids to uniquely identify the node.
+        """
+        architecture: pulumi.Input[str]
+        """
+        The Architecture reported by the node
+        """
+        boot_id: pulumi.Input[str]
+        """
+        Boot ID reported by the node.
+        """
+        container_runtime_version: pulumi.Input[str]
+        """
+        ContainerRuntime Version reported by the node through runtime remote API (e.g. containerd://1.4.2).
+        """
+        kernel_version: pulumi.Input[str]
+        """
+        Kernel Version reported by the node from 'uname -r' (e.g. 3.16.0-0.bpo.4-amd64).
+        """
+        kube_proxy_version: pulumi.Input[str]
+        """
+        KubeProxy Version reported by the node.
+        """
+        kubelet_version: pulumi.Input[str]
+        """
+        Kubelet Version reported by the node.
+        """
+        machine_id: pulumi.Input[str]
+        """
+        MachineID reported by the node. For unique machine identification in the cluster this field is preferred. Learn more from man(5) machine-id: http://man7.org/linux/man-pages/man5/machine-id.5.html
+        """
+        operating_system: pulumi.Input[str]
+        """
+        The Operating System reported by the node
+        """
+        os_image: pulumi.Input[str]
+        """
+        OS Image reported by the node from /etc/os-release (e.g. Debian GNU/Linux 7 (wheezy)).
+        """
+        system_uuid: pulumi.Input[str]
+        """
+        SystemUUID reported by the node. For unique machine identification MachineID is preferred. This field is specific to Red Hat hosts https://access.redhat.com/documentation/en-us/red_hat_subscription_management/1/html/rhsm/uuid
+        """
+elif False:
+    NodeSystemInfoArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class NodeSystemInfoArgs:
     def __init__(__self__, *,
@@ -12769,6 +17301,34 @@ class NodeSystemInfoArgs:
         pulumi.set(self, "system_uuid", value)
 
 
+if not MYPY:
+    class NodeArgsDict(TypedDict):
+        """
+        Node is a worker node in Kubernetes. Each node will have a unique identifier in the cache (i.e. in etcd).
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['NodeSpecArgsDict']]
+        """
+        Spec defines the behavior of a node. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+        status: NotRequired[pulumi.Input['NodeStatusArgsDict']]
+        """
+        Most recently observed status of the node. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+elif False:
+    NodeArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class NodeArgs:
     def __init__(__self__, *,
@@ -12857,6 +17417,22 @@ class NodeArgs:
         pulumi.set(self, "status", value)
 
 
+if not MYPY:
+    class ObjectFieldSelectorPatchArgsDict(TypedDict):
+        """
+        ObjectFieldSelector selects an APIVersioned field of an object.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        Version of the schema the FieldPath is written in terms of, defaults to "v1".
+        """
+        field_path: NotRequired[pulumi.Input[str]]
+        """
+        Path of the field to select in the specified API version.
+        """
+elif False:
+    ObjectFieldSelectorPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ObjectFieldSelectorPatchArgs:
     def __init__(__self__, *,
@@ -12897,6 +17473,22 @@ class ObjectFieldSelectorPatchArgs:
         pulumi.set(self, "field_path", value)
 
 
+if not MYPY:
+    class ObjectFieldSelectorArgsDict(TypedDict):
+        """
+        ObjectFieldSelector selects an APIVersioned field of an object.
+        """
+        field_path: pulumi.Input[str]
+        """
+        Path of the field to select in the specified API version.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        Version of the schema the FieldPath is written in terms of, defaults to "v1".
+        """
+elif False:
+    ObjectFieldSelectorArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ObjectFieldSelectorArgs:
     def __init__(__self__, *,
@@ -12935,6 +17527,42 @@ class ObjectFieldSelectorArgs:
     def api_version(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "api_version", value)
 
+
+if not MYPY:
+    class ObjectReferencePatchArgsDict(TypedDict):
+        """
+        ObjectReference contains enough information to let you inspect or modify the referred object.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        API version of the referent.
+        """
+        field_path: NotRequired[pulumi.Input[str]]
+        """
+        If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object.
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+        """
+        namespace: NotRequired[pulumi.Input[str]]
+        """
+        Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+        """
+        resource_version: NotRequired[pulumi.Input[str]]
+        """
+        Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+        """
+        uid: NotRequired[pulumi.Input[str]]
+        """
+        UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+        """
+elif False:
+    ObjectReferencePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ObjectReferencePatchArgs:
@@ -13056,6 +17684,42 @@ class ObjectReferencePatchArgs:
         pulumi.set(self, "uid", value)
 
 
+if not MYPY:
+    class ObjectReferenceArgsDict(TypedDict):
+        """
+        ObjectReference contains enough information to let you inspect or modify the referred object.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        API version of the referent.
+        """
+        field_path: NotRequired[pulumi.Input[str]]
+        """
+        If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object.
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+        """
+        namespace: NotRequired[pulumi.Input[str]]
+        """
+        Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+        """
+        resource_version: NotRequired[pulumi.Input[str]]
+        """
+        Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+        """
+        uid: NotRequired[pulumi.Input[str]]
+        """
+        UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+        """
+elif False:
+    ObjectReferenceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ObjectReferenceArgs:
     def __init__(__self__, *,
@@ -13176,6 +17840,32 @@ class ObjectReferenceArgs:
         pulumi.set(self, "uid", value)
 
 
+if not MYPY:
+    class PersistentVolumeClaimConditionPatchArgsDict(TypedDict):
+        """
+        PersistentVolumeClaimCondition contains details about state of pvc
+        """
+        last_probe_time: NotRequired[pulumi.Input[str]]
+        """
+        lastProbeTime is the time we probed the condition.
+        """
+        last_transition_time: NotRequired[pulumi.Input[str]]
+        """
+        lastTransitionTime is the time the condition transitioned from one status to another.
+        """
+        message: NotRequired[pulumi.Input[str]]
+        """
+        message is the human-readable message indicating details about last transition.
+        """
+        reason: NotRequired[pulumi.Input[str]]
+        """
+        reason is a unique, this should be a short, machine understandable string that gives the reason for condition's last transition. If it reports "Resizing" that means the underlying persistent volume is being resized.
+        """
+        status: NotRequired[pulumi.Input[str]]
+        type: NotRequired[pulumi.Input[str]]
+elif False:
+    PersistentVolumeClaimConditionPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PersistentVolumeClaimConditionPatchArgs:
     def __init__(__self__, *,
@@ -13272,6 +17962,32 @@ class PersistentVolumeClaimConditionPatchArgs:
         pulumi.set(self, "type", value)
 
 
+if not MYPY:
+    class PersistentVolumeClaimConditionArgsDict(TypedDict):
+        """
+        PersistentVolumeClaimCondition contains details about state of pvc
+        """
+        status: pulumi.Input[str]
+        type: pulumi.Input[str]
+        last_probe_time: NotRequired[pulumi.Input[str]]
+        """
+        lastProbeTime is the time we probed the condition.
+        """
+        last_transition_time: NotRequired[pulumi.Input[str]]
+        """
+        lastTransitionTime is the time the condition transitioned from one status to another.
+        """
+        message: NotRequired[pulumi.Input[str]]
+        """
+        message is the human-readable message indicating details about last transition.
+        """
+        reason: NotRequired[pulumi.Input[str]]
+        """
+        reason is a unique, this should be a short, machine understandable string that gives the reason for condition's last transition. If it reports "Resizing" that means the underlying persistent volume is being resized.
+        """
+elif False:
+    PersistentVolumeClaimConditionArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PersistentVolumeClaimConditionArgs:
     def __init__(__self__, *,
@@ -13366,6 +18082,34 @@ class PersistentVolumeClaimConditionArgs:
         pulumi.set(self, "reason", value)
 
 
+if not MYPY:
+    class PersistentVolumeClaimPatchArgsDict(TypedDict):
+        """
+        PersistentVolumeClaim is a user's request for and claim to a persistent volume
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaPatchArgsDict']]
+        """
+        Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['PersistentVolumeClaimSpecPatchArgsDict']]
+        """
+        spec defines the desired characteristics of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+        """
+        status: NotRequired[pulumi.Input['PersistentVolumeClaimStatusPatchArgsDict']]
+        """
+        status represents the current information/status of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+        """
+elif False:
+    PersistentVolumeClaimPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PersistentVolumeClaimPatchArgs:
     def __init__(__self__, *,
@@ -13453,6 +18197,57 @@ class PersistentVolumeClaimPatchArgs:
     def status(self, value: Optional[pulumi.Input['PersistentVolumeClaimStatusPatchArgs']]):
         pulumi.set(self, "status", value)
 
+
+if not MYPY:
+    class PersistentVolumeClaimSpecPatchArgsDict(TypedDict):
+        """
+        PersistentVolumeClaimSpec describes the common attributes of storage devices and allows a Source for provider-specific attributes
+        """
+        access_modes: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        accessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+        """
+        data_source: NotRequired[pulumi.Input['TypedLocalObjectReferencePatchArgsDict']]
+        """
+        dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef, and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified. If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+        """
+        data_source_ref: NotRequired[pulumi.Input['TypedObjectReferencePatchArgsDict']]
+        """
+        dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the dataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, when namespace isn't specified in dataSourceRef, both fields (dataSource and dataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. When namespace is specified in dataSourceRef, dataSource isn't set to the same value and must be empty. There are three important differences between dataSource and dataSourceRef: * While dataSource only allows two specific types of objects, dataSourceRef
+          allows any non-core object, as well as PersistentVolumeClaim objects.
+        * While dataSource ignores disallowed values (dropping them), dataSourceRef
+          preserves all values, and generates an error if a disallowed value is
+          specified.
+        * While dataSource only allows local objects, dataSourceRef allows objects
+          in any namespaces.
+        (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled. (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+        """
+        resources: NotRequired[pulumi.Input['VolumeResourceRequirementsPatchArgsDict']]
+        """
+        resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+        """
+        selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorPatchArgsDict']]
+        """
+        selector is a label query over volumes to consider for binding.
+        """
+        storage_class_name: NotRequired[pulumi.Input[str]]
+        """
+        storageClassName is the name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+        """
+        volume_attributes_class_name: NotRequired[pulumi.Input[str]]
+        """
+        volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim. If specified, the CSI driver will create or update the volume with the attributes defined in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName, it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass will be applied to the claim but it's not allowed to reset this field to empty string once it is set. If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass will be set by the persistentvolume controller if it exists. If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource exists. More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/ (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
+        """
+        volume_mode: NotRequired[pulumi.Input[str]]
+        """
+        volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.
+        """
+        volume_name: NotRequired[pulumi.Input[str]]
+        """
+        volumeName is the binding reference to the PersistentVolume backing this claim.
+        """
+elif False:
+    PersistentVolumeClaimSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class PersistentVolumeClaimSpecPatchArgs:
@@ -13620,6 +18415,57 @@ class PersistentVolumeClaimSpecPatchArgs:
         pulumi.set(self, "volume_name", value)
 
 
+if not MYPY:
+    class PersistentVolumeClaimSpecArgsDict(TypedDict):
+        """
+        PersistentVolumeClaimSpec describes the common attributes of storage devices and allows a Source for provider-specific attributes
+        """
+        access_modes: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        accessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+        """
+        data_source: NotRequired[pulumi.Input['TypedLocalObjectReferenceArgsDict']]
+        """
+        dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef, and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified. If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+        """
+        data_source_ref: NotRequired[pulumi.Input['TypedObjectReferenceArgsDict']]
+        """
+        dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the dataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, when namespace isn't specified in dataSourceRef, both fields (dataSource and dataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. When namespace is specified in dataSourceRef, dataSource isn't set to the same value and must be empty. There are three important differences between dataSource and dataSourceRef: * While dataSource only allows two specific types of objects, dataSourceRef
+          allows any non-core object, as well as PersistentVolumeClaim objects.
+        * While dataSource ignores disallowed values (dropping them), dataSourceRef
+          preserves all values, and generates an error if a disallowed value is
+          specified.
+        * While dataSource only allows local objects, dataSourceRef allows objects
+          in any namespaces.
+        (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled. (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+        """
+        resources: NotRequired[pulumi.Input['VolumeResourceRequirementsArgsDict']]
+        """
+        resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+        """
+        selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorArgsDict']]
+        """
+        selector is a label query over volumes to consider for binding.
+        """
+        storage_class_name: NotRequired[pulumi.Input[str]]
+        """
+        storageClassName is the name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+        """
+        volume_attributes_class_name: NotRequired[pulumi.Input[str]]
+        """
+        volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim. If specified, the CSI driver will create or update the volume with the attributes defined in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName, it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass will be applied to the claim but it's not allowed to reset this field to empty string once it is set. If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass will be set by the persistentvolume controller if it exists. If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource exists. More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/ (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
+        """
+        volume_mode: NotRequired[pulumi.Input[str]]
+        """
+        volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.
+        """
+        volume_name: NotRequired[pulumi.Input[str]]
+        """
+        volumeName is the binding reference to the PersistentVolume backing this claim.
+        """
+elif False:
+    PersistentVolumeClaimSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PersistentVolumeClaimSpecArgs:
     def __init__(__self__, *,
@@ -13785,6 +18631,89 @@ class PersistentVolumeClaimSpecArgs:
     def volume_name(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "volume_name", value)
 
+
+if not MYPY:
+    class PersistentVolumeClaimStatusPatchArgsDict(TypedDict):
+        """
+        PersistentVolumeClaimStatus is the current status of a persistent volume claim.
+        """
+        access_modes: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        accessModes contains the actual access modes the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+        """
+        allocated_resource_statuses: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        allocatedResourceStatuses stores status of resource being resized for the given PVC. Key names follow standard Kubernetes label syntax. Valid values are either:
+        	* Un-prefixed keys:
+        		- storage - the capacity of the volume.
+        	* Custom resources must use implementation-defined prefixed names such as "example.com/my-custom-resource"
+        Apart from above values - keys that are unprefixed or have kubernetes.io prefix are considered reserved and hence may not be used.
+
+        ClaimResourceStatus can be in any of following states:
+        	- ControllerResizeInProgress:
+        		State set when resize controller starts resizing the volume in control-plane.
+        	- ControllerResizeFailed:
+        		State set when resize has failed in resize controller with a terminal error.
+        	- NodeResizePending:
+        		State set when resize controller has finished resizing the volume but further resizing of
+        		volume is needed on the node.
+        	- NodeResizeInProgress:
+        		State set when kubelet starts resizing the volume.
+        	- NodeResizeFailed:
+        		State set when resizing has failed in kubelet with a terminal error. Transient errors don't set
+        		NodeResizeFailed.
+        For example: if expanding a PVC for more capacity - this field can be one of the following states:
+        	- pvc.status.allocatedResourceStatus['storage'] = "ControllerResizeInProgress"
+             - pvc.status.allocatedResourceStatus['storage'] = "ControllerResizeFailed"
+             - pvc.status.allocatedResourceStatus['storage'] = "NodeResizePending"
+             - pvc.status.allocatedResourceStatus['storage'] = "NodeResizeInProgress"
+             - pvc.status.allocatedResourceStatus['storage'] = "NodeResizeFailed"
+        When this field is not set, it means that no resize operation is in progress for the given PVC.
+
+        A controller that receives PVC update with previously unknown resourceName or ClaimResourceStatus should ignore the update for the purpose it was designed. For example - a controller that only is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid resources associated with PVC.
+
+        This is an alpha field and requires enabling RecoverVolumeExpansionFailure feature.
+        """
+        allocated_resources: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        allocatedResources tracks the resources allocated to a PVC including its capacity. Key names follow standard Kubernetes label syntax. Valid values are either:
+        	* Un-prefixed keys:
+        		- storage - the capacity of the volume.
+        	* Custom resources must use implementation-defined prefixed names such as "example.com/my-custom-resource"
+        Apart from above values - keys that are unprefixed or have kubernetes.io prefix are considered reserved and hence may not be used.
+
+        Capacity reported here may be larger than the actual capacity when a volume expansion operation is requested. For storage quota, the larger value from allocatedResources and PVC.spec.resources is used. If allocatedResources is not set, PVC.spec.resources alone is used for quota calculation. If a volume expansion capacity request is lowered, allocatedResources is only lowered if there are no expansion operations in progress and if the actual volume capacity is equal or lower than the requested capacity.
+
+        A controller that receives PVC update with previously unknown resourceName should ignore the update for the purpose it was designed. For example - a controller that only is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid resources associated with PVC.
+
+        This is an alpha field and requires enabling RecoverVolumeExpansionFailure feature.
+        """
+        capacity: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        capacity represents the actual resources of the underlying volume.
+        """
+        conditions: NotRequired[pulumi.Input[Sequence[pulumi.Input['PersistentVolumeClaimConditionPatchArgsDict']]]]
+        """
+        conditions is the current Condition of persistent volume claim. If underlying persistent volume is being resized then the Condition will be set to 'Resizing'.
+        """
+        current_volume_attributes_class_name: NotRequired[pulumi.Input[str]]
+        """
+        currentVolumeAttributesClassName is the current name of the VolumeAttributesClass the PVC is using. When unset, there is no VolumeAttributeClass applied to this PersistentVolumeClaim This is an alpha field and requires enabling VolumeAttributesClass feature.
+        """
+        modify_volume_status: NotRequired[pulumi.Input['ModifyVolumeStatusPatchArgsDict']]
+        """
+        ModifyVolumeStatus represents the status object of ControllerModifyVolume operation. When this is unset, there is no ModifyVolume operation being attempted. This is an alpha field and requires enabling VolumeAttributesClass feature.
+        """
+        phase: NotRequired[pulumi.Input[str]]
+        """
+        phase represents the current phase of PersistentVolumeClaim.
+        """
+        resize_status: NotRequired[pulumi.Input[str]]
+        """
+        resizeStatus stores status of resize operation. ResizeStatus is not set by default but when expansion is complete resizeStatus is set to empty string by resize controller or kubelet. This is an alpha field and requires enabling RecoverVolumeExpansionFailure feature.
+        """
+elif False:
+    PersistentVolumeClaimStatusPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class PersistentVolumeClaimStatusPatchArgs:
@@ -14016,6 +18945,89 @@ class PersistentVolumeClaimStatusPatchArgs:
         pulumi.set(self, "resize_status", value)
 
 
+if not MYPY:
+    class PersistentVolumeClaimStatusArgsDict(TypedDict):
+        """
+        PersistentVolumeClaimStatus is the current status of a persistent volume claim.
+        """
+        access_modes: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        accessModes contains the actual access modes the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+        """
+        allocated_resource_statuses: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        allocatedResourceStatuses stores status of resource being resized for the given PVC. Key names follow standard Kubernetes label syntax. Valid values are either:
+        	* Un-prefixed keys:
+        		- storage - the capacity of the volume.
+        	* Custom resources must use implementation-defined prefixed names such as "example.com/my-custom-resource"
+        Apart from above values - keys that are unprefixed or have kubernetes.io prefix are considered reserved and hence may not be used.
+
+        ClaimResourceStatus can be in any of following states:
+        	- ControllerResizeInProgress:
+        		State set when resize controller starts resizing the volume in control-plane.
+        	- ControllerResizeFailed:
+        		State set when resize has failed in resize controller with a terminal error.
+        	- NodeResizePending:
+        		State set when resize controller has finished resizing the volume but further resizing of
+        		volume is needed on the node.
+        	- NodeResizeInProgress:
+        		State set when kubelet starts resizing the volume.
+        	- NodeResizeFailed:
+        		State set when resizing has failed in kubelet with a terminal error. Transient errors don't set
+        		NodeResizeFailed.
+        For example: if expanding a PVC for more capacity - this field can be one of the following states:
+        	- pvc.status.allocatedResourceStatus['storage'] = "ControllerResizeInProgress"
+             - pvc.status.allocatedResourceStatus['storage'] = "ControllerResizeFailed"
+             - pvc.status.allocatedResourceStatus['storage'] = "NodeResizePending"
+             - pvc.status.allocatedResourceStatus['storage'] = "NodeResizeInProgress"
+             - pvc.status.allocatedResourceStatus['storage'] = "NodeResizeFailed"
+        When this field is not set, it means that no resize operation is in progress for the given PVC.
+
+        A controller that receives PVC update with previously unknown resourceName or ClaimResourceStatus should ignore the update for the purpose it was designed. For example - a controller that only is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid resources associated with PVC.
+
+        This is an alpha field and requires enabling RecoverVolumeExpansionFailure feature.
+        """
+        allocated_resources: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        allocatedResources tracks the resources allocated to a PVC including its capacity. Key names follow standard Kubernetes label syntax. Valid values are either:
+        	* Un-prefixed keys:
+        		- storage - the capacity of the volume.
+        	* Custom resources must use implementation-defined prefixed names such as "example.com/my-custom-resource"
+        Apart from above values - keys that are unprefixed or have kubernetes.io prefix are considered reserved and hence may not be used.
+
+        Capacity reported here may be larger than the actual capacity when a volume expansion operation is requested. For storage quota, the larger value from allocatedResources and PVC.spec.resources is used. If allocatedResources is not set, PVC.spec.resources alone is used for quota calculation. If a volume expansion capacity request is lowered, allocatedResources is only lowered if there are no expansion operations in progress and if the actual volume capacity is equal or lower than the requested capacity.
+
+        A controller that receives PVC update with previously unknown resourceName should ignore the update for the purpose it was designed. For example - a controller that only is responsible for resizing capacity of the volume, should ignore PVC updates that change other valid resources associated with PVC.
+
+        This is an alpha field and requires enabling RecoverVolumeExpansionFailure feature.
+        """
+        capacity: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        capacity represents the actual resources of the underlying volume.
+        """
+        conditions: NotRequired[pulumi.Input[Sequence[pulumi.Input['PersistentVolumeClaimConditionArgsDict']]]]
+        """
+        conditions is the current Condition of persistent volume claim. If underlying persistent volume is being resized then the Condition will be set to 'Resizing'.
+        """
+        current_volume_attributes_class_name: NotRequired[pulumi.Input[str]]
+        """
+        currentVolumeAttributesClassName is the current name of the VolumeAttributesClass the PVC is using. When unset, there is no VolumeAttributeClass applied to this PersistentVolumeClaim This is an alpha field and requires enabling VolumeAttributesClass feature.
+        """
+        modify_volume_status: NotRequired[pulumi.Input['ModifyVolumeStatusArgsDict']]
+        """
+        ModifyVolumeStatus represents the status object of ControllerModifyVolume operation. When this is unset, there is no ModifyVolume operation being attempted. This is an alpha field and requires enabling VolumeAttributesClass feature.
+        """
+        phase: NotRequired[pulumi.Input[str]]
+        """
+        phase represents the current phase of PersistentVolumeClaim.
+        """
+        resize_status: NotRequired[pulumi.Input[str]]
+        """
+        resizeStatus stores status of resize operation. ResizeStatus is not set by default but when expansion is complete resizeStatus is set to empty string by resize controller or kubelet. This is an alpha field and requires enabling RecoverVolumeExpansionFailure feature.
+        """
+elif False:
+    PersistentVolumeClaimStatusArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PersistentVolumeClaimStatusArgs:
     def __init__(__self__, *,
@@ -14246,6 +19258,22 @@ class PersistentVolumeClaimStatusArgs:
         pulumi.set(self, "resize_status", value)
 
 
+if not MYPY:
+    class PersistentVolumeClaimTemplatePatchArgsDict(TypedDict):
+        """
+        PersistentVolumeClaimTemplate is used to produce PersistentVolumeClaim objects as part of an EphemeralVolumeSource.
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaPatchArgsDict']]
+        """
+        May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.
+        """
+        spec: NotRequired[pulumi.Input['PersistentVolumeClaimSpecPatchArgsDict']]
+        """
+        The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.
+        """
+elif False:
+    PersistentVolumeClaimTemplatePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PersistentVolumeClaimTemplatePatchArgs:
     def __init__(__self__, *,
@@ -14286,6 +19314,22 @@ class PersistentVolumeClaimTemplatePatchArgs:
         pulumi.set(self, "spec", value)
 
 
+if not MYPY:
+    class PersistentVolumeClaimTemplateArgsDict(TypedDict):
+        """
+        PersistentVolumeClaimTemplate is used to produce PersistentVolumeClaim objects as part of an EphemeralVolumeSource.
+        """
+        spec: pulumi.Input['PersistentVolumeClaimSpecArgsDict']
+        """
+        The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.
+        """
+elif False:
+    PersistentVolumeClaimTemplateArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PersistentVolumeClaimTemplateArgs:
     def __init__(__self__, *,
@@ -14324,6 +19368,22 @@ class PersistentVolumeClaimTemplateArgs:
     def metadata(self, value: Optional[pulumi.Input['_meta.v1.ObjectMetaArgs']]):
         pulumi.set(self, "metadata", value)
 
+
+if not MYPY:
+    class PersistentVolumeClaimVolumeSourcePatchArgsDict(TypedDict):
+        """
+        PersistentVolumeClaimVolumeSource references the user's PVC in the same namespace. This volume finds the bound PV and mounts that volume for the pod. A PersistentVolumeClaimVolumeSource is, essentially, a wrapper around another type of volume that is owned by someone else (the system).
+        """
+        claim_name: NotRequired[pulumi.Input[str]]
+        """
+        claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        readOnly Will force the ReadOnly setting in VolumeMounts. Default false.
+        """
+elif False:
+    PersistentVolumeClaimVolumeSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class PersistentVolumeClaimVolumeSourcePatchArgs:
@@ -14365,6 +19425,22 @@ class PersistentVolumeClaimVolumeSourcePatchArgs:
         pulumi.set(self, "read_only", value)
 
 
+if not MYPY:
+    class PersistentVolumeClaimVolumeSourceArgsDict(TypedDict):
+        """
+        PersistentVolumeClaimVolumeSource references the user's PVC in the same namespace. This volume finds the bound PV and mounts that volume for the pod. A PersistentVolumeClaimVolumeSource is, essentially, a wrapper around another type of volume that is owned by someone else (the system).
+        """
+        claim_name: pulumi.Input[str]
+        """
+        claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        readOnly Will force the ReadOnly setting in VolumeMounts. Default false.
+        """
+elif False:
+    PersistentVolumeClaimVolumeSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PersistentVolumeClaimVolumeSourceArgs:
     def __init__(__self__, *,
@@ -14403,6 +19479,34 @@ class PersistentVolumeClaimVolumeSourceArgs:
     def read_only(self, value: Optional[pulumi.Input[bool]]):
         pulumi.set(self, "read_only", value)
 
+
+if not MYPY:
+    class PersistentVolumeClaimArgsDict(TypedDict):
+        """
+        PersistentVolumeClaim is a user's request for and claim to a persistent volume
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['PersistentVolumeClaimSpecArgsDict']]
+        """
+        spec defines the desired characteristics of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+        """
+        status: NotRequired[pulumi.Input['PersistentVolumeClaimStatusArgsDict']]
+        """
+        status represents the current information/status of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+        """
+elif False:
+    PersistentVolumeClaimArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class PersistentVolumeClaimArgs:
@@ -14491,6 +19595,138 @@ class PersistentVolumeClaimArgs:
     def status(self, value: Optional[pulumi.Input['PersistentVolumeClaimStatusArgs']]):
         pulumi.set(self, "status", value)
 
+
+if not MYPY:
+    class PersistentVolumeSpecPatchArgsDict(TypedDict):
+        """
+        PersistentVolumeSpec is the specification of a persistent volume.
+        """
+        access_modes: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        accessModes contains all ways the volume can be mounted. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes
+        """
+        aws_elastic_block_store: NotRequired[pulumi.Input['AWSElasticBlockStoreVolumeSourcePatchArgsDict']]
+        """
+        awsElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+        """
+        azure_disk: NotRequired[pulumi.Input['AzureDiskVolumeSourcePatchArgsDict']]
+        """
+        azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+        """
+        azure_file: NotRequired[pulumi.Input['AzureFilePersistentVolumeSourcePatchArgsDict']]
+        """
+        azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+        """
+        capacity: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        capacity is the description of the persistent volume's resources and capacity. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#capacity
+        """
+        cephfs: NotRequired[pulumi.Input['CephFSPersistentVolumeSourcePatchArgsDict']]
+        """
+        cephFS represents a Ceph FS mount on the host that shares a pod's lifetime
+        """
+        cinder: NotRequired[pulumi.Input['CinderPersistentVolumeSourcePatchArgsDict']]
+        """
+        cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+        """
+        claim_ref: NotRequired[pulumi.Input['ObjectReferencePatchArgsDict']]
+        """
+        claimRef is part of a bi-directional binding between PersistentVolume and PersistentVolumeClaim. Expected to be non-nil when bound. claim.VolumeName is the authoritative bind between PV and PVC. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#binding
+        """
+        csi: NotRequired[pulumi.Input['CSIPersistentVolumeSourcePatchArgsDict']]
+        """
+        csi represents storage that is handled by an external CSI driver (Beta feature).
+        """
+        fc: NotRequired[pulumi.Input['FCVolumeSourcePatchArgsDict']]
+        """
+        fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
+        """
+        flex_volume: NotRequired[pulumi.Input['FlexPersistentVolumeSourcePatchArgsDict']]
+        """
+        flexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
+        """
+        flocker: NotRequired[pulumi.Input['FlockerVolumeSourcePatchArgsDict']]
+        """
+        flocker represents a Flocker volume attached to a kubelet's host machine and exposed to the pod for its usage. This depends on the Flocker control service being running
+        """
+        gce_persistent_disk: NotRequired[pulumi.Input['GCEPersistentDiskVolumeSourcePatchArgsDict']]
+        """
+        gcePersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. Provisioned by an admin. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+        """
+        glusterfs: NotRequired[pulumi.Input['GlusterfsPersistentVolumeSourcePatchArgsDict']]
+        """
+        glusterfs represents a Glusterfs volume that is attached to a host and exposed to the pod. Provisioned by an admin. More info: https://examples.k8s.io/volumes/glusterfs/README.md
+        """
+        host_path: NotRequired[pulumi.Input['HostPathVolumeSourcePatchArgsDict']]
+        """
+        hostPath represents a directory on the host. Provisioned by a developer or tester. This is useful for single-node development and testing only! On-host storage is not supported in any way and WILL NOT WORK in a multi-node cluster. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+        """
+        iscsi: NotRequired[pulumi.Input['ISCSIPersistentVolumeSourcePatchArgsDict']]
+        """
+        iscsi represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. Provisioned by an admin.
+        """
+        local: NotRequired[pulumi.Input['LocalVolumeSourcePatchArgsDict']]
+        """
+        local represents directly-attached storage with node affinity
+        """
+        mount_options: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        mountOptions is the list of mount options, e.g. ["ro", "soft"]. Not validated - mount will simply fail if one is invalid. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#mount-options
+        """
+        nfs: NotRequired[pulumi.Input['NFSVolumeSourcePatchArgsDict']]
+        """
+        nfs represents an NFS mount on the host. Provisioned by an admin. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+        """
+        node_affinity: NotRequired[pulumi.Input['VolumeNodeAffinityPatchArgsDict']]
+        """
+        nodeAffinity defines constraints that limit what nodes this volume can be accessed from. This field influences the scheduling of pods that use this volume.
+        """
+        persistent_volume_reclaim_policy: NotRequired[pulumi.Input[str]]
+        """
+        persistentVolumeReclaimPolicy defines what happens to a persistent volume when released from its claim. Valid options are Retain (default for manually created PersistentVolumes), Delete (default for dynamically provisioned PersistentVolumes), and Recycle (deprecated). Recycle must be supported by the volume plugin underlying this PersistentVolume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#reclaiming
+        """
+        photon_persistent_disk: NotRequired[pulumi.Input['PhotonPersistentDiskVolumeSourcePatchArgsDict']]
+        """
+        photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
+        """
+        portworx_volume: NotRequired[pulumi.Input['PortworxVolumeSourcePatchArgsDict']]
+        """
+        portworxVolume represents a portworx volume attached and mounted on kubelets host machine
+        """
+        quobyte: NotRequired[pulumi.Input['QuobyteVolumeSourcePatchArgsDict']]
+        """
+        quobyte represents a Quobyte mount on the host that shares a pod's lifetime
+        """
+        rbd: NotRequired[pulumi.Input['RBDPersistentVolumeSourcePatchArgsDict']]
+        """
+        rbd represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md
+        """
+        scale_io: NotRequired[pulumi.Input['ScaleIOPersistentVolumeSourcePatchArgsDict']]
+        """
+        scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+        """
+        storage_class_name: NotRequired[pulumi.Input[str]]
+        """
+        storageClassName is the name of StorageClass to which this persistent volume belongs. Empty value means that this volume does not belong to any StorageClass.
+        """
+        storageos: NotRequired[pulumi.Input['StorageOSPersistentVolumeSourcePatchArgsDict']]
+        """
+        storageOS represents a StorageOS volume that is attached to the kubelet's host machine and mounted into the pod More info: https://examples.k8s.io/volumes/storageos/README.md
+        """
+        volume_attributes_class_name: NotRequired[pulumi.Input[str]]
+        """
+        Name of VolumeAttributesClass to which this persistent volume belongs. Empty value is not allowed. When this field is not set, it indicates that this volume does not belong to any VolumeAttributesClass. This field is mutable and can be changed by the CSI driver after a volume has been updated successfully to a new class. For an unbound PersistentVolume, the volumeAttributesClassName will be matched with unbound PersistentVolumeClaims during the binding process. This is an alpha field and requires enabling VolumeAttributesClass feature.
+        """
+        volume_mode: NotRequired[pulumi.Input[str]]
+        """
+        volumeMode defines if a volume is intended to be used with a formatted filesystem or to remain in raw block state. Value of Filesystem is implied when not included in spec.
+        """
+        vsphere_volume: NotRequired[pulumi.Input['VsphereVirtualDiskVolumeSourcePatchArgsDict']]
+        """
+        vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
+        """
+elif False:
+    PersistentVolumeSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class PersistentVolumeSpecPatchArgs:
@@ -14996,6 +20232,138 @@ class PersistentVolumeSpecPatchArgs:
         pulumi.set(self, "vsphere_volume", value)
 
 
+if not MYPY:
+    class PersistentVolumeSpecArgsDict(TypedDict):
+        """
+        PersistentVolumeSpec is the specification of a persistent volume.
+        """
+        access_modes: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        accessModes contains all ways the volume can be mounted. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes
+        """
+        aws_elastic_block_store: NotRequired[pulumi.Input['AWSElasticBlockStoreVolumeSourceArgsDict']]
+        """
+        awsElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+        """
+        azure_disk: NotRequired[pulumi.Input['AzureDiskVolumeSourceArgsDict']]
+        """
+        azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+        """
+        azure_file: NotRequired[pulumi.Input['AzureFilePersistentVolumeSourceArgsDict']]
+        """
+        azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+        """
+        capacity: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        capacity is the description of the persistent volume's resources and capacity. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#capacity
+        """
+        cephfs: NotRequired[pulumi.Input['CephFSPersistentVolumeSourceArgsDict']]
+        """
+        cephFS represents a Ceph FS mount on the host that shares a pod's lifetime
+        """
+        cinder: NotRequired[pulumi.Input['CinderPersistentVolumeSourceArgsDict']]
+        """
+        cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+        """
+        claim_ref: NotRequired[pulumi.Input['ObjectReferenceArgsDict']]
+        """
+        claimRef is part of a bi-directional binding between PersistentVolume and PersistentVolumeClaim. Expected to be non-nil when bound. claim.VolumeName is the authoritative bind between PV and PVC. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#binding
+        """
+        csi: NotRequired[pulumi.Input['CSIPersistentVolumeSourceArgsDict']]
+        """
+        csi represents storage that is handled by an external CSI driver (Beta feature).
+        """
+        fc: NotRequired[pulumi.Input['FCVolumeSourceArgsDict']]
+        """
+        fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
+        """
+        flex_volume: NotRequired[pulumi.Input['FlexPersistentVolumeSourceArgsDict']]
+        """
+        flexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
+        """
+        flocker: NotRequired[pulumi.Input['FlockerVolumeSourceArgsDict']]
+        """
+        flocker represents a Flocker volume attached to a kubelet's host machine and exposed to the pod for its usage. This depends on the Flocker control service being running
+        """
+        gce_persistent_disk: NotRequired[pulumi.Input['GCEPersistentDiskVolumeSourceArgsDict']]
+        """
+        gcePersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. Provisioned by an admin. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+        """
+        glusterfs: NotRequired[pulumi.Input['GlusterfsPersistentVolumeSourceArgsDict']]
+        """
+        glusterfs represents a Glusterfs volume that is attached to a host and exposed to the pod. Provisioned by an admin. More info: https://examples.k8s.io/volumes/glusterfs/README.md
+        """
+        host_path: NotRequired[pulumi.Input['HostPathVolumeSourceArgsDict']]
+        """
+        hostPath represents a directory on the host. Provisioned by a developer or tester. This is useful for single-node development and testing only! On-host storage is not supported in any way and WILL NOT WORK in a multi-node cluster. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+        """
+        iscsi: NotRequired[pulumi.Input['ISCSIPersistentVolumeSourceArgsDict']]
+        """
+        iscsi represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. Provisioned by an admin.
+        """
+        local: NotRequired[pulumi.Input['LocalVolumeSourceArgsDict']]
+        """
+        local represents directly-attached storage with node affinity
+        """
+        mount_options: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        mountOptions is the list of mount options, e.g. ["ro", "soft"]. Not validated - mount will simply fail if one is invalid. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#mount-options
+        """
+        nfs: NotRequired[pulumi.Input['NFSVolumeSourceArgsDict']]
+        """
+        nfs represents an NFS mount on the host. Provisioned by an admin. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+        """
+        node_affinity: NotRequired[pulumi.Input['VolumeNodeAffinityArgsDict']]
+        """
+        nodeAffinity defines constraints that limit what nodes this volume can be accessed from. This field influences the scheduling of pods that use this volume.
+        """
+        persistent_volume_reclaim_policy: NotRequired[pulumi.Input[str]]
+        """
+        persistentVolumeReclaimPolicy defines what happens to a persistent volume when released from its claim. Valid options are Retain (default for manually created PersistentVolumes), Delete (default for dynamically provisioned PersistentVolumes), and Recycle (deprecated). Recycle must be supported by the volume plugin underlying this PersistentVolume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#reclaiming
+        """
+        photon_persistent_disk: NotRequired[pulumi.Input['PhotonPersistentDiskVolumeSourceArgsDict']]
+        """
+        photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
+        """
+        portworx_volume: NotRequired[pulumi.Input['PortworxVolumeSourceArgsDict']]
+        """
+        portworxVolume represents a portworx volume attached and mounted on kubelets host machine
+        """
+        quobyte: NotRequired[pulumi.Input['QuobyteVolumeSourceArgsDict']]
+        """
+        quobyte represents a Quobyte mount on the host that shares a pod's lifetime
+        """
+        rbd: NotRequired[pulumi.Input['RBDPersistentVolumeSourceArgsDict']]
+        """
+        rbd represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md
+        """
+        scale_io: NotRequired[pulumi.Input['ScaleIOPersistentVolumeSourceArgsDict']]
+        """
+        scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+        """
+        storage_class_name: NotRequired[pulumi.Input[str]]
+        """
+        storageClassName is the name of StorageClass to which this persistent volume belongs. Empty value means that this volume does not belong to any StorageClass.
+        """
+        storageos: NotRequired[pulumi.Input['StorageOSPersistentVolumeSourceArgsDict']]
+        """
+        storageOS represents a StorageOS volume that is attached to the kubelet's host machine and mounted into the pod More info: https://examples.k8s.io/volumes/storageos/README.md
+        """
+        volume_attributes_class_name: NotRequired[pulumi.Input[str]]
+        """
+        Name of VolumeAttributesClass to which this persistent volume belongs. Empty value is not allowed. When this field is not set, it indicates that this volume does not belong to any VolumeAttributesClass. This field is mutable and can be changed by the CSI driver after a volume has been updated successfully to a new class. For an unbound PersistentVolume, the volumeAttributesClassName will be matched with unbound PersistentVolumeClaims during the binding process. This is an alpha field and requires enabling VolumeAttributesClass feature.
+        """
+        volume_mode: NotRequired[pulumi.Input[str]]
+        """
+        volumeMode defines if a volume is intended to be used with a formatted filesystem or to remain in raw block state. Value of Filesystem is implied when not included in spec.
+        """
+        vsphere_volume: NotRequired[pulumi.Input['VsphereVirtualDiskVolumeSourceArgsDict']]
+        """
+        vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
+        """
+elif False:
+    PersistentVolumeSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PersistentVolumeSpecArgs:
     def __init__(__self__, *,
@@ -15500,6 +20868,30 @@ class PersistentVolumeSpecArgs:
         pulumi.set(self, "vsphere_volume", value)
 
 
+if not MYPY:
+    class PersistentVolumeStatusArgsDict(TypedDict):
+        """
+        PersistentVolumeStatus is the current status of a persistent volume.
+        """
+        last_phase_transition_time: NotRequired[pulumi.Input[str]]
+        """
+        lastPhaseTransitionTime is the time the phase transitioned from one to another and automatically resets to current time everytime a volume phase transitions. This is a beta field and requires the PersistentVolumeLastPhaseTransitionTime feature to be enabled (enabled by default).
+        """
+        message: NotRequired[pulumi.Input[str]]
+        """
+        message is a human-readable message indicating details about why the volume is in this state.
+        """
+        phase: NotRequired[pulumi.Input[str]]
+        """
+        phase indicates if a volume is available, bound to a claim, or released by a claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#phase
+        """
+        reason: NotRequired[pulumi.Input[str]]
+        """
+        reason is a brief CamelCase string that describes any failure and is meant for machine parsing and tidy display in the CLI.
+        """
+elif False:
+    PersistentVolumeStatusArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PersistentVolumeStatusArgs:
     def __init__(__self__, *,
@@ -15571,6 +20963,34 @@ class PersistentVolumeStatusArgs:
     def reason(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "reason", value)
 
+
+if not MYPY:
+    class PersistentVolumeArgsDict(TypedDict):
+        """
+        PersistentVolume (PV) is a storage resource provisioned by an administrator. It is analogous to a node. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['PersistentVolumeSpecArgsDict']]
+        """
+        spec defines a specification of a persistent volume owned by the cluster. Provisioned by an administrator. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistent-volumes
+        """
+        status: NotRequired[pulumi.Input['PersistentVolumeStatusArgsDict']]
+        """
+        status represents the current information/status for the persistent volume. Populated by the system. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistent-volumes
+        """
+elif False:
+    PersistentVolumeArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class PersistentVolumeArgs:
@@ -15660,6 +21080,22 @@ class PersistentVolumeArgs:
         pulumi.set(self, "status", value)
 
 
+if not MYPY:
+    class PhotonPersistentDiskVolumeSourcePatchArgsDict(TypedDict):
+        """
+        Represents a Photon Controller persistent disk resource.
+        """
+        fs_type: NotRequired[pulumi.Input[str]]
+        """
+        fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+        """
+        pd_id: NotRequired[pulumi.Input[str]]
+        """
+        pdID is the ID that identifies Photon Controller persistent disk
+        """
+elif False:
+    PhotonPersistentDiskVolumeSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PhotonPersistentDiskVolumeSourcePatchArgs:
     def __init__(__self__, *,
@@ -15700,6 +21136,22 @@ class PhotonPersistentDiskVolumeSourcePatchArgs:
         pulumi.set(self, "pd_id", value)
 
 
+if not MYPY:
+    class PhotonPersistentDiskVolumeSourceArgsDict(TypedDict):
+        """
+        Represents a Photon Controller persistent disk resource.
+        """
+        pd_id: pulumi.Input[str]
+        """
+        pdID is the ID that identifies Photon Controller persistent disk
+        """
+        fs_type: NotRequired[pulumi.Input[str]]
+        """
+        fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+        """
+elif False:
+    PhotonPersistentDiskVolumeSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PhotonPersistentDiskVolumeSourceArgs:
     def __init__(__self__, *,
@@ -15738,6 +21190,22 @@ class PhotonPersistentDiskVolumeSourceArgs:
     def fs_type(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "fs_type", value)
 
+
+if not MYPY:
+    class PodAffinityPatchArgsDict(TypedDict):
+        """
+        Pod affinity is a group of inter pod affinity scheduling rules.
+        """
+        preferred_during_scheduling_ignored_during_execution: NotRequired[pulumi.Input[Sequence[pulumi.Input['WeightedPodAffinityTermPatchArgsDict']]]]
+        """
+        The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+        """
+        required_during_scheduling_ignored_during_execution: NotRequired[pulumi.Input[Sequence[pulumi.Input['PodAffinityTermPatchArgsDict']]]]
+        """
+        If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+        """
+elif False:
+    PodAffinityPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class PodAffinityPatchArgs:
@@ -15778,6 +21246,38 @@ class PodAffinityPatchArgs:
     def required_during_scheduling_ignored_during_execution(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['PodAffinityTermPatchArgs']]]]):
         pulumi.set(self, "required_during_scheduling_ignored_during_execution", value)
 
+
+if not MYPY:
+    class PodAffinityTermPatchArgsDict(TypedDict):
+        """
+        Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+        """
+        label_selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorPatchArgsDict']]
+        """
+        A label query over a set of resources, in this case pods. If it's null, this PodAffinityTerm matches with no Pods.
+        """
+        match_label_keys: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration. The keys are used to lookup values from the incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)` to select the group of existing pods which pods will be taken into consideration for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming pod labels will be ignored. The default value is empty. The same key is forbidden to exist in both matchLabelKeys and labelSelector. Also, matchLabelKeys cannot be set when labelSelector isn't set. This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+        """
+        mismatch_label_keys: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration. The keys are used to lookup values from the incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)` to select the group of existing pods which pods will be taken into consideration for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming pod labels will be ignored. The default value is empty. The same key is forbidden to exist in both mismatchLabelKeys and labelSelector. Also, mismatchLabelKeys cannot be set when labelSelector isn't set. This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+        """
+        namespace_selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorPatchArgsDict']]
+        """
+        A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+        """
+        namespaces: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+        """
+        topology_key: NotRequired[pulumi.Input[str]]
+        """
+        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+        """
+elif False:
+    PodAffinityTermPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class PodAffinityTermPatchArgs:
@@ -15883,6 +21383,38 @@ class PodAffinityTermPatchArgs:
         pulumi.set(self, "topology_key", value)
 
 
+if not MYPY:
+    class PodAffinityTermArgsDict(TypedDict):
+        """
+        Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+        """
+        topology_key: pulumi.Input[str]
+        """
+        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+        """
+        label_selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorArgsDict']]
+        """
+        A label query over a set of resources, in this case pods. If it's null, this PodAffinityTerm matches with no Pods.
+        """
+        match_label_keys: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        MatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration. The keys are used to lookup values from the incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)` to select the group of existing pods which pods will be taken into consideration for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming pod labels will be ignored. The default value is empty. The same key is forbidden to exist in both matchLabelKeys and labelSelector. Also, matchLabelKeys cannot be set when labelSelector isn't set. This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+        """
+        mismatch_label_keys: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        MismatchLabelKeys is a set of pod label keys to select which pods will be taken into consideration. The keys are used to lookup values from the incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)` to select the group of existing pods which pods will be taken into consideration for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming pod labels will be ignored. The default value is empty. The same key is forbidden to exist in both mismatchLabelKeys and labelSelector. Also, mismatchLabelKeys cannot be set when labelSelector isn't set. This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+        """
+        namespace_selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorArgsDict']]
+        """
+        A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+        """
+        namespaces: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+        """
+elif False:
+    PodAffinityTermArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PodAffinityTermArgs:
     def __init__(__self__, *,
@@ -15986,6 +21518,22 @@ class PodAffinityTermArgs:
         pulumi.set(self, "namespaces", value)
 
 
+if not MYPY:
+    class PodAffinityArgsDict(TypedDict):
+        """
+        Pod affinity is a group of inter pod affinity scheduling rules.
+        """
+        preferred_during_scheduling_ignored_during_execution: NotRequired[pulumi.Input[Sequence[pulumi.Input['WeightedPodAffinityTermArgsDict']]]]
+        """
+        The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+        """
+        required_during_scheduling_ignored_during_execution: NotRequired[pulumi.Input[Sequence[pulumi.Input['PodAffinityTermArgsDict']]]]
+        """
+        If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+        """
+elif False:
+    PodAffinityArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PodAffinityArgs:
     def __init__(__self__, *,
@@ -16025,6 +21573,22 @@ class PodAffinityArgs:
     def required_during_scheduling_ignored_during_execution(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['PodAffinityTermArgs']]]]):
         pulumi.set(self, "required_during_scheduling_ignored_during_execution", value)
 
+
+if not MYPY:
+    class PodAntiAffinityPatchArgsDict(TypedDict):
+        """
+        Pod anti affinity is a group of inter pod anti affinity scheduling rules.
+        """
+        preferred_during_scheduling_ignored_during_execution: NotRequired[pulumi.Input[Sequence[pulumi.Input['WeightedPodAffinityTermPatchArgsDict']]]]
+        """
+        The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+        """
+        required_during_scheduling_ignored_during_execution: NotRequired[pulumi.Input[Sequence[pulumi.Input['PodAffinityTermPatchArgsDict']]]]
+        """
+        If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+        """
+elif False:
+    PodAntiAffinityPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class PodAntiAffinityPatchArgs:
@@ -16066,6 +21630,22 @@ class PodAntiAffinityPatchArgs:
         pulumi.set(self, "required_during_scheduling_ignored_during_execution", value)
 
 
+if not MYPY:
+    class PodAntiAffinityArgsDict(TypedDict):
+        """
+        Pod anti affinity is a group of inter pod anti affinity scheduling rules.
+        """
+        preferred_during_scheduling_ignored_during_execution: NotRequired[pulumi.Input[Sequence[pulumi.Input['WeightedPodAffinityTermArgsDict']]]]
+        """
+        The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+        """
+        required_during_scheduling_ignored_during_execution: NotRequired[pulumi.Input[Sequence[pulumi.Input['PodAffinityTermArgsDict']]]]
+        """
+        If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+        """
+elif False:
+    PodAntiAffinityArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PodAntiAffinityArgs:
     def __init__(__self__, *,
@@ -16105,6 +21685,38 @@ class PodAntiAffinityArgs:
     def required_during_scheduling_ignored_during_execution(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['PodAffinityTermArgs']]]]):
         pulumi.set(self, "required_during_scheduling_ignored_during_execution", value)
 
+
+if not MYPY:
+    class PodConditionArgsDict(TypedDict):
+        """
+        PodCondition contains details for the current condition of this pod.
+        """
+        status: pulumi.Input[str]
+        """
+        Status is the status of the condition. Can be True, False, Unknown. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions
+        """
+        type: pulumi.Input[str]
+        """
+        Type is the type of the condition. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions
+        """
+        last_probe_time: NotRequired[pulumi.Input[str]]
+        """
+        Last time we probed the condition.
+        """
+        last_transition_time: NotRequired[pulumi.Input[str]]
+        """
+        Last time the condition transitioned from one status to another.
+        """
+        message: NotRequired[pulumi.Input[str]]
+        """
+        Human-readable message indicating details about last transition.
+        """
+        reason: NotRequired[pulumi.Input[str]]
+        """
+        Unique, one-word, CamelCase reason for the condition's last transition.
+        """
+elif False:
+    PodConditionArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class PodConditionArgs:
@@ -16208,6 +21820,19 @@ class PodConditionArgs:
         pulumi.set(self, "reason", value)
 
 
+if not MYPY:
+    class PodDNSConfigOptionPatchArgsDict(TypedDict):
+        """
+        PodDNSConfigOption defines DNS resolver options of a pod.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Required.
+        """
+        value: NotRequired[pulumi.Input[str]]
+elif False:
+    PodDNSConfigOptionPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PodDNSConfigOptionPatchArgs:
     def __init__(__self__, *,
@@ -16244,6 +21869,19 @@ class PodDNSConfigOptionPatchArgs:
         pulumi.set(self, "value", value)
 
 
+if not MYPY:
+    class PodDNSConfigOptionArgsDict(TypedDict):
+        """
+        PodDNSConfigOption defines DNS resolver options of a pod.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Required.
+        """
+        value: NotRequired[pulumi.Input[str]]
+elif False:
+    PodDNSConfigOptionArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PodDNSConfigOptionArgs:
     def __init__(__self__, *,
@@ -16279,6 +21917,26 @@ class PodDNSConfigOptionArgs:
     def value(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "value", value)
 
+
+if not MYPY:
+    class PodDNSConfigPatchArgsDict(TypedDict):
+        """
+        PodDNSConfig defines the DNS parameters of a pod in addition to those generated from DNSPolicy.
+        """
+        nameservers: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        A list of DNS name server IP addresses. This will be appended to the base nameservers generated from DNSPolicy. Duplicated nameservers will be removed.
+        """
+        options: NotRequired[pulumi.Input[Sequence[pulumi.Input['PodDNSConfigOptionPatchArgsDict']]]]
+        """
+        A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy.
+        """
+        searches: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        A list of DNS search domains for host-name lookup. This will be appended to the base search paths generated from DNSPolicy. Duplicated search paths will be removed.
+        """
+elif False:
+    PodDNSConfigPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class PodDNSConfigPatchArgs:
@@ -16336,6 +21994,26 @@ class PodDNSConfigPatchArgs:
         pulumi.set(self, "searches", value)
 
 
+if not MYPY:
+    class PodDNSConfigArgsDict(TypedDict):
+        """
+        PodDNSConfig defines the DNS parameters of a pod in addition to those generated from DNSPolicy.
+        """
+        nameservers: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        A list of DNS name server IP addresses. This will be appended to the base nameservers generated from DNSPolicy. Duplicated nameservers will be removed.
+        """
+        options: NotRequired[pulumi.Input[Sequence[pulumi.Input['PodDNSConfigOptionArgsDict']]]]
+        """
+        A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy.
+        """
+        searches: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        A list of DNS search domains for host-name lookup. This will be appended to the base search paths generated from DNSPolicy. Duplicated search paths will be removed.
+        """
+elif False:
+    PodDNSConfigArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PodDNSConfigArgs:
     def __init__(__self__, *,
@@ -16392,6 +22070,18 @@ class PodDNSConfigArgs:
         pulumi.set(self, "searches", value)
 
 
+if not MYPY:
+    class PodIPArgsDict(TypedDict):
+        """
+        PodIP represents a single IP address allocated to the pod.
+        """
+        ip: NotRequired[pulumi.Input[str]]
+        """
+        IP is the IP address assigned to the pod
+        """
+elif False:
+    PodIPArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PodIPArgs:
     def __init__(__self__, *,
@@ -16415,6 +22105,18 @@ class PodIPArgs:
     def ip(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "ip", value)
 
+
+if not MYPY:
+    class PodOSPatchArgsDict(TypedDict):
+        """
+        PodOS defines the OS parameters of a pod.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name is the name of the operating system. The currently supported values are linux and windows. Additional value may be defined in future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration Clients should expect to handle additional values and treat unrecognized values in this field as os: null
+        """
+elif False:
+    PodOSPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class PodOSPatchArgs:
@@ -16440,6 +22142,18 @@ class PodOSPatchArgs:
         pulumi.set(self, "name", value)
 
 
+if not MYPY:
+    class PodOSArgsDict(TypedDict):
+        """
+        PodOS defines the OS parameters of a pod.
+        """
+        name: pulumi.Input[str]
+        """
+        Name is the name of the operating system. The currently supported values are linux and windows. Additional value may be defined in future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration Clients should expect to handle additional values and treat unrecognized values in this field as os: null
+        """
+elif False:
+    PodOSArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PodOSArgs:
     def __init__(__self__, *,
@@ -16462,6 +22176,18 @@ class PodOSArgs:
     def name(self, value: pulumi.Input[str]):
         pulumi.set(self, "name", value)
 
+
+if not MYPY:
+    class PodReadinessGatePatchArgsDict(TypedDict):
+        """
+        PodReadinessGate contains the reference to a pod condition
+        """
+        condition_type: NotRequired[pulumi.Input[str]]
+        """
+        ConditionType refers to a condition in the pod's condition list with matching type.
+        """
+elif False:
+    PodReadinessGatePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class PodReadinessGatePatchArgs:
@@ -16487,6 +22213,18 @@ class PodReadinessGatePatchArgs:
         pulumi.set(self, "condition_type", value)
 
 
+if not MYPY:
+    class PodReadinessGateArgsDict(TypedDict):
+        """
+        PodReadinessGate contains the reference to a pod condition
+        """
+        condition_type: pulumi.Input[str]
+        """
+        ConditionType refers to a condition in the pod's condition list with matching type.
+        """
+elif False:
+    PodReadinessGateArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PodReadinessGateArgs:
     def __init__(__self__, *,
@@ -16509,6 +22247,22 @@ class PodReadinessGateArgs:
     def condition_type(self, value: pulumi.Input[str]):
         pulumi.set(self, "condition_type", value)
 
+
+if not MYPY:
+    class PodResourceClaimPatchArgsDict(TypedDict):
+        """
+        PodResourceClaim references exactly one ResourceClaim through a ClaimSource. It adds a name to it that uniquely identifies the ResourceClaim inside the Pod. Containers that need access to the ResourceClaim reference it with this name.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name uniquely identifies this resource claim inside the pod. This must be a DNS_LABEL.
+        """
+        source: NotRequired[pulumi.Input['ClaimSourcePatchArgsDict']]
+        """
+        Source describes where to find the ResourceClaim.
+        """
+elif False:
+    PodResourceClaimPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class PodResourceClaimPatchArgs:
@@ -16550,6 +22304,22 @@ class PodResourceClaimPatchArgs:
         pulumi.set(self, "source", value)
 
 
+if not MYPY:
+    class PodResourceClaimStatusArgsDict(TypedDict):
+        """
+        PodResourceClaimStatus is stored in the PodStatus for each PodResourceClaim which references a ResourceClaimTemplate. It stores the generated name for the corresponding ResourceClaim.
+        """
+        name: pulumi.Input[str]
+        """
+        Name uniquely identifies this resource claim inside the pod. This must match the name of an entry in pod.spec.resourceClaims, which implies that the string must be a DNS_LABEL.
+        """
+        resource_claim_name: NotRequired[pulumi.Input[str]]
+        """
+        ResourceClaimName is the name of the ResourceClaim that was generated for the Pod in the namespace of the Pod. It this is unset, then generating a ResourceClaim was not necessary. The pod.spec.resourceClaims entry can be ignored in this case.
+        """
+elif False:
+    PodResourceClaimStatusArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PodResourceClaimStatusArgs:
     def __init__(__self__, *,
@@ -16588,6 +22358,22 @@ class PodResourceClaimStatusArgs:
     def resource_claim_name(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "resource_claim_name", value)
 
+
+if not MYPY:
+    class PodResourceClaimArgsDict(TypedDict):
+        """
+        PodResourceClaim references exactly one ResourceClaim through a ClaimSource. It adds a name to it that uniquely identifies the ResourceClaim inside the Pod. Containers that need access to the ResourceClaim reference it with this name.
+        """
+        name: pulumi.Input[str]
+        """
+        Name uniquely identifies this resource claim inside the pod. This must be a DNS_LABEL.
+        """
+        source: NotRequired[pulumi.Input['ClaimSourceArgsDict']]
+        """
+        Source describes where to find the ResourceClaim.
+        """
+elif False:
+    PodResourceClaimArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class PodResourceClaimArgs:
@@ -16628,6 +22414,18 @@ class PodResourceClaimArgs:
         pulumi.set(self, "source", value)
 
 
+if not MYPY:
+    class PodSchedulingGatePatchArgsDict(TypedDict):
+        """
+        PodSchedulingGate is associated to a Pod to guard its scheduling.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name of the scheduling gate. Each scheduling gate must have a unique name field.
+        """
+elif False:
+    PodSchedulingGatePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PodSchedulingGatePatchArgs:
     def __init__(__self__, *,
@@ -16652,6 +22450,18 @@ class PodSchedulingGatePatchArgs:
         pulumi.set(self, "name", value)
 
 
+if not MYPY:
+    class PodSchedulingGateArgsDict(TypedDict):
+        """
+        PodSchedulingGate is associated to a Pod to guard its scheduling.
+        """
+        name: pulumi.Input[str]
+        """
+        Name of the scheduling gate. Each scheduling gate must have a unique name field.
+        """
+elif False:
+    PodSchedulingGateArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PodSchedulingGateArgs:
     def __init__(__self__, *,
@@ -16674,6 +22484,62 @@ class PodSchedulingGateArgs:
     def name(self, value: pulumi.Input[str]):
         pulumi.set(self, "name", value)
 
+
+if not MYPY:
+    class PodSecurityContextPatchArgsDict(TypedDict):
+        """
+        PodSecurityContext holds pod-level security attributes and common container settings. Some fields are also present in container.securityContext.  Field values of container.securityContext take precedence over field values of PodSecurityContext.
+        """
+        app_armor_profile: NotRequired[pulumi.Input['AppArmorProfilePatchArgsDict']]
+        """
+        appArmorProfile is the AppArmor options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows.
+        """
+        fs_group: NotRequired[pulumi.Input[int]]
+        """
+        A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:
+
+        1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----
+
+        If unset, the Kubelet will not modify the ownership and permissions of any volume. Note that this field cannot be set when spec.os.name is windows.
+        """
+        fs_group_change_policy: NotRequired[pulumi.Input[str]]
+        """
+        fsGroupChangePolicy defines behavior of changing ownership and permission of the volume before being exposed inside Pod. This field will only apply to volume types which support fsGroup based ownership(and permissions). It will have no effect on ephemeral volume types such as: secret, configmaps and emptydir. Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used. Note that this field cannot be set when spec.os.name is windows.
+        """
+        run_as_group: NotRequired[pulumi.Input[int]]
+        """
+        The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.
+        """
+        run_as_non_root: NotRequired[pulumi.Input[bool]]
+        """
+        Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+        """
+        run_as_user: NotRequired[pulumi.Input[int]]
+        """
+        The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.
+        """
+        se_linux_options: NotRequired[pulumi.Input['SELinuxOptionsPatchArgsDict']]
+        """
+        The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.
+        """
+        seccomp_profile: NotRequired[pulumi.Input['SeccompProfilePatchArgsDict']]
+        """
+        The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows.
+        """
+        supplemental_groups: NotRequired[pulumi.Input[Sequence[pulumi.Input[int]]]]
+        """
+        A list of groups applied to the first process run in each container, in addition to the container's primary GID, the fsGroup (if specified), and group memberships defined in the container image for the uid of the container process. If unspecified, no additional groups are added to any container. Note that group memberships defined in the container image for the uid of the container process are still effective, even if they are not included in this list. Note that this field cannot be set when spec.os.name is windows.
+        """
+        sysctls: NotRequired[pulumi.Input[Sequence[pulumi.Input['SysctlPatchArgsDict']]]]
+        """
+        Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported sysctls (by the container runtime) might fail to launch. Note that this field cannot be set when spec.os.name is windows.
+        """
+        windows_options: NotRequired[pulumi.Input['WindowsSecurityContextOptionsPatchArgsDict']]
+        """
+        The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.
+        """
+elif False:
+    PodSecurityContextPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class PodSecurityContextPatchArgs:
@@ -16867,6 +22733,62 @@ class PodSecurityContextPatchArgs:
         pulumi.set(self, "windows_options", value)
 
 
+if not MYPY:
+    class PodSecurityContextArgsDict(TypedDict):
+        """
+        PodSecurityContext holds pod-level security attributes and common container settings. Some fields are also present in container.securityContext.  Field values of container.securityContext take precedence over field values of PodSecurityContext.
+        """
+        app_armor_profile: NotRequired[pulumi.Input['AppArmorProfileArgsDict']]
+        """
+        appArmorProfile is the AppArmor options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows.
+        """
+        fs_group: NotRequired[pulumi.Input[int]]
+        """
+        A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:
+
+        1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----
+
+        If unset, the Kubelet will not modify the ownership and permissions of any volume. Note that this field cannot be set when spec.os.name is windows.
+        """
+        fs_group_change_policy: NotRequired[pulumi.Input[str]]
+        """
+        fsGroupChangePolicy defines behavior of changing ownership and permission of the volume before being exposed inside Pod. This field will only apply to volume types which support fsGroup based ownership(and permissions). It will have no effect on ephemeral volume types such as: secret, configmaps and emptydir. Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used. Note that this field cannot be set when spec.os.name is windows.
+        """
+        run_as_group: NotRequired[pulumi.Input[int]]
+        """
+        The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.
+        """
+        run_as_non_root: NotRequired[pulumi.Input[bool]]
+        """
+        Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+        """
+        run_as_user: NotRequired[pulumi.Input[int]]
+        """
+        The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.
+        """
+        se_linux_options: NotRequired[pulumi.Input['SELinuxOptionsArgsDict']]
+        """
+        The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.
+        """
+        seccomp_profile: NotRequired[pulumi.Input['SeccompProfileArgsDict']]
+        """
+        The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows.
+        """
+        supplemental_groups: NotRequired[pulumi.Input[Sequence[pulumi.Input[int]]]]
+        """
+        A list of groups applied to the first process run in each container, in addition to the container's primary GID, the fsGroup (if specified), and group memberships defined in the container image for the uid of the container process. If unspecified, no additional groups are added to any container. Note that group memberships defined in the container image for the uid of the container process are still effective, even if they are not included in this list. Note that this field cannot be set when spec.os.name is windows.
+        """
+        sysctls: NotRequired[pulumi.Input[Sequence[pulumi.Input['SysctlArgsDict']]]]
+        """
+        Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported sysctls (by the container runtime) might fail to launch. Note that this field cannot be set when spec.os.name is windows.
+        """
+        windows_options: NotRequired[pulumi.Input['WindowsSecurityContextOptionsArgsDict']]
+        """
+        The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.
+        """
+elif False:
+    PodSecurityContextArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PodSecurityContextArgs:
     def __init__(__self__, *,
@@ -17058,6 +22980,180 @@ class PodSecurityContextArgs:
     def windows_options(self, value: Optional[pulumi.Input['WindowsSecurityContextOptionsArgs']]):
         pulumi.set(self, "windows_options", value)
 
+
+if not MYPY:
+    class PodSpecPatchArgsDict(TypedDict):
+        """
+        PodSpec is a description of a pod.
+        """
+        active_deadline_seconds: NotRequired[pulumi.Input[int]]
+        """
+        Optional duration in seconds the pod may be active on the node relative to StartTime before the system will actively try to mark it failed and kill associated containers. Value must be a positive integer.
+        """
+        affinity: NotRequired[pulumi.Input['AffinityPatchArgsDict']]
+        """
+        If specified, the pod's scheduling constraints
+        """
+        automount_service_account_token: NotRequired[pulumi.Input[bool]]
+        """
+        AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.
+        """
+        containers: NotRequired[pulumi.Input[Sequence[pulumi.Input['ContainerPatchArgsDict']]]]
+        """
+        List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated.
+        """
+        dns_config: NotRequired[pulumi.Input['PodDNSConfigPatchArgsDict']]
+        """
+        Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy.
+        """
+        dns_policy: NotRequired[pulumi.Input[str]]
+        """
+        Set DNS policy for the pod. Defaults to "ClusterFirst". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.
+        """
+        enable_service_links: NotRequired[pulumi.Input[bool]]
+        """
+        EnableServiceLinks indicates whether information about services should be injected into pod's environment variables, matching the syntax of Docker links. Optional: Defaults to true.
+        """
+        ephemeral_containers: NotRequired[pulumi.Input[Sequence[pulumi.Input['EphemeralContainerPatchArgsDict']]]]
+        """
+        List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing pod to perform user-initiated actions such as debugging. This list cannot be specified when creating a pod, and it cannot be modified by updating the pod spec. In order to add an ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource.
+        """
+        host_aliases: NotRequired[pulumi.Input[Sequence[pulumi.Input['HostAliasPatchArgsDict']]]]
+        """
+        HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+        """
+        host_ipc: NotRequired[pulumi.Input[bool]]
+        """
+        Use the host's ipc namespace. Optional: Default to false.
+        """
+        host_network: NotRequired[pulumi.Input[bool]]
+        """
+        Host networking requested for this pod. Use the host's network namespace. If this option is set, the ports that will be used must be specified. Default to false.
+        """
+        host_pid: NotRequired[pulumi.Input[bool]]
+        """
+        Use the host's pid namespace. Optional: Default to false.
+        """
+        host_users: NotRequired[pulumi.Input[bool]]
+        """
+        Use the host's user namespace. Optional: Default to true. If set to true or not present, the pod will be run in the host user namespace, useful for when the pod needs a feature only available to the host user namespace, such as loading a kernel module with CAP_SYS_MODULE. When set to false, a new userns is created for the pod. Setting false is useful for mitigating container breakout vulnerabilities even allowing users to run their containers as root without actually having root privileges on the host. This field is alpha-level and is only honored by servers that enable the UserNamespacesSupport feature.
+        """
+        hostname: NotRequired[pulumi.Input[str]]
+        """
+        Specifies the hostname of the Pod If not specified, the pod's hostname will be set to a system-defined value.
+        """
+        image_pull_secrets: NotRequired[pulumi.Input[Sequence[pulumi.Input['LocalObjectReferencePatchArgsDict']]]]
+        """
+        ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+        """
+        init_containers: NotRequired[pulumi.Input[Sequence[pulumi.Input['ContainerPatchArgsDict']]]]
+        """
+        List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+        """
+        node_name: NotRequired[pulumi.Input[str]]
+        """
+        NodeName is a request to schedule this pod onto a specific node. If it is non-empty, the scheduler simply schedules this pod onto that node, assuming that it fits resource requirements.
+        """
+        node_selector: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+        """
+        os: NotRequired[pulumi.Input['PodOSPatchArgsDict']]
+        """
+        Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set.
+
+        If the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions
+
+        If the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers - spec.securityContext.appArmorProfile - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.appArmorProfile - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup
+        """
+        overhead: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md
+        """
+        preemption_policy: NotRequired[pulumi.Input[str]]
+        """
+        PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset.
+        """
+        priority: NotRequired[pulumi.Input[int]]
+        """
+        The priority value. Various system components use this field to find the priority of the pod. When Priority Admission Controller is enabled, it prevents users from setting this field. The admission controller populates this field from PriorityClassName. The higher the value, the higher the priority.
+        """
+        priority_class_name: NotRequired[pulumi.Input[str]]
+        """
+        If specified, indicates the pod's priority. "system-node-critical" and "system-cluster-critical" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.
+        """
+        readiness_gates: NotRequired[pulumi.Input[Sequence[pulumi.Input['PodReadinessGatePatchArgsDict']]]]
+        """
+        If specified, all readiness gates will be evaluated for pod readiness. A pod is ready when all its containers are ready AND all conditions specified in the readiness gates have status equal to "True" More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates
+        """
+        resource_claims: NotRequired[pulumi.Input[Sequence[pulumi.Input['PodResourceClaimPatchArgsDict']]]]
+        """
+        ResourceClaims defines which ResourceClaims must be allocated and reserved before the Pod is allowed to start. The resources will be made available to those containers which consume them by name.
+
+        This is an alpha field and requires enabling the DynamicResourceAllocation feature gate.
+
+        This field is immutable.
+        """
+        restart_policy: NotRequired[pulumi.Input[str]]
+        """
+        Restart policy for all containers within the pod. One of Always, OnFailure, Never. In some contexts, only a subset of those values may be permitted. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
+        """
+        runtime_class_name: NotRequired[pulumi.Input[str]]
+        """
+        RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class
+        """
+        scheduler_name: NotRequired[pulumi.Input[str]]
+        """
+        If specified, the pod will be dispatched by specified scheduler. If not specified, the pod will be dispatched by default scheduler.
+        """
+        scheduling_gates: NotRequired[pulumi.Input[Sequence[pulumi.Input['PodSchedulingGatePatchArgsDict']]]]
+        """
+        SchedulingGates is an opaque list of values that if specified will block scheduling the pod. If schedulingGates is not empty, the pod will stay in the SchedulingGated state and the scheduler will not attempt to schedule the pod.
+
+        SchedulingGates can only be set at pod creation time, and be removed only afterwards.
+        """
+        security_context: NotRequired[pulumi.Input['PodSecurityContextPatchArgsDict']]
+        """
+        SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty.  See type description for default values of each field.
+        """
+        service_account: NotRequired[pulumi.Input[str]]
+        """
+        DeprecatedServiceAccount is a deprecated alias for ServiceAccountName. Deprecated: Use serviceAccountName instead.
+        """
+        service_account_name: NotRequired[pulumi.Input[str]]
+        """
+        ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+        """
+        set_hostname_as_fqdn: NotRequired[pulumi.Input[bool]]
+        """
+        If true the pod's hostname will be configured as the pod's FQDN, rather than the leaf name (the default). In Linux containers, this means setting the FQDN in the hostname field of the kernel (the nodename field of struct utsname). In Windows containers, this means setting the registry value of hostname for the registry key HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters to FQDN. If a pod does not have FQDN, this has no effect. Default to false.
+        """
+        share_process_namespace: NotRequired[pulumi.Input[bool]]
+        """
+        Share a single process namespace between all of the containers in a pod. When this is set containers will be able to view and signal processes from other containers in the same pod, and the first process in each container will not be assigned PID 1. HostPID and ShareProcessNamespace cannot both be set. Optional: Default to false.
+        """
+        subdomain: NotRequired[pulumi.Input[str]]
+        """
+        If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>". If not specified, the pod will not have a domainname at all.
+        """
+        termination_grace_period_seconds: NotRequired[pulumi.Input[int]]
+        """
+        Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). If this value is nil, the default grace period will be used instead. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. Defaults to 30 seconds.
+        """
+        tolerations: NotRequired[pulumi.Input[Sequence[pulumi.Input['TolerationPatchArgsDict']]]]
+        """
+        If specified, the pod's tolerations.
+        """
+        topology_spread_constraints: NotRequired[pulumi.Input[Sequence[pulumi.Input['TopologySpreadConstraintPatchArgsDict']]]]
+        """
+        TopologySpreadConstraints describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints. All topologySpreadConstraints are ANDed.
+        """
+        volumes: NotRequired[pulumi.Input[Sequence[pulumi.Input['VolumePatchArgsDict']]]]
+        """
+        List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes
+        """
+elif False:
+    PodSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class PodSpecPatchArgs:
@@ -17711,6 +23807,180 @@ class PodSpecPatchArgs:
         pulumi.set(self, "volumes", value)
 
 
+if not MYPY:
+    class PodSpecArgsDict(TypedDict):
+        """
+        PodSpec is a description of a pod.
+        """
+        containers: pulumi.Input[Sequence[pulumi.Input['ContainerArgsDict']]]
+        """
+        List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated.
+        """
+        active_deadline_seconds: NotRequired[pulumi.Input[int]]
+        """
+        Optional duration in seconds the pod may be active on the node relative to StartTime before the system will actively try to mark it failed and kill associated containers. Value must be a positive integer.
+        """
+        affinity: NotRequired[pulumi.Input['AffinityArgsDict']]
+        """
+        If specified, the pod's scheduling constraints
+        """
+        automount_service_account_token: NotRequired[pulumi.Input[bool]]
+        """
+        AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.
+        """
+        dns_config: NotRequired[pulumi.Input['PodDNSConfigArgsDict']]
+        """
+        Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy.
+        """
+        dns_policy: NotRequired[pulumi.Input[str]]
+        """
+        Set DNS policy for the pod. Defaults to "ClusterFirst". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.
+        """
+        enable_service_links: NotRequired[pulumi.Input[bool]]
+        """
+        EnableServiceLinks indicates whether information about services should be injected into pod's environment variables, matching the syntax of Docker links. Optional: Defaults to true.
+        """
+        ephemeral_containers: NotRequired[pulumi.Input[Sequence[pulumi.Input['EphemeralContainerArgsDict']]]]
+        """
+        List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing pod to perform user-initiated actions such as debugging. This list cannot be specified when creating a pod, and it cannot be modified by updating the pod spec. In order to add an ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource.
+        """
+        host_aliases: NotRequired[pulumi.Input[Sequence[pulumi.Input['HostAliasArgsDict']]]]
+        """
+        HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified.
+        """
+        host_ipc: NotRequired[pulumi.Input[bool]]
+        """
+        Use the host's ipc namespace. Optional: Default to false.
+        """
+        host_network: NotRequired[pulumi.Input[bool]]
+        """
+        Host networking requested for this pod. Use the host's network namespace. If this option is set, the ports that will be used must be specified. Default to false.
+        """
+        host_pid: NotRequired[pulumi.Input[bool]]
+        """
+        Use the host's pid namespace. Optional: Default to false.
+        """
+        host_users: NotRequired[pulumi.Input[bool]]
+        """
+        Use the host's user namespace. Optional: Default to true. If set to true or not present, the pod will be run in the host user namespace, useful for when the pod needs a feature only available to the host user namespace, such as loading a kernel module with CAP_SYS_MODULE. When set to false, a new userns is created for the pod. Setting false is useful for mitigating container breakout vulnerabilities even allowing users to run their containers as root without actually having root privileges on the host. This field is alpha-level and is only honored by servers that enable the UserNamespacesSupport feature.
+        """
+        hostname: NotRequired[pulumi.Input[str]]
+        """
+        Specifies the hostname of the Pod If not specified, the pod's hostname will be set to a system-defined value.
+        """
+        image_pull_secrets: NotRequired[pulumi.Input[Sequence[pulumi.Input['LocalObjectReferenceArgsDict']]]]
+        """
+        ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+        """
+        init_containers: NotRequired[pulumi.Input[Sequence[pulumi.Input['ContainerArgsDict']]]]
+        """
+        List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+        """
+        node_name: NotRequired[pulumi.Input[str]]
+        """
+        NodeName is a request to schedule this pod onto a specific node. If it is non-empty, the scheduler simply schedules this pod onto that node, assuming that it fits resource requirements.
+        """
+        node_selector: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+        """
+        os: NotRequired[pulumi.Input['PodOSArgsDict']]
+        """
+        Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set.
+
+        If the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions
+
+        If the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers - spec.securityContext.appArmorProfile - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.appArmorProfile - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup
+        """
+        overhead: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md
+        """
+        preemption_policy: NotRequired[pulumi.Input[str]]
+        """
+        PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset.
+        """
+        priority: NotRequired[pulumi.Input[int]]
+        """
+        The priority value. Various system components use this field to find the priority of the pod. When Priority Admission Controller is enabled, it prevents users from setting this field. The admission controller populates this field from PriorityClassName. The higher the value, the higher the priority.
+        """
+        priority_class_name: NotRequired[pulumi.Input[str]]
+        """
+        If specified, indicates the pod's priority. "system-node-critical" and "system-cluster-critical" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.
+        """
+        readiness_gates: NotRequired[pulumi.Input[Sequence[pulumi.Input['PodReadinessGateArgsDict']]]]
+        """
+        If specified, all readiness gates will be evaluated for pod readiness. A pod is ready when all its containers are ready AND all conditions specified in the readiness gates have status equal to "True" More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates
+        """
+        resource_claims: NotRequired[pulumi.Input[Sequence[pulumi.Input['PodResourceClaimArgsDict']]]]
+        """
+        ResourceClaims defines which ResourceClaims must be allocated and reserved before the Pod is allowed to start. The resources will be made available to those containers which consume them by name.
+
+        This is an alpha field and requires enabling the DynamicResourceAllocation feature gate.
+
+        This field is immutable.
+        """
+        restart_policy: NotRequired[pulumi.Input[str]]
+        """
+        Restart policy for all containers within the pod. One of Always, OnFailure, Never. In some contexts, only a subset of those values may be permitted. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
+        """
+        runtime_class_name: NotRequired[pulumi.Input[str]]
+        """
+        RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class
+        """
+        scheduler_name: NotRequired[pulumi.Input[str]]
+        """
+        If specified, the pod will be dispatched by specified scheduler. If not specified, the pod will be dispatched by default scheduler.
+        """
+        scheduling_gates: NotRequired[pulumi.Input[Sequence[pulumi.Input['PodSchedulingGateArgsDict']]]]
+        """
+        SchedulingGates is an opaque list of values that if specified will block scheduling the pod. If schedulingGates is not empty, the pod will stay in the SchedulingGated state and the scheduler will not attempt to schedule the pod.
+
+        SchedulingGates can only be set at pod creation time, and be removed only afterwards.
+        """
+        security_context: NotRequired[pulumi.Input['PodSecurityContextArgsDict']]
+        """
+        SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty.  See type description for default values of each field.
+        """
+        service_account: NotRequired[pulumi.Input[str]]
+        """
+        DeprecatedServiceAccount is a deprecated alias for ServiceAccountName. Deprecated: Use serviceAccountName instead.
+        """
+        service_account_name: NotRequired[pulumi.Input[str]]
+        """
+        ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+        """
+        set_hostname_as_fqdn: NotRequired[pulumi.Input[bool]]
+        """
+        If true the pod's hostname will be configured as the pod's FQDN, rather than the leaf name (the default). In Linux containers, this means setting the FQDN in the hostname field of the kernel (the nodename field of struct utsname). In Windows containers, this means setting the registry value of hostname for the registry key HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters to FQDN. If a pod does not have FQDN, this has no effect. Default to false.
+        """
+        share_process_namespace: NotRequired[pulumi.Input[bool]]
+        """
+        Share a single process namespace between all of the containers in a pod. When this is set containers will be able to view and signal processes from other containers in the same pod, and the first process in each container will not be assigned PID 1. HostPID and ShareProcessNamespace cannot both be set. Optional: Default to false.
+        """
+        subdomain: NotRequired[pulumi.Input[str]]
+        """
+        If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>". If not specified, the pod will not have a domainname at all.
+        """
+        termination_grace_period_seconds: NotRequired[pulumi.Input[int]]
+        """
+        Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). If this value is nil, the default grace period will be used instead. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. Defaults to 30 seconds.
+        """
+        tolerations: NotRequired[pulumi.Input[Sequence[pulumi.Input['TolerationArgsDict']]]]
+        """
+        If specified, the pod's tolerations.
+        """
+        topology_spread_constraints: NotRequired[pulumi.Input[Sequence[pulumi.Input['TopologySpreadConstraintArgsDict']]]]
+        """
+        TopologySpreadConstraints describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints. All topologySpreadConstraints are ANDed.
+        """
+        volumes: NotRequired[pulumi.Input[Sequence[pulumi.Input['VolumeArgsDict']]]]
+        """
+        List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes
+        """
+elif False:
+    PodSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PodSpecArgs:
     def __init__(__self__, *,
@@ -18362,6 +24632,82 @@ class PodSpecArgs:
         pulumi.set(self, "volumes", value)
 
 
+if not MYPY:
+    class PodStatusArgsDict(TypedDict):
+        """
+        PodStatus represents information about the status of a pod. Status may trail the actual state of a system, especially if the node that hosts the pod cannot contact the control plane.
+        """
+        conditions: NotRequired[pulumi.Input[Sequence[pulumi.Input['PodConditionArgsDict']]]]
+        """
+        Current service state of pod. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions
+        """
+        container_statuses: NotRequired[pulumi.Input[Sequence[pulumi.Input['ContainerStatusArgsDict']]]]
+        """
+        The list has one entry per container in the manifest. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-and-container-status
+        """
+        ephemeral_container_statuses: NotRequired[pulumi.Input[Sequence[pulumi.Input['ContainerStatusArgsDict']]]]
+        """
+        Status for any ephemeral containers that have run in this pod.
+        """
+        host_ip: NotRequired[pulumi.Input[str]]
+        """
+        hostIP holds the IP address of the host to which the pod is assigned. Empty if the pod has not started yet. A pod can be assigned to a node that has a problem in kubelet which in turns mean that HostIP will not be updated even if there is a node is assigned to pod
+        """
+        host_ips: NotRequired[pulumi.Input[Sequence[pulumi.Input['HostIPArgsDict']]]]
+        """
+        hostIPs holds the IP addresses allocated to the host. If this field is specified, the first entry must match the hostIP field. This list is empty if the pod has not started yet. A pod can be assigned to a node that has a problem in kubelet which in turns means that HostIPs will not be updated even if there is a node is assigned to this pod.
+        """
+        init_container_statuses: NotRequired[pulumi.Input[Sequence[pulumi.Input['ContainerStatusArgsDict']]]]
+        """
+        The list has one entry per init container in the manifest. The most recent successful init container will have ready = true, the most recently started container will have startTime set. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-and-container-status
+        """
+        message: NotRequired[pulumi.Input[str]]
+        """
+        A human readable message indicating details about why the pod is in this condition.
+        """
+        nominated_node_name: NotRequired[pulumi.Input[str]]
+        """
+        nominatedNodeName is set only when this pod preempts other pods on the node, but it cannot be scheduled right away as preemption victims receive their graceful termination periods. This field does not guarantee that the pod will be scheduled on this node. Scheduler may decide to place the pod elsewhere if other nodes become available sooner. Scheduler may also decide to give the resources on this node to a higher priority pod that is created after preemption. As a result, this field may be different than PodSpec.nodeName when the pod is scheduled.
+        """
+        phase: NotRequired[pulumi.Input[str]]
+        """
+        The phase of a Pod is a simple, high-level summary of where the Pod is in its lifecycle. The conditions array, the reason and message fields, and the individual container status arrays contain more detail about the pod's status. There are five possible phase values:
+
+        Pending: The pod has been accepted by the Kubernetes system, but one or more of the container images has not been created. This includes time before being scheduled as well as time spent downloading images over the network, which could take a while. Running: The pod has been bound to a node, and all of the containers have been created. At least one container is still running, or is in the process of starting or restarting. Succeeded: All containers in the pod have terminated in success, and will not be restarted. Failed: All containers in the pod have terminated, and at least one container has terminated in failure. The container either exited with non-zero status or was terminated by the system. Unknown: For some reason the state of the pod could not be obtained, typically due to an error in communicating with the host of the pod.
+
+        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-phase
+        """
+        pod_ip: NotRequired[pulumi.Input[str]]
+        """
+        podIP address allocated to the pod. Routable at least within the cluster. Empty if not yet allocated.
+        """
+        pod_ips: NotRequired[pulumi.Input[Sequence[pulumi.Input['PodIPArgsDict']]]]
+        """
+        podIPs holds the IP addresses allocated to the pod. If this field is specified, the 0th entry must match the podIP field. Pods may be allocated at most 1 value for each of IPv4 and IPv6. This list is empty if no IPs have been allocated yet.
+        """
+        qos_class: NotRequired[pulumi.Input[str]]
+        """
+        The Quality of Service (QOS) classification assigned to the pod based on resource requirements See PodQOSClass type for available QOS classes More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-qos/#quality-of-service-classes
+        """
+        reason: NotRequired[pulumi.Input[str]]
+        """
+        A brief CamelCase message indicating details about why the pod is in this state. e.g. 'Evicted'
+        """
+        resize: NotRequired[pulumi.Input[str]]
+        """
+        Status of resources resize desired for pod's containers. It is empty if no resources resize is pending. Any changes to container resources will automatically set this to "Proposed"
+        """
+        resource_claim_statuses: NotRequired[pulumi.Input[Sequence[pulumi.Input['PodResourceClaimStatusArgsDict']]]]
+        """
+        Status of resource claims.
+        """
+        start_time: NotRequired[pulumi.Input[str]]
+        """
+        RFC 3339 date and time at which the object was acknowledged by the Kubelet. This is before the Kubelet pulled the container image(s) for the pod.
+        """
+elif False:
+    PodStatusArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PodStatusArgs:
     def __init__(__self__, *,
@@ -18634,6 +24980,22 @@ class PodStatusArgs:
         pulumi.set(self, "start_time", value)
 
 
+if not MYPY:
+    class PodTemplateSpecPatchArgsDict(TypedDict):
+        """
+        PodTemplateSpec describes the data a pod should have when created from a template
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaPatchArgsDict']]
+        """
+        Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['PodSpecPatchArgsDict']]
+        """
+        Specification of the desired behavior of the pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+elif False:
+    PodTemplateSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PodTemplateSpecPatchArgs:
     def __init__(__self__, *,
@@ -18674,6 +25036,22 @@ class PodTemplateSpecPatchArgs:
         pulumi.set(self, "spec", value)
 
 
+if not MYPY:
+    class PodTemplateSpecArgsDict(TypedDict):
+        """
+        PodTemplateSpec describes the data a pod should have when created from a template
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['PodSpecArgsDict']]
+        """
+        Specification of the desired behavior of the pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+elif False:
+    PodTemplateSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PodTemplateSpecArgs:
     def __init__(__self__, *,
@@ -18713,6 +25091,30 @@ class PodTemplateSpecArgs:
     def spec(self, value: Optional[pulumi.Input['PodSpecArgs']]):
         pulumi.set(self, "spec", value)
 
+
+if not MYPY:
+    class PodTemplateArgsDict(TypedDict):
+        """
+        PodTemplate describes a template for creating copies of a predefined pod.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        template: NotRequired[pulumi.Input['PodTemplateSpecArgsDict']]
+        """
+        Template defines the pods that will be created from this pod template. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+elif False:
+    PodTemplateArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class PodTemplateArgs:
@@ -18785,6 +25187,49 @@ class PodTemplateArgs:
     def template(self, value: Optional[pulumi.Input['PodTemplateSpecArgs']]):
         pulumi.set(self, "template", value)
 
+
+if not MYPY:
+    class PodArgsDict(TypedDict):
+        """
+        Pod is a collection of containers that can run on a host. This resource is created by clients and scheduled onto hosts.
+
+        This resource waits until its status is ready before registering success
+        for create/update, and populating output properties from the current state of the resource.
+        The following conditions are used to determine whether the resource creation has
+        succeeded or failed:
+
+        1. The Pod is scheduled ("PodScheduled"" '.status.condition' is true).
+        2. The Pod is initialized ("Initialized" '.status.condition' is true).
+        3. The Pod is ready ("Ready" '.status.condition' is true) and the '.status.phase' is
+           set to "Running".
+        Or (for Jobs): The Pod succeeded ('.status.phase' set to "Succeeded").
+
+        If the Pod has not reached a Ready state after 10 minutes, it will
+        time out and mark the resource update as Failed. You can override the default timeout value
+        by setting the 'customTimeouts' option on the resource.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['PodSpecArgsDict']]
+        """
+        Specification of the desired behavior of the pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+        status: NotRequired[pulumi.Input['PodStatusArgsDict']]
+        """
+        Most recently observed status of the pod. This data may not be up to date. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+elif False:
+    PodArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class PodArgs:
@@ -18889,6 +25334,26 @@ class PodArgs:
         pulumi.set(self, "status", value)
 
 
+if not MYPY:
+    class PortStatusArgsDict(TypedDict):
+        port: pulumi.Input[int]
+        """
+        Port is the port number of the service port of which status is recorded here
+        """
+        protocol: pulumi.Input[str]
+        """
+        Protocol is the protocol of the service port of which status is recorded here The supported values are: "TCP", "UDP", "SCTP"
+        """
+        error: NotRequired[pulumi.Input[str]]
+        """
+        Error is to record the problem with the service port The format of the error shall comply with the following rules: - built-in error values shall be specified in this file and those shall use
+          CamelCase names
+        - cloud provider specific error values must have names that comply with the
+          format foo.example.com/CamelCase.
+        """
+elif False:
+    PortStatusArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PortStatusArgs:
     def __init__(__self__, *,
@@ -18948,6 +25413,26 @@ class PortStatusArgs:
         pulumi.set(self, "error", value)
 
 
+if not MYPY:
+    class PortworxVolumeSourcePatchArgsDict(TypedDict):
+        """
+        PortworxVolumeSource represents a Portworx volume resource.
+        """
+        fs_type: NotRequired[pulumi.Input[str]]
+        """
+        fSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+        """
+        volume_id: NotRequired[pulumi.Input[str]]
+        """
+        volumeID uniquely identifies a Portworx volume
+        """
+elif False:
+    PortworxVolumeSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PortworxVolumeSourcePatchArgs:
     def __init__(__self__, *,
@@ -19004,6 +25489,26 @@ class PortworxVolumeSourcePatchArgs:
         pulumi.set(self, "volume_id", value)
 
 
+if not MYPY:
+    class PortworxVolumeSourceArgsDict(TypedDict):
+        """
+        PortworxVolumeSource represents a Portworx volume resource.
+        """
+        volume_id: pulumi.Input[str]
+        """
+        volumeID uniquely identifies a Portworx volume
+        """
+        fs_type: NotRequired[pulumi.Input[str]]
+        """
+        fSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+        """
+elif False:
+    PortworxVolumeSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PortworxVolumeSourceArgs:
     def __init__(__self__, *,
@@ -19059,6 +25564,22 @@ class PortworxVolumeSourceArgs:
         pulumi.set(self, "read_only", value)
 
 
+if not MYPY:
+    class PreferredSchedulingTermPatchArgsDict(TypedDict):
+        """
+        An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+        """
+        preference: NotRequired[pulumi.Input['NodeSelectorTermPatchArgsDict']]
+        """
+        A node selector term, associated with the corresponding weight.
+        """
+        weight: NotRequired[pulumi.Input[int]]
+        """
+        Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+        """
+elif False:
+    PreferredSchedulingTermPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PreferredSchedulingTermPatchArgs:
     def __init__(__self__, *,
@@ -19099,6 +25620,22 @@ class PreferredSchedulingTermPatchArgs:
         pulumi.set(self, "weight", value)
 
 
+if not MYPY:
+    class PreferredSchedulingTermArgsDict(TypedDict):
+        """
+        An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+        """
+        preference: pulumi.Input['NodeSelectorTermArgsDict']
+        """
+        A node selector term, associated with the corresponding weight.
+        """
+        weight: pulumi.Input[int]
+        """
+        Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+        """
+elif False:
+    PreferredSchedulingTermArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PreferredSchedulingTermArgs:
     def __init__(__self__, *,
@@ -19136,6 +25673,54 @@ class PreferredSchedulingTermArgs:
     def weight(self, value: pulumi.Input[int]):
         pulumi.set(self, "weight", value)
 
+
+if not MYPY:
+    class ProbePatchArgsDict(TypedDict):
+        """
+        Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.
+        """
+        exec_: NotRequired[pulumi.Input['ExecActionPatchArgsDict']]
+        """
+        Exec specifies the action to take.
+        """
+        failure_threshold: NotRequired[pulumi.Input[int]]
+        """
+        Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+        """
+        grpc: NotRequired[pulumi.Input['GRPCActionPatchArgsDict']]
+        """
+        GRPC specifies an action involving a GRPC port.
+        """
+        http_get: NotRequired[pulumi.Input['HTTPGetActionPatchArgsDict']]
+        """
+        HTTPGet specifies the http request to perform.
+        """
+        initial_delay_seconds: NotRequired[pulumi.Input[int]]
+        """
+        Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+        """
+        period_seconds: NotRequired[pulumi.Input[int]]
+        """
+        How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+        """
+        success_threshold: NotRequired[pulumi.Input[int]]
+        """
+        Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+        """
+        tcp_socket: NotRequired[pulumi.Input['TCPSocketActionPatchArgsDict']]
+        """
+        TCPSocket specifies an action involving a TCP port.
+        """
+        termination_grace_period_seconds: NotRequired[pulumi.Input[int]]
+        """
+        Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+        """
+        timeout_seconds: NotRequired[pulumi.Input[int]]
+        """
+        Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+        """
+elif False:
+    ProbePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ProbePatchArgs:
@@ -19305,6 +25890,54 @@ class ProbePatchArgs:
         pulumi.set(self, "timeout_seconds", value)
 
 
+if not MYPY:
+    class ProbeArgsDict(TypedDict):
+        """
+        Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.
+        """
+        exec_: NotRequired[pulumi.Input['ExecActionArgsDict']]
+        """
+        Exec specifies the action to take.
+        """
+        failure_threshold: NotRequired[pulumi.Input[int]]
+        """
+        Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+        """
+        grpc: NotRequired[pulumi.Input['GRPCActionArgsDict']]
+        """
+        GRPC specifies an action involving a GRPC port.
+        """
+        http_get: NotRequired[pulumi.Input['HTTPGetActionArgsDict']]
+        """
+        HTTPGet specifies the http request to perform.
+        """
+        initial_delay_seconds: NotRequired[pulumi.Input[int]]
+        """
+        Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+        """
+        period_seconds: NotRequired[pulumi.Input[int]]
+        """
+        How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+        """
+        success_threshold: NotRequired[pulumi.Input[int]]
+        """
+        Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+        """
+        tcp_socket: NotRequired[pulumi.Input['TCPSocketActionArgsDict']]
+        """
+        TCPSocket specifies an action involving a TCP port.
+        """
+        termination_grace_period_seconds: NotRequired[pulumi.Input[int]]
+        """
+        Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+        """
+        timeout_seconds: NotRequired[pulumi.Input[int]]
+        """
+        Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+        """
+elif False:
+    ProbeArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ProbeArgs:
     def __init__(__self__, *,
@@ -19473,6 +26106,22 @@ class ProbeArgs:
         pulumi.set(self, "timeout_seconds", value)
 
 
+if not MYPY:
+    class ProjectedVolumeSourcePatchArgsDict(TypedDict):
+        """
+        Represents a projected volume source
+        """
+        default_mode: NotRequired[pulumi.Input[int]]
+        """
+        defaultMode are the mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+        """
+        sources: NotRequired[pulumi.Input[Sequence[pulumi.Input['VolumeProjectionPatchArgsDict']]]]
+        """
+        sources is the list of volume projections
+        """
+elif False:
+    ProjectedVolumeSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ProjectedVolumeSourcePatchArgs:
     def __init__(__self__, *,
@@ -19513,6 +26162,22 @@ class ProjectedVolumeSourcePatchArgs:
         pulumi.set(self, "sources", value)
 
 
+if not MYPY:
+    class ProjectedVolumeSourceArgsDict(TypedDict):
+        """
+        Represents a projected volume source
+        """
+        sources: pulumi.Input[Sequence[pulumi.Input['VolumeProjectionArgsDict']]]
+        """
+        sources is the list of volume projections
+        """
+        default_mode: NotRequired[pulumi.Input[int]]
+        """
+        defaultMode are the mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+        """
+elif False:
+    ProjectedVolumeSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ProjectedVolumeSourceArgs:
     def __init__(__self__, *,
@@ -19551,6 +26216,38 @@ class ProjectedVolumeSourceArgs:
     def default_mode(self, value: Optional[pulumi.Input[int]]):
         pulumi.set(self, "default_mode", value)
 
+
+if not MYPY:
+    class QuobyteVolumeSourcePatchArgsDict(TypedDict):
+        """
+        Represents a Quobyte mount that lasts the lifetime of a pod. Quobyte volumes do not support ownership management or SELinux relabeling.
+        """
+        group: NotRequired[pulumi.Input[str]]
+        """
+        group to map volume access to Default is no group
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        readOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.
+        """
+        registry: NotRequired[pulumi.Input[str]]
+        """
+        registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes
+        """
+        tenant: NotRequired[pulumi.Input[str]]
+        """
+        tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin
+        """
+        user: NotRequired[pulumi.Input[str]]
+        """
+        user to map volume access to Defaults to serivceaccount user
+        """
+        volume: NotRequired[pulumi.Input[str]]
+        """
+        volume is a string that references an already created Quobyte volume by name.
+        """
+elif False:
+    QuobyteVolumeSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class QuobyteVolumeSourcePatchArgs:
@@ -19656,6 +26353,38 @@ class QuobyteVolumeSourcePatchArgs:
         pulumi.set(self, "volume", value)
 
 
+if not MYPY:
+    class QuobyteVolumeSourceArgsDict(TypedDict):
+        """
+        Represents a Quobyte mount that lasts the lifetime of a pod. Quobyte volumes do not support ownership management or SELinux relabeling.
+        """
+        registry: pulumi.Input[str]
+        """
+        registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes
+        """
+        volume: pulumi.Input[str]
+        """
+        volume is a string that references an already created Quobyte volume by name.
+        """
+        group: NotRequired[pulumi.Input[str]]
+        """
+        group to map volume access to Default is no group
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        readOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.
+        """
+        tenant: NotRequired[pulumi.Input[str]]
+        """
+        tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin
+        """
+        user: NotRequired[pulumi.Input[str]]
+        """
+        user to map volume access to Defaults to serivceaccount user
+        """
+elif False:
+    QuobyteVolumeSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class QuobyteVolumeSourceArgs:
     def __init__(__self__, *,
@@ -19757,6 +26486,46 @@ class QuobyteVolumeSourceArgs:
     def user(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "user", value)
 
+
+if not MYPY:
+    class RBDPersistentVolumeSourcePatchArgsDict(TypedDict):
+        """
+        Represents a Rados Block Device mount that lasts the lifetime of a pod. RBD volumes support ownership management and SELinux relabeling.
+        """
+        fs_type: NotRequired[pulumi.Input[str]]
+        """
+        fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+        """
+        image: NotRequired[pulumi.Input[str]]
+        """
+        image is the rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+        """
+        keyring: NotRequired[pulumi.Input[str]]
+        """
+        keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+        """
+        monitors: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+        """
+        pool: NotRequired[pulumi.Input[str]]
+        """
+        pool is the rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+        """
+        secret_ref: NotRequired[pulumi.Input['SecretReferencePatchArgsDict']]
+        """
+        secretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+        """
+        user: NotRequired[pulumi.Input[str]]
+        """
+        user is the rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+        """
+elif False:
+    RBDPersistentVolumeSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class RBDPersistentVolumeSourcePatchArgs:
@@ -19894,6 +26663,46 @@ class RBDPersistentVolumeSourcePatchArgs:
         pulumi.set(self, "user", value)
 
 
+if not MYPY:
+    class RBDPersistentVolumeSourceArgsDict(TypedDict):
+        """
+        Represents a Rados Block Device mount that lasts the lifetime of a pod. RBD volumes support ownership management and SELinux relabeling.
+        """
+        image: pulumi.Input[str]
+        """
+        image is the rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+        """
+        monitors: pulumi.Input[Sequence[pulumi.Input[str]]]
+        """
+        monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+        """
+        fs_type: NotRequired[pulumi.Input[str]]
+        """
+        fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+        """
+        keyring: NotRequired[pulumi.Input[str]]
+        """
+        keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+        """
+        pool: NotRequired[pulumi.Input[str]]
+        """
+        pool is the rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+        """
+        secret_ref: NotRequired[pulumi.Input['SecretReferenceArgsDict']]
+        """
+        secretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+        """
+        user: NotRequired[pulumi.Input[str]]
+        """
+        user is the rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+        """
+elif False:
+    RBDPersistentVolumeSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class RBDPersistentVolumeSourceArgs:
     def __init__(__self__, *,
@@ -20027,6 +26836,46 @@ class RBDPersistentVolumeSourceArgs:
     def user(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "user", value)
 
+
+if not MYPY:
+    class RBDVolumeSourcePatchArgsDict(TypedDict):
+        """
+        Represents a Rados Block Device mount that lasts the lifetime of a pod. RBD volumes support ownership management and SELinux relabeling.
+        """
+        fs_type: NotRequired[pulumi.Input[str]]
+        """
+        fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+        """
+        image: NotRequired[pulumi.Input[str]]
+        """
+        image is the rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+        """
+        keyring: NotRequired[pulumi.Input[str]]
+        """
+        keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+        """
+        monitors: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+        """
+        pool: NotRequired[pulumi.Input[str]]
+        """
+        pool is the rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+        """
+        secret_ref: NotRequired[pulumi.Input['LocalObjectReferencePatchArgsDict']]
+        """
+        secretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+        """
+        user: NotRequired[pulumi.Input[str]]
+        """
+        user is the rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+        """
+elif False:
+    RBDVolumeSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class RBDVolumeSourcePatchArgs:
@@ -20164,6 +27013,46 @@ class RBDVolumeSourcePatchArgs:
         pulumi.set(self, "user", value)
 
 
+if not MYPY:
+    class RBDVolumeSourceArgsDict(TypedDict):
+        """
+        Represents a Rados Block Device mount that lasts the lifetime of a pod. RBD volumes support ownership management and SELinux relabeling.
+        """
+        image: pulumi.Input[str]
+        """
+        image is the rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+        """
+        monitors: pulumi.Input[Sequence[pulumi.Input[str]]]
+        """
+        monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+        """
+        fs_type: NotRequired[pulumi.Input[str]]
+        """
+        fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+        """
+        keyring: NotRequired[pulumi.Input[str]]
+        """
+        keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+        """
+        pool: NotRequired[pulumi.Input[str]]
+        """
+        pool is the rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+        """
+        secret_ref: NotRequired[pulumi.Input['LocalObjectReferenceArgsDict']]
+        """
+        secretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+        """
+        user: NotRequired[pulumi.Input[str]]
+        """
+        user is the rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+        """
+elif False:
+    RBDVolumeSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class RBDVolumeSourceArgs:
     def __init__(__self__, *,
@@ -20298,6 +27187,34 @@ class RBDVolumeSourceArgs:
         pulumi.set(self, "user", value)
 
 
+if not MYPY:
+    class ReplicationControllerConditionArgsDict(TypedDict):
+        """
+        ReplicationControllerCondition describes the state of a replication controller at a certain point.
+        """
+        status: pulumi.Input[str]
+        """
+        Status of the condition, one of True, False, Unknown.
+        """
+        type: pulumi.Input[str]
+        """
+        Type of replication controller condition.
+        """
+        last_transition_time: NotRequired[pulumi.Input[str]]
+        """
+        The last time the condition transitioned from one status to another.
+        """
+        message: NotRequired[pulumi.Input[str]]
+        """
+        A human readable message indicating details about the transition.
+        """
+        reason: NotRequired[pulumi.Input[str]]
+        """
+        The reason for the condition's last transition.
+        """
+elif False:
+    ReplicationControllerConditionArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ReplicationControllerConditionArgs:
     def __init__(__self__, *,
@@ -20384,6 +27301,30 @@ class ReplicationControllerConditionArgs:
         pulumi.set(self, "reason", value)
 
 
+if not MYPY:
+    class ReplicationControllerSpecPatchArgsDict(TypedDict):
+        """
+        ReplicationControllerSpec is the specification of a replication controller.
+        """
+        min_ready_seconds: NotRequired[pulumi.Input[int]]
+        """
+        Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)
+        """
+        replicas: NotRequired[pulumi.Input[int]]
+        """
+        Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#what-is-a-replicationcontroller
+        """
+        selector: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        Selector is a label query over pods that should match the Replicas count. If Selector is empty, it is defaulted to the labels present on the Pod template. Label keys and values that must match in order to be controlled by this replication controller, if empty defaulted to labels on Pod template. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+        """
+        template: NotRequired[pulumi.Input['PodTemplateSpecPatchArgsDict']]
+        """
+        Template is the object that describes the pod that will be created if insufficient replicas are detected. This takes precedence over a TemplateRef. The only allowed template.spec.restartPolicy value is "Always". More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template
+        """
+elif False:
+    ReplicationControllerSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ReplicationControllerSpecPatchArgs:
     def __init__(__self__, *,
@@ -20456,6 +27397,30 @@ class ReplicationControllerSpecPatchArgs:
         pulumi.set(self, "template", value)
 
 
+if not MYPY:
+    class ReplicationControllerSpecArgsDict(TypedDict):
+        """
+        ReplicationControllerSpec is the specification of a replication controller.
+        """
+        min_ready_seconds: NotRequired[pulumi.Input[int]]
+        """
+        Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)
+        """
+        replicas: NotRequired[pulumi.Input[int]]
+        """
+        Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#what-is-a-replicationcontroller
+        """
+        selector: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        Selector is a label query over pods that should match the Replicas count. If Selector is empty, it is defaulted to the labels present on the Pod template. Label keys and values that must match in order to be controlled by this replication controller, if empty defaulted to labels on Pod template. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+        """
+        template: NotRequired[pulumi.Input['PodTemplateSpecArgsDict']]
+        """
+        Template is the object that describes the pod that will be created if insufficient replicas are detected. This takes precedence over a TemplateRef. The only allowed template.spec.restartPolicy value is "Always". More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template
+        """
+elif False:
+    ReplicationControllerSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ReplicationControllerSpecArgs:
     def __init__(__self__, *,
@@ -20527,6 +27492,38 @@ class ReplicationControllerSpecArgs:
     def template(self, value: Optional[pulumi.Input['PodTemplateSpecArgs']]):
         pulumi.set(self, "template", value)
 
+
+if not MYPY:
+    class ReplicationControllerStatusArgsDict(TypedDict):
+        """
+        ReplicationControllerStatus represents the current status of a replication controller.
+        """
+        replicas: pulumi.Input[int]
+        """
+        Replicas is the most recently observed number of replicas. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#what-is-a-replicationcontroller
+        """
+        available_replicas: NotRequired[pulumi.Input[int]]
+        """
+        The number of available replicas (ready for at least minReadySeconds) for this replication controller.
+        """
+        conditions: NotRequired[pulumi.Input[Sequence[pulumi.Input['ReplicationControllerConditionArgsDict']]]]
+        """
+        Represents the latest available observations of a replication controller's current state.
+        """
+        fully_labeled_replicas: NotRequired[pulumi.Input[int]]
+        """
+        The number of pods that have labels matching the labels of the pod template of the replication controller.
+        """
+        observed_generation: NotRequired[pulumi.Input[int]]
+        """
+        ObservedGeneration reflects the generation of the most recently observed replication controller.
+        """
+        ready_replicas: NotRequired[pulumi.Input[int]]
+        """
+        The number of ready replicas for this replication controller.
+        """
+elif False:
+    ReplicationControllerStatusArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ReplicationControllerStatusArgs:
@@ -20631,6 +27628,34 @@ class ReplicationControllerStatusArgs:
         pulumi.set(self, "ready_replicas", value)
 
 
+if not MYPY:
+    class ReplicationControllerArgsDict(TypedDict):
+        """
+        ReplicationController represents the configuration of a replication controller.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        If the Labels of a ReplicationController are empty, they are defaulted to be the same as the Pod(s) that the replication controller manages. Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['ReplicationControllerSpecArgsDict']]
+        """
+        Spec defines the specification of the desired behavior of the replication controller. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+        status: NotRequired[pulumi.Input['ReplicationControllerStatusArgsDict']]
+        """
+        Status is the most recently observed status of the replication controller. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+elif False:
+    ReplicationControllerArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ReplicationControllerArgs:
     def __init__(__self__, *,
@@ -20719,6 +27744,18 @@ class ReplicationControllerArgs:
         pulumi.set(self, "status", value)
 
 
+if not MYPY:
+    class ResourceClaimPatchArgsDict(TypedDict):
+        """
+        ResourceClaim references one entry in PodSpec.ResourceClaims.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.
+        """
+elif False:
+    ResourceClaimPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ResourceClaimPatchArgs:
     def __init__(__self__, *,
@@ -20743,6 +27780,18 @@ class ResourceClaimPatchArgs:
         pulumi.set(self, "name", value)
 
 
+if not MYPY:
+    class ResourceClaimArgsDict(TypedDict):
+        """
+        ResourceClaim references one entry in PodSpec.ResourceClaims.
+        """
+        name: pulumi.Input[str]
+        """
+        Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.
+        """
+elif False:
+    ResourceClaimArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ResourceClaimArgs:
     def __init__(__self__, *,
@@ -20765,6 +27814,26 @@ class ResourceClaimArgs:
     def name(self, value: pulumi.Input[str]):
         pulumi.set(self, "name", value)
 
+
+if not MYPY:
+    class ResourceFieldSelectorPatchArgsDict(TypedDict):
+        """
+        ResourceFieldSelector represents container resources (cpu, memory) and their output format
+        """
+        container_name: NotRequired[pulumi.Input[str]]
+        """
+        Container name: required for volumes, optional for env vars
+        """
+        divisor: NotRequired[pulumi.Input[str]]
+        """
+        Specifies the output format of the exposed resources, defaults to "1"
+        """
+        resource: NotRequired[pulumi.Input[str]]
+        """
+        Required: resource to select
+        """
+elif False:
+    ResourceFieldSelectorPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ResourceFieldSelectorPatchArgs:
@@ -20822,6 +27891,26 @@ class ResourceFieldSelectorPatchArgs:
         pulumi.set(self, "resource", value)
 
 
+if not MYPY:
+    class ResourceFieldSelectorArgsDict(TypedDict):
+        """
+        ResourceFieldSelector represents container resources (cpu, memory) and their output format
+        """
+        resource: pulumi.Input[str]
+        """
+        Required: resource to select
+        """
+        container_name: NotRequired[pulumi.Input[str]]
+        """
+        Container name: required for volumes, optional for env vars
+        """
+        divisor: NotRequired[pulumi.Input[str]]
+        """
+        Specifies the output format of the exposed resources, defaults to "1"
+        """
+elif False:
+    ResourceFieldSelectorArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ResourceFieldSelectorArgs:
     def __init__(__self__, *,
@@ -20876,6 +27965,26 @@ class ResourceFieldSelectorArgs:
     def divisor(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "divisor", value)
 
+
+if not MYPY:
+    class ResourceQuotaSpecPatchArgsDict(TypedDict):
+        """
+        ResourceQuotaSpec defines the desired hard limits to enforce for Quota.
+        """
+        hard: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        hard is the set of desired hard limits for each named resource. More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/
+        """
+        scope_selector: NotRequired[pulumi.Input['ScopeSelectorPatchArgsDict']]
+        """
+        scopeSelector is also a collection of filters like scopes that must match each object tracked by a quota but expressed using ScopeSelectorOperator in combination with possible values. For a resource to match, both scopes AND scopeSelector (if specified in spec), must be matched.
+        """
+        scopes: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        A collection of filters that must match each object tracked by a quota. If not specified, the quota matches all objects.
+        """
+elif False:
+    ResourceQuotaSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ResourceQuotaSpecPatchArgs:
@@ -20933,6 +28042,26 @@ class ResourceQuotaSpecPatchArgs:
         pulumi.set(self, "scopes", value)
 
 
+if not MYPY:
+    class ResourceQuotaSpecArgsDict(TypedDict):
+        """
+        ResourceQuotaSpec defines the desired hard limits to enforce for Quota.
+        """
+        hard: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        hard is the set of desired hard limits for each named resource. More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/
+        """
+        scope_selector: NotRequired[pulumi.Input['ScopeSelectorArgsDict']]
+        """
+        scopeSelector is also a collection of filters like scopes that must match each object tracked by a quota but expressed using ScopeSelectorOperator in combination with possible values. For a resource to match, both scopes AND scopeSelector (if specified in spec), must be matched.
+        """
+        scopes: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        A collection of filters that must match each object tracked by a quota. If not specified, the quota matches all objects.
+        """
+elif False:
+    ResourceQuotaSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ResourceQuotaSpecArgs:
     def __init__(__self__, *,
@@ -20989,6 +28118,22 @@ class ResourceQuotaSpecArgs:
         pulumi.set(self, "scopes", value)
 
 
+if not MYPY:
+    class ResourceQuotaStatusArgsDict(TypedDict):
+        """
+        ResourceQuotaStatus defines the enforced hard limits and observed use.
+        """
+        hard: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        Hard is the set of enforced hard limits for each named resource. More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/
+        """
+        used: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        Used is the current observed total usage of the resource in the namespace.
+        """
+elif False:
+    ResourceQuotaStatusArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ResourceQuotaStatusArgs:
     def __init__(__self__, *,
@@ -21028,6 +28173,34 @@ class ResourceQuotaStatusArgs:
     def used(self, value: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]):
         pulumi.set(self, "used", value)
 
+
+if not MYPY:
+    class ResourceQuotaArgsDict(TypedDict):
+        """
+        ResourceQuota sets aggregate quota restrictions enforced per namespace
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['ResourceQuotaSpecArgsDict']]
+        """
+        Spec defines the desired quota. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+        status: NotRequired[pulumi.Input['ResourceQuotaStatusArgsDict']]
+        """
+        Status defines the actual enforced quota and its current usage. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+elif False:
+    ResourceQuotaArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ResourceQuotaArgs:
@@ -21117,6 +28290,30 @@ class ResourceQuotaArgs:
         pulumi.set(self, "status", value)
 
 
+if not MYPY:
+    class ResourceRequirementsPatchArgsDict(TypedDict):
+        """
+        ResourceRequirements describes the compute resource requirements.
+        """
+        claims: NotRequired[pulumi.Input[Sequence[pulumi.Input['ResourceClaimPatchArgsDict']]]]
+        """
+        Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container.
+
+        This is an alpha field and requires enabling the DynamicResourceAllocation feature gate.
+
+        This field is immutable. It can only be set for containers.
+        """
+        limits: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+        """
+        requests: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+        """
+elif False:
+    ResourceRequirementsPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ResourceRequirementsPatchArgs:
     def __init__(__self__, *,
@@ -21181,6 +28378,30 @@ class ResourceRequirementsPatchArgs:
         pulumi.set(self, "requests", value)
 
 
+if not MYPY:
+    class ResourceRequirementsArgsDict(TypedDict):
+        """
+        ResourceRequirements describes the compute resource requirements.
+        """
+        claims: NotRequired[pulumi.Input[Sequence[pulumi.Input['ResourceClaimArgsDict']]]]
+        """
+        Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container.
+
+        This is an alpha field and requires enabling the DynamicResourceAllocation feature gate.
+
+        This field is immutable. It can only be set for containers.
+        """
+        limits: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+        """
+        requests: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+        """
+elif False:
+    ResourceRequirementsArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ResourceRequirementsArgs:
     def __init__(__self__, *,
@@ -21244,6 +28465,30 @@ class ResourceRequirementsArgs:
     def requests(self, value: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]):
         pulumi.set(self, "requests", value)
 
+
+if not MYPY:
+    class SELinuxOptionsPatchArgsDict(TypedDict):
+        """
+        SELinuxOptions are the labels to be applied to the container
+        """
+        level: NotRequired[pulumi.Input[str]]
+        """
+        Level is SELinux level label that applies to the container.
+        """
+        role: NotRequired[pulumi.Input[str]]
+        """
+        Role is a SELinux role label that applies to the container.
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        Type is a SELinux type label that applies to the container.
+        """
+        user: NotRequired[pulumi.Input[str]]
+        """
+        User is a SELinux user label that applies to the container.
+        """
+elif False:
+    SELinuxOptionsPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class SELinuxOptionsPatchArgs:
@@ -21317,6 +28562,30 @@ class SELinuxOptionsPatchArgs:
         pulumi.set(self, "user", value)
 
 
+if not MYPY:
+    class SELinuxOptionsArgsDict(TypedDict):
+        """
+        SELinuxOptions are the labels to be applied to the container
+        """
+        level: NotRequired[pulumi.Input[str]]
+        """
+        Level is SELinux level label that applies to the container.
+        """
+        role: NotRequired[pulumi.Input[str]]
+        """
+        Role is a SELinux role label that applies to the container.
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        Type is a SELinux type label that applies to the container.
+        """
+        user: NotRequired[pulumi.Input[str]]
+        """
+        User is a SELinux user label that applies to the container.
+        """
+elif False:
+    SELinuxOptionsArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class SELinuxOptionsArgs:
     def __init__(__self__, *,
@@ -21388,6 +28657,54 @@ class SELinuxOptionsArgs:
     def user(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "user", value)
 
+
+if not MYPY:
+    class ScaleIOPersistentVolumeSourcePatchArgsDict(TypedDict):
+        """
+        ScaleIOPersistentVolumeSource represents a persistent ScaleIO volume
+        """
+        fs_type: NotRequired[pulumi.Input[str]]
+        """
+        fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Default is "xfs"
+        """
+        gateway: NotRequired[pulumi.Input[str]]
+        """
+        gateway is the host address of the ScaleIO API Gateway.
+        """
+        protection_domain: NotRequired[pulumi.Input[str]]
+        """
+        protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+        """
+        secret_ref: NotRequired[pulumi.Input['SecretReferencePatchArgsDict']]
+        """
+        secretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.
+        """
+        ssl_enabled: NotRequired[pulumi.Input[bool]]
+        """
+        sslEnabled is the flag to enable/disable SSL communication with Gateway, default false
+        """
+        storage_mode: NotRequired[pulumi.Input[str]]
+        """
+        storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
+        """
+        storage_pool: NotRequired[pulumi.Input[str]]
+        """
+        storagePool is the ScaleIO Storage Pool associated with the protection domain.
+        """
+        system: NotRequired[pulumi.Input[str]]
+        """
+        system is the name of the storage system as configured in ScaleIO.
+        """
+        volume_name: NotRequired[pulumi.Input[str]]
+        """
+        volumeName is the name of a volume already created in the ScaleIO system that is associated with this volume source.
+        """
+elif False:
+    ScaleIOPersistentVolumeSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ScaleIOPersistentVolumeSourcePatchArgs:
@@ -21557,6 +28874,54 @@ class ScaleIOPersistentVolumeSourcePatchArgs:
         pulumi.set(self, "volume_name", value)
 
 
+if not MYPY:
+    class ScaleIOPersistentVolumeSourceArgsDict(TypedDict):
+        """
+        ScaleIOPersistentVolumeSource represents a persistent ScaleIO volume
+        """
+        gateway: pulumi.Input[str]
+        """
+        gateway is the host address of the ScaleIO API Gateway.
+        """
+        secret_ref: pulumi.Input['SecretReferenceArgsDict']
+        """
+        secretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.
+        """
+        system: pulumi.Input[str]
+        """
+        system is the name of the storage system as configured in ScaleIO.
+        """
+        fs_type: NotRequired[pulumi.Input[str]]
+        """
+        fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Default is "xfs"
+        """
+        protection_domain: NotRequired[pulumi.Input[str]]
+        """
+        protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+        """
+        ssl_enabled: NotRequired[pulumi.Input[bool]]
+        """
+        sslEnabled is the flag to enable/disable SSL communication with Gateway, default false
+        """
+        storage_mode: NotRequired[pulumi.Input[str]]
+        """
+        storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
+        """
+        storage_pool: NotRequired[pulumi.Input[str]]
+        """
+        storagePool is the ScaleIO Storage Pool associated with the protection domain.
+        """
+        volume_name: NotRequired[pulumi.Input[str]]
+        """
+        volumeName is the name of a volume already created in the ScaleIO system that is associated with this volume source.
+        """
+elif False:
+    ScaleIOPersistentVolumeSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ScaleIOPersistentVolumeSourceArgs:
     def __init__(__self__, *,
@@ -21721,6 +29086,54 @@ class ScaleIOPersistentVolumeSourceArgs:
     def volume_name(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "volume_name", value)
 
+
+if not MYPY:
+    class ScaleIOVolumeSourcePatchArgsDict(TypedDict):
+        """
+        ScaleIOVolumeSource represents a persistent ScaleIO volume
+        """
+        fs_type: NotRequired[pulumi.Input[str]]
+        """
+        fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".
+        """
+        gateway: NotRequired[pulumi.Input[str]]
+        """
+        gateway is the host address of the ScaleIO API Gateway.
+        """
+        protection_domain: NotRequired[pulumi.Input[str]]
+        """
+        protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+        """
+        secret_ref: NotRequired[pulumi.Input['LocalObjectReferencePatchArgsDict']]
+        """
+        secretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.
+        """
+        ssl_enabled: NotRequired[pulumi.Input[bool]]
+        """
+        sslEnabled Flag enable/disable SSL communication with Gateway, default false
+        """
+        storage_mode: NotRequired[pulumi.Input[str]]
+        """
+        storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
+        """
+        storage_pool: NotRequired[pulumi.Input[str]]
+        """
+        storagePool is the ScaleIO Storage Pool associated with the protection domain.
+        """
+        system: NotRequired[pulumi.Input[str]]
+        """
+        system is the name of the storage system as configured in ScaleIO.
+        """
+        volume_name: NotRequired[pulumi.Input[str]]
+        """
+        volumeName is the name of a volume already created in the ScaleIO system that is associated with this volume source.
+        """
+elif False:
+    ScaleIOVolumeSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ScaleIOVolumeSourcePatchArgs:
@@ -21890,6 +29303,54 @@ class ScaleIOVolumeSourcePatchArgs:
         pulumi.set(self, "volume_name", value)
 
 
+if not MYPY:
+    class ScaleIOVolumeSourceArgsDict(TypedDict):
+        """
+        ScaleIOVolumeSource represents a persistent ScaleIO volume
+        """
+        gateway: pulumi.Input[str]
+        """
+        gateway is the host address of the ScaleIO API Gateway.
+        """
+        secret_ref: pulumi.Input['LocalObjectReferenceArgsDict']
+        """
+        secretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.
+        """
+        system: pulumi.Input[str]
+        """
+        system is the name of the storage system as configured in ScaleIO.
+        """
+        fs_type: NotRequired[pulumi.Input[str]]
+        """
+        fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".
+        """
+        protection_domain: NotRequired[pulumi.Input[str]]
+        """
+        protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+        """
+        ssl_enabled: NotRequired[pulumi.Input[bool]]
+        """
+        sslEnabled Flag enable/disable SSL communication with Gateway, default false
+        """
+        storage_mode: NotRequired[pulumi.Input[str]]
+        """
+        storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
+        """
+        storage_pool: NotRequired[pulumi.Input[str]]
+        """
+        storagePool is the ScaleIO Storage Pool associated with the protection domain.
+        """
+        volume_name: NotRequired[pulumi.Input[str]]
+        """
+        volumeName is the name of a volume already created in the ScaleIO system that is associated with this volume source.
+        """
+elif False:
+    ScaleIOVolumeSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ScaleIOVolumeSourceArgs:
     def __init__(__self__, *,
@@ -22055,6 +29516,18 @@ class ScaleIOVolumeSourceArgs:
         pulumi.set(self, "volume_name", value)
 
 
+if not MYPY:
+    class ScopeSelectorPatchArgsDict(TypedDict):
+        """
+        A scope selector represents the AND of the selectors represented by the scoped-resource selector requirements.
+        """
+        match_expressions: NotRequired[pulumi.Input[Sequence[pulumi.Input['ScopedResourceSelectorRequirementPatchArgsDict']]]]
+        """
+        A list of scope selector requirements by scope of the resources.
+        """
+elif False:
+    ScopeSelectorPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ScopeSelectorPatchArgs:
     def __init__(__self__, *,
@@ -22079,6 +29552,18 @@ class ScopeSelectorPatchArgs:
         pulumi.set(self, "match_expressions", value)
 
 
+if not MYPY:
+    class ScopeSelectorArgsDict(TypedDict):
+        """
+        A scope selector represents the AND of the selectors represented by the scoped-resource selector requirements.
+        """
+        match_expressions: NotRequired[pulumi.Input[Sequence[pulumi.Input['ScopedResourceSelectorRequirementArgsDict']]]]
+        """
+        A list of scope selector requirements by scope of the resources.
+        """
+elif False:
+    ScopeSelectorArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ScopeSelectorArgs:
     def __init__(__self__, *,
@@ -22102,6 +29587,26 @@ class ScopeSelectorArgs:
     def match_expressions(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['ScopedResourceSelectorRequirementArgs']]]]):
         pulumi.set(self, "match_expressions", value)
 
+
+if not MYPY:
+    class ScopedResourceSelectorRequirementPatchArgsDict(TypedDict):
+        """
+        A scoped-resource selector requirement is a selector that contains values, a scope name, and an operator that relates the scope name and values.
+        """
+        operator: NotRequired[pulumi.Input[str]]
+        """
+        Represents a scope's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist.
+        """
+        scope_name: NotRequired[pulumi.Input[str]]
+        """
+        The name of the scope that the selector applies to.
+        """
+        values: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+        """
+elif False:
+    ScopedResourceSelectorRequirementPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ScopedResourceSelectorRequirementPatchArgs:
@@ -22159,6 +29664,26 @@ class ScopedResourceSelectorRequirementPatchArgs:
         pulumi.set(self, "values", value)
 
 
+if not MYPY:
+    class ScopedResourceSelectorRequirementArgsDict(TypedDict):
+        """
+        A scoped-resource selector requirement is a selector that contains values, a scope name, and an operator that relates the scope name and values.
+        """
+        operator: pulumi.Input[str]
+        """
+        Represents a scope's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist.
+        """
+        scope_name: pulumi.Input[str]
+        """
+        The name of the scope that the selector applies to.
+        """
+        values: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+        """
+elif False:
+    ScopedResourceSelectorRequirementArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ScopedResourceSelectorRequirementArgs:
     def __init__(__self__, *,
@@ -22213,6 +29738,24 @@ class ScopedResourceSelectorRequirementArgs:
         pulumi.set(self, "values", value)
 
 
+if not MYPY:
+    class SeccompProfilePatchArgsDict(TypedDict):
+        """
+        SeccompProfile defines a pod/container's seccomp profile settings. Only one profile source may be set.
+        """
+        localhost_profile: NotRequired[pulumi.Input[str]]
+        """
+        localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must be set if type is "Localhost". Must NOT be set for any other type.
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        type indicates which kind of seccomp profile will be applied. Valid options are:
+
+        Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+        """
+elif False:
+    SeccompProfilePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class SeccompProfilePatchArgs:
     def __init__(__self__, *,
@@ -22257,6 +29800,24 @@ class SeccompProfilePatchArgs:
         pulumi.set(self, "type", value)
 
 
+if not MYPY:
+    class SeccompProfileArgsDict(TypedDict):
+        """
+        SeccompProfile defines a pod/container's seccomp profile settings. Only one profile source may be set.
+        """
+        type: pulumi.Input[str]
+        """
+        type indicates which kind of seccomp profile will be applied. Valid options are:
+
+        Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+        """
+        localhost_profile: NotRequired[pulumi.Input[str]]
+        """
+        localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must be set if type is "Localhost". Must NOT be set for any other type.
+        """
+elif False:
+    SeccompProfileArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class SeccompProfileArgs:
     def __init__(__self__, *,
@@ -22300,6 +29861,24 @@ class SeccompProfileArgs:
         pulumi.set(self, "localhost_profile", value)
 
 
+if not MYPY:
+    class SecretEnvSourcePatchArgsDict(TypedDict):
+        """
+        SecretEnvSource selects a Secret to populate the environment variables with.
+
+        The contents of the target Secret's Data field will represent the key-value pairs as environment variables.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+        """
+        optional: NotRequired[pulumi.Input[bool]]
+        """
+        Specify whether the Secret must be defined
+        """
+elif False:
+    SecretEnvSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class SecretEnvSourcePatchArgs:
     def __init__(__self__, *,
@@ -22342,6 +29921,24 @@ class SecretEnvSourcePatchArgs:
         pulumi.set(self, "optional", value)
 
 
+if not MYPY:
+    class SecretEnvSourceArgsDict(TypedDict):
+        """
+        SecretEnvSource selects a Secret to populate the environment variables with.
+
+        The contents of the target Secret's Data field will represent the key-value pairs as environment variables.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+        """
+        optional: NotRequired[pulumi.Input[bool]]
+        """
+        Specify whether the Secret must be defined
+        """
+elif False:
+    SecretEnvSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class SecretEnvSourceArgs:
     def __init__(__self__, *,
@@ -22383,6 +29980,26 @@ class SecretEnvSourceArgs:
     def optional(self, value: Optional[pulumi.Input[bool]]):
         pulumi.set(self, "optional", value)
 
+
+if not MYPY:
+    class SecretKeySelectorPatchArgsDict(TypedDict):
+        """
+        SecretKeySelector selects a key of a Secret.
+        """
+        key: NotRequired[pulumi.Input[str]]
+        """
+        The key of the secret to select from.  Must be a valid secret key.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+        """
+        optional: NotRequired[pulumi.Input[bool]]
+        """
+        Specify whether the Secret or its key must be defined
+        """
+elif False:
+    SecretKeySelectorPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class SecretKeySelectorPatchArgs:
@@ -22440,6 +30057,26 @@ class SecretKeySelectorPatchArgs:
         pulumi.set(self, "optional", value)
 
 
+if not MYPY:
+    class SecretKeySelectorArgsDict(TypedDict):
+        """
+        SecretKeySelector selects a key of a Secret.
+        """
+        key: pulumi.Input[str]
+        """
+        The key of the secret to select from.  Must be a valid secret key.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+        """
+        optional: NotRequired[pulumi.Input[bool]]
+        """
+        Specify whether the Secret or its key must be defined
+        """
+elif False:
+    SecretKeySelectorArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class SecretKeySelectorArgs:
     def __init__(__self__, *,
@@ -22494,6 +30131,28 @@ class SecretKeySelectorArgs:
     def optional(self, value: Optional[pulumi.Input[bool]]):
         pulumi.set(self, "optional", value)
 
+
+if not MYPY:
+    class SecretProjectionPatchArgsDict(TypedDict):
+        """
+        Adapts a secret into a projected volume.
+
+        The contents of the target Secret's Data field will be presented in a projected volume as files using the keys in the Data field as the file names. Note that this is identical to a secret volume source without the default mode.
+        """
+        items: NotRequired[pulumi.Input[Sequence[pulumi.Input['KeyToPathPatchArgsDict']]]]
+        """
+        items if unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+        """
+        optional: NotRequired[pulumi.Input[bool]]
+        """
+        optional field specify whether the Secret or its key must be defined
+        """
+elif False:
+    SecretProjectionPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class SecretProjectionPatchArgs:
@@ -22553,6 +30212,28 @@ class SecretProjectionPatchArgs:
         pulumi.set(self, "optional", value)
 
 
+if not MYPY:
+    class SecretProjectionArgsDict(TypedDict):
+        """
+        Adapts a secret into a projected volume.
+
+        The contents of the target Secret's Data field will be presented in a projected volume as files using the keys in the Data field as the file names. Note that this is identical to a secret volume source without the default mode.
+        """
+        items: NotRequired[pulumi.Input[Sequence[pulumi.Input['KeyToPathArgsDict']]]]
+        """
+        items if unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+        """
+        optional: NotRequired[pulumi.Input[bool]]
+        """
+        optional field specify whether the Secret or its key must be defined
+        """
+elif False:
+    SecretProjectionArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class SecretProjectionArgs:
     def __init__(__self__, *,
@@ -22611,6 +30292,22 @@ class SecretProjectionArgs:
         pulumi.set(self, "optional", value)
 
 
+if not MYPY:
+    class SecretReferencePatchArgsDict(TypedDict):
+        """
+        SecretReference represents a Secret Reference. It has enough information to retrieve secret in any namespace
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        name is unique within a namespace to reference a secret resource.
+        """
+        namespace: NotRequired[pulumi.Input[str]]
+        """
+        namespace defines the space within which the secret name must be unique.
+        """
+elif False:
+    SecretReferencePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class SecretReferencePatchArgs:
     def __init__(__self__, *,
@@ -22651,6 +30348,22 @@ class SecretReferencePatchArgs:
         pulumi.set(self, "namespace", value)
 
 
+if not MYPY:
+    class SecretReferenceArgsDict(TypedDict):
+        """
+        SecretReference represents a Secret Reference. It has enough information to retrieve secret in any namespace
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        name is unique within a namespace to reference a secret resource.
+        """
+        namespace: NotRequired[pulumi.Input[str]]
+        """
+        namespace defines the space within which the secret name must be unique.
+        """
+elif False:
+    SecretReferenceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class SecretReferenceArgs:
     def __init__(__self__, *,
@@ -22690,6 +30403,32 @@ class SecretReferenceArgs:
     def namespace(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "namespace", value)
 
+
+if not MYPY:
+    class SecretVolumeSourcePatchArgsDict(TypedDict):
+        """
+        Adapts a Secret into a volume.
+
+        The contents of the target Secret's Data field will be presented in a volume as files using the keys in the Data field as the file names. Secret volumes support ownership management and SELinux relabeling.
+        """
+        default_mode: NotRequired[pulumi.Input[int]]
+        """
+        defaultMode is Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+        """
+        items: NotRequired[pulumi.Input[Sequence[pulumi.Input['KeyToPathPatchArgsDict']]]]
+        """
+        items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+        """
+        optional: NotRequired[pulumi.Input[bool]]
+        """
+        optional field specify whether the Secret or its keys must be defined
+        """
+        secret_name: NotRequired[pulumi.Input[str]]
+        """
+        secretName is the name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+        """
+elif False:
+    SecretVolumeSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class SecretVolumeSourcePatchArgs:
@@ -22765,6 +30504,32 @@ class SecretVolumeSourcePatchArgs:
         pulumi.set(self, "secret_name", value)
 
 
+if not MYPY:
+    class SecretVolumeSourceArgsDict(TypedDict):
+        """
+        Adapts a Secret into a volume.
+
+        The contents of the target Secret's Data field will be presented in a volume as files using the keys in the Data field as the file names. Secret volumes support ownership management and SELinux relabeling.
+        """
+        default_mode: NotRequired[pulumi.Input[int]]
+        """
+        defaultMode is Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+        """
+        items: NotRequired[pulumi.Input[Sequence[pulumi.Input['KeyToPathArgsDict']]]]
+        """
+        items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+        """
+        optional: NotRequired[pulumi.Input[bool]]
+        """
+        optional field specify whether the Secret or its keys must be defined
+        """
+        secret_name: NotRequired[pulumi.Input[str]]
+        """
+        secretName is the name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+        """
+elif False:
+    SecretVolumeSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class SecretVolumeSourceArgs:
     def __init__(__self__, *,
@@ -22838,6 +30603,52 @@ class SecretVolumeSourceArgs:
     def secret_name(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "secret_name", value)
 
+
+if not MYPY:
+    class SecretArgsDict(TypedDict):
+        """
+        Secret holds secret data of a certain type. The total bytes of the values in the Data field must be less than MaxSecretSize bytes.
+
+        Note: While Pulumi automatically encrypts the 'data' and 'stringData'
+        fields, this encryption only applies to Pulumi's context, including the state file, 
+        the Service, the CLI, etc. Kubernetes does not encrypt Secret resources by default,
+        and the contents are visible to users with access to the Secret in Kubernetes using
+        tools like 'kubectl'.
+
+        For more information on securing Kubernetes Secrets, see the following links:
+        https://kubernetes.io/docs/concepts/configuration/secret/#security-properties
+        https://kubernetes.io/docs/concepts/configuration/secret/#risks
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        data: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        Data contains the secret data. Each key must consist of alphanumeric characters, '-', '_' or '.'. The serialized form of the secret data is a base64 encoded string, representing the arbitrary (possibly non-string) data value here. Described in https://tools.ietf.org/html/rfc4648#section-4
+        """
+        immutable: NotRequired[pulumi.Input[bool]]
+        """
+        Immutable, if set to true, ensures that data stored in the Secret cannot be updated (only object metadata can be modified). If not set to true, the field can be modified at any time. Defaulted to nil.
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        string_data: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        stringData allows specifying non-binary secret data in string form. It is provided as a write-only input field for convenience. All keys and values are merged into the data field on write, overwriting any existing values. The stringData field is never output when reading from the API.
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        Used to facilitate programmatic handling of secret data. More info: https://kubernetes.io/docs/concepts/configuration/secret/#secret-types
+        """
+elif False:
+    SecretArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class SecretArgs:
@@ -22968,6 +30779,62 @@ class SecretArgs:
     def type(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "type", value)
 
+
+if not MYPY:
+    class SecurityContextPatchArgsDict(TypedDict):
+        """
+        SecurityContext holds security configuration that will be applied to a container. Some fields are present in both SecurityContext and PodSecurityContext.  When both are set, the values in SecurityContext take precedence.
+        """
+        allow_privilege_escalation: NotRequired[pulumi.Input[bool]]
+        """
+        AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.
+        """
+        app_armor_profile: NotRequired[pulumi.Input['AppArmorProfilePatchArgsDict']]
+        """
+        appArmorProfile is the AppArmor options to use by this container. If set, this profile overrides the pod's appArmorProfile. Note that this field cannot be set when spec.os.name is windows.
+        """
+        capabilities: NotRequired[pulumi.Input['CapabilitiesPatchArgsDict']]
+        """
+        The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.
+        """
+        privileged: NotRequired[pulumi.Input[bool]]
+        """
+        Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false. Note that this field cannot be set when spec.os.name is windows.
+        """
+        proc_mount: NotRequired[pulumi.Input[str]]
+        """
+        procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled. Note that this field cannot be set when spec.os.name is windows.
+        """
+        read_only_root_filesystem: NotRequired[pulumi.Input[bool]]
+        """
+        Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.
+        """
+        run_as_group: NotRequired[pulumi.Input[int]]
+        """
+        The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
+        """
+        run_as_non_root: NotRequired[pulumi.Input[bool]]
+        """
+        Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+        """
+        run_as_user: NotRequired[pulumi.Input[int]]
+        """
+        The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
+        """
+        se_linux_options: NotRequired[pulumi.Input['SELinuxOptionsPatchArgsDict']]
+        """
+        The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
+        """
+        seccomp_profile: NotRequired[pulumi.Input['SeccompProfilePatchArgsDict']]
+        """
+        The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.
+        """
+        windows_options: NotRequired[pulumi.Input['WindowsSecurityContextOptionsPatchArgsDict']]
+        """
+        The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.
+        """
+elif False:
+    SecurityContextPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class SecurityContextPatchArgs:
@@ -23169,6 +31036,62 @@ class SecurityContextPatchArgs:
         pulumi.set(self, "windows_options", value)
 
 
+if not MYPY:
+    class SecurityContextArgsDict(TypedDict):
+        """
+        SecurityContext holds security configuration that will be applied to a container. Some fields are present in both SecurityContext and PodSecurityContext.  When both are set, the values in SecurityContext take precedence.
+        """
+        allow_privilege_escalation: NotRequired[pulumi.Input[bool]]
+        """
+        AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.
+        """
+        app_armor_profile: NotRequired[pulumi.Input['AppArmorProfileArgsDict']]
+        """
+        appArmorProfile is the AppArmor options to use by this container. If set, this profile overrides the pod's appArmorProfile. Note that this field cannot be set when spec.os.name is windows.
+        """
+        capabilities: NotRequired[pulumi.Input['CapabilitiesArgsDict']]
+        """
+        The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.
+        """
+        privileged: NotRequired[pulumi.Input[bool]]
+        """
+        Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false. Note that this field cannot be set when spec.os.name is windows.
+        """
+        proc_mount: NotRequired[pulumi.Input[str]]
+        """
+        procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled. Note that this field cannot be set when spec.os.name is windows.
+        """
+        read_only_root_filesystem: NotRequired[pulumi.Input[bool]]
+        """
+        Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.
+        """
+        run_as_group: NotRequired[pulumi.Input[int]]
+        """
+        The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
+        """
+        run_as_non_root: NotRequired[pulumi.Input[bool]]
+        """
+        Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+        """
+        run_as_user: NotRequired[pulumi.Input[int]]
+        """
+        The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
+        """
+        se_linux_options: NotRequired[pulumi.Input['SELinuxOptionsArgsDict']]
+        """
+        The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
+        """
+        seccomp_profile: NotRequired[pulumi.Input['SeccompProfileArgsDict']]
+        """
+        The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.
+        """
+        windows_options: NotRequired[pulumi.Input['WindowsSecurityContextOptionsArgsDict']]
+        """
+        The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.
+        """
+elif False:
+    SecurityContextArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class SecurityContextArgs:
     def __init__(__self__, *,
@@ -23369,6 +31292,26 @@ class SecurityContextArgs:
         pulumi.set(self, "windows_options", value)
 
 
+if not MYPY:
+    class ServiceAccountTokenProjectionPatchArgsDict(TypedDict):
+        """
+        ServiceAccountTokenProjection represents a projected service account token volume. This projection can be used to insert a service account token into the pods runtime filesystem for use against APIs (Kubernetes API Server or otherwise).
+        """
+        audience: NotRequired[pulumi.Input[str]]
+        """
+        audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
+        """
+        expiration_seconds: NotRequired[pulumi.Input[int]]
+        """
+        expirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
+        """
+        path: NotRequired[pulumi.Input[str]]
+        """
+        path is the path relative to the mount point of the file to project the token into.
+        """
+elif False:
+    ServiceAccountTokenProjectionPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ServiceAccountTokenProjectionPatchArgs:
     def __init__(__self__, *,
@@ -23425,6 +31368,26 @@ class ServiceAccountTokenProjectionPatchArgs:
         pulumi.set(self, "path", value)
 
 
+if not MYPY:
+    class ServiceAccountTokenProjectionArgsDict(TypedDict):
+        """
+        ServiceAccountTokenProjection represents a projected service account token volume. This projection can be used to insert a service account token into the pods runtime filesystem for use against APIs (Kubernetes API Server or otherwise).
+        """
+        path: pulumi.Input[str]
+        """
+        path is the path relative to the mount point of the file to project the token into.
+        """
+        audience: NotRequired[pulumi.Input[str]]
+        """
+        audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
+        """
+        expiration_seconds: NotRequired[pulumi.Input[int]]
+        """
+        expirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
+        """
+elif False:
+    ServiceAccountTokenProjectionArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ServiceAccountTokenProjectionArgs:
     def __init__(__self__, *,
@@ -23479,6 +31442,38 @@ class ServiceAccountTokenProjectionArgs:
     def expiration_seconds(self, value: Optional[pulumi.Input[int]]):
         pulumi.set(self, "expiration_seconds", value)
 
+
+if not MYPY:
+    class ServiceAccountArgsDict(TypedDict):
+        """
+        ServiceAccount binds together: * a name, understood by users, and perhaps by peripheral systems, for an identity * a principal that can be authenticated and authorized * a set of secrets
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        automount_service_account_token: NotRequired[pulumi.Input[bool]]
+        """
+        AutomountServiceAccountToken indicates whether pods running as this service account should have an API token automatically mounted. Can be overridden at the pod level.
+        """
+        image_pull_secrets: NotRequired[pulumi.Input[Sequence[pulumi.Input['LocalObjectReferenceArgsDict']]]]
+        """
+        ImagePullSecrets is a list of references to secrets in the same namespace to use for pulling any images in pods that reference this ServiceAccount. ImagePullSecrets are distinct from Secrets because Secrets can be mounted in the pod, but ImagePullSecrets are only accessed by the kubelet. More info: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        secrets: NotRequired[pulumi.Input[Sequence[pulumi.Input['ObjectReferenceArgsDict']]]]
+        """
+        Secrets is a list of the secrets in the same namespace that pods running using this ServiceAccount are allowed to use. Pods are only limited to this list if this service account has a "kubernetes.io/enforce-mountable-secrets" annotation set to "true". This field should not be used to find auto-generated service account token secrets for use outside of pods. Instead, tokens can be requested directly using the TokenRequest API, or service account token secrets can be manually created. More info: https://kubernetes.io/docs/concepts/configuration/secret
+        """
+elif False:
+    ServiceAccountArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ServiceAccountArgs:
@@ -23583,6 +31578,47 @@ class ServiceAccountArgs:
     def secrets(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['ObjectReferenceArgs']]]]):
         pulumi.set(self, "secrets", value)
 
+
+if not MYPY:
+    class ServicePortPatchArgsDict(TypedDict):
+        """
+        ServicePort contains information on service's port.
+        """
+        app_protocol: NotRequired[pulumi.Input[str]]
+        """
+        The application protocol for this port. This is used as a hint for implementations to offer richer behavior for protocols that they understand. This field follows standard Kubernetes label syntax. Valid values are either:
+
+        * Un-prefixed protocol names - reserved for IANA standard service names (as per RFC-6335 and https://www.iana.org/assignments/service-names).
+
+        * Kubernetes-defined prefixed names:
+          * 'kubernetes.io/h2c' - HTTP/2 prior knowledge over cleartext as described in https://www.rfc-editor.org/rfc/rfc9113.html#name-starting-http-2-with-prior-
+          * 'kubernetes.io/ws'  - WebSocket over cleartext as described in https://www.rfc-editor.org/rfc/rfc6455
+          * 'kubernetes.io/wss' - WebSocket over TLS as described in https://www.rfc-editor.org/rfc/rfc6455
+
+        * Other protocols should use implementation-defined prefixed names such as mycompany.com/my-custom-protocol.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.
+        """
+        node_port: NotRequired[pulumi.Input[int]]
+        """
+        The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+        """
+        port: NotRequired[pulumi.Input[int]]
+        """
+        The port that will be exposed by this service.
+        """
+        protocol: NotRequired[pulumi.Input[str]]
+        """
+        The IP protocol for this port. Supports "TCP", "UDP", and "SCTP". Default is TCP.
+        """
+        target_port: NotRequired[pulumi.Input[Union[int, str]]]
+        """
+        Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of the 'port' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the 'port' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service
+        """
+elif False:
+    ServicePortPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ServicePortPatchArgs:
@@ -23706,6 +31742,47 @@ class ServicePortPatchArgs:
         pulumi.set(self, "target_port", value)
 
 
+if not MYPY:
+    class ServicePortArgsDict(TypedDict):
+        """
+        ServicePort contains information on service's port.
+        """
+        port: pulumi.Input[int]
+        """
+        The port that will be exposed by this service.
+        """
+        app_protocol: NotRequired[pulumi.Input[str]]
+        """
+        The application protocol for this port. This is used as a hint for implementations to offer richer behavior for protocols that they understand. This field follows standard Kubernetes label syntax. Valid values are either:
+
+        * Un-prefixed protocol names - reserved for IANA standard service names (as per RFC-6335 and https://www.iana.org/assignments/service-names).
+
+        * Kubernetes-defined prefixed names:
+          * 'kubernetes.io/h2c' - HTTP/2 prior knowledge over cleartext as described in https://www.rfc-editor.org/rfc/rfc9113.html#name-starting-http-2-with-prior-
+          * 'kubernetes.io/ws'  - WebSocket over cleartext as described in https://www.rfc-editor.org/rfc/rfc6455
+          * 'kubernetes.io/wss' - WebSocket over TLS as described in https://www.rfc-editor.org/rfc/rfc6455
+
+        * Other protocols should use implementation-defined prefixed names such as mycompany.com/my-custom-protocol.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.
+        """
+        node_port: NotRequired[pulumi.Input[int]]
+        """
+        The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+        """
+        protocol: NotRequired[pulumi.Input[str]]
+        """
+        The IP protocol for this port. Supports "TCP", "UDP", and "SCTP". Default is TCP.
+        """
+        target_port: NotRequired[pulumi.Input[Union[int, str]]]
+        """
+        Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of the 'port' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the 'port' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service
+        """
+elif False:
+    ServicePortArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ServicePortArgs:
     def __init__(__self__, *,
@@ -23826,6 +31903,106 @@ class ServicePortArgs:
     def target_port(self, value: Optional[pulumi.Input[Union[int, str]]]):
         pulumi.set(self, "target_port", value)
 
+
+if not MYPY:
+    class ServiceSpecPatchArgsDict(TypedDict):
+        """
+        ServiceSpec describes the attributes that a user creates on a service.
+        """
+        allocate_load_balancer_node_ports: NotRequired[pulumi.Input[bool]]
+        """
+        allocateLoadBalancerNodePorts defines if NodePorts will be automatically allocated for services with type LoadBalancer.  Default is "true". It may be set to "false" if the cluster load-balancer does not rely on NodePorts.  If the caller requests specific NodePorts (by specifying a value), those requests will be respected, regardless of this field. This field may only be set for services with type LoadBalancer and will be cleared if the type is changed to any other type.
+        """
+        cluster_ip: NotRequired[pulumi.Input[str]]
+        """
+        clusterIP is the IP address of the service and is usually assigned randomly. If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be blank) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are "None", empty string (""), or a valid IP address. Setting this to "None" makes a "headless service" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+        """
+        cluster_ips: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        ClusterIPs is a list of IP addresses assigned to this service, and are usually assigned randomly.  If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be empty) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are "None", empty string (""), or a valid IP address.  Setting this to "None" makes a "headless service" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName.  If this field is not specified, it will be initialized from the clusterIP field.  If this field is specified, clients must ensure that clusterIPs[0] and clusterIP have the same value.
+
+        This field may hold a maximum of two entries (dual-stack IPs, in either order). These IPs must correspond to the values of the ipFamilies field. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+        """
+        external_ips: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        externalIPs is a list of IP addresses for which nodes in the cluster will also accept traffic for this service.  These IPs are not managed by Kubernetes.  The user is responsible for ensuring that traffic arrives at a node with this IP.  A common example is external load-balancers that are not part of the Kubernetes system.
+        """
+        external_name: NotRequired[pulumi.Input[str]]
+        """
+        externalName is the external reference that discovery mechanisms will return as an alias for this service (e.g. a DNS CNAME record). No proxying will be involved.  Must be a lowercase RFC-1123 hostname (https://tools.ietf.org/html/rfc1123) and requires `type` to be "ExternalName".
+        """
+        external_traffic_policy: NotRequired[pulumi.Input[str]]
+        """
+        externalTrafficPolicy describes how nodes distribute service traffic they receive on one of the Service's "externally-facing" addresses (NodePorts, ExternalIPs, and LoadBalancer IPs). If set to "Local", the proxy will configure the service in a way that assumes that external load balancers will take care of balancing the service traffic between nodes, and so each node will deliver traffic only to the node-local endpoints of the service, without masquerading the client source IP. (Traffic mistakenly sent to a node with no endpoints will be dropped.) The default value, "Cluster", uses the standard behavior of routing to all endpoints evenly (possibly modified by topology and other features). Note that traffic sent to an External IP or LoadBalancer IP from within the cluster will always get "Cluster" semantics, but clients sending to a NodePort from within the cluster may need to take traffic policy into account when picking a node.
+        """
+        health_check_node_port: NotRequired[pulumi.Input[int]]
+        """
+        healthCheckNodePort specifies the healthcheck nodePort for the service. This only applies when type is set to LoadBalancer and externalTrafficPolicy is set to Local. If a value is specified, is in-range, and is not in use, it will be used.  If not specified, a value will be automatically allocated.  External systems (e.g. load-balancers) can use this port to determine if a given node holds endpoints for this service or not.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type). This field cannot be updated once set.
+        """
+        internal_traffic_policy: NotRequired[pulumi.Input[str]]
+        """
+        InternalTrafficPolicy describes how nodes distribute service traffic they receive on the ClusterIP. If set to "Local", the proxy will assume that pods only want to talk to endpoints of the service on the same node as the pod, dropping the traffic if there are no local endpoints. The default value, "Cluster", uses the standard behavior of routing to all endpoints evenly (possibly modified by topology and other features).
+        """
+        ip_families: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        IPFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this service. This field is usually assigned automatically based on cluster configuration and the ipFamilyPolicy field. If this field is specified manually, the requested family is available in the cluster, and ipFamilyPolicy allows it, it will be used; otherwise creation of the service will fail. This field is conditionally mutable: it allows for adding or removing a secondary IP family, but it does not allow changing the primary IP family of the Service. Valid values are "IPv4" and "IPv6".  This field only applies to Services of types ClusterIP, NodePort, and LoadBalancer, and does apply to "headless" services. This field will be wiped when updating a Service to type ExternalName.
+
+        This field may hold a maximum of two entries (dual-stack families, in either order).  These families must correspond to the values of the clusterIPs field, if specified. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field.
+        """
+        ip_family: NotRequired[pulumi.Input[str]]
+        """
+        ipFamily specifies whether this Service has a preference for a particular IP family (e.g. IPv4 vs. IPv6).  If a specific IP family is requested, the clusterIP field will be allocated from that family, if it is available in the cluster.  If no IP family is requested, the cluster's primary IP family will be used. Other IP fields (loadBalancerIP, loadBalancerSourceRanges, externalIPs) and controllers which allocate external load-balancers should use the same IP family.  Endpoints for this Service will be of this family.  This field is immutable after creation. Assigning a ServiceIPFamily not available in the cluster (e.g. IPv6 in IPv4 only cluster) is an error condition and will fail during clusterIP assignment.
+        """
+        ip_family_policy: NotRequired[pulumi.Input[str]]
+        """
+        IPFamilyPolicy represents the dual-stack-ness requested or required by this Service. If there is no value provided, then this field will be set to SingleStack. Services can be "SingleStack" (a single IP family), "PreferDualStack" (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), or "RequireDualStack" (two IP families on dual-stack configured clusters, otherwise fail). The ipFamilies and clusterIPs fields depend on the value of this field. This field will be wiped when updating a service to type ExternalName.
+        """
+        load_balancer_class: NotRequired[pulumi.Input[str]]
+        """
+        loadBalancerClass is the class of the load balancer implementation this Service belongs to. If specified, the value of this field must be a label-style identifier, with an optional prefix, e.g. "internal-vip" or "example.com/internal-vip". Unprefixed names are reserved for end-users. This field can only be set when the Service type is 'LoadBalancer'. If not set, the default load balancer implementation is used, today this is typically done through the cloud provider integration, but should apply for any default implementation. If set, it is assumed that a load balancer implementation is watching for Services with a matching class. Any default load balancer implementation (e.g. cloud providers) should ignore Services that set this field. This field can only be set when creating or updating a Service to type 'LoadBalancer'. Once set, it can not be changed. This field will be wiped when a service is updated to a non 'LoadBalancer' type.
+        """
+        load_balancer_ip: NotRequired[pulumi.Input[str]]
+        """
+        Only applies to Service Type: LoadBalancer. This feature depends on whether the underlying cloud-provider supports specifying the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature. Deprecated: This field was under-specified and its meaning varies across implementations. Using it is non-portable and it may not support dual-stack. Users are encouraged to use implementation-specific annotations when available.
+        """
+        load_balancer_source_ranges: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/
+        """
+        ports: NotRequired[pulumi.Input[Sequence[pulumi.Input['ServicePortPatchArgsDict']]]]
+        """
+        The list of ports that are exposed by this service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+        """
+        publish_not_ready_addresses: NotRequired[pulumi.Input[bool]]
+        """
+        publishNotReadyAddresses indicates that any agent which deals with endpoints for this Service should disregard any indications of ready/not-ready. The primary use case for setting this field is for a StatefulSet's Headless Service to propagate SRV DNS records for its Pods for the purpose of peer discovery. The Kubernetes controllers that generate Endpoints and EndpointSlice resources for Services interpret this to mean that all endpoints are considered "ready" even if the Pods themselves are not. Agents which consume only Kubernetes generated endpoints through the Endpoints or EndpointSlice resources can safely assume this behavior.
+        """
+        selector: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        Route service traffic to pods with label keys and values matching this selector. If empty or not present, the service is assumed to have an external process managing its endpoints, which Kubernetes will not modify. Only applies to types ClusterIP, NodePort, and LoadBalancer. Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/
+        """
+        session_affinity: NotRequired[pulumi.Input[str]]
+        """
+        Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+        """
+        session_affinity_config: NotRequired[pulumi.Input['SessionAffinityConfigPatchArgsDict']]
+        """
+        sessionAffinityConfig contains the configurations of session affinity.
+        """
+        topology_keys: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        topologyKeys is a preference-order list of topology keys which implementations of services should use to preferentially sort endpoints when accessing this Service, it can not be used at the same time as externalTrafficPolicy=Local. Topology keys must be valid label keys and at most 16 keys may be specified. Endpoints are chosen based on the first topology key with available backends. If this field is specified and all entries have no backends that match the topology of the client, the service has no backends for that client and connections should fail. The special value "*" may be used to mean "any topology". This catch-all value, if used, only makes sense as the last value in the list. If this is not specified or empty, no topology constraints will be applied.
+        """
+        traffic_distribution: NotRequired[pulumi.Input[str]]
+        """
+        TrafficDistribution offers a way to express preferences for how traffic is distributed to Service endpoints. Implementations can use this field as a hint, but are not required to guarantee strict adherence. If the field is not set, the implementation will apply its default routing strategy. If set to "PreferClose", implementations should prioritize endpoints that are topologically close (e.g., same zone).
+        """
+        type: NotRequired[pulumi.Input[Union[str, 'ServiceSpecType']]]
+        """
+        type determines how the Service is exposed. Defaults to ClusterIP. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. "ClusterIP" allocates a cluster-internal IP address for load-balancing to endpoints. Endpoints are determined by the selector or if that is not specified, by manual construction of an Endpoints object or EndpointSlice objects. If clusterIP is "None", no virtual IP is allocated and the endpoints are published as a set of endpoints rather than a virtual IP. "NodePort" builds on ClusterIP and allocates a port on every node which routes to the same endpoints as the clusterIP. "LoadBalancer" builds on NodePort and creates an external load-balancer (if supported in the current cloud) which routes to the same endpoints as the clusterIP. "ExternalName" aliases this service to the specified externalName. Several other fields do not apply to ExternalName services. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+        """
+elif False:
+    ServiceSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ServiceSpecPatchArgs:
@@ -24195,6 +32372,106 @@ class ServiceSpecPatchArgs:
         pulumi.set(self, "type", value)
 
 
+if not MYPY:
+    class ServiceSpecArgsDict(TypedDict):
+        """
+        ServiceSpec describes the attributes that a user creates on a service.
+        """
+        allocate_load_balancer_node_ports: NotRequired[pulumi.Input[bool]]
+        """
+        allocateLoadBalancerNodePorts defines if NodePorts will be automatically allocated for services with type LoadBalancer.  Default is "true". It may be set to "false" if the cluster load-balancer does not rely on NodePorts.  If the caller requests specific NodePorts (by specifying a value), those requests will be respected, regardless of this field. This field may only be set for services with type LoadBalancer and will be cleared if the type is changed to any other type.
+        """
+        cluster_ip: NotRequired[pulumi.Input[str]]
+        """
+        clusterIP is the IP address of the service and is usually assigned randomly. If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be blank) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are "None", empty string (""), or a valid IP address. Setting this to "None" makes a "headless service" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+        """
+        cluster_ips: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        ClusterIPs is a list of IP addresses assigned to this service, and are usually assigned randomly.  If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be empty) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are "None", empty string (""), or a valid IP address.  Setting this to "None" makes a "headless service" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName.  If this field is not specified, it will be initialized from the clusterIP field.  If this field is specified, clients must ensure that clusterIPs[0] and clusterIP have the same value.
+
+        This field may hold a maximum of two entries (dual-stack IPs, in either order). These IPs must correspond to the values of the ipFamilies field. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+        """
+        external_ips: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        externalIPs is a list of IP addresses for which nodes in the cluster will also accept traffic for this service.  These IPs are not managed by Kubernetes.  The user is responsible for ensuring that traffic arrives at a node with this IP.  A common example is external load-balancers that are not part of the Kubernetes system.
+        """
+        external_name: NotRequired[pulumi.Input[str]]
+        """
+        externalName is the external reference that discovery mechanisms will return as an alias for this service (e.g. a DNS CNAME record). No proxying will be involved.  Must be a lowercase RFC-1123 hostname (https://tools.ietf.org/html/rfc1123) and requires `type` to be "ExternalName".
+        """
+        external_traffic_policy: NotRequired[pulumi.Input[str]]
+        """
+        externalTrafficPolicy describes how nodes distribute service traffic they receive on one of the Service's "externally-facing" addresses (NodePorts, ExternalIPs, and LoadBalancer IPs). If set to "Local", the proxy will configure the service in a way that assumes that external load balancers will take care of balancing the service traffic between nodes, and so each node will deliver traffic only to the node-local endpoints of the service, without masquerading the client source IP. (Traffic mistakenly sent to a node with no endpoints will be dropped.) The default value, "Cluster", uses the standard behavior of routing to all endpoints evenly (possibly modified by topology and other features). Note that traffic sent to an External IP or LoadBalancer IP from within the cluster will always get "Cluster" semantics, but clients sending to a NodePort from within the cluster may need to take traffic policy into account when picking a node.
+        """
+        health_check_node_port: NotRequired[pulumi.Input[int]]
+        """
+        healthCheckNodePort specifies the healthcheck nodePort for the service. This only applies when type is set to LoadBalancer and externalTrafficPolicy is set to Local. If a value is specified, is in-range, and is not in use, it will be used.  If not specified, a value will be automatically allocated.  External systems (e.g. load-balancers) can use this port to determine if a given node holds endpoints for this service or not.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type). This field cannot be updated once set.
+        """
+        internal_traffic_policy: NotRequired[pulumi.Input[str]]
+        """
+        InternalTrafficPolicy describes how nodes distribute service traffic they receive on the ClusterIP. If set to "Local", the proxy will assume that pods only want to talk to endpoints of the service on the same node as the pod, dropping the traffic if there are no local endpoints. The default value, "Cluster", uses the standard behavior of routing to all endpoints evenly (possibly modified by topology and other features).
+        """
+        ip_families: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        IPFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this service. This field is usually assigned automatically based on cluster configuration and the ipFamilyPolicy field. If this field is specified manually, the requested family is available in the cluster, and ipFamilyPolicy allows it, it will be used; otherwise creation of the service will fail. This field is conditionally mutable: it allows for adding or removing a secondary IP family, but it does not allow changing the primary IP family of the Service. Valid values are "IPv4" and "IPv6".  This field only applies to Services of types ClusterIP, NodePort, and LoadBalancer, and does apply to "headless" services. This field will be wiped when updating a Service to type ExternalName.
+
+        This field may hold a maximum of two entries (dual-stack families, in either order).  These families must correspond to the values of the clusterIPs field, if specified. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field.
+        """
+        ip_family: NotRequired[pulumi.Input[str]]
+        """
+        ipFamily specifies whether this Service has a preference for a particular IP family (e.g. IPv4 vs. IPv6).  If a specific IP family is requested, the clusterIP field will be allocated from that family, if it is available in the cluster.  If no IP family is requested, the cluster's primary IP family will be used. Other IP fields (loadBalancerIP, loadBalancerSourceRanges, externalIPs) and controllers which allocate external load-balancers should use the same IP family.  Endpoints for this Service will be of this family.  This field is immutable after creation. Assigning a ServiceIPFamily not available in the cluster (e.g. IPv6 in IPv4 only cluster) is an error condition and will fail during clusterIP assignment.
+        """
+        ip_family_policy: NotRequired[pulumi.Input[str]]
+        """
+        IPFamilyPolicy represents the dual-stack-ness requested or required by this Service. If there is no value provided, then this field will be set to SingleStack. Services can be "SingleStack" (a single IP family), "PreferDualStack" (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), or "RequireDualStack" (two IP families on dual-stack configured clusters, otherwise fail). The ipFamilies and clusterIPs fields depend on the value of this field. This field will be wiped when updating a service to type ExternalName.
+        """
+        load_balancer_class: NotRequired[pulumi.Input[str]]
+        """
+        loadBalancerClass is the class of the load balancer implementation this Service belongs to. If specified, the value of this field must be a label-style identifier, with an optional prefix, e.g. "internal-vip" or "example.com/internal-vip". Unprefixed names are reserved for end-users. This field can only be set when the Service type is 'LoadBalancer'. If not set, the default load balancer implementation is used, today this is typically done through the cloud provider integration, but should apply for any default implementation. If set, it is assumed that a load balancer implementation is watching for Services with a matching class. Any default load balancer implementation (e.g. cloud providers) should ignore Services that set this field. This field can only be set when creating or updating a Service to type 'LoadBalancer'. Once set, it can not be changed. This field will be wiped when a service is updated to a non 'LoadBalancer' type.
+        """
+        load_balancer_ip: NotRequired[pulumi.Input[str]]
+        """
+        Only applies to Service Type: LoadBalancer. This feature depends on whether the underlying cloud-provider supports specifying the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature. Deprecated: This field was under-specified and its meaning varies across implementations. Using it is non-portable and it may not support dual-stack. Users are encouraged to use implementation-specific annotations when available.
+        """
+        load_balancer_source_ranges: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/
+        """
+        ports: NotRequired[pulumi.Input[Sequence[pulumi.Input['ServicePortArgsDict']]]]
+        """
+        The list of ports that are exposed by this service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+        """
+        publish_not_ready_addresses: NotRequired[pulumi.Input[bool]]
+        """
+        publishNotReadyAddresses indicates that any agent which deals with endpoints for this Service should disregard any indications of ready/not-ready. The primary use case for setting this field is for a StatefulSet's Headless Service to propagate SRV DNS records for its Pods for the purpose of peer discovery. The Kubernetes controllers that generate Endpoints and EndpointSlice resources for Services interpret this to mean that all endpoints are considered "ready" even if the Pods themselves are not. Agents which consume only Kubernetes generated endpoints through the Endpoints or EndpointSlice resources can safely assume this behavior.
+        """
+        selector: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        Route service traffic to pods with label keys and values matching this selector. If empty or not present, the service is assumed to have an external process managing its endpoints, which Kubernetes will not modify. Only applies to types ClusterIP, NodePort, and LoadBalancer. Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/
+        """
+        session_affinity: NotRequired[pulumi.Input[str]]
+        """
+        Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+        """
+        session_affinity_config: NotRequired[pulumi.Input['SessionAffinityConfigArgsDict']]
+        """
+        sessionAffinityConfig contains the configurations of session affinity.
+        """
+        topology_keys: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        topologyKeys is a preference-order list of topology keys which implementations of services should use to preferentially sort endpoints when accessing this Service, it can not be used at the same time as externalTrafficPolicy=Local. Topology keys must be valid label keys and at most 16 keys may be specified. Endpoints are chosen based on the first topology key with available backends. If this field is specified and all entries have no backends that match the topology of the client, the service has no backends for that client and connections should fail. The special value "*" may be used to mean "any topology". This catch-all value, if used, only makes sense as the last value in the list. If this is not specified or empty, no topology constraints will be applied.
+        """
+        traffic_distribution: NotRequired[pulumi.Input[str]]
+        """
+        TrafficDistribution offers a way to express preferences for how traffic is distributed to Service endpoints. Implementations can use this field as a hint, but are not required to guarantee strict adherence. If the field is not set, the implementation will apply its default routing strategy. If set to "PreferClose", implementations should prioritize endpoints that are topologically close (e.g., same zone).
+        """
+        type: NotRequired[pulumi.Input[Union[str, 'ServiceSpecType']]]
+        """
+        type determines how the Service is exposed. Defaults to ClusterIP. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. "ClusterIP" allocates a cluster-internal IP address for load-balancing to endpoints. Endpoints are determined by the selector or if that is not specified, by manual construction of an Endpoints object or EndpointSlice objects. If clusterIP is "None", no virtual IP is allocated and the endpoints are published as a set of endpoints rather than a virtual IP. "NodePort" builds on ClusterIP and allocates a port on every node which routes to the same endpoints as the clusterIP. "LoadBalancer" builds on NodePort and creates an external load-balancer (if supported in the current cloud) which routes to the same endpoints as the clusterIP. "ExternalName" aliases this service to the specified externalName. Several other fields do not apply to ExternalName services. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+        """
+elif False:
+    ServiceSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ServiceSpecArgs:
     def __init__(__self__, *,
@@ -24563,6 +32840,22 @@ class ServiceSpecArgs:
         pulumi.set(self, "type", value)
 
 
+if not MYPY:
+    class ServiceStatusArgsDict(TypedDict):
+        """
+        ServiceStatus represents the current status of a service.
+        """
+        conditions: NotRequired[pulumi.Input[Sequence[pulumi.Input['_meta.v1.ConditionArgsDict']]]]
+        """
+        Current service state
+        """
+        load_balancer: NotRequired[pulumi.Input['LoadBalancerStatusArgsDict']]
+        """
+        LoadBalancer contains the current status of the load-balancer, if one is present.
+        """
+elif False:
+    ServiceStatusArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ServiceStatusArgs:
     def __init__(__self__, *,
@@ -24602,6 +32895,59 @@ class ServiceStatusArgs:
     def load_balancer(self, value: Optional[pulumi.Input['LoadBalancerStatusArgs']]):
         pulumi.set(self, "load_balancer", value)
 
+
+if not MYPY:
+    class ServiceArgsDict(TypedDict):
+        """
+        Service is a named abstraction of software service (for example, mysql) consisting of local port (for example 3306) that the proxy listens on, and the selector that determines which pods will answer requests sent through the proxy.
+
+        This resource waits until its status is ready before registering success
+        for create/update, and populating output properties from the current state of the resource.
+        The following conditions are used to determine whether the resource creation has
+        succeeded or failed:
+
+        1. Service object exists.
+        2. Related Endpoint objects are created. Each time we get an update, wait 10 seconds
+           for any stragglers.
+        3. The endpoints objects target some number of living objects (unless the Service is
+           an "empty headless" Service [1] or a Service with '.spec.type: ExternalName').
+        4. External IP address is allocated (if Service has '.spec.type: LoadBalancer').
+
+        Known limitations: 
+        Services targeting ReplicaSets (and, by extension, Deployments,
+        StatefulSets, etc.) with '.spec.replicas' set to 0 are not handled, and will time
+        out. To work around this limitation, set 'pulumi.com/skipAwait: "true"' on
+        '.metadata.annotations' for the Service. Work to handle this case is in progress [2].
+
+        [1] https://kubernetes.io/docs/concepts/services-networking/service/#headless-services
+        [2] https://github.com/pulumi/pulumi-kubernetes/pull/703
+
+        If the Service has not reached a Ready state after 10 minutes, it will
+        time out and mark the resource update as Failed. You can override the default timeout value
+        by setting the 'customTimeouts' option on the resource.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['ServiceSpecArgsDict']]
+        """
+        Spec defines the behavior of a service. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+        status: NotRequired[pulumi.Input['ServiceStatusArgsDict']]
+        """
+        Most recently observed status of the service. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+elif False:
+    ServiceArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ServiceArgs:
@@ -24716,6 +33062,18 @@ class ServiceArgs:
         pulumi.set(self, "status", value)
 
 
+if not MYPY:
+    class SessionAffinityConfigPatchArgsDict(TypedDict):
+        """
+        SessionAffinityConfig represents the configurations of session affinity.
+        """
+        client_ip: NotRequired[pulumi.Input['ClientIPConfigPatchArgsDict']]
+        """
+        clientIP contains the configurations of Client IP based session affinity.
+        """
+elif False:
+    SessionAffinityConfigPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class SessionAffinityConfigPatchArgs:
     def __init__(__self__, *,
@@ -24739,6 +33097,18 @@ class SessionAffinityConfigPatchArgs:
     def client_ip(self, value: Optional[pulumi.Input['ClientIPConfigPatchArgs']]):
         pulumi.set(self, "client_ip", value)
 
+
+if not MYPY:
+    class SessionAffinityConfigArgsDict(TypedDict):
+        """
+        SessionAffinityConfig represents the configurations of session affinity.
+        """
+        client_ip: NotRequired[pulumi.Input['ClientIPConfigArgsDict']]
+        """
+        clientIP contains the configurations of Client IP based session affinity.
+        """
+elif False:
+    SessionAffinityConfigArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class SessionAffinityConfigArgs:
@@ -24764,6 +33134,18 @@ class SessionAffinityConfigArgs:
         pulumi.set(self, "client_ip", value)
 
 
+if not MYPY:
+    class SleepActionPatchArgsDict(TypedDict):
+        """
+        SleepAction describes a "sleep" action.
+        """
+        seconds: NotRequired[pulumi.Input[int]]
+        """
+        Seconds is the number of seconds to sleep.
+        """
+elif False:
+    SleepActionPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class SleepActionPatchArgs:
     def __init__(__self__, *,
@@ -24788,6 +33170,18 @@ class SleepActionPatchArgs:
         pulumi.set(self, "seconds", value)
 
 
+if not MYPY:
+    class SleepActionArgsDict(TypedDict):
+        """
+        SleepAction describes a "sleep" action.
+        """
+        seconds: pulumi.Input[int]
+        """
+        Seconds is the number of seconds to sleep.
+        """
+elif False:
+    SleepActionArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class SleepActionArgs:
     def __init__(__self__, *,
@@ -24810,6 +33204,34 @@ class SleepActionArgs:
     def seconds(self, value: pulumi.Input[int]):
         pulumi.set(self, "seconds", value)
 
+
+if not MYPY:
+    class StorageOSPersistentVolumeSourcePatchArgsDict(TypedDict):
+        """
+        Represents a StorageOS persistent volume resource.
+        """
+        fs_type: NotRequired[pulumi.Input[str]]
+        """
+        fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+        """
+        secret_ref: NotRequired[pulumi.Input['ObjectReferencePatchArgsDict']]
+        """
+        secretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.
+        """
+        volume_name: NotRequired[pulumi.Input[str]]
+        """
+        volumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.
+        """
+        volume_namespace: NotRequired[pulumi.Input[str]]
+        """
+        volumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.
+        """
+elif False:
+    StorageOSPersistentVolumeSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class StorageOSPersistentVolumeSourcePatchArgs:
@@ -24899,6 +33321,34 @@ class StorageOSPersistentVolumeSourcePatchArgs:
         pulumi.set(self, "volume_namespace", value)
 
 
+if not MYPY:
+    class StorageOSPersistentVolumeSourceArgsDict(TypedDict):
+        """
+        Represents a StorageOS persistent volume resource.
+        """
+        fs_type: NotRequired[pulumi.Input[str]]
+        """
+        fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+        """
+        secret_ref: NotRequired[pulumi.Input['ObjectReferenceArgsDict']]
+        """
+        secretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.
+        """
+        volume_name: NotRequired[pulumi.Input[str]]
+        """
+        volumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.
+        """
+        volume_namespace: NotRequired[pulumi.Input[str]]
+        """
+        volumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.
+        """
+elif False:
+    StorageOSPersistentVolumeSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class StorageOSPersistentVolumeSourceArgs:
     def __init__(__self__, *,
@@ -24986,6 +33436,34 @@ class StorageOSPersistentVolumeSourceArgs:
     def volume_namespace(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "volume_namespace", value)
 
+
+if not MYPY:
+    class StorageOSVolumeSourcePatchArgsDict(TypedDict):
+        """
+        Represents a StorageOS persistent volume resource.
+        """
+        fs_type: NotRequired[pulumi.Input[str]]
+        """
+        fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+        """
+        secret_ref: NotRequired[pulumi.Input['LocalObjectReferencePatchArgsDict']]
+        """
+        secretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.
+        """
+        volume_name: NotRequired[pulumi.Input[str]]
+        """
+        volumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.
+        """
+        volume_namespace: NotRequired[pulumi.Input[str]]
+        """
+        volumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.
+        """
+elif False:
+    StorageOSVolumeSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class StorageOSVolumeSourcePatchArgs:
@@ -25075,6 +33553,34 @@ class StorageOSVolumeSourcePatchArgs:
         pulumi.set(self, "volume_namespace", value)
 
 
+if not MYPY:
+    class StorageOSVolumeSourceArgsDict(TypedDict):
+        """
+        Represents a StorageOS persistent volume resource.
+        """
+        fs_type: NotRequired[pulumi.Input[str]]
+        """
+        fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+        """
+        secret_ref: NotRequired[pulumi.Input['LocalObjectReferenceArgsDict']]
+        """
+        secretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.
+        """
+        volume_name: NotRequired[pulumi.Input[str]]
+        """
+        volumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.
+        """
+        volume_namespace: NotRequired[pulumi.Input[str]]
+        """
+        volumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.
+        """
+elif False:
+    StorageOSVolumeSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class StorageOSVolumeSourceArgs:
     def __init__(__self__, *,
@@ -25163,6 +33669,22 @@ class StorageOSVolumeSourceArgs:
         pulumi.set(self, "volume_namespace", value)
 
 
+if not MYPY:
+    class SysctlPatchArgsDict(TypedDict):
+        """
+        Sysctl defines a kernel parameter to be set
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name of a property to set
+        """
+        value: NotRequired[pulumi.Input[str]]
+        """
+        Value of a property to set
+        """
+elif False:
+    SysctlPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class SysctlPatchArgs:
     def __init__(__self__, *,
@@ -25203,6 +33725,22 @@ class SysctlPatchArgs:
         pulumi.set(self, "value", value)
 
 
+if not MYPY:
+    class SysctlArgsDict(TypedDict):
+        """
+        Sysctl defines a kernel parameter to be set
+        """
+        name: pulumi.Input[str]
+        """
+        Name of a property to set
+        """
+        value: pulumi.Input[str]
+        """
+        Value of a property to set
+        """
+elif False:
+    SysctlArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class SysctlArgs:
     def __init__(__self__, *,
@@ -25240,6 +33778,22 @@ class SysctlArgs:
     def value(self, value: pulumi.Input[str]):
         pulumi.set(self, "value", value)
 
+
+if not MYPY:
+    class TCPSocketActionPatchArgsDict(TypedDict):
+        """
+        TCPSocketAction describes an action based on opening a socket
+        """
+        host: NotRequired[pulumi.Input[str]]
+        """
+        Optional: Host name to connect to, defaults to the pod IP.
+        """
+        port: NotRequired[pulumi.Input[Union[int, str]]]
+        """
+        Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+        """
+elif False:
+    TCPSocketActionPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class TCPSocketActionPatchArgs:
@@ -25281,6 +33835,22 @@ class TCPSocketActionPatchArgs:
         pulumi.set(self, "port", value)
 
 
+if not MYPY:
+    class TCPSocketActionArgsDict(TypedDict):
+        """
+        TCPSocketAction describes an action based on opening a socket
+        """
+        port: pulumi.Input[Union[int, str]]
+        """
+        Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+        """
+        host: NotRequired[pulumi.Input[str]]
+        """
+        Optional: Host name to connect to, defaults to the pod IP.
+        """
+elif False:
+    TCPSocketActionArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class TCPSocketActionArgs:
     def __init__(__self__, *,
@@ -25319,6 +33889,30 @@ class TCPSocketActionArgs:
     def host(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "host", value)
 
+
+if not MYPY:
+    class TaintPatchArgsDict(TypedDict):
+        """
+        The node this Taint is attached to has the "effect" on any pod that does not tolerate the Taint.
+        """
+        effect: NotRequired[pulumi.Input[str]]
+        """
+        Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+        """
+        key: NotRequired[pulumi.Input[str]]
+        """
+        Required. The taint key to be applied to a node.
+        """
+        time_added: NotRequired[pulumi.Input[str]]
+        """
+        TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.
+        """
+        value: NotRequired[pulumi.Input[str]]
+        """
+        The taint value corresponding to the taint key.
+        """
+elif False:
+    TaintPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class TaintPatchArgs:
@@ -25392,6 +33986,30 @@ class TaintPatchArgs:
         pulumi.set(self, "value", value)
 
 
+if not MYPY:
+    class TaintArgsDict(TypedDict):
+        """
+        The node this Taint is attached to has the "effect" on any pod that does not tolerate the Taint.
+        """
+        effect: pulumi.Input[str]
+        """
+        Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+        """
+        key: pulumi.Input[str]
+        """
+        Required. The taint key to be applied to a node.
+        """
+        time_added: NotRequired[pulumi.Input[str]]
+        """
+        TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.
+        """
+        value: NotRequired[pulumi.Input[str]]
+        """
+        The taint value corresponding to the taint key.
+        """
+elif False:
+    TaintArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class TaintArgs:
     def __init__(__self__, *,
@@ -25461,6 +34079,34 @@ class TaintArgs:
     def value(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "value", value)
 
+
+if not MYPY:
+    class TolerationPatchArgsDict(TypedDict):
+        """
+        The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+        """
+        effect: NotRequired[pulumi.Input[str]]
+        """
+        Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+        """
+        key: NotRequired[pulumi.Input[str]]
+        """
+        Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+        """
+        operator: NotRequired[pulumi.Input[str]]
+        """
+        Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+        """
+        toleration_seconds: NotRequired[pulumi.Input[int]]
+        """
+        TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+        """
+        value: NotRequired[pulumi.Input[str]]
+        """
+        Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+        """
+elif False:
+    TolerationPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class TolerationPatchArgs:
@@ -25550,6 +34196,34 @@ class TolerationPatchArgs:
         pulumi.set(self, "value", value)
 
 
+if not MYPY:
+    class TolerationArgsDict(TypedDict):
+        """
+        The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+        """
+        effect: NotRequired[pulumi.Input[str]]
+        """
+        Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+        """
+        key: NotRequired[pulumi.Input[str]]
+        """
+        Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+        """
+        operator: NotRequired[pulumi.Input[str]]
+        """
+        Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+        """
+        toleration_seconds: NotRequired[pulumi.Input[int]]
+        """
+        TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+        """
+        value: NotRequired[pulumi.Input[str]]
+        """
+        Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+        """
+elif False:
+    TolerationArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class TolerationArgs:
     def __init__(__self__, *,
@@ -25638,6 +34312,22 @@ class TolerationArgs:
         pulumi.set(self, "value", value)
 
 
+if not MYPY:
+    class TopologySelectorLabelRequirementPatchArgsDict(TypedDict):
+        """
+        A topology selector requirement is a selector that matches given label. This is an alpha feature and may change in the future.
+        """
+        key: NotRequired[pulumi.Input[str]]
+        """
+        The label key that the selector applies to.
+        """
+        values: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        An array of string values. One value must match the label to be selected. Each entry in Values is ORed.
+        """
+elif False:
+    TopologySelectorLabelRequirementPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class TopologySelectorLabelRequirementPatchArgs:
     def __init__(__self__, *,
@@ -25678,6 +34368,22 @@ class TopologySelectorLabelRequirementPatchArgs:
         pulumi.set(self, "values", value)
 
 
+if not MYPY:
+    class TopologySelectorLabelRequirementArgsDict(TypedDict):
+        """
+        A topology selector requirement is a selector that matches given label. This is an alpha feature and may change in the future.
+        """
+        key: pulumi.Input[str]
+        """
+        The label key that the selector applies to.
+        """
+        values: pulumi.Input[Sequence[pulumi.Input[str]]]
+        """
+        An array of string values. One value must match the label to be selected. Each entry in Values is ORed.
+        """
+elif False:
+    TopologySelectorLabelRequirementArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class TopologySelectorLabelRequirementArgs:
     def __init__(__self__, *,
@@ -25716,6 +34422,18 @@ class TopologySelectorLabelRequirementArgs:
         pulumi.set(self, "values", value)
 
 
+if not MYPY:
+    class TopologySelectorTermPatchArgsDict(TypedDict):
+        """
+        A topology selector term represents the result of label queries. A null or empty topology selector term matches no objects. The requirements of them are ANDed. It provides a subset of functionality as NodeSelectorTerm. This is an alpha feature and may change in the future.
+        """
+        match_label_expressions: NotRequired[pulumi.Input[Sequence[pulumi.Input['TopologySelectorLabelRequirementPatchArgsDict']]]]
+        """
+        A list of topology selector requirements by labels.
+        """
+elif False:
+    TopologySelectorTermPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class TopologySelectorTermPatchArgs:
     def __init__(__self__, *,
@@ -25740,6 +34458,18 @@ class TopologySelectorTermPatchArgs:
         pulumi.set(self, "match_label_expressions", value)
 
 
+if not MYPY:
+    class TopologySelectorTermArgsDict(TypedDict):
+        """
+        A topology selector term represents the result of label queries. A null or empty topology selector term matches no objects. The requirements of them are ANDed. It provides a subset of functionality as NodeSelectorTerm. This is an alpha feature and may change in the future.
+        """
+        match_label_expressions: NotRequired[pulumi.Input[Sequence[pulumi.Input['TopologySelectorLabelRequirementArgsDict']]]]
+        """
+        A list of topology selector requirements by labels.
+        """
+elif False:
+    TopologySelectorTermArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class TopologySelectorTermArgs:
     def __init__(__self__, *,
@@ -25763,6 +34493,57 @@ class TopologySelectorTermArgs:
     def match_label_expressions(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['TopologySelectorLabelRequirementArgs']]]]):
         pulumi.set(self, "match_label_expressions", value)
 
+
+if not MYPY:
+    class TopologySpreadConstraintPatchArgsDict(TypedDict):
+        """
+        TopologySpreadConstraint specifies how to spread matching pods among the given topology.
+        """
+        label_selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorPatchArgsDict']]
+        """
+        LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.
+        """
+        match_label_keys: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated. The keys are used to lookup values from the incoming pod labels, those key-value labels are ANDed with labelSelector to select the group of existing pods over which spreading will be calculated for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector. MatchLabelKeys cannot be set when LabelSelector isn't set. Keys that don't exist in the incoming pod labels will be ignored. A null or empty list means only match against labelSelector.
+
+        This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
+        """
+        max_skew: NotRequired[pulumi.Input[int]]
+        """
+        MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. The global minimum is the minimum number of matching pods in an eligible domain or zero if the number of eligible domains is less than MinDomains. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 2/2/1: In this case, the global minimum is 1. | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2; scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It's a required field. Default value is 1 and 0 is not allowed.
+        """
+        min_domains: NotRequired[pulumi.Input[int]]
+        """
+        MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+        For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew.
+        """
+        node_affinity_policy: NotRequired[pulumi.Input[str]]
+        """
+        NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+        If this value is nil, the behavior is equivalent to the Honor policy. This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+        """
+        node_taints_policy: NotRequired[pulumi.Input[str]]
+        """
+        NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included.
+
+        If this value is nil, the behavior is equivalent to the Ignore policy. This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+        """
+        topology_key: NotRequired[pulumi.Input[str]]
+        """
+        TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. We define a domain as a particular instance of a topology. Also, we define an eligible domain as a domain whose nodes meet the requirements of nodeAffinityPolicy and nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology. It's a required field.
+        """
+        when_unsatisfiable: NotRequired[pulumi.Input[str]]
+        """
+        WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+          but giving higher precedence to topologies that would help reduce the
+          skew.
+        A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.
+        """
+elif False:
+    TopologySpreadConstraintPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class TopologySpreadConstraintPatchArgs:
@@ -25922,6 +34703,57 @@ class TopologySpreadConstraintPatchArgs:
         pulumi.set(self, "when_unsatisfiable", value)
 
 
+if not MYPY:
+    class TopologySpreadConstraintArgsDict(TypedDict):
+        """
+        TopologySpreadConstraint specifies how to spread matching pods among the given topology.
+        """
+        max_skew: pulumi.Input[int]
+        """
+        MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. The global minimum is the minimum number of matching pods in an eligible domain or zero if the number of eligible domains is less than MinDomains. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 2/2/1: In this case, the global minimum is 1. | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2; scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It's a required field. Default value is 1 and 0 is not allowed.
+        """
+        topology_key: pulumi.Input[str]
+        """
+        TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. We define a domain as a particular instance of a topology. Also, we define an eligible domain as a domain whose nodes meet the requirements of nodeAffinityPolicy and nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology. It's a required field.
+        """
+        when_unsatisfiable: pulumi.Input[str]
+        """
+        WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+          but giving higher precedence to topologies that would help reduce the
+          skew.
+        A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.
+        """
+        label_selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorArgsDict']]
+        """
+        LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.
+        """
+        match_label_keys: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated. The keys are used to lookup values from the incoming pod labels, those key-value labels are ANDed with labelSelector to select the group of existing pods over which spreading will be calculated for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector. MatchLabelKeys cannot be set when LabelSelector isn't set. Keys that don't exist in the incoming pod labels will be ignored. A null or empty list means only match against labelSelector.
+
+        This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
+        """
+        min_domains: NotRequired[pulumi.Input[int]]
+        """
+        MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+        For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew.
+        """
+        node_affinity_policy: NotRequired[pulumi.Input[str]]
+        """
+        NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+        If this value is nil, the behavior is equivalent to the Honor policy. This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+        """
+        node_taints_policy: NotRequired[pulumi.Input[str]]
+        """
+        NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included.
+
+        If this value is nil, the behavior is equivalent to the Ignore policy. This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+        """
+elif False:
+    TopologySpreadConstraintArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class TopologySpreadConstraintArgs:
     def __init__(__self__, *,
@@ -26077,6 +34909,26 @@ class TopologySpreadConstraintArgs:
         pulumi.set(self, "node_taints_policy", value)
 
 
+if not MYPY:
+    class TypedLocalObjectReferencePatchArgsDict(TypedDict):
+        """
+        TypedLocalObjectReference contains enough information to let you locate the typed referenced object inside the same namespace.
+        """
+        api_group: NotRequired[pulumi.Input[str]]
+        """
+        APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is the type of resource being referenced
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name is the name of resource being referenced
+        """
+elif False:
+    TypedLocalObjectReferencePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class TypedLocalObjectReferencePatchArgs:
     def __init__(__self__, *,
@@ -26133,6 +34985,26 @@ class TypedLocalObjectReferencePatchArgs:
         pulumi.set(self, "name", value)
 
 
+if not MYPY:
+    class TypedLocalObjectReferenceArgsDict(TypedDict):
+        """
+        TypedLocalObjectReference contains enough information to let you locate the typed referenced object inside the same namespace.
+        """
+        kind: pulumi.Input[str]
+        """
+        Kind is the type of resource being referenced
+        """
+        name: pulumi.Input[str]
+        """
+        Name is the name of resource being referenced
+        """
+        api_group: NotRequired[pulumi.Input[str]]
+        """
+        APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+        """
+elif False:
+    TypedLocalObjectReferenceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class TypedLocalObjectReferenceArgs:
     def __init__(__self__, *,
@@ -26186,6 +35058,27 @@ class TypedLocalObjectReferenceArgs:
     def api_group(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "api_group", value)
 
+
+if not MYPY:
+    class TypedObjectReferencePatchArgsDict(TypedDict):
+        api_group: NotRequired[pulumi.Input[str]]
+        """
+        APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is the type of resource being referenced
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name is the name of resource being referenced
+        """
+        namespace: NotRequired[pulumi.Input[str]]
+        """
+        Namespace is the namespace of resource being referenced Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details. (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+        """
+elif False:
+    TypedObjectReferencePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class TypedObjectReferencePatchArgs:
@@ -26258,6 +35151,27 @@ class TypedObjectReferencePatchArgs:
         pulumi.set(self, "namespace", value)
 
 
+if not MYPY:
+    class TypedObjectReferenceArgsDict(TypedDict):
+        kind: pulumi.Input[str]
+        """
+        Kind is the type of resource being referenced
+        """
+        name: pulumi.Input[str]
+        """
+        Name is the name of resource being referenced
+        """
+        api_group: NotRequired[pulumi.Input[str]]
+        """
+        APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+        """
+        namespace: NotRequired[pulumi.Input[str]]
+        """
+        Namespace is the namespace of resource being referenced Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details. (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+        """
+elif False:
+    TypedObjectReferenceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class TypedObjectReferenceArgs:
     def __init__(__self__, *,
@@ -26327,6 +35241,22 @@ class TypedObjectReferenceArgs:
         pulumi.set(self, "namespace", value)
 
 
+if not MYPY:
+    class VolumeDevicePatchArgsDict(TypedDict):
+        """
+        volumeDevice describes a mapping of a raw block device within a container.
+        """
+        device_path: NotRequired[pulumi.Input[str]]
+        """
+        devicePath is the path inside of the container that the device will be mapped to.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        name must match the name of a persistentVolumeClaim in the pod
+        """
+elif False:
+    VolumeDevicePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class VolumeDevicePatchArgs:
     def __init__(__self__, *,
@@ -26367,6 +35297,22 @@ class VolumeDevicePatchArgs:
         pulumi.set(self, "name", value)
 
 
+if not MYPY:
+    class VolumeDeviceArgsDict(TypedDict):
+        """
+        volumeDevice describes a mapping of a raw block device within a container.
+        """
+        device_path: pulumi.Input[str]
+        """
+        devicePath is the path inside of the container that the device will be mapped to.
+        """
+        name: pulumi.Input[str]
+        """
+        name must match the name of a persistentVolumeClaim in the pod
+        """
+elif False:
+    VolumeDeviceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class VolumeDeviceArgs:
     def __init__(__self__, *,
@@ -26404,6 +35350,50 @@ class VolumeDeviceArgs:
     def name(self, value: pulumi.Input[str]):
         pulumi.set(self, "name", value)
 
+
+if not MYPY:
+    class VolumeMountPatchArgsDict(TypedDict):
+        """
+        VolumeMount describes a mounting of a Volume within a container.
+        """
+        mount_path: NotRequired[pulumi.Input[str]]
+        """
+        Path within the container at which the volume should be mounted.  Must not contain ':'.
+        """
+        mount_propagation: NotRequired[pulumi.Input[str]]
+        """
+        mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10. When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified (which defaults to None).
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        This must match the Name of a Volume.
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+        """
+        recursive_read_only: NotRequired[pulumi.Input[str]]
+        """
+        RecursiveReadOnly specifies whether read-only mounts should be handled recursively.
+
+        If ReadOnly is false, this field has no meaning and must be unspecified.
+
+        If ReadOnly is true, and this field is set to Disabled, the mount is not made recursively read-only.  If this field is set to IfPossible, the mount is made recursively read-only, if it is supported by the container runtime.  If this field is set to Enabled, the mount is made recursively read-only if it is supported by the container runtime, otherwise the pod will not be started and an error will be generated to indicate the reason.
+
+        If this field is set to IfPossible or Enabled, MountPropagation must be set to None (or be unspecified, which defaults to None).
+
+        If this field is not specified, it is treated as an equivalent of Disabled.
+        """
+        sub_path: NotRequired[pulumi.Input[str]]
+        """
+        Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
+        """
+        sub_path_expr: NotRequired[pulumi.Input[str]]
+        """
+        Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
+        """
+elif False:
+    VolumeMountPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class VolumeMountPatchArgs:
@@ -26541,6 +35531,30 @@ class VolumeMountPatchArgs:
         pulumi.set(self, "sub_path_expr", value)
 
 
+if not MYPY:
+    class VolumeMountStatusArgsDict(TypedDict):
+        """
+        VolumeMountStatus shows status of volume mounts.
+        """
+        mount_path: pulumi.Input[str]
+        """
+        MountPath corresponds to the original VolumeMount.
+        """
+        name: pulumi.Input[str]
+        """
+        Name corresponds to the name of the original VolumeMount.
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        ReadOnly corresponds to the original VolumeMount.
+        """
+        recursive_read_only: NotRequired[pulumi.Input[str]]
+        """
+        RecursiveReadOnly must be set to Disabled, Enabled, or unspecified (for non-readonly mounts). An IfPossible value in the original VolumeMount must be translated to Disabled or Enabled, depending on the mount result.
+        """
+elif False:
+    VolumeMountStatusArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class VolumeMountStatusArgs:
     def __init__(__self__, *,
@@ -26610,6 +35624,50 @@ class VolumeMountStatusArgs:
     def recursive_read_only(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "recursive_read_only", value)
 
+
+if not MYPY:
+    class VolumeMountArgsDict(TypedDict):
+        """
+        VolumeMount describes a mounting of a Volume within a container.
+        """
+        mount_path: pulumi.Input[str]
+        """
+        Path within the container at which the volume should be mounted.  Must not contain ':'.
+        """
+        name: pulumi.Input[str]
+        """
+        This must match the Name of a Volume.
+        """
+        mount_propagation: NotRequired[pulumi.Input[str]]
+        """
+        mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10. When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified (which defaults to None).
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+        """
+        recursive_read_only: NotRequired[pulumi.Input[str]]
+        """
+        RecursiveReadOnly specifies whether read-only mounts should be handled recursively.
+
+        If ReadOnly is false, this field has no meaning and must be unspecified.
+
+        If ReadOnly is true, and this field is set to Disabled, the mount is not made recursively read-only.  If this field is set to IfPossible, the mount is made recursively read-only, if it is supported by the container runtime.  If this field is set to Enabled, the mount is made recursively read-only if it is supported by the container runtime, otherwise the pod will not be started and an error will be generated to indicate the reason.
+
+        If this field is set to IfPossible or Enabled, MountPropagation must be set to None (or be unspecified, which defaults to None).
+
+        If this field is not specified, it is treated as an equivalent of Disabled.
+        """
+        sub_path: NotRequired[pulumi.Input[str]]
+        """
+        Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
+        """
+        sub_path_expr: NotRequired[pulumi.Input[str]]
+        """
+        Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
+        """
+elif False:
+    VolumeMountArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class VolumeMountArgs:
@@ -26745,6 +35803,18 @@ class VolumeMountArgs:
         pulumi.set(self, "sub_path_expr", value)
 
 
+if not MYPY:
+    class VolumeNodeAffinityPatchArgsDict(TypedDict):
+        """
+        VolumeNodeAffinity defines constraints that limit what nodes this volume can be accessed from.
+        """
+        required: NotRequired[pulumi.Input['NodeSelectorPatchArgsDict']]
+        """
+        required specifies hard node constraints that must be met.
+        """
+elif False:
+    VolumeNodeAffinityPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class VolumeNodeAffinityPatchArgs:
     def __init__(__self__, *,
@@ -26769,6 +35839,18 @@ class VolumeNodeAffinityPatchArgs:
         pulumi.set(self, "required", value)
 
 
+if not MYPY:
+    class VolumeNodeAffinityArgsDict(TypedDict):
+        """
+        VolumeNodeAffinity defines constraints that limit what nodes this volume can be accessed from.
+        """
+        required: NotRequired[pulumi.Input['NodeSelectorArgsDict']]
+        """
+        required specifies hard node constraints that must be met.
+        """
+elif False:
+    VolumeNodeAffinityArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class VolumeNodeAffinityArgs:
     def __init__(__self__, *,
@@ -26792,6 +35874,147 @@ class VolumeNodeAffinityArgs:
     def required(self, value: Optional[pulumi.Input['NodeSelectorArgs']]):
         pulumi.set(self, "required", value)
 
+
+if not MYPY:
+    class VolumePatchArgsDict(TypedDict):
+        """
+        Volume represents a named volume in a pod that may be accessed by any container in the pod.
+        """
+        aws_elastic_block_store: NotRequired[pulumi.Input['AWSElasticBlockStoreVolumeSourcePatchArgsDict']]
+        """
+        awsElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+        """
+        azure_disk: NotRequired[pulumi.Input['AzureDiskVolumeSourcePatchArgsDict']]
+        """
+        azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+        """
+        azure_file: NotRequired[pulumi.Input['AzureFileVolumeSourcePatchArgsDict']]
+        """
+        azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+        """
+        cephfs: NotRequired[pulumi.Input['CephFSVolumeSourcePatchArgsDict']]
+        """
+        cephFS represents a Ceph FS mount on the host that shares a pod's lifetime
+        """
+        cinder: NotRequired[pulumi.Input['CinderVolumeSourcePatchArgsDict']]
+        """
+        cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+        """
+        config_map: NotRequired[pulumi.Input['ConfigMapVolumeSourcePatchArgsDict']]
+        """
+        configMap represents a configMap that should populate this volume
+        """
+        csi: NotRequired[pulumi.Input['CSIVolumeSourcePatchArgsDict']]
+        """
+        csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).
+        """
+        downward_api: NotRequired[pulumi.Input['DownwardAPIVolumeSourcePatchArgsDict']]
+        """
+        downwardAPI represents downward API about the pod that should populate this volume
+        """
+        empty_dir: NotRequired[pulumi.Input['EmptyDirVolumeSourcePatchArgsDict']]
+        """
+        emptyDir represents a temporary directory that shares a pod's lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+        """
+        ephemeral: NotRequired[pulumi.Input['EphemeralVolumeSourcePatchArgsDict']]
+        """
+        ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed.
+
+        Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity
+           tracking are needed,
+        c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through
+           a PersistentVolumeClaim (see EphemeralVolumeSource for more
+           information on the connection between this volume type
+           and PersistentVolumeClaim).
+
+        Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod.
+
+        Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information.
+
+        A pod can use both types of ephemeral volumes and persistent volumes at the same time.
+        """
+        fc: NotRequired[pulumi.Input['FCVolumeSourcePatchArgsDict']]
+        """
+        fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
+        """
+        flex_volume: NotRequired[pulumi.Input['FlexVolumeSourcePatchArgsDict']]
+        """
+        flexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
+        """
+        flocker: NotRequired[pulumi.Input['FlockerVolumeSourcePatchArgsDict']]
+        """
+        flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
+        """
+        gce_persistent_disk: NotRequired[pulumi.Input['GCEPersistentDiskVolumeSourcePatchArgsDict']]
+        """
+        gcePersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+        """
+        git_repo: NotRequired[pulumi.Input['GitRepoVolumeSourcePatchArgsDict']]
+        """
+        gitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.
+        """
+        glusterfs: NotRequired[pulumi.Input['GlusterfsVolumeSourcePatchArgsDict']]
+        """
+        glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md
+        """
+        host_path: NotRequired[pulumi.Input['HostPathVolumeSourcePatchArgsDict']]
+        """
+        hostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+        """
+        iscsi: NotRequired[pulumi.Input['ISCSIVolumeSourcePatchArgsDict']]
+        """
+        iscsi represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        name of the volume. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+        """
+        nfs: NotRequired[pulumi.Input['NFSVolumeSourcePatchArgsDict']]
+        """
+        nfs represents an NFS mount on the host that shares a pod's lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+        """
+        persistent_volume_claim: NotRequired[pulumi.Input['PersistentVolumeClaimVolumeSourcePatchArgsDict']]
+        """
+        persistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+        """
+        photon_persistent_disk: NotRequired[pulumi.Input['PhotonPersistentDiskVolumeSourcePatchArgsDict']]
+        """
+        photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
+        """
+        portworx_volume: NotRequired[pulumi.Input['PortworxVolumeSourcePatchArgsDict']]
+        """
+        portworxVolume represents a portworx volume attached and mounted on kubelets host machine
+        """
+        projected: NotRequired[pulumi.Input['ProjectedVolumeSourcePatchArgsDict']]
+        """
+        projected items for all in one resources secrets, configmaps, and downward API
+        """
+        quobyte: NotRequired[pulumi.Input['QuobyteVolumeSourcePatchArgsDict']]
+        """
+        quobyte represents a Quobyte mount on the host that shares a pod's lifetime
+        """
+        rbd: NotRequired[pulumi.Input['RBDVolumeSourcePatchArgsDict']]
+        """
+        rbd represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md
+        """
+        scale_io: NotRequired[pulumi.Input['ScaleIOVolumeSourcePatchArgsDict']]
+        """
+        scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+        """
+        secret: NotRequired[pulumi.Input['SecretVolumeSourcePatchArgsDict']]
+        """
+        secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+        """
+        storageos: NotRequired[pulumi.Input['StorageOSVolumeSourcePatchArgsDict']]
+        """
+        storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+        """
+        vsphere_volume: NotRequired[pulumi.Input['VsphereVirtualDiskVolumeSourcePatchArgsDict']]
+        """
+        vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
+        """
+elif False:
+    VolumePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class VolumePatchArgs:
@@ -27307,6 +36530,40 @@ class VolumePatchArgs:
         pulumi.set(self, "vsphere_volume", value)
 
 
+if not MYPY:
+    class VolumeProjectionPatchArgsDict(TypedDict):
+        """
+        Projection that may be projected along with other supported volume types
+        """
+        cluster_trust_bundle: NotRequired[pulumi.Input['ClusterTrustBundleProjectionPatchArgsDict']]
+        """
+        ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field of ClusterTrustBundle objects in an auto-updating file.
+
+        Alpha, gated by the ClusterTrustBundleProjection feature gate.
+
+        ClusterTrustBundle objects can either be selected by name, or by the combination of signer name and a label selector.
+
+        Kubelet performs aggressive normalization of the PEM contents written into the pod filesystem.  Esoteric PEM features such as inter-block comments and block headers are stripped.  Certificates are deduplicated. The ordering of certificates within the file is arbitrary, and Kubelet may change the order over time.
+        """
+        config_map: NotRequired[pulumi.Input['ConfigMapProjectionPatchArgsDict']]
+        """
+        configMap information about the configMap data to project
+        """
+        downward_api: NotRequired[pulumi.Input['DownwardAPIProjectionPatchArgsDict']]
+        """
+        downwardAPI information about the downwardAPI data to project
+        """
+        secret: NotRequired[pulumi.Input['SecretProjectionPatchArgsDict']]
+        """
+        secret information about the secret data to project
+        """
+        service_account_token: NotRequired[pulumi.Input['ServiceAccountTokenProjectionPatchArgsDict']]
+        """
+        serviceAccountToken is information about the serviceAccountToken data to project
+        """
+elif False:
+    VolumeProjectionPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class VolumeProjectionPatchArgs:
     def __init__(__self__, *,
@@ -27406,6 +36663,40 @@ class VolumeProjectionPatchArgs:
     def service_account_token(self, value: Optional[pulumi.Input['ServiceAccountTokenProjectionPatchArgs']]):
         pulumi.set(self, "service_account_token", value)
 
+
+if not MYPY:
+    class VolumeProjectionArgsDict(TypedDict):
+        """
+        Projection that may be projected along with other supported volume types
+        """
+        cluster_trust_bundle: NotRequired[pulumi.Input['ClusterTrustBundleProjectionArgsDict']]
+        """
+        ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field of ClusterTrustBundle objects in an auto-updating file.
+
+        Alpha, gated by the ClusterTrustBundleProjection feature gate.
+
+        ClusterTrustBundle objects can either be selected by name, or by the combination of signer name and a label selector.
+
+        Kubelet performs aggressive normalization of the PEM contents written into the pod filesystem.  Esoteric PEM features such as inter-block comments and block headers are stripped.  Certificates are deduplicated. The ordering of certificates within the file is arbitrary, and Kubelet may change the order over time.
+        """
+        config_map: NotRequired[pulumi.Input['ConfigMapProjectionArgsDict']]
+        """
+        configMap information about the configMap data to project
+        """
+        downward_api: NotRequired[pulumi.Input['DownwardAPIProjectionArgsDict']]
+        """
+        downwardAPI information about the downwardAPI data to project
+        """
+        secret: NotRequired[pulumi.Input['SecretProjectionArgsDict']]
+        """
+        secret information about the secret data to project
+        """
+        service_account_token: NotRequired[pulumi.Input['ServiceAccountTokenProjectionArgsDict']]
+        """
+        serviceAccountToken is information about the serviceAccountToken data to project
+        """
+elif False:
+    VolumeProjectionArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class VolumeProjectionArgs:
@@ -27507,6 +36798,22 @@ class VolumeProjectionArgs:
         pulumi.set(self, "service_account_token", value)
 
 
+if not MYPY:
+    class VolumeResourceRequirementsPatchArgsDict(TypedDict):
+        """
+        VolumeResourceRequirements describes the storage resource requirements for a volume.
+        """
+        limits: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+        """
+        requests: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+        """
+elif False:
+    VolumeResourceRequirementsPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class VolumeResourceRequirementsPatchArgs:
     def __init__(__self__, *,
@@ -27547,6 +36854,22 @@ class VolumeResourceRequirementsPatchArgs:
         pulumi.set(self, "requests", value)
 
 
+if not MYPY:
+    class VolumeResourceRequirementsArgsDict(TypedDict):
+        """
+        VolumeResourceRequirements describes the storage resource requirements for a volume.
+        """
+        limits: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+        """
+        requests: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+        """
+elif False:
+    VolumeResourceRequirementsArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class VolumeResourceRequirementsArgs:
     def __init__(__self__, *,
@@ -27586,6 +36909,147 @@ class VolumeResourceRequirementsArgs:
     def requests(self, value: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]):
         pulumi.set(self, "requests", value)
 
+
+if not MYPY:
+    class VolumeArgsDict(TypedDict):
+        """
+        Volume represents a named volume in a pod that may be accessed by any container in the pod.
+        """
+        name: pulumi.Input[str]
+        """
+        name of the volume. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+        """
+        aws_elastic_block_store: NotRequired[pulumi.Input['AWSElasticBlockStoreVolumeSourceArgsDict']]
+        """
+        awsElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+        """
+        azure_disk: NotRequired[pulumi.Input['AzureDiskVolumeSourceArgsDict']]
+        """
+        azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+        """
+        azure_file: NotRequired[pulumi.Input['AzureFileVolumeSourceArgsDict']]
+        """
+        azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+        """
+        cephfs: NotRequired[pulumi.Input['CephFSVolumeSourceArgsDict']]
+        """
+        cephFS represents a Ceph FS mount on the host that shares a pod's lifetime
+        """
+        cinder: NotRequired[pulumi.Input['CinderVolumeSourceArgsDict']]
+        """
+        cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+        """
+        config_map: NotRequired[pulumi.Input['ConfigMapVolumeSourceArgsDict']]
+        """
+        configMap represents a configMap that should populate this volume
+        """
+        csi: NotRequired[pulumi.Input['CSIVolumeSourceArgsDict']]
+        """
+        csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).
+        """
+        downward_api: NotRequired[pulumi.Input['DownwardAPIVolumeSourceArgsDict']]
+        """
+        downwardAPI represents downward API about the pod that should populate this volume
+        """
+        empty_dir: NotRequired[pulumi.Input['EmptyDirVolumeSourceArgsDict']]
+        """
+        emptyDir represents a temporary directory that shares a pod's lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+        """
+        ephemeral: NotRequired[pulumi.Input['EphemeralVolumeSourceArgsDict']]
+        """
+        ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed.
+
+        Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity
+           tracking are needed,
+        c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through
+           a PersistentVolumeClaim (see EphemeralVolumeSource for more
+           information on the connection between this volume type
+           and PersistentVolumeClaim).
+
+        Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod.
+
+        Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information.
+
+        A pod can use both types of ephemeral volumes and persistent volumes at the same time.
+        """
+        fc: NotRequired[pulumi.Input['FCVolumeSourceArgsDict']]
+        """
+        fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
+        """
+        flex_volume: NotRequired[pulumi.Input['FlexVolumeSourceArgsDict']]
+        """
+        flexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
+        """
+        flocker: NotRequired[pulumi.Input['FlockerVolumeSourceArgsDict']]
+        """
+        flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
+        """
+        gce_persistent_disk: NotRequired[pulumi.Input['GCEPersistentDiskVolumeSourceArgsDict']]
+        """
+        gcePersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+        """
+        git_repo: NotRequired[pulumi.Input['GitRepoVolumeSourceArgsDict']]
+        """
+        gitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.
+        """
+        glusterfs: NotRequired[pulumi.Input['GlusterfsVolumeSourceArgsDict']]
+        """
+        glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md
+        """
+        host_path: NotRequired[pulumi.Input['HostPathVolumeSourceArgsDict']]
+        """
+        hostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+        """
+        iscsi: NotRequired[pulumi.Input['ISCSIVolumeSourceArgsDict']]
+        """
+        iscsi represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md
+        """
+        nfs: NotRequired[pulumi.Input['NFSVolumeSourceArgsDict']]
+        """
+        nfs represents an NFS mount on the host that shares a pod's lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+        """
+        persistent_volume_claim: NotRequired[pulumi.Input['PersistentVolumeClaimVolumeSourceArgsDict']]
+        """
+        persistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+        """
+        photon_persistent_disk: NotRequired[pulumi.Input['PhotonPersistentDiskVolumeSourceArgsDict']]
+        """
+        photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
+        """
+        portworx_volume: NotRequired[pulumi.Input['PortworxVolumeSourceArgsDict']]
+        """
+        portworxVolume represents a portworx volume attached and mounted on kubelets host machine
+        """
+        projected: NotRequired[pulumi.Input['ProjectedVolumeSourceArgsDict']]
+        """
+        projected items for all in one resources secrets, configmaps, and downward API
+        """
+        quobyte: NotRequired[pulumi.Input['QuobyteVolumeSourceArgsDict']]
+        """
+        quobyte represents a Quobyte mount on the host that shares a pod's lifetime
+        """
+        rbd: NotRequired[pulumi.Input['RBDVolumeSourceArgsDict']]
+        """
+        rbd represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md
+        """
+        scale_io: NotRequired[pulumi.Input['ScaleIOVolumeSourceArgsDict']]
+        """
+        scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+        """
+        secret: NotRequired[pulumi.Input['SecretVolumeSourceArgsDict']]
+        """
+        secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+        """
+        storageos: NotRequired[pulumi.Input['StorageOSVolumeSourceArgsDict']]
+        """
+        storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+        """
+        vsphere_volume: NotRequired[pulumi.Input['VsphereVirtualDiskVolumeSourceArgsDict']]
+        """
+        vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
+        """
+elif False:
+    VolumeArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class VolumeArgs:
@@ -28100,6 +37564,30 @@ class VolumeArgs:
         pulumi.set(self, "vsphere_volume", value)
 
 
+if not MYPY:
+    class VsphereVirtualDiskVolumeSourcePatchArgsDict(TypedDict):
+        """
+        Represents a vSphere volume resource.
+        """
+        fs_type: NotRequired[pulumi.Input[str]]
+        """
+        fsType is filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+        """
+        storage_policy_id: NotRequired[pulumi.Input[str]]
+        """
+        storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
+        """
+        storage_policy_name: NotRequired[pulumi.Input[str]]
+        """
+        storagePolicyName is the storage Policy Based Management (SPBM) profile name.
+        """
+        volume_path: NotRequired[pulumi.Input[str]]
+        """
+        volumePath is the path that identifies vSphere volume vmdk
+        """
+elif False:
+    VsphereVirtualDiskVolumeSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class VsphereVirtualDiskVolumeSourcePatchArgs:
     def __init__(__self__, *,
@@ -28172,6 +37660,30 @@ class VsphereVirtualDiskVolumeSourcePatchArgs:
         pulumi.set(self, "volume_path", value)
 
 
+if not MYPY:
+    class VsphereVirtualDiskVolumeSourceArgsDict(TypedDict):
+        """
+        Represents a vSphere volume resource.
+        """
+        volume_path: pulumi.Input[str]
+        """
+        volumePath is the path that identifies vSphere volume vmdk
+        """
+        fs_type: NotRequired[pulumi.Input[str]]
+        """
+        fsType is filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+        """
+        storage_policy_id: NotRequired[pulumi.Input[str]]
+        """
+        storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
+        """
+        storage_policy_name: NotRequired[pulumi.Input[str]]
+        """
+        storagePolicyName is the storage Policy Based Management (SPBM) profile name.
+        """
+elif False:
+    VsphereVirtualDiskVolumeSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class VsphereVirtualDiskVolumeSourceArgs:
     def __init__(__self__, *,
@@ -28243,6 +37755,22 @@ class VsphereVirtualDiskVolumeSourceArgs:
         pulumi.set(self, "storage_policy_name", value)
 
 
+if not MYPY:
+    class WeightedPodAffinityTermPatchArgsDict(TypedDict):
+        """
+        The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+        """
+        pod_affinity_term: NotRequired[pulumi.Input['PodAffinityTermPatchArgsDict']]
+        """
+        Required. A pod affinity term, associated with the corresponding weight.
+        """
+        weight: NotRequired[pulumi.Input[int]]
+        """
+        weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+        """
+elif False:
+    WeightedPodAffinityTermPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class WeightedPodAffinityTermPatchArgs:
     def __init__(__self__, *,
@@ -28283,6 +37811,22 @@ class WeightedPodAffinityTermPatchArgs:
         pulumi.set(self, "weight", value)
 
 
+if not MYPY:
+    class WeightedPodAffinityTermArgsDict(TypedDict):
+        """
+        The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+        """
+        pod_affinity_term: pulumi.Input['PodAffinityTermArgsDict']
+        """
+        Required. A pod affinity term, associated with the corresponding weight.
+        """
+        weight: pulumi.Input[int]
+        """
+        weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+        """
+elif False:
+    WeightedPodAffinityTermArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class WeightedPodAffinityTermArgs:
     def __init__(__self__, *,
@@ -28320,6 +37864,30 @@ class WeightedPodAffinityTermArgs:
     def weight(self, value: pulumi.Input[int]):
         pulumi.set(self, "weight", value)
 
+
+if not MYPY:
+    class WindowsSecurityContextOptionsPatchArgsDict(TypedDict):
+        """
+        WindowsSecurityContextOptions contain Windows-specific options and credentials.
+        """
+        gmsa_credential_spec: NotRequired[pulumi.Input[str]]
+        """
+        GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.
+        """
+        gmsa_credential_spec_name: NotRequired[pulumi.Input[str]]
+        """
+        GMSACredentialSpecName is the name of the GMSA credential spec to use.
+        """
+        host_process: NotRequired[pulumi.Input[bool]]
+        """
+        HostProcess determines if a container should be run as a 'Host Process' container. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers). In addition, if HostProcess is true then HostNetwork must also be set to true.
+        """
+        run_as_user_name: NotRequired[pulumi.Input[str]]
+        """
+        The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+        """
+elif False:
+    WindowsSecurityContextOptionsPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class WindowsSecurityContextOptionsPatchArgs:
@@ -28392,6 +37960,30 @@ class WindowsSecurityContextOptionsPatchArgs:
     def run_as_user_name(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "run_as_user_name", value)
 
+
+if not MYPY:
+    class WindowsSecurityContextOptionsArgsDict(TypedDict):
+        """
+        WindowsSecurityContextOptions contain Windows-specific options and credentials.
+        """
+        gmsa_credential_spec: NotRequired[pulumi.Input[str]]
+        """
+        GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.
+        """
+        gmsa_credential_spec_name: NotRequired[pulumi.Input[str]]
+        """
+        GMSACredentialSpecName is the name of the GMSA credential spec to use.
+        """
+        host_process: NotRequired[pulumi.Input[bool]]
+        """
+        HostProcess determines if a container should be run as a 'Host Process' container. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers). In addition, if HostProcess is true then HostNetwork must also be set to true.
+        """
+        run_as_user_name: NotRequired[pulumi.Input[str]]
+        """
+        The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+        """
+elif False:
+    WindowsSecurityContextOptionsArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class WindowsSecurityContextOptionsArgs:

--- a/sdk/python/pulumi_kubernetes/core/v1/outputs.py
+++ b/sdk/python/pulumi_kubernetes/core/v1/outputs.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta

--- a/sdk/python/pulumi_kubernetes/discovery/v1/EndpointSlice.py
+++ b/sdk/python/pulumi_kubernetes/discovery/v1/EndpointSlice.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -124,10 +129,10 @@ class EndpointSlice(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  address_type: Optional[pulumi.Input[str]] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 endpoints: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['EndpointArgs']]]]] = None,
+                 endpoints: Optional[pulumi.Input[Sequence[pulumi.Input[Union['EndpointArgs', 'EndpointArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 ports: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['EndpointPortArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 ports: Optional[pulumi.Input[Sequence[pulumi.Input[Union['EndpointPortArgs', 'EndpointPortArgsDict']]]]] = None,
                  __props__=None):
         """
         EndpointSlice represents a subset of the endpoints that implement a service. For a given service there may be multiple EndpointSlice objects, selected by labels, which must be joined to produce the full set of endpoints.
@@ -136,10 +141,10 @@ class EndpointSlice(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] address_type: addressType specifies the type of address carried by this EndpointSlice. All addresses in this slice must be the same type. This field is immutable after creation. The following address types are currently supported: * IPv4: Represents an IPv4 Address. * IPv6: Represents an IPv6 Address. * FQDN: Represents a Fully Qualified Domain Name.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['EndpointArgs']]]] endpoints: endpoints is a list of unique endpoints in this slice. Each slice may include a maximum of 1000 endpoints.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['EndpointArgs', 'EndpointArgsDict']]]] endpoints: endpoints is a list of unique endpoints in this slice. Each slice may include a maximum of 1000 endpoints.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata.
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['EndpointPortArgs']]]] ports: ports specifies the list of network ports exposed by each endpoint in this slice. Each port must have a unique name. When ports is empty, it indicates that there are no defined ports. When a port is defined with a nil port value, it indicates "all ports". Each slice may include a maximum of 100 ports.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['EndpointPortArgs', 'EndpointPortArgsDict']]]] ports: ports specifies the list of network ports exposed by each endpoint in this slice. Each port must have a unique name. When ports is empty, it indicates that there are no defined ports. When a port is defined with a nil port value, it indicates "all ports". Each slice may include a maximum of 100 ports.
         """
         ...
     @overload
@@ -167,10 +172,10 @@ class EndpointSlice(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  address_type: Optional[pulumi.Input[str]] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 endpoints: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['EndpointArgs']]]]] = None,
+                 endpoints: Optional[pulumi.Input[Sequence[pulumi.Input[Union['EndpointArgs', 'EndpointArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 ports: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['EndpointPortArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 ports: Optional[pulumi.Input[Sequence[pulumi.Input[Union['EndpointPortArgs', 'EndpointPortArgsDict']]]]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/discovery/v1/EndpointSliceList.py
+++ b/sdk/python/pulumi_kubernetes/discovery/v1/EndpointSliceList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -92,9 +97,9 @@ class EndpointSliceList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['EndpointSliceArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['EndpointSliceArgs', 'EndpointSliceArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         EndpointSliceList represents a list of endpoint slices
@@ -102,9 +107,9 @@ class EndpointSliceList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['EndpointSliceArgs']]]] items: items is the list of endpoint slices
+        :param pulumi.Input[Sequence[pulumi.Input[Union['EndpointSliceArgs', 'EndpointSliceArgsDict']]]] items: items is the list of endpoint slices
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata.
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata.
         """
         ...
     @overload
@@ -131,9 +136,9 @@ class EndpointSliceList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['EndpointSliceArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['EndpointSliceArgs', 'EndpointSliceArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/discovery/v1/EndpointSlicePatch.py
+++ b/sdk/python/pulumi_kubernetes/discovery/v1/EndpointSlicePatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -126,10 +131,10 @@ class EndpointSlicePatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  address_type: Optional[pulumi.Input[str]] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 endpoints: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['EndpointPatchArgs']]]]] = None,
+                 endpoints: Optional[pulumi.Input[Sequence[pulumi.Input[Union['EndpointPatchArgs', 'EndpointPatchArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 ports: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['EndpointPortPatchArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 ports: Optional[pulumi.Input[Sequence[pulumi.Input[Union['EndpointPortPatchArgs', 'EndpointPortPatchArgsDict']]]]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -144,10 +149,10 @@ class EndpointSlicePatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] address_type: addressType specifies the type of address carried by this EndpointSlice. All addresses in this slice must be the same type. This field is immutable after creation. The following address types are currently supported: * IPv4: Represents an IPv4 Address. * IPv6: Represents an IPv6 Address. * FQDN: Represents a Fully Qualified Domain Name.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['EndpointPatchArgs']]]] endpoints: endpoints is a list of unique endpoints in this slice. Each slice may include a maximum of 1000 endpoints.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['EndpointPatchArgs', 'EndpointPatchArgsDict']]]] endpoints: endpoints is a list of unique endpoints in this slice. Each slice may include a maximum of 1000 endpoints.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata.
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['EndpointPortPatchArgs']]]] ports: ports specifies the list of network ports exposed by each endpoint in this slice. Each port must have a unique name. When ports is empty, it indicates that there are no defined ports. When a port is defined with a nil port value, it indicates "all ports". Each slice may include a maximum of 100 ports.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['EndpointPortPatchArgs', 'EndpointPortPatchArgsDict']]]] ports: ports specifies the list of network ports exposed by each endpoint in this slice. Each port must have a unique name. When ports is empty, it indicates that there are no defined ports. When a port is defined with a nil port value, it indicates "all ports". Each slice may include a maximum of 100 ports.
         """
         ...
     @overload
@@ -181,10 +186,10 @@ class EndpointSlicePatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  address_type: Optional[pulumi.Input[str]] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 endpoints: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['EndpointPatchArgs']]]]] = None,
+                 endpoints: Optional[pulumi.Input[Sequence[pulumi.Input[Union['EndpointPatchArgs', 'EndpointPatchArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 ports: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['EndpointPortPatchArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 ports: Optional[pulumi.Input[Sequence[pulumi.Input[Union['EndpointPortPatchArgs', 'EndpointPortPatchArgsDict']]]]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/discovery/v1/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/discovery/v1/_inputs.py
@@ -4,26 +4,64 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import core as _core
 from ... import meta as _meta
 
 __all__ = [
     'EndpointConditionsPatchArgs',
+    'EndpointConditionsPatchArgsDict',
     'EndpointConditionsArgs',
+    'EndpointConditionsArgsDict',
     'EndpointHintsPatchArgs',
+    'EndpointHintsPatchArgsDict',
     'EndpointHintsArgs',
+    'EndpointHintsArgsDict',
     'EndpointPatchArgs',
+    'EndpointPatchArgsDict',
     'EndpointPortPatchArgs',
+    'EndpointPortPatchArgsDict',
     'EndpointPortArgs',
+    'EndpointPortArgsDict',
     'EndpointSliceArgs',
+    'EndpointSliceArgsDict',
     'EndpointArgs',
+    'EndpointArgsDict',
     'ForZonePatchArgs',
+    'ForZonePatchArgsDict',
     'ForZoneArgs',
+    'ForZoneArgsDict',
 ]
+
+MYPY = False
+
+if not MYPY:
+    class EndpointConditionsPatchArgsDict(TypedDict):
+        """
+        EndpointConditions represents the current condition of an endpoint.
+        """
+        ready: NotRequired[pulumi.Input[bool]]
+        """
+        ready indicates that this endpoint is prepared to receive traffic, according to whatever system is managing the endpoint. A nil value indicates an unknown state. In most cases consumers should interpret this unknown state as ready. For compatibility reasons, ready should never be "true" for terminating endpoints, except when the normal readiness behavior is being explicitly overridden, for example when the associated Service has set the publishNotReadyAddresses flag.
+        """
+        serving: NotRequired[pulumi.Input[bool]]
+        """
+        serving is identical to ready except that it is set regardless of the terminating state of endpoints. This condition should be set to true for a ready endpoint that is terminating. If nil, consumers should defer to the ready condition.
+        """
+        terminating: NotRequired[pulumi.Input[bool]]
+        """
+        terminating indicates that this endpoint is terminating. A nil value indicates an unknown state. Consumers should interpret this unknown state to mean that the endpoint is not terminating.
+        """
+elif False:
+    EndpointConditionsPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class EndpointConditionsPatchArgs:
@@ -81,6 +119,26 @@ class EndpointConditionsPatchArgs:
         pulumi.set(self, "terminating", value)
 
 
+if not MYPY:
+    class EndpointConditionsArgsDict(TypedDict):
+        """
+        EndpointConditions represents the current condition of an endpoint.
+        """
+        ready: NotRequired[pulumi.Input[bool]]
+        """
+        ready indicates that this endpoint is prepared to receive traffic, according to whatever system is managing the endpoint. A nil value indicates an unknown state. In most cases consumers should interpret this unknown state as ready. For compatibility reasons, ready should never be "true" for terminating endpoints, except when the normal readiness behavior is being explicitly overridden, for example when the associated Service has set the publishNotReadyAddresses flag.
+        """
+        serving: NotRequired[pulumi.Input[bool]]
+        """
+        serving is identical to ready except that it is set regardless of the terminating state of endpoints. This condition should be set to true for a ready endpoint that is terminating. If nil, consumers should defer to the ready condition.
+        """
+        terminating: NotRequired[pulumi.Input[bool]]
+        """
+        terminating indicates that this endpoint is terminating. A nil value indicates an unknown state. Consumers should interpret this unknown state to mean that the endpoint is not terminating.
+        """
+elif False:
+    EndpointConditionsArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class EndpointConditionsArgs:
     def __init__(__self__, *,
@@ -137,6 +195,18 @@ class EndpointConditionsArgs:
         pulumi.set(self, "terminating", value)
 
 
+if not MYPY:
+    class EndpointHintsPatchArgsDict(TypedDict):
+        """
+        EndpointHints provides hints describing how an endpoint should be consumed.
+        """
+        for_zones: NotRequired[pulumi.Input[Sequence[pulumi.Input['ForZonePatchArgsDict']]]]
+        """
+        forZones indicates the zone(s) this endpoint should be consumed by to enable topology aware routing.
+        """
+elif False:
+    EndpointHintsPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class EndpointHintsPatchArgs:
     def __init__(__self__, *,
@@ -161,6 +231,18 @@ class EndpointHintsPatchArgs:
         pulumi.set(self, "for_zones", value)
 
 
+if not MYPY:
+    class EndpointHintsArgsDict(TypedDict):
+        """
+        EndpointHints provides hints describing how an endpoint should be consumed.
+        """
+        for_zones: NotRequired[pulumi.Input[Sequence[pulumi.Input['ForZoneArgsDict']]]]
+        """
+        forZones indicates the zone(s) this endpoint should be consumed by to enable topology aware routing.
+        """
+elif False:
+    EndpointHintsArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class EndpointHintsArgs:
     def __init__(__self__, *,
@@ -184,6 +266,46 @@ class EndpointHintsArgs:
     def for_zones(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['ForZoneArgs']]]]):
         pulumi.set(self, "for_zones", value)
 
+
+if not MYPY:
+    class EndpointPatchArgsDict(TypedDict):
+        """
+        Endpoint represents a single logical "backend" implementing a service.
+        """
+        addresses: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        addresses of this endpoint. The contents of this field are interpreted according to the corresponding EndpointSlice addressType field. Consumers must handle different types of addresses in the context of their own capabilities. This must contain at least one address but no more than 100. These are all assumed to be fungible and clients may choose to only use the first element. Refer to: https://issue.k8s.io/106267
+        """
+        conditions: NotRequired[pulumi.Input['EndpointConditionsPatchArgsDict']]
+        """
+        conditions contains information about the current status of the endpoint.
+        """
+        deprecated_topology: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        deprecatedTopology contains topology information part of the v1beta1 API. This field is deprecated, and will be removed when the v1beta1 API is removed (no sooner than kubernetes v1.24).  While this field can hold values, it is not writable through the v1 API, and any attempts to write to it will be silently ignored. Topology information can be found in the zone and nodeName fields instead.
+        """
+        hints: NotRequired[pulumi.Input['EndpointHintsPatchArgsDict']]
+        """
+        hints contains information associated with how an endpoint should be consumed.
+        """
+        hostname: NotRequired[pulumi.Input[str]]
+        """
+        hostname of this endpoint. This field may be used by consumers of endpoints to distinguish endpoints from each other (e.g. in DNS names). Multiple endpoints which use the same hostname should be considered fungible (e.g. multiple A values in DNS). Must be lowercase and pass DNS Label (RFC 1123) validation.
+        """
+        node_name: NotRequired[pulumi.Input[str]]
+        """
+        nodeName represents the name of the Node hosting this endpoint. This can be used to determine endpoints local to a Node.
+        """
+        target_ref: NotRequired[pulumi.Input['_core.v1.ObjectReferencePatchArgsDict']]
+        """
+        targetRef is a reference to a Kubernetes object that represents this endpoint.
+        """
+        zone: NotRequired[pulumi.Input[str]]
+        """
+        zone is the name of the Zone this endpoint exists in.
+        """
+elif False:
+    EndpointPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class EndpointPatchArgs:
@@ -321,6 +443,39 @@ class EndpointPatchArgs:
         pulumi.set(self, "zone", value)
 
 
+if not MYPY:
+    class EndpointPortPatchArgsDict(TypedDict):
+        """
+        EndpointPort represents a Port used by an EndpointSlice
+        """
+        app_protocol: NotRequired[pulumi.Input[str]]
+        """
+        The application protocol for this port. This is used as a hint for implementations to offer richer behavior for protocols that they understand. This field follows standard Kubernetes label syntax. Valid values are either:
+
+        * Un-prefixed protocol names - reserved for IANA standard service names (as per RFC-6335 and https://www.iana.org/assignments/service-names).
+
+        * Kubernetes-defined prefixed names:
+          * 'kubernetes.io/h2c' - HTTP/2 prior knowledge over cleartext as described in https://www.rfc-editor.org/rfc/rfc9113.html#name-starting-http-2-with-prior-
+          * 'kubernetes.io/ws'  - WebSocket over cleartext as described in https://www.rfc-editor.org/rfc/rfc6455
+          * 'kubernetes.io/wss' - WebSocket over TLS as described in https://www.rfc-editor.org/rfc/rfc6455
+
+        * Other protocols should use implementation-defined prefixed names such as mycompany.com/my-custom-protocol.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        name represents the name of this port. All ports in an EndpointSlice must have a unique name. If the EndpointSlice is derived from a Kubernetes service, this corresponds to the Service.ports[].name. Name must either be an empty string or pass DNS_LABEL validation: * must be no more than 63 characters long. * must consist of lower case alphanumeric characters or '-'. * must start and end with an alphanumeric character. Default is empty string.
+        """
+        port: NotRequired[pulumi.Input[int]]
+        """
+        port represents the port number of the endpoint. If this is not specified, ports are not restricted and must be interpreted in the context of the specific consumer.
+        """
+        protocol: NotRequired[pulumi.Input[str]]
+        """
+        protocol represents the IP protocol for this port. Must be UDP, TCP, or SCTP. Default is TCP.
+        """
+elif False:
+    EndpointPortPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class EndpointPortPatchArgs:
     def __init__(__self__, *,
@@ -411,6 +566,39 @@ class EndpointPortPatchArgs:
         pulumi.set(self, "protocol", value)
 
 
+if not MYPY:
+    class EndpointPortArgsDict(TypedDict):
+        """
+        EndpointPort represents a Port used by an EndpointSlice
+        """
+        app_protocol: NotRequired[pulumi.Input[str]]
+        """
+        The application protocol for this port. This is used as a hint for implementations to offer richer behavior for protocols that they understand. This field follows standard Kubernetes label syntax. Valid values are either:
+
+        * Un-prefixed protocol names - reserved for IANA standard service names (as per RFC-6335 and https://www.iana.org/assignments/service-names).
+
+        * Kubernetes-defined prefixed names:
+          * 'kubernetes.io/h2c' - HTTP/2 prior knowledge over cleartext as described in https://www.rfc-editor.org/rfc/rfc9113.html#name-starting-http-2-with-prior-
+          * 'kubernetes.io/ws'  - WebSocket over cleartext as described in https://www.rfc-editor.org/rfc/rfc6455
+          * 'kubernetes.io/wss' - WebSocket over TLS as described in https://www.rfc-editor.org/rfc/rfc6455
+
+        * Other protocols should use implementation-defined prefixed names such as mycompany.com/my-custom-protocol.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        name represents the name of this port. All ports in an EndpointSlice must have a unique name. If the EndpointSlice is derived from a Kubernetes service, this corresponds to the Service.ports[].name. Name must either be an empty string or pass DNS_LABEL validation: * must be no more than 63 characters long. * must consist of lower case alphanumeric characters or '-'. * must start and end with an alphanumeric character. Default is empty string.
+        """
+        port: NotRequired[pulumi.Input[int]]
+        """
+        port represents the port number of the endpoint. If this is not specified, ports are not restricted and must be interpreted in the context of the specific consumer.
+        """
+        protocol: NotRequired[pulumi.Input[str]]
+        """
+        protocol represents the IP protocol for this port. Must be UDP, TCP, or SCTP. Default is TCP.
+        """
+elif False:
+    EndpointPortArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class EndpointPortArgs:
     def __init__(__self__, *,
@@ -500,6 +688,38 @@ class EndpointPortArgs:
     def protocol(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "protocol", value)
 
+
+if not MYPY:
+    class EndpointSliceArgsDict(TypedDict):
+        """
+        EndpointSlice represents a subset of the endpoints that implement a service. For a given service there may be multiple EndpointSlice objects, selected by labels, which must be joined to produce the full set of endpoints.
+        """
+        address_type: pulumi.Input[str]
+        """
+        addressType specifies the type of address carried by this EndpointSlice. All addresses in this slice must be the same type. This field is immutable after creation. The following address types are currently supported: * IPv4: Represents an IPv4 Address. * IPv6: Represents an IPv6 Address. * FQDN: Represents a Fully Qualified Domain Name.
+        """
+        endpoints: pulumi.Input[Sequence[pulumi.Input['EndpointArgsDict']]]
+        """
+        endpoints is a list of unique endpoints in this slice. Each slice may include a maximum of 1000 endpoints.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata.
+        """
+        ports: NotRequired[pulumi.Input[Sequence[pulumi.Input['EndpointPortArgsDict']]]]
+        """
+        ports specifies the list of network ports exposed by each endpoint in this slice. Each port must have a unique name. When ports is empty, it indicates that there are no defined ports. When a port is defined with a nil port value, it indicates "all ports". Each slice may include a maximum of 100 ports.
+        """
+elif False:
+    EndpointSliceArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class EndpointSliceArgs:
@@ -602,6 +822,46 @@ class EndpointSliceArgs:
     def ports(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['EndpointPortArgs']]]]):
         pulumi.set(self, "ports", value)
 
+
+if not MYPY:
+    class EndpointArgsDict(TypedDict):
+        """
+        Endpoint represents a single logical "backend" implementing a service.
+        """
+        addresses: pulumi.Input[Sequence[pulumi.Input[str]]]
+        """
+        addresses of this endpoint. The contents of this field are interpreted according to the corresponding EndpointSlice addressType field. Consumers must handle different types of addresses in the context of their own capabilities. This must contain at least one address but no more than 100. These are all assumed to be fungible and clients may choose to only use the first element. Refer to: https://issue.k8s.io/106267
+        """
+        conditions: NotRequired[pulumi.Input['EndpointConditionsArgsDict']]
+        """
+        conditions contains information about the current status of the endpoint.
+        """
+        deprecated_topology: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        deprecatedTopology contains topology information part of the v1beta1 API. This field is deprecated, and will be removed when the v1beta1 API is removed (no sooner than kubernetes v1.24).  While this field can hold values, it is not writable through the v1 API, and any attempts to write to it will be silently ignored. Topology information can be found in the zone and nodeName fields instead.
+        """
+        hints: NotRequired[pulumi.Input['EndpointHintsArgsDict']]
+        """
+        hints contains information associated with how an endpoint should be consumed.
+        """
+        hostname: NotRequired[pulumi.Input[str]]
+        """
+        hostname of this endpoint. This field may be used by consumers of endpoints to distinguish endpoints from each other (e.g. in DNS names). Multiple endpoints which use the same hostname should be considered fungible (e.g. multiple A values in DNS). Must be lowercase and pass DNS Label (RFC 1123) validation.
+        """
+        node_name: NotRequired[pulumi.Input[str]]
+        """
+        nodeName represents the name of the Node hosting this endpoint. This can be used to determine endpoints local to a Node.
+        """
+        target_ref: NotRequired[pulumi.Input['_core.v1.ObjectReferenceArgsDict']]
+        """
+        targetRef is a reference to a Kubernetes object that represents this endpoint.
+        """
+        zone: NotRequired[pulumi.Input[str]]
+        """
+        zone is the name of the Zone this endpoint exists in.
+        """
+elif False:
+    EndpointArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class EndpointArgs:
@@ -738,6 +998,18 @@ class EndpointArgs:
         pulumi.set(self, "zone", value)
 
 
+if not MYPY:
+    class ForZonePatchArgsDict(TypedDict):
+        """
+        ForZone provides information about which zones should consume this endpoint.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        name represents the name of the zone.
+        """
+elif False:
+    ForZonePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ForZonePatchArgs:
     def __init__(__self__, *,
@@ -761,6 +1033,18 @@ class ForZonePatchArgs:
     def name(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "name", value)
 
+
+if not MYPY:
+    class ForZoneArgsDict(TypedDict):
+        """
+        ForZone provides information about which zones should consume this endpoint.
+        """
+        name: pulumi.Input[str]
+        """
+        name represents the name of the zone.
+        """
+elif False:
+    ForZoneArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ForZoneArgs:

--- a/sdk/python/pulumi_kubernetes/discovery/v1/outputs.py
+++ b/sdk/python/pulumi_kubernetes/discovery/v1/outputs.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core

--- a/sdk/python/pulumi_kubernetes/discovery/v1beta1/EndpointSlice.py
+++ b/sdk/python/pulumi_kubernetes/discovery/v1beta1/EndpointSlice.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -124,10 +129,10 @@ class EndpointSlice(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  address_type: Optional[pulumi.Input[str]] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 endpoints: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['EndpointArgs']]]]] = None,
+                 endpoints: Optional[pulumi.Input[Sequence[pulumi.Input[Union['EndpointArgs', 'EndpointArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 ports: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['EndpointPortArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 ports: Optional[pulumi.Input[Sequence[pulumi.Input[Union['EndpointPortArgs', 'EndpointPortArgsDict']]]]] = None,
                  __props__=None):
         """
         EndpointSlice represents a subset of the endpoints that implement a service. For a given service there may be multiple EndpointSlice objects, selected by labels, which must be joined to produce the full set of endpoints.
@@ -136,10 +141,10 @@ class EndpointSlice(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] address_type: addressType specifies the type of address carried by this EndpointSlice. All addresses in this slice must be the same type. This field is immutable after creation. The following address types are currently supported: * IPv4: Represents an IPv4 Address. * IPv6: Represents an IPv6 Address. * FQDN: Represents a Fully Qualified Domain Name.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['EndpointArgs']]]] endpoints: endpoints is a list of unique endpoints in this slice. Each slice may include a maximum of 1000 endpoints.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['EndpointArgs', 'EndpointArgsDict']]]] endpoints: endpoints is a list of unique endpoints in this slice. Each slice may include a maximum of 1000 endpoints.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata.
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['EndpointPortArgs']]]] ports: ports specifies the list of network ports exposed by each endpoint in this slice. Each port must have a unique name. When ports is empty, it indicates that there are no defined ports. When a port is defined with a nil port value, it indicates "all ports". Each slice may include a maximum of 100 ports.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['EndpointPortArgs', 'EndpointPortArgsDict']]]] ports: ports specifies the list of network ports exposed by each endpoint in this slice. Each port must have a unique name. When ports is empty, it indicates that there are no defined ports. When a port is defined with a nil port value, it indicates "all ports". Each slice may include a maximum of 100 ports.
         """
         ...
     @overload
@@ -167,10 +172,10 @@ class EndpointSlice(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  address_type: Optional[pulumi.Input[str]] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 endpoints: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['EndpointArgs']]]]] = None,
+                 endpoints: Optional[pulumi.Input[Sequence[pulumi.Input[Union['EndpointArgs', 'EndpointArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 ports: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['EndpointPortArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 ports: Optional[pulumi.Input[Sequence[pulumi.Input[Union['EndpointPortArgs', 'EndpointPortArgsDict']]]]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/discovery/v1beta1/EndpointSliceList.py
+++ b/sdk/python/pulumi_kubernetes/discovery/v1beta1/EndpointSliceList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -92,9 +97,9 @@ class EndpointSliceList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['EndpointSliceArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['EndpointSliceArgs', 'EndpointSliceArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         EndpointSliceList represents a list of endpoint slices
@@ -102,9 +107,9 @@ class EndpointSliceList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['EndpointSliceArgs']]]] items: List of endpoint slices
+        :param pulumi.Input[Sequence[pulumi.Input[Union['EndpointSliceArgs', 'EndpointSliceArgsDict']]]] items: List of endpoint slices
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata.
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata.
         """
         ...
     @overload
@@ -131,9 +136,9 @@ class EndpointSliceList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['EndpointSliceArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['EndpointSliceArgs', 'EndpointSliceArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/discovery/v1beta1/EndpointSlicePatch.py
+++ b/sdk/python/pulumi_kubernetes/discovery/v1beta1/EndpointSlicePatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -126,10 +131,10 @@ class EndpointSlicePatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  address_type: Optional[pulumi.Input[str]] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 endpoints: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['EndpointPatchArgs']]]]] = None,
+                 endpoints: Optional[pulumi.Input[Sequence[pulumi.Input[Union['EndpointPatchArgs', 'EndpointPatchArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 ports: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['EndpointPortPatchArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 ports: Optional[pulumi.Input[Sequence[pulumi.Input[Union['EndpointPortPatchArgs', 'EndpointPortPatchArgsDict']]]]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -144,10 +149,10 @@ class EndpointSlicePatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] address_type: addressType specifies the type of address carried by this EndpointSlice. All addresses in this slice must be the same type. This field is immutable after creation. The following address types are currently supported: * IPv4: Represents an IPv4 Address. * IPv6: Represents an IPv6 Address. * FQDN: Represents a Fully Qualified Domain Name.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['EndpointPatchArgs']]]] endpoints: endpoints is a list of unique endpoints in this slice. Each slice may include a maximum of 1000 endpoints.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['EndpointPatchArgs', 'EndpointPatchArgsDict']]]] endpoints: endpoints is a list of unique endpoints in this slice. Each slice may include a maximum of 1000 endpoints.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata.
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['EndpointPortPatchArgs']]]] ports: ports specifies the list of network ports exposed by each endpoint in this slice. Each port must have a unique name. When ports is empty, it indicates that there are no defined ports. When a port is defined with a nil port value, it indicates "all ports". Each slice may include a maximum of 100 ports.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['EndpointPortPatchArgs', 'EndpointPortPatchArgsDict']]]] ports: ports specifies the list of network ports exposed by each endpoint in this slice. Each port must have a unique name. When ports is empty, it indicates that there are no defined ports. When a port is defined with a nil port value, it indicates "all ports". Each slice may include a maximum of 100 ports.
         """
         ...
     @overload
@@ -181,10 +186,10 @@ class EndpointSlicePatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  address_type: Optional[pulumi.Input[str]] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 endpoints: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['EndpointPatchArgs']]]]] = None,
+                 endpoints: Optional[pulumi.Input[Sequence[pulumi.Input[Union['EndpointPatchArgs', 'EndpointPatchArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 ports: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['EndpointPortPatchArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 ports: Optional[pulumi.Input[Sequence[pulumi.Input[Union['EndpointPortPatchArgs', 'EndpointPortPatchArgsDict']]]]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/discovery/v1beta1/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/discovery/v1beta1/_inputs.py
@@ -4,22 +4,56 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import core as _core
 from ... import meta as _meta
 
 __all__ = [
     'EndpointConditionsPatchArgs',
+    'EndpointConditionsPatchArgsDict',
     'EndpointConditionsArgs',
+    'EndpointConditionsArgsDict',
     'EndpointPatchArgs',
+    'EndpointPatchArgsDict',
     'EndpointPortPatchArgs',
+    'EndpointPortPatchArgsDict',
     'EndpointPortArgs',
+    'EndpointPortArgsDict',
     'EndpointSliceArgs',
+    'EndpointSliceArgsDict',
     'EndpointArgs',
+    'EndpointArgsDict',
 ]
+
+MYPY = False
+
+if not MYPY:
+    class EndpointConditionsPatchArgsDict(TypedDict):
+        """
+        EndpointConditions represents the current condition of an endpoint.
+        """
+        ready: NotRequired[pulumi.Input[bool]]
+        """
+        ready indicates that this endpoint is prepared to receive traffic, according to whatever system is managing the endpoint. A nil value indicates an unknown state. In most cases consumers should interpret this unknown state as ready.
+        """
+        serving: NotRequired[pulumi.Input[bool]]
+        """
+        serving is identical to ready except that it is set regardless of the terminating state of endpoints. This condition should be set to true for a ready endpoint that is terminating. If nil, consumers should defer to the ready condition. This field can be enabled with the EndpointSliceTerminatingCondition feature gate.
+        """
+        terminating: NotRequired[pulumi.Input[bool]]
+        """
+        terminating indicates that this endpoint is terminating. A nil value indicates an unknown state. Consumers should interpret this unknown state to mean that the endpoint is not terminating. This field can be enabled with the EndpointSliceTerminatingCondition feature gate.
+        """
+elif False:
+    EndpointConditionsPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class EndpointConditionsPatchArgs:
@@ -77,6 +111,26 @@ class EndpointConditionsPatchArgs:
         pulumi.set(self, "terminating", value)
 
 
+if not MYPY:
+    class EndpointConditionsArgsDict(TypedDict):
+        """
+        EndpointConditions represents the current condition of an endpoint.
+        """
+        ready: NotRequired[pulumi.Input[bool]]
+        """
+        ready indicates that this endpoint is prepared to receive traffic, according to whatever system is managing the endpoint. A nil value indicates an unknown state. In most cases consumers should interpret this unknown state as ready.
+        """
+        serving: NotRequired[pulumi.Input[bool]]
+        """
+        serving is identical to ready except that it is set regardless of the terminating state of endpoints. This condition should be set to true for a ready endpoint that is terminating. If nil, consumers should defer to the ready condition. This field can be enabled with the EndpointSliceTerminatingCondition feature gate.
+        """
+        terminating: NotRequired[pulumi.Input[bool]]
+        """
+        terminating indicates that this endpoint is terminating. A nil value indicates an unknown state. Consumers should interpret this unknown state to mean that the endpoint is not terminating. This field can be enabled with the EndpointSliceTerminatingCondition feature gate.
+        """
+elif False:
+    EndpointConditionsArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class EndpointConditionsArgs:
     def __init__(__self__, *,
@@ -132,6 +186,44 @@ class EndpointConditionsArgs:
     def terminating(self, value: Optional[pulumi.Input[bool]]):
         pulumi.set(self, "terminating", value)
 
+
+if not MYPY:
+    class EndpointPatchArgsDict(TypedDict):
+        """
+        Endpoint represents a single logical "backend" implementing a service.
+        """
+        addresses: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        addresses of this endpoint. The contents of this field are interpreted according to the corresponding EndpointSlice addressType field. Consumers must handle different types of addresses in the context of their own capabilities. This must contain at least one address but no more than 100.
+        """
+        conditions: NotRequired[pulumi.Input['EndpointConditionsPatchArgsDict']]
+        """
+        conditions contains information about the current status of the endpoint.
+        """
+        hostname: NotRequired[pulumi.Input[str]]
+        """
+        hostname of this endpoint. This field may be used by consumers of endpoints to distinguish endpoints from each other (e.g. in DNS names). Multiple endpoints which use the same hostname should be considered fungible (e.g. multiple A values in DNS). Must pass DNS Label (RFC 1123) validation.
+        """
+        node_name: NotRequired[pulumi.Input[str]]
+        """
+        nodeName represents the name of the Node hosting this endpoint. This can be used to determine endpoints local to a Node. This field can be enabled with the EndpointSliceNodeName feature gate.
+        """
+        target_ref: NotRequired[pulumi.Input['_core.v1.ObjectReferencePatchArgsDict']]
+        """
+        targetRef is a reference to a Kubernetes object that represents this endpoint.
+        """
+        topology: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        topology contains arbitrary topology information associated with the endpoint. These key/value pairs must conform with the label format. https://kubernetes.io/docs/concepts/overview/working-with-objects/labels Topology may include a maximum of 16 key/value pairs. This includes, but is not limited to the following well known keys: * kubernetes.io/hostname: the value indicates the hostname of the node
+          where the endpoint is located. This should match the corresponding
+          node label.
+        * topology.kubernetes.io/zone: the value indicates the zone where the
+          endpoint is located. This should match the corresponding node label.
+        * topology.kubernetes.io/region: the value indicates the region where the
+          endpoint is located. This should match the corresponding node label.
+        """
+elif False:
+    EndpointPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class EndpointPatchArgs:
@@ -249,6 +341,30 @@ class EndpointPatchArgs:
         pulumi.set(self, "topology", value)
 
 
+if not MYPY:
+    class EndpointPortPatchArgsDict(TypedDict):
+        """
+        EndpointPort represents a Port used by an EndpointSlice
+        """
+        app_protocol: NotRequired[pulumi.Input[str]]
+        """
+        The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names. Default is empty string.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        The name of this port. All ports in an EndpointSlice must have a unique name. If the EndpointSlice is dervied from a Kubernetes service, this corresponds to the Service.ports[].name. Name must either be an empty string or pass DNS_LABEL validation: * must be no more than 63 characters long. * must consist of lower case alphanumeric characters or '-'. * must start and end with an alphanumeric character. Default is empty string.
+        """
+        port: NotRequired[pulumi.Input[int]]
+        """
+        The port number of the endpoint. If this is not specified, ports are not restricted and must be interpreted in the context of the specific consumer.
+        """
+        protocol: NotRequired[pulumi.Input[str]]
+        """
+        The IP protocol for this port. Must be UDP, TCP, or SCTP. Default is TCP.
+        """
+elif False:
+    EndpointPortPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class EndpointPortPatchArgs:
     def __init__(__self__, *,
@@ -321,6 +437,30 @@ class EndpointPortPatchArgs:
         pulumi.set(self, "protocol", value)
 
 
+if not MYPY:
+    class EndpointPortArgsDict(TypedDict):
+        """
+        EndpointPort represents a Port used by an EndpointSlice
+        """
+        app_protocol: NotRequired[pulumi.Input[str]]
+        """
+        The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names. Default is empty string.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        The name of this port. All ports in an EndpointSlice must have a unique name. If the EndpointSlice is dervied from a Kubernetes service, this corresponds to the Service.ports[].name. Name must either be an empty string or pass DNS_LABEL validation: * must be no more than 63 characters long. * must consist of lower case alphanumeric characters or '-'. * must start and end with an alphanumeric character. Default is empty string.
+        """
+        port: NotRequired[pulumi.Input[int]]
+        """
+        The port number of the endpoint. If this is not specified, ports are not restricted and must be interpreted in the context of the specific consumer.
+        """
+        protocol: NotRequired[pulumi.Input[str]]
+        """
+        The IP protocol for this port. Must be UDP, TCP, or SCTP. Default is TCP.
+        """
+elif False:
+    EndpointPortArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class EndpointPortArgs:
     def __init__(__self__, *,
@@ -392,6 +532,38 @@ class EndpointPortArgs:
     def protocol(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "protocol", value)
 
+
+if not MYPY:
+    class EndpointSliceArgsDict(TypedDict):
+        """
+        EndpointSlice represents a subset of the endpoints that implement a service. For a given service there may be multiple EndpointSlice objects, selected by labels, which must be joined to produce the full set of endpoints.
+        """
+        address_type: pulumi.Input[str]
+        """
+        addressType specifies the type of address carried by this EndpointSlice. All addresses in this slice must be the same type. This field is immutable after creation. The following address types are currently supported: * IPv4: Represents an IPv4 Address. * IPv6: Represents an IPv6 Address. * FQDN: Represents a Fully Qualified Domain Name.
+        """
+        endpoints: pulumi.Input[Sequence[pulumi.Input['EndpointArgsDict']]]
+        """
+        endpoints is a list of unique endpoints in this slice. Each slice may include a maximum of 1000 endpoints.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata.
+        """
+        ports: NotRequired[pulumi.Input[Sequence[pulumi.Input['EndpointPortArgsDict']]]]
+        """
+        ports specifies the list of network ports exposed by each endpoint in this slice. Each port must have a unique name. When ports is empty, it indicates that there are no defined ports. When a port is defined with a nil port value, it indicates "all ports". Each slice may include a maximum of 100 ports.
+        """
+elif False:
+    EndpointSliceArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class EndpointSliceArgs:
@@ -494,6 +666,44 @@ class EndpointSliceArgs:
     def ports(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['EndpointPortArgs']]]]):
         pulumi.set(self, "ports", value)
 
+
+if not MYPY:
+    class EndpointArgsDict(TypedDict):
+        """
+        Endpoint represents a single logical "backend" implementing a service.
+        """
+        addresses: pulumi.Input[Sequence[pulumi.Input[str]]]
+        """
+        addresses of this endpoint. The contents of this field are interpreted according to the corresponding EndpointSlice addressType field. Consumers must handle different types of addresses in the context of their own capabilities. This must contain at least one address but no more than 100.
+        """
+        conditions: NotRequired[pulumi.Input['EndpointConditionsArgsDict']]
+        """
+        conditions contains information about the current status of the endpoint.
+        """
+        hostname: NotRequired[pulumi.Input[str]]
+        """
+        hostname of this endpoint. This field may be used by consumers of endpoints to distinguish endpoints from each other (e.g. in DNS names). Multiple endpoints which use the same hostname should be considered fungible (e.g. multiple A values in DNS). Must pass DNS Label (RFC 1123) validation.
+        """
+        node_name: NotRequired[pulumi.Input[str]]
+        """
+        nodeName represents the name of the Node hosting this endpoint. This can be used to determine endpoints local to a Node. This field can be enabled with the EndpointSliceNodeName feature gate.
+        """
+        target_ref: NotRequired[pulumi.Input['_core.v1.ObjectReferenceArgsDict']]
+        """
+        targetRef is a reference to a Kubernetes object that represents this endpoint.
+        """
+        topology: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        topology contains arbitrary topology information associated with the endpoint. These key/value pairs must conform with the label format. https://kubernetes.io/docs/concepts/overview/working-with-objects/labels Topology may include a maximum of 16 key/value pairs. This includes, but is not limited to the following well known keys: * kubernetes.io/hostname: the value indicates the hostname of the node
+          where the endpoint is located. This should match the corresponding
+          node label.
+        * topology.kubernetes.io/zone: the value indicates the zone where the
+          endpoint is located. This should match the corresponding node label.
+        * topology.kubernetes.io/region: the value indicates the region where the
+          endpoint is located. This should match the corresponding node label.
+        """
+elif False:
+    EndpointArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class EndpointArgs:

--- a/sdk/python/pulumi_kubernetes/discovery/v1beta1/outputs.py
+++ b/sdk/python/pulumi_kubernetes/discovery/v1beta1/outputs.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core

--- a/sdk/python/pulumi_kubernetes/events/v1/Event.py
+++ b/sdk/python/pulumi_kubernetes/events/v1/Event.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -304,17 +309,17 @@ class Event(pulumi.CustomResource):
                  deprecated_count: Optional[pulumi.Input[int]] = None,
                  deprecated_first_timestamp: Optional[pulumi.Input[str]] = None,
                  deprecated_last_timestamp: Optional[pulumi.Input[str]] = None,
-                 deprecated_source: Optional[pulumi.Input[pulumi.InputType['_core.v1.EventSourceArgs']]] = None,
+                 deprecated_source: Optional[pulumi.Input[Union['_core.v1.EventSourceArgs', '_core.v1.EventSourceArgsDict']]] = None,
                  event_time: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
                  note: Optional[pulumi.Input[str]] = None,
                  reason: Optional[pulumi.Input[str]] = None,
-                 regarding: Optional[pulumi.Input[pulumi.InputType['_core.v1.ObjectReferenceArgs']]] = None,
-                 related: Optional[pulumi.Input[pulumi.InputType['_core.v1.ObjectReferenceArgs']]] = None,
+                 regarding: Optional[pulumi.Input[Union['_core.v1.ObjectReferenceArgs', '_core.v1.ObjectReferenceArgsDict']]] = None,
+                 related: Optional[pulumi.Input[Union['_core.v1.ObjectReferenceArgs', '_core.v1.ObjectReferenceArgsDict']]] = None,
                  reporting_controller: Optional[pulumi.Input[str]] = None,
                  reporting_instance: Optional[pulumi.Input[str]] = None,
-                 series: Optional[pulumi.Input[pulumi.InputType['EventSeriesArgs']]] = None,
+                 series: Optional[pulumi.Input[Union['EventSeriesArgs', 'EventSeriesArgsDict']]] = None,
                  type: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         """
@@ -327,17 +332,17 @@ class Event(pulumi.CustomResource):
         :param pulumi.Input[int] deprecated_count: deprecatedCount is the deprecated field assuring backward compatibility with core.v1 Event type.
         :param pulumi.Input[str] deprecated_first_timestamp: deprecatedFirstTimestamp is the deprecated field assuring backward compatibility with core.v1 Event type.
         :param pulumi.Input[str] deprecated_last_timestamp: deprecatedLastTimestamp is the deprecated field assuring backward compatibility with core.v1 Event type.
-        :param pulumi.Input[pulumi.InputType['_core.v1.EventSourceArgs']] deprecated_source: deprecatedSource is the deprecated field assuring backward compatibility with core.v1 Event type.
+        :param pulumi.Input[Union['_core.v1.EventSourceArgs', '_core.v1.EventSourceArgsDict']] deprecated_source: deprecatedSource is the deprecated field assuring backward compatibility with core.v1 Event type.
         :param pulumi.Input[str] event_time: eventTime is the time when this Event was first observed. It is required.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         :param pulumi.Input[str] note: note is a human-readable description of the status of this operation. Maximal length of the note is 1kB, but libraries should be prepared to handle values up to 64kB.
         :param pulumi.Input[str] reason: reason is why the action was taken. It is human-readable. This field cannot be empty for new Events and it can have at most 128 characters.
-        :param pulumi.Input[pulumi.InputType['_core.v1.ObjectReferenceArgs']] regarding: regarding contains the object this Event is about. In most cases it's an Object reporting controller implements, e.g. ReplicaSetController implements ReplicaSets and this event is emitted because it acts on some changes in a ReplicaSet object.
-        :param pulumi.Input[pulumi.InputType['_core.v1.ObjectReferenceArgs']] related: related is the optional secondary object for more complex actions. E.g. when regarding object triggers a creation or deletion of related object.
+        :param pulumi.Input[Union['_core.v1.ObjectReferenceArgs', '_core.v1.ObjectReferenceArgsDict']] regarding: regarding contains the object this Event is about. In most cases it's an Object reporting controller implements, e.g. ReplicaSetController implements ReplicaSets and this event is emitted because it acts on some changes in a ReplicaSet object.
+        :param pulumi.Input[Union['_core.v1.ObjectReferenceArgs', '_core.v1.ObjectReferenceArgsDict']] related: related is the optional secondary object for more complex actions. E.g. when regarding object triggers a creation or deletion of related object.
         :param pulumi.Input[str] reporting_controller: reportingController is the name of the controller that emitted this Event, e.g. `kubernetes.io/kubelet`. This field cannot be empty for new Events.
         :param pulumi.Input[str] reporting_instance: reportingInstance is the ID of the controller instance, e.g. `kubelet-xyzf`. This field cannot be empty for new Events and it can have at most 128 characters.
-        :param pulumi.Input[pulumi.InputType['EventSeriesArgs']] series: series is data about the Event series this event represents or nil if it's a singleton Event.
+        :param pulumi.Input[Union['EventSeriesArgs', 'EventSeriesArgsDict']] series: series is data about the Event series this event represents or nil if it's a singleton Event.
         :param pulumi.Input[str] type: type is the type of this event (Normal, Warning), new types could be added in the future. It is machine-readable. This field cannot be empty for new Events.
         """
         ...
@@ -369,17 +374,17 @@ class Event(pulumi.CustomResource):
                  deprecated_count: Optional[pulumi.Input[int]] = None,
                  deprecated_first_timestamp: Optional[pulumi.Input[str]] = None,
                  deprecated_last_timestamp: Optional[pulumi.Input[str]] = None,
-                 deprecated_source: Optional[pulumi.Input[pulumi.InputType['_core.v1.EventSourceArgs']]] = None,
+                 deprecated_source: Optional[pulumi.Input[Union['_core.v1.EventSourceArgs', '_core.v1.EventSourceArgsDict']]] = None,
                  event_time: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
                  note: Optional[pulumi.Input[str]] = None,
                  reason: Optional[pulumi.Input[str]] = None,
-                 regarding: Optional[pulumi.Input[pulumi.InputType['_core.v1.ObjectReferenceArgs']]] = None,
-                 related: Optional[pulumi.Input[pulumi.InputType['_core.v1.ObjectReferenceArgs']]] = None,
+                 regarding: Optional[pulumi.Input[Union['_core.v1.ObjectReferenceArgs', '_core.v1.ObjectReferenceArgsDict']]] = None,
+                 related: Optional[pulumi.Input[Union['_core.v1.ObjectReferenceArgs', '_core.v1.ObjectReferenceArgsDict']]] = None,
                  reporting_controller: Optional[pulumi.Input[str]] = None,
                  reporting_instance: Optional[pulumi.Input[str]] = None,
-                 series: Optional[pulumi.Input[pulumi.InputType['EventSeriesArgs']]] = None,
+                 series: Optional[pulumi.Input[Union['EventSeriesArgs', 'EventSeriesArgsDict']]] = None,
                  type: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)

--- a/sdk/python/pulumi_kubernetes/events/v1/EventList.py
+++ b/sdk/python/pulumi_kubernetes/events/v1/EventList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -92,9 +97,9 @@ class EventList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['EventArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['EventArgs', 'EventArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         EventList is a list of Event objects.
@@ -102,9 +107,9 @@ class EventList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['EventArgs']]]] items: items is a list of schema objects.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['EventArgs', 'EventArgsDict']]]] items: items is a list of schema objects.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -131,9 +136,9 @@ class EventList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['EventArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['EventArgs', 'EventArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/events/v1/EventPatch.py
+++ b/sdk/python/pulumi_kubernetes/events/v1/EventPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -305,17 +310,17 @@ class EventPatch(pulumi.CustomResource):
                  deprecated_count: Optional[pulumi.Input[int]] = None,
                  deprecated_first_timestamp: Optional[pulumi.Input[str]] = None,
                  deprecated_last_timestamp: Optional[pulumi.Input[str]] = None,
-                 deprecated_source: Optional[pulumi.Input[pulumi.InputType['_core.v1.EventSourcePatchArgs']]] = None,
+                 deprecated_source: Optional[pulumi.Input[Union['_core.v1.EventSourcePatchArgs', '_core.v1.EventSourcePatchArgsDict']]] = None,
                  event_time: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
                  note: Optional[pulumi.Input[str]] = None,
                  reason: Optional[pulumi.Input[str]] = None,
-                 regarding: Optional[pulumi.Input[pulumi.InputType['_core.v1.ObjectReferencePatchArgs']]] = None,
-                 related: Optional[pulumi.Input[pulumi.InputType['_core.v1.ObjectReferencePatchArgs']]] = None,
+                 regarding: Optional[pulumi.Input[Union['_core.v1.ObjectReferencePatchArgs', '_core.v1.ObjectReferencePatchArgsDict']]] = None,
+                 related: Optional[pulumi.Input[Union['_core.v1.ObjectReferencePatchArgs', '_core.v1.ObjectReferencePatchArgsDict']]] = None,
                  reporting_controller: Optional[pulumi.Input[str]] = None,
                  reporting_instance: Optional[pulumi.Input[str]] = None,
-                 series: Optional[pulumi.Input[pulumi.InputType['EventSeriesPatchArgs']]] = None,
+                 series: Optional[pulumi.Input[Union['EventSeriesPatchArgs', 'EventSeriesPatchArgsDict']]] = None,
                  type: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         """
@@ -334,17 +339,17 @@ class EventPatch(pulumi.CustomResource):
         :param pulumi.Input[int] deprecated_count: deprecatedCount is the deprecated field assuring backward compatibility with core.v1 Event type.
         :param pulumi.Input[str] deprecated_first_timestamp: deprecatedFirstTimestamp is the deprecated field assuring backward compatibility with core.v1 Event type.
         :param pulumi.Input[str] deprecated_last_timestamp: deprecatedLastTimestamp is the deprecated field assuring backward compatibility with core.v1 Event type.
-        :param pulumi.Input[pulumi.InputType['_core.v1.EventSourcePatchArgs']] deprecated_source: deprecatedSource is the deprecated field assuring backward compatibility with core.v1 Event type.
+        :param pulumi.Input[Union['_core.v1.EventSourcePatchArgs', '_core.v1.EventSourcePatchArgsDict']] deprecated_source: deprecatedSource is the deprecated field assuring backward compatibility with core.v1 Event type.
         :param pulumi.Input[str] event_time: eventTime is the time when this Event was first observed. It is required.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         :param pulumi.Input[str] note: note is a human-readable description of the status of this operation. Maximal length of the note is 1kB, but libraries should be prepared to handle values up to 64kB.
         :param pulumi.Input[str] reason: reason is why the action was taken. It is human-readable. This field cannot be empty for new Events and it can have at most 128 characters.
-        :param pulumi.Input[pulumi.InputType['_core.v1.ObjectReferencePatchArgs']] regarding: regarding contains the object this Event is about. In most cases it's an Object reporting controller implements, e.g. ReplicaSetController implements ReplicaSets and this event is emitted because it acts on some changes in a ReplicaSet object.
-        :param pulumi.Input[pulumi.InputType['_core.v1.ObjectReferencePatchArgs']] related: related is the optional secondary object for more complex actions. E.g. when regarding object triggers a creation or deletion of related object.
+        :param pulumi.Input[Union['_core.v1.ObjectReferencePatchArgs', '_core.v1.ObjectReferencePatchArgsDict']] regarding: regarding contains the object this Event is about. In most cases it's an Object reporting controller implements, e.g. ReplicaSetController implements ReplicaSets and this event is emitted because it acts on some changes in a ReplicaSet object.
+        :param pulumi.Input[Union['_core.v1.ObjectReferencePatchArgs', '_core.v1.ObjectReferencePatchArgsDict']] related: related is the optional secondary object for more complex actions. E.g. when regarding object triggers a creation or deletion of related object.
         :param pulumi.Input[str] reporting_controller: reportingController is the name of the controller that emitted this Event, e.g. `kubernetes.io/kubelet`. This field cannot be empty for new Events.
         :param pulumi.Input[str] reporting_instance: reportingInstance is the ID of the controller instance, e.g. `kubelet-xyzf`. This field cannot be empty for new Events and it can have at most 128 characters.
-        :param pulumi.Input[pulumi.InputType['EventSeriesPatchArgs']] series: series is data about the Event series this event represents or nil if it's a singleton Event.
+        :param pulumi.Input[Union['EventSeriesPatchArgs', 'EventSeriesPatchArgsDict']] series: series is data about the Event series this event represents or nil if it's a singleton Event.
         :param pulumi.Input[str] type: type is the type of this event (Normal, Warning), new types could be added in the future. It is machine-readable. This field cannot be empty for new Events.
         """
         ...
@@ -382,17 +387,17 @@ class EventPatch(pulumi.CustomResource):
                  deprecated_count: Optional[pulumi.Input[int]] = None,
                  deprecated_first_timestamp: Optional[pulumi.Input[str]] = None,
                  deprecated_last_timestamp: Optional[pulumi.Input[str]] = None,
-                 deprecated_source: Optional[pulumi.Input[pulumi.InputType['_core.v1.EventSourcePatchArgs']]] = None,
+                 deprecated_source: Optional[pulumi.Input[Union['_core.v1.EventSourcePatchArgs', '_core.v1.EventSourcePatchArgsDict']]] = None,
                  event_time: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
                  note: Optional[pulumi.Input[str]] = None,
                  reason: Optional[pulumi.Input[str]] = None,
-                 regarding: Optional[pulumi.Input[pulumi.InputType['_core.v1.ObjectReferencePatchArgs']]] = None,
-                 related: Optional[pulumi.Input[pulumi.InputType['_core.v1.ObjectReferencePatchArgs']]] = None,
+                 regarding: Optional[pulumi.Input[Union['_core.v1.ObjectReferencePatchArgs', '_core.v1.ObjectReferencePatchArgsDict']]] = None,
+                 related: Optional[pulumi.Input[Union['_core.v1.ObjectReferencePatchArgs', '_core.v1.ObjectReferencePatchArgsDict']]] = None,
                  reporting_controller: Optional[pulumi.Input[str]] = None,
                  reporting_instance: Optional[pulumi.Input[str]] = None,
-                 series: Optional[pulumi.Input[pulumi.InputType['EventSeriesPatchArgs']]] = None,
+                 series: Optional[pulumi.Input[Union['EventSeriesPatchArgs', 'EventSeriesPatchArgsDict']]] = None,
                  type: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)

--- a/sdk/python/pulumi_kubernetes/events/v1/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/events/v1/_inputs.py
@@ -4,18 +4,44 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import core as _core
 from ... import meta as _meta
 
 __all__ = [
     'EventSeriesPatchArgs',
+    'EventSeriesPatchArgsDict',
     'EventSeriesArgs',
+    'EventSeriesArgsDict',
     'EventArgs',
+    'EventArgsDict',
 ]
+
+MYPY = False
+
+if not MYPY:
+    class EventSeriesPatchArgsDict(TypedDict):
+        """
+        EventSeries contain information on series of events, i.e. thing that was/is happening continuously for some time. How often to update the EventSeries is up to the event reporters. The default event reporter in "k8s.io/client-go/tools/events/event_broadcaster.go" shows how this struct is updated on heartbeats and can guide customized reporter implementations.
+        """
+        count: NotRequired[pulumi.Input[int]]
+        """
+        count is the number of occurrences in this series up to the last heartbeat time.
+        """
+        last_observed_time: NotRequired[pulumi.Input[str]]
+        """
+        lastObservedTime is the time when last Event from the series was seen before last heartbeat.
+        """
+elif False:
+    EventSeriesPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class EventSeriesPatchArgs:
@@ -57,6 +83,22 @@ class EventSeriesPatchArgs:
         pulumi.set(self, "last_observed_time", value)
 
 
+if not MYPY:
+    class EventSeriesArgsDict(TypedDict):
+        """
+        EventSeries contain information on series of events, i.e. thing that was/is happening continuously for some time. How often to update the EventSeries is up to the event reporters. The default event reporter in "k8s.io/client-go/tools/events/event_broadcaster.go" shows how this struct is updated on heartbeats and can guide customized reporter implementations.
+        """
+        count: pulumi.Input[int]
+        """
+        count is the number of occurrences in this series up to the last heartbeat time.
+        """
+        last_observed_time: pulumi.Input[str]
+        """
+        lastObservedTime is the time when last Event from the series was seen before last heartbeat.
+        """
+elif False:
+    EventSeriesArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class EventSeriesArgs:
     def __init__(__self__, *,
@@ -94,6 +136,82 @@ class EventSeriesArgs:
     def last_observed_time(self, value: pulumi.Input[str]):
         pulumi.set(self, "last_observed_time", value)
 
+
+if not MYPY:
+    class EventArgsDict(TypedDict):
+        """
+        Event is a report of an event somewhere in the cluster. It generally denotes some state change in the system. Events have a limited retention time and triggers and messages may evolve with time.  Event consumers should not rely on the timing of an event with a given Reason reflecting a consistent underlying trigger, or the continued existence of events with that Reason.  Events should be treated as informative, best-effort, supplemental data.
+        """
+        event_time: pulumi.Input[str]
+        """
+        eventTime is the time when this Event was first observed. It is required.
+        """
+        action: NotRequired[pulumi.Input[str]]
+        """
+        action is what action was taken/failed regarding to the regarding object. It is machine-readable. This field cannot be empty for new Events and it can have at most 128 characters.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        deprecated_count: NotRequired[pulumi.Input[int]]
+        """
+        deprecatedCount is the deprecated field assuring backward compatibility with core.v1 Event type.
+        """
+        deprecated_first_timestamp: NotRequired[pulumi.Input[str]]
+        """
+        deprecatedFirstTimestamp is the deprecated field assuring backward compatibility with core.v1 Event type.
+        """
+        deprecated_last_timestamp: NotRequired[pulumi.Input[str]]
+        """
+        deprecatedLastTimestamp is the deprecated field assuring backward compatibility with core.v1 Event type.
+        """
+        deprecated_source: NotRequired[pulumi.Input['_core.v1.EventSourceArgsDict']]
+        """
+        deprecatedSource is the deprecated field assuring backward compatibility with core.v1 Event type.
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        note: NotRequired[pulumi.Input[str]]
+        """
+        note is a human-readable description of the status of this operation. Maximal length of the note is 1kB, but libraries should be prepared to handle values up to 64kB.
+        """
+        reason: NotRequired[pulumi.Input[str]]
+        """
+        reason is why the action was taken. It is human-readable. This field cannot be empty for new Events and it can have at most 128 characters.
+        """
+        regarding: NotRequired[pulumi.Input['_core.v1.ObjectReferenceArgsDict']]
+        """
+        regarding contains the object this Event is about. In most cases it's an Object reporting controller implements, e.g. ReplicaSetController implements ReplicaSets and this event is emitted because it acts on some changes in a ReplicaSet object.
+        """
+        related: NotRequired[pulumi.Input['_core.v1.ObjectReferenceArgsDict']]
+        """
+        related is the optional secondary object for more complex actions. E.g. when regarding object triggers a creation or deletion of related object.
+        """
+        reporting_controller: NotRequired[pulumi.Input[str]]
+        """
+        reportingController is the name of the controller that emitted this Event, e.g. `kubernetes.io/kubelet`. This field cannot be empty for new Events.
+        """
+        reporting_instance: NotRequired[pulumi.Input[str]]
+        """
+        reportingInstance is the ID of the controller instance, e.g. `kubelet-xyzf`. This field cannot be empty for new Events and it can have at most 128 characters.
+        """
+        series: NotRequired[pulumi.Input['EventSeriesArgsDict']]
+        """
+        series is data about the Event series this event represents or nil if it's a singleton Event.
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        type is the type of this event (Normal, Warning), new types could be added in the future. It is machine-readable. This field cannot be empty for new Events.
+        """
+elif False:
+    EventArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class EventArgs:

--- a/sdk/python/pulumi_kubernetes/events/v1/outputs.py
+++ b/sdk/python/pulumi_kubernetes/events/v1/outputs.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core

--- a/sdk/python/pulumi_kubernetes/events/v1beta1/Event.py
+++ b/sdk/python/pulumi_kubernetes/events/v1beta1/Event.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -300,17 +305,17 @@ class Event(pulumi.CustomResource):
                  deprecated_count: Optional[pulumi.Input[int]] = None,
                  deprecated_first_timestamp: Optional[pulumi.Input[str]] = None,
                  deprecated_last_timestamp: Optional[pulumi.Input[str]] = None,
-                 deprecated_source: Optional[pulumi.Input[pulumi.InputType['_core.v1.EventSourceArgs']]] = None,
+                 deprecated_source: Optional[pulumi.Input[Union['_core.v1.EventSourceArgs', '_core.v1.EventSourceArgsDict']]] = None,
                  event_time: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
                  note: Optional[pulumi.Input[str]] = None,
                  reason: Optional[pulumi.Input[str]] = None,
-                 regarding: Optional[pulumi.Input[pulumi.InputType['_core.v1.ObjectReferenceArgs']]] = None,
-                 related: Optional[pulumi.Input[pulumi.InputType['_core.v1.ObjectReferenceArgs']]] = None,
+                 regarding: Optional[pulumi.Input[Union['_core.v1.ObjectReferenceArgs', '_core.v1.ObjectReferenceArgsDict']]] = None,
+                 related: Optional[pulumi.Input[Union['_core.v1.ObjectReferenceArgs', '_core.v1.ObjectReferenceArgsDict']]] = None,
                  reporting_controller: Optional[pulumi.Input[str]] = None,
                  reporting_instance: Optional[pulumi.Input[str]] = None,
-                 series: Optional[pulumi.Input[pulumi.InputType['EventSeriesArgs']]] = None,
+                 series: Optional[pulumi.Input[Union['EventSeriesArgs', 'EventSeriesArgsDict']]] = None,
                  type: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         """
@@ -323,16 +328,16 @@ class Event(pulumi.CustomResource):
         :param pulumi.Input[int] deprecated_count: Deprecated field assuring backward compatibility with core.v1 Event type
         :param pulumi.Input[str] deprecated_first_timestamp: Deprecated field assuring backward compatibility with core.v1 Event type
         :param pulumi.Input[str] deprecated_last_timestamp: Deprecated field assuring backward compatibility with core.v1 Event type
-        :param pulumi.Input[pulumi.InputType['_core.v1.EventSourceArgs']] deprecated_source: Deprecated field assuring backward compatibility with core.v1 Event type
+        :param pulumi.Input[Union['_core.v1.EventSourceArgs', '_core.v1.EventSourceArgsDict']] deprecated_source: Deprecated field assuring backward compatibility with core.v1 Event type
         :param pulumi.Input[str] event_time: Required. Time when this Event was first observed.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
         :param pulumi.Input[str] note: Optional. A human-readable description of the status of this operation. Maximal length of the note is 1kB, but libraries should be prepared to handle values up to 64kB.
         :param pulumi.Input[str] reason: Why the action was taken.
-        :param pulumi.Input[pulumi.InputType['_core.v1.ObjectReferenceArgs']] regarding: The object this Event is about. In most cases it's an Object reporting controller implements. E.g. ReplicaSetController implements ReplicaSets and this event is emitted because it acts on some changes in a ReplicaSet object.
-        :param pulumi.Input[pulumi.InputType['_core.v1.ObjectReferenceArgs']] related: Optional secondary object for more complex actions. E.g. when regarding object triggers a creation or deletion of related object.
+        :param pulumi.Input[Union['_core.v1.ObjectReferenceArgs', '_core.v1.ObjectReferenceArgsDict']] regarding: The object this Event is about. In most cases it's an Object reporting controller implements. E.g. ReplicaSetController implements ReplicaSets and this event is emitted because it acts on some changes in a ReplicaSet object.
+        :param pulumi.Input[Union['_core.v1.ObjectReferenceArgs', '_core.v1.ObjectReferenceArgsDict']] related: Optional secondary object for more complex actions. E.g. when regarding object triggers a creation or deletion of related object.
         :param pulumi.Input[str] reporting_controller: Name of the controller that emitted this Event, e.g. `kubernetes.io/kubelet`.
         :param pulumi.Input[str] reporting_instance: ID of the controller instance, e.g. `kubelet-xyzf`.
-        :param pulumi.Input[pulumi.InputType['EventSeriesArgs']] series: Data about the Event series this event represents or nil if it's a singleton Event.
+        :param pulumi.Input[Union['EventSeriesArgs', 'EventSeriesArgsDict']] series: Data about the Event series this event represents or nil if it's a singleton Event.
         :param pulumi.Input[str] type: Type of this event (Normal, Warning), new types could be added in the future.
         """
         ...
@@ -364,17 +369,17 @@ class Event(pulumi.CustomResource):
                  deprecated_count: Optional[pulumi.Input[int]] = None,
                  deprecated_first_timestamp: Optional[pulumi.Input[str]] = None,
                  deprecated_last_timestamp: Optional[pulumi.Input[str]] = None,
-                 deprecated_source: Optional[pulumi.Input[pulumi.InputType['_core.v1.EventSourceArgs']]] = None,
+                 deprecated_source: Optional[pulumi.Input[Union['_core.v1.EventSourceArgs', '_core.v1.EventSourceArgsDict']]] = None,
                  event_time: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
                  note: Optional[pulumi.Input[str]] = None,
                  reason: Optional[pulumi.Input[str]] = None,
-                 regarding: Optional[pulumi.Input[pulumi.InputType['_core.v1.ObjectReferenceArgs']]] = None,
-                 related: Optional[pulumi.Input[pulumi.InputType['_core.v1.ObjectReferenceArgs']]] = None,
+                 regarding: Optional[pulumi.Input[Union['_core.v1.ObjectReferenceArgs', '_core.v1.ObjectReferenceArgsDict']]] = None,
+                 related: Optional[pulumi.Input[Union['_core.v1.ObjectReferenceArgs', '_core.v1.ObjectReferenceArgsDict']]] = None,
                  reporting_controller: Optional[pulumi.Input[str]] = None,
                  reporting_instance: Optional[pulumi.Input[str]] = None,
-                 series: Optional[pulumi.Input[pulumi.InputType['EventSeriesArgs']]] = None,
+                 series: Optional[pulumi.Input[Union['EventSeriesArgs', 'EventSeriesArgsDict']]] = None,
                  type: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)

--- a/sdk/python/pulumi_kubernetes/events/v1beta1/EventList.py
+++ b/sdk/python/pulumi_kubernetes/events/v1beta1/EventList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -92,9 +97,9 @@ class EventList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['EventArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['EventArgs', 'EventArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         EventList is a list of Event objects.
@@ -102,9 +107,9 @@ class EventList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['EventArgs']]]] items: Items is a list of schema objects.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['EventArgs', 'EventArgsDict']]]] items: Items is a list of schema objects.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -131,9 +136,9 @@ class EventList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['EventArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['EventArgs', 'EventArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/events/v1beta1/EventPatch.py
+++ b/sdk/python/pulumi_kubernetes/events/v1beta1/EventPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -301,17 +306,17 @@ class EventPatch(pulumi.CustomResource):
                  deprecated_count: Optional[pulumi.Input[int]] = None,
                  deprecated_first_timestamp: Optional[pulumi.Input[str]] = None,
                  deprecated_last_timestamp: Optional[pulumi.Input[str]] = None,
-                 deprecated_source: Optional[pulumi.Input[pulumi.InputType['_core.v1.EventSourcePatchArgs']]] = None,
+                 deprecated_source: Optional[pulumi.Input[Union['_core.v1.EventSourcePatchArgs', '_core.v1.EventSourcePatchArgsDict']]] = None,
                  event_time: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
                  note: Optional[pulumi.Input[str]] = None,
                  reason: Optional[pulumi.Input[str]] = None,
-                 regarding: Optional[pulumi.Input[pulumi.InputType['_core.v1.ObjectReferencePatchArgs']]] = None,
-                 related: Optional[pulumi.Input[pulumi.InputType['_core.v1.ObjectReferencePatchArgs']]] = None,
+                 regarding: Optional[pulumi.Input[Union['_core.v1.ObjectReferencePatchArgs', '_core.v1.ObjectReferencePatchArgsDict']]] = None,
+                 related: Optional[pulumi.Input[Union['_core.v1.ObjectReferencePatchArgs', '_core.v1.ObjectReferencePatchArgsDict']]] = None,
                  reporting_controller: Optional[pulumi.Input[str]] = None,
                  reporting_instance: Optional[pulumi.Input[str]] = None,
-                 series: Optional[pulumi.Input[pulumi.InputType['EventSeriesPatchArgs']]] = None,
+                 series: Optional[pulumi.Input[Union['EventSeriesPatchArgs', 'EventSeriesPatchArgsDict']]] = None,
                  type: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         """
@@ -330,16 +335,16 @@ class EventPatch(pulumi.CustomResource):
         :param pulumi.Input[int] deprecated_count: Deprecated field assuring backward compatibility with core.v1 Event type
         :param pulumi.Input[str] deprecated_first_timestamp: Deprecated field assuring backward compatibility with core.v1 Event type
         :param pulumi.Input[str] deprecated_last_timestamp: Deprecated field assuring backward compatibility with core.v1 Event type
-        :param pulumi.Input[pulumi.InputType['_core.v1.EventSourcePatchArgs']] deprecated_source: Deprecated field assuring backward compatibility with core.v1 Event type
+        :param pulumi.Input[Union['_core.v1.EventSourcePatchArgs', '_core.v1.EventSourcePatchArgsDict']] deprecated_source: Deprecated field assuring backward compatibility with core.v1 Event type
         :param pulumi.Input[str] event_time: Required. Time when this Event was first observed.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
         :param pulumi.Input[str] note: Optional. A human-readable description of the status of this operation. Maximal length of the note is 1kB, but libraries should be prepared to handle values up to 64kB.
         :param pulumi.Input[str] reason: Why the action was taken.
-        :param pulumi.Input[pulumi.InputType['_core.v1.ObjectReferencePatchArgs']] regarding: The object this Event is about. In most cases it's an Object reporting controller implements. E.g. ReplicaSetController implements ReplicaSets and this event is emitted because it acts on some changes in a ReplicaSet object.
-        :param pulumi.Input[pulumi.InputType['_core.v1.ObjectReferencePatchArgs']] related: Optional secondary object for more complex actions. E.g. when regarding object triggers a creation or deletion of related object.
+        :param pulumi.Input[Union['_core.v1.ObjectReferencePatchArgs', '_core.v1.ObjectReferencePatchArgsDict']] regarding: The object this Event is about. In most cases it's an Object reporting controller implements. E.g. ReplicaSetController implements ReplicaSets and this event is emitted because it acts on some changes in a ReplicaSet object.
+        :param pulumi.Input[Union['_core.v1.ObjectReferencePatchArgs', '_core.v1.ObjectReferencePatchArgsDict']] related: Optional secondary object for more complex actions. E.g. when regarding object triggers a creation or deletion of related object.
         :param pulumi.Input[str] reporting_controller: Name of the controller that emitted this Event, e.g. `kubernetes.io/kubelet`.
         :param pulumi.Input[str] reporting_instance: ID of the controller instance, e.g. `kubelet-xyzf`.
-        :param pulumi.Input[pulumi.InputType['EventSeriesPatchArgs']] series: Data about the Event series this event represents or nil if it's a singleton Event.
+        :param pulumi.Input[Union['EventSeriesPatchArgs', 'EventSeriesPatchArgsDict']] series: Data about the Event series this event represents or nil if it's a singleton Event.
         :param pulumi.Input[str] type: Type of this event (Normal, Warning), new types could be added in the future.
         """
         ...
@@ -377,17 +382,17 @@ class EventPatch(pulumi.CustomResource):
                  deprecated_count: Optional[pulumi.Input[int]] = None,
                  deprecated_first_timestamp: Optional[pulumi.Input[str]] = None,
                  deprecated_last_timestamp: Optional[pulumi.Input[str]] = None,
-                 deprecated_source: Optional[pulumi.Input[pulumi.InputType['_core.v1.EventSourcePatchArgs']]] = None,
+                 deprecated_source: Optional[pulumi.Input[Union['_core.v1.EventSourcePatchArgs', '_core.v1.EventSourcePatchArgsDict']]] = None,
                  event_time: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
                  note: Optional[pulumi.Input[str]] = None,
                  reason: Optional[pulumi.Input[str]] = None,
-                 regarding: Optional[pulumi.Input[pulumi.InputType['_core.v1.ObjectReferencePatchArgs']]] = None,
-                 related: Optional[pulumi.Input[pulumi.InputType['_core.v1.ObjectReferencePatchArgs']]] = None,
+                 regarding: Optional[pulumi.Input[Union['_core.v1.ObjectReferencePatchArgs', '_core.v1.ObjectReferencePatchArgsDict']]] = None,
+                 related: Optional[pulumi.Input[Union['_core.v1.ObjectReferencePatchArgs', '_core.v1.ObjectReferencePatchArgsDict']]] = None,
                  reporting_controller: Optional[pulumi.Input[str]] = None,
                  reporting_instance: Optional[pulumi.Input[str]] = None,
-                 series: Optional[pulumi.Input[pulumi.InputType['EventSeriesPatchArgs']]] = None,
+                 series: Optional[pulumi.Input[Union['EventSeriesPatchArgs', 'EventSeriesPatchArgsDict']]] = None,
                  type: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)

--- a/sdk/python/pulumi_kubernetes/events/v1beta1/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/events/v1beta1/_inputs.py
@@ -4,18 +4,48 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import core as _core
 from ... import meta as _meta
 
 __all__ = [
     'EventSeriesPatchArgs',
+    'EventSeriesPatchArgsDict',
     'EventSeriesArgs',
+    'EventSeriesArgsDict',
     'EventArgs',
+    'EventArgsDict',
 ]
+
+MYPY = False
+
+if not MYPY:
+    class EventSeriesPatchArgsDict(TypedDict):
+        """
+        EventSeries contain information on series of events, i.e. thing that was/is happening continuously for some time.
+        """
+        count: NotRequired[pulumi.Input[int]]
+        """
+        Number of occurrences in this series up to the last heartbeat time
+        """
+        last_observed_time: NotRequired[pulumi.Input[str]]
+        """
+        Time when last Event from the series was seen before last heartbeat.
+        """
+        state: NotRequired[pulumi.Input[str]]
+        """
+        Information whether this series is ongoing or finished. Deprecated. Planned removal for 1.18
+        """
+elif False:
+    EventSeriesPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class EventSeriesPatchArgs:
@@ -73,6 +103,26 @@ class EventSeriesPatchArgs:
         pulumi.set(self, "state", value)
 
 
+if not MYPY:
+    class EventSeriesArgsDict(TypedDict):
+        """
+        EventSeries contain information on series of events, i.e. thing that was/is happening continuously for some time.
+        """
+        count: pulumi.Input[int]
+        """
+        Number of occurrences in this series up to the last heartbeat time
+        """
+        last_observed_time: pulumi.Input[str]
+        """
+        Time when last Event from the series was seen before last heartbeat.
+        """
+        state: pulumi.Input[str]
+        """
+        Information whether this series is ongoing or finished. Deprecated. Planned removal for 1.18
+        """
+elif False:
+    EventSeriesArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class EventSeriesArgs:
     def __init__(__self__, *,
@@ -125,6 +175,79 @@ class EventSeriesArgs:
     def state(self, value: pulumi.Input[str]):
         pulumi.set(self, "state", value)
 
+
+if not MYPY:
+    class EventArgsDict(TypedDict):
+        """
+        Event is a report of an event somewhere in the cluster. It generally denotes some state change in the system.
+        """
+        event_time: pulumi.Input[str]
+        """
+        Required. Time when this Event was first observed.
+        """
+        action: NotRequired[pulumi.Input[str]]
+        """
+        What action was taken/failed regarding to the regarding object.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        deprecated_count: NotRequired[pulumi.Input[int]]
+        """
+        Deprecated field assuring backward compatibility with core.v1 Event type
+        """
+        deprecated_first_timestamp: NotRequired[pulumi.Input[str]]
+        """
+        Deprecated field assuring backward compatibility with core.v1 Event type
+        """
+        deprecated_last_timestamp: NotRequired[pulumi.Input[str]]
+        """
+        Deprecated field assuring backward compatibility with core.v1 Event type
+        """
+        deprecated_source: NotRequired[pulumi.Input['_core.v1.EventSourceArgsDict']]
+        """
+        Deprecated field assuring backward compatibility with core.v1 Event type
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        note: NotRequired[pulumi.Input[str]]
+        """
+        Optional. A human-readable description of the status of this operation. Maximal length of the note is 1kB, but libraries should be prepared to handle values up to 64kB.
+        """
+        reason: NotRequired[pulumi.Input[str]]
+        """
+        Why the action was taken.
+        """
+        regarding: NotRequired[pulumi.Input['_core.v1.ObjectReferenceArgsDict']]
+        """
+        The object this Event is about. In most cases it's an Object reporting controller implements. E.g. ReplicaSetController implements ReplicaSets and this event is emitted because it acts on some changes in a ReplicaSet object.
+        """
+        related: NotRequired[pulumi.Input['_core.v1.ObjectReferenceArgsDict']]
+        """
+        Optional secondary object for more complex actions. E.g. when regarding object triggers a creation or deletion of related object.
+        """
+        reporting_controller: NotRequired[pulumi.Input[str]]
+        """
+        Name of the controller that emitted this Event, e.g. `kubernetes.io/kubelet`.
+        """
+        reporting_instance: NotRequired[pulumi.Input[str]]
+        """
+        ID of the controller instance, e.g. `kubelet-xyzf`.
+        """
+        series: NotRequired[pulumi.Input['EventSeriesArgsDict']]
+        """
+        Data about the Event series this event represents or nil if it's a singleton Event.
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        Type of this event (Normal, Warning), new types could be added in the future.
+        """
+elif False:
+    EventArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class EventArgs:

--- a/sdk/python/pulumi_kubernetes/events/v1beta1/outputs.py
+++ b/sdk/python/pulumi_kubernetes/events/v1beta1/outputs.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/DaemonSet.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/DaemonSet.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -94,8 +99,8 @@ class DaemonSet(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['DaemonSetSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['DaemonSetSpecArgs', 'DaemonSetSpecArgsDict']]] = None,
                  __props__=None):
         """
         DaemonSet represents the configuration of a daemon set.
@@ -104,8 +109,8 @@ class DaemonSet(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['DaemonSetSpecArgs']] spec: The desired behavior of this daemon set. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['DaemonSetSpecArgs', 'DaemonSetSpecArgsDict']] spec: The desired behavior of this daemon set. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -133,8 +138,8 @@ class DaemonSet(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['DaemonSetSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['DaemonSetSpecArgs', 'DaemonSetSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/DaemonSetList.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/DaemonSetList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -92,9 +97,9 @@ class DaemonSetList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['DaemonSetArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['DaemonSetArgs', 'DaemonSetArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         DaemonSetList is a collection of daemon sets.
@@ -102,9 +107,9 @@ class DaemonSetList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['DaemonSetArgs']]]] items: A list of daemon sets.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['DaemonSetArgs', 'DaemonSetArgsDict']]]] items: A list of daemon sets.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -131,9 +136,9 @@ class DaemonSetList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['DaemonSetArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['DaemonSetArgs', 'DaemonSetArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/DaemonSetPatch.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/DaemonSetPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -94,8 +99,8 @@ class DaemonSetPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['DaemonSetSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['DaemonSetSpecPatchArgs', 'DaemonSetSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -110,8 +115,8 @@ class DaemonSetPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['DaemonSetSpecPatchArgs']] spec: The desired behavior of this daemon set. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['DaemonSetSpecPatchArgs', 'DaemonSetSpecPatchArgsDict']] spec: The desired behavior of this daemon set. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -145,8 +150,8 @@ class DaemonSetPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['DaemonSetSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['DaemonSetSpecPatchArgs', 'DaemonSetSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/Deployment.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/Deployment.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -94,8 +99,8 @@ class Deployment(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['DeploymentSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['DeploymentSpecArgs', 'DeploymentSpecArgsDict']]] = None,
                  __props__=None):
         """
         Deployment enables declarative updates for Pods and ReplicaSets.
@@ -126,8 +131,8 @@ class Deployment(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object metadata.
-        :param pulumi.Input[pulumi.InputType['DeploymentSpecArgs']] spec: Specification of the desired behavior of the Deployment.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object metadata.
+        :param pulumi.Input[Union['DeploymentSpecArgs', 'DeploymentSpecArgsDict']] spec: Specification of the desired behavior of the Deployment.
         """
         ...
     @overload
@@ -177,8 +182,8 @@ class Deployment(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['DeploymentSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['DeploymentSpecArgs', 'DeploymentSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/DeploymentList.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/DeploymentList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -92,9 +97,9 @@ class DeploymentList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['DeploymentArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['DeploymentArgs', 'DeploymentArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         DeploymentList is a list of Deployments.
@@ -102,9 +107,9 @@ class DeploymentList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['DeploymentArgs']]]] items: Items is the list of Deployments.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['DeploymentArgs', 'DeploymentArgsDict']]]] items: Items is the list of Deployments.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata.
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata.
         """
         ...
     @overload
@@ -131,9 +136,9 @@ class DeploymentList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['DeploymentArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['DeploymentArgs', 'DeploymentArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/DeploymentPatch.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/DeploymentPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -94,8 +99,8 @@ class DeploymentPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['DeploymentSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['DeploymentSpecPatchArgs', 'DeploymentSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -132,8 +137,8 @@ class DeploymentPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object metadata.
-        :param pulumi.Input[pulumi.InputType['DeploymentSpecPatchArgs']] spec: Specification of the desired behavior of the Deployment.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object metadata.
+        :param pulumi.Input[Union['DeploymentSpecPatchArgs', 'DeploymentSpecPatchArgsDict']] spec: Specification of the desired behavior of the Deployment.
         """
         ...
     @overload
@@ -189,8 +194,8 @@ class DeploymentPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['DeploymentSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['DeploymentSpecPatchArgs', 'DeploymentSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/Ingress.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/Ingress.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -94,8 +99,8 @@ class Ingress(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['IngressSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['IngressSpecArgs', 'IngressSpecArgsDict']]] = None,
                  __props__=None):
         """
         Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.
@@ -118,8 +123,8 @@ class Ingress(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['IngressSpecArgs']] spec: Spec is the desired state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['IngressSpecArgs', 'IngressSpecArgsDict']] spec: Spec is the desired state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -161,8 +166,8 @@ class Ingress(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['IngressSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['IngressSpecArgs', 'IngressSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/IngressList.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/IngressList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -92,9 +97,9 @@ class IngressList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['IngressArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['IngressArgs', 'IngressArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         IngressList is a collection of Ingress.
@@ -102,9 +107,9 @@ class IngressList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['IngressArgs']]]] items: Items is the list of Ingress.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['IngressArgs', 'IngressArgsDict']]]] items: Items is the list of Ingress.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -131,9 +136,9 @@ class IngressList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['IngressArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['IngressArgs', 'IngressArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/IngressPatch.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/IngressPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -94,8 +99,8 @@ class IngressPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['IngressSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['IngressSpecPatchArgs', 'IngressSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -124,8 +129,8 @@ class IngressPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['IngressSpecPatchArgs']] spec: Spec is the desired state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['IngressSpecPatchArgs', 'IngressSpecPatchArgsDict']] spec: Spec is the desired state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -173,8 +178,8 @@ class IngressPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['IngressSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['IngressSpecPatchArgs', 'IngressSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/NetworkPolicy.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/NetworkPolicy.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class NetworkPolicy(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['NetworkPolicySpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['NetworkPolicySpecArgs', 'NetworkPolicySpecArgsDict']]] = None,
                  __props__=None):
         """
         DEPRECATED 1.9 - This group version of NetworkPolicy is deprecated by networking/v1/NetworkPolicy. NetworkPolicy describes what network traffic is allowed for a set of Pods
@@ -103,8 +108,8 @@ class NetworkPolicy(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['NetworkPolicySpecArgs']] spec: Specification of the desired behavior for this NetworkPolicy.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['NetworkPolicySpecArgs', 'NetworkPolicySpecArgsDict']] spec: Specification of the desired behavior for this NetworkPolicy.
         """
         ...
     @overload
@@ -132,8 +137,8 @@ class NetworkPolicy(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['NetworkPolicySpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['NetworkPolicySpecArgs', 'NetworkPolicySpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/NetworkPolicyList.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/NetworkPolicyList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class NetworkPolicyList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['NetworkPolicyArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['NetworkPolicyArgs', 'NetworkPolicyArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         DEPRECATED 1.9 - This group version of NetworkPolicyList is deprecated by networking/v1/NetworkPolicyList. Network Policy List is a list of NetworkPolicy objects.
@@ -101,9 +106,9 @@ class NetworkPolicyList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['NetworkPolicyArgs']]]] items: Items is a list of schema objects.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['NetworkPolicyArgs', 'NetworkPolicyArgsDict']]]] items: Items is a list of schema objects.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class NetworkPolicyList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['NetworkPolicyArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['NetworkPolicyArgs', 'NetworkPolicyArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/NetworkPolicyPatch.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/NetworkPolicyPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class NetworkPolicyPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['NetworkPolicySpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['NetworkPolicySpecPatchArgs', 'NetworkPolicySpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -109,8 +114,8 @@ class NetworkPolicyPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['NetworkPolicySpecPatchArgs']] spec: Specification of the desired behavior for this NetworkPolicy.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['NetworkPolicySpecPatchArgs', 'NetworkPolicySpecPatchArgsDict']] spec: Specification of the desired behavior for this NetworkPolicy.
         """
         ...
     @overload
@@ -144,8 +149,8 @@ class NetworkPolicyPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['NetworkPolicySpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['NetworkPolicySpecPatchArgs', 'NetworkPolicySpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/PodSecurityPolicy.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/PodSecurityPolicy.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -94,8 +99,8 @@ class PodSecurityPolicy(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PodSecurityPolicySpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PodSecurityPolicySpecArgs', 'PodSecurityPolicySpecArgsDict']]] = None,
                  __props__=None):
         """
         PodSecurityPolicy governs the ability to make requests that affect the Security Context that will be applied to a pod and container. Deprecated: use PodSecurityPolicy from policy API Group instead.
@@ -104,8 +109,8 @@ class PodSecurityPolicy(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['PodSecurityPolicySpecArgs']] spec: spec defines the policy enforced.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['PodSecurityPolicySpecArgs', 'PodSecurityPolicySpecArgsDict']] spec: spec defines the policy enforced.
         """
         ...
     @overload
@@ -133,8 +138,8 @@ class PodSecurityPolicy(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PodSecurityPolicySpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PodSecurityPolicySpecArgs', 'PodSecurityPolicySpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/PodSecurityPolicyList.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/PodSecurityPolicyList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -92,9 +97,9 @@ class PodSecurityPolicyList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PodSecurityPolicyArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PodSecurityPolicyArgs', 'PodSecurityPolicyArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         PodSecurityPolicyList is a list of PodSecurityPolicy objects. Deprecated: use PodSecurityPolicyList from policy API Group instead.
@@ -102,9 +107,9 @@ class PodSecurityPolicyList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PodSecurityPolicyArgs']]]] items: items is a list of schema objects.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['PodSecurityPolicyArgs', 'PodSecurityPolicyArgsDict']]]] items: items is a list of schema objects.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -131,9 +136,9 @@ class PodSecurityPolicyList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PodSecurityPolicyArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PodSecurityPolicyArgs', 'PodSecurityPolicyArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/PodSecurityPolicyPatch.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/PodSecurityPolicyPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -94,8 +99,8 @@ class PodSecurityPolicyPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PodSecurityPolicySpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PodSecurityPolicySpecPatchArgs', 'PodSecurityPolicySpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -110,8 +115,8 @@ class PodSecurityPolicyPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['PodSecurityPolicySpecPatchArgs']] spec: spec defines the policy enforced.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['PodSecurityPolicySpecPatchArgs', 'PodSecurityPolicySpecPatchArgsDict']] spec: spec defines the policy enforced.
         """
         ...
     @overload
@@ -145,8 +150,8 @@ class PodSecurityPolicyPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PodSecurityPolicySpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PodSecurityPolicySpecPatchArgs', 'PodSecurityPolicySpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/ReplicaSet.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/ReplicaSet.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -94,8 +99,8 @@ class ReplicaSet(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ReplicaSetSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ReplicaSetSpecArgs', 'ReplicaSetSpecArgsDict']]] = None,
                  __props__=None):
         """
         ReplicaSet ensures that a specified number of pod replicas are running at any given time.
@@ -104,8 +109,8 @@ class ReplicaSet(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: If the Labels of a ReplicaSet are empty, they are defaulted to be the same as the Pod(s) that the ReplicaSet manages. Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['ReplicaSetSpecArgs']] spec: Spec defines the specification of the desired behavior of the ReplicaSet. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: If the Labels of a ReplicaSet are empty, they are defaulted to be the same as the Pod(s) that the ReplicaSet manages. Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['ReplicaSetSpecArgs', 'ReplicaSetSpecArgsDict']] spec: Spec defines the specification of the desired behavior of the ReplicaSet. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -133,8 +138,8 @@ class ReplicaSet(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ReplicaSetSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ReplicaSetSpecArgs', 'ReplicaSetSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/ReplicaSetList.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/ReplicaSetList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -92,9 +97,9 @@ class ReplicaSetList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ReplicaSetArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ReplicaSetArgs', 'ReplicaSetArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         ReplicaSetList is a collection of ReplicaSets.
@@ -102,9 +107,9 @@ class ReplicaSetList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ReplicaSetArgs']]]] items: List of ReplicaSets. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller
+        :param pulumi.Input[Sequence[pulumi.Input[Union['ReplicaSetArgs', 'ReplicaSetArgsDict']]]] items: List of ReplicaSets. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
         """
         ...
     @overload
@@ -131,9 +136,9 @@ class ReplicaSetList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ReplicaSetArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ReplicaSetArgs', 'ReplicaSetArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/ReplicaSetPatch.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/ReplicaSetPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -94,8 +99,8 @@ class ReplicaSetPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ReplicaSetSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ReplicaSetSpecPatchArgs', 'ReplicaSetSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -110,8 +115,8 @@ class ReplicaSetPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: If the Labels of a ReplicaSet are empty, they are defaulted to be the same as the Pod(s) that the ReplicaSet manages. Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['ReplicaSetSpecPatchArgs']] spec: Spec defines the specification of the desired behavior of the ReplicaSet. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: If the Labels of a ReplicaSet are empty, they are defaulted to be the same as the Pod(s) that the ReplicaSet manages. Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['ReplicaSetSpecPatchArgs', 'ReplicaSetSpecPatchArgsDict']] spec: Spec defines the specification of the desired behavior of the ReplicaSet. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -145,8 +150,8 @@ class ReplicaSetPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ReplicaSetSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ReplicaSetSpecPatchArgs', 'ReplicaSetSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/_inputs.py
@@ -4,92 +4,188 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import core as _core
 from ... import meta as _meta
 
 __all__ = [
     'AllowedCSIDriverPatchArgs',
+    'AllowedCSIDriverPatchArgsDict',
     'AllowedCSIDriverArgs',
+    'AllowedCSIDriverArgsDict',
     'AllowedFlexVolumePatchArgs',
+    'AllowedFlexVolumePatchArgsDict',
     'AllowedFlexVolumeArgs',
+    'AllowedFlexVolumeArgsDict',
     'AllowedHostPathPatchArgs',
+    'AllowedHostPathPatchArgsDict',
     'AllowedHostPathArgs',
+    'AllowedHostPathArgsDict',
     'DaemonSetConditionArgs',
+    'DaemonSetConditionArgsDict',
     'DaemonSetSpecPatchArgs',
+    'DaemonSetSpecPatchArgsDict',
     'DaemonSetSpecArgs',
+    'DaemonSetSpecArgsDict',
     'DaemonSetStatusArgs',
+    'DaemonSetStatusArgsDict',
     'DaemonSetUpdateStrategyPatchArgs',
+    'DaemonSetUpdateStrategyPatchArgsDict',
     'DaemonSetUpdateStrategyArgs',
+    'DaemonSetUpdateStrategyArgsDict',
     'DaemonSetArgs',
+    'DaemonSetArgsDict',
     'DeploymentConditionArgs',
+    'DeploymentConditionArgsDict',
     'DeploymentSpecPatchArgs',
+    'DeploymentSpecPatchArgsDict',
     'DeploymentSpecArgs',
+    'DeploymentSpecArgsDict',
     'DeploymentStatusArgs',
+    'DeploymentStatusArgsDict',
     'DeploymentStrategyPatchArgs',
+    'DeploymentStrategyPatchArgsDict',
     'DeploymentStrategyArgs',
+    'DeploymentStrategyArgsDict',
     'DeploymentArgs',
+    'DeploymentArgsDict',
     'FSGroupStrategyOptionsPatchArgs',
+    'FSGroupStrategyOptionsPatchArgsDict',
     'FSGroupStrategyOptionsArgs',
+    'FSGroupStrategyOptionsArgsDict',
     'HTTPIngressPathPatchArgs',
+    'HTTPIngressPathPatchArgsDict',
     'HTTPIngressPathArgs',
+    'HTTPIngressPathArgsDict',
     'HTTPIngressRuleValuePatchArgs',
+    'HTTPIngressRuleValuePatchArgsDict',
     'HTTPIngressRuleValueArgs',
+    'HTTPIngressRuleValueArgsDict',
     'HostPortRangePatchArgs',
+    'HostPortRangePatchArgsDict',
     'HostPortRangeArgs',
+    'HostPortRangeArgsDict',
     'IDRangePatchArgs',
+    'IDRangePatchArgsDict',
     'IDRangeArgs',
+    'IDRangeArgsDict',
     'IPBlockPatchArgs',
+    'IPBlockPatchArgsDict',
     'IPBlockArgs',
+    'IPBlockArgsDict',
     'IngressBackendPatchArgs',
+    'IngressBackendPatchArgsDict',
     'IngressBackendArgs',
+    'IngressBackendArgsDict',
     'IngressRulePatchArgs',
+    'IngressRulePatchArgsDict',
     'IngressRuleArgs',
+    'IngressRuleArgsDict',
     'IngressSpecPatchArgs',
+    'IngressSpecPatchArgsDict',
     'IngressSpecArgs',
+    'IngressSpecArgsDict',
     'IngressStatusArgs',
+    'IngressStatusArgsDict',
     'IngressTLSPatchArgs',
+    'IngressTLSPatchArgsDict',
     'IngressTLSArgs',
+    'IngressTLSArgsDict',
     'IngressArgs',
+    'IngressArgsDict',
     'NetworkPolicyEgressRulePatchArgs',
+    'NetworkPolicyEgressRulePatchArgsDict',
     'NetworkPolicyEgressRuleArgs',
+    'NetworkPolicyEgressRuleArgsDict',
     'NetworkPolicyIngressRulePatchArgs',
+    'NetworkPolicyIngressRulePatchArgsDict',
     'NetworkPolicyIngressRuleArgs',
+    'NetworkPolicyIngressRuleArgsDict',
     'NetworkPolicyPeerPatchArgs',
+    'NetworkPolicyPeerPatchArgsDict',
     'NetworkPolicyPeerArgs',
+    'NetworkPolicyPeerArgsDict',
     'NetworkPolicyPortPatchArgs',
+    'NetworkPolicyPortPatchArgsDict',
     'NetworkPolicyPortArgs',
+    'NetworkPolicyPortArgsDict',
     'NetworkPolicySpecPatchArgs',
+    'NetworkPolicySpecPatchArgsDict',
     'NetworkPolicySpecArgs',
+    'NetworkPolicySpecArgsDict',
     'NetworkPolicyArgs',
+    'NetworkPolicyArgsDict',
     'PodSecurityPolicySpecPatchArgs',
+    'PodSecurityPolicySpecPatchArgsDict',
     'PodSecurityPolicySpecArgs',
+    'PodSecurityPolicySpecArgsDict',
     'PodSecurityPolicyArgs',
+    'PodSecurityPolicyArgsDict',
     'ReplicaSetConditionArgs',
+    'ReplicaSetConditionArgsDict',
     'ReplicaSetSpecPatchArgs',
+    'ReplicaSetSpecPatchArgsDict',
     'ReplicaSetSpecArgs',
+    'ReplicaSetSpecArgsDict',
     'ReplicaSetStatusArgs',
+    'ReplicaSetStatusArgsDict',
     'ReplicaSetArgs',
+    'ReplicaSetArgsDict',
     'RollbackConfigPatchArgs',
+    'RollbackConfigPatchArgsDict',
     'RollbackConfigArgs',
+    'RollbackConfigArgsDict',
     'RollingUpdateDaemonSetPatchArgs',
+    'RollingUpdateDaemonSetPatchArgsDict',
     'RollingUpdateDaemonSetArgs',
+    'RollingUpdateDaemonSetArgsDict',
     'RollingUpdateDeploymentPatchArgs',
+    'RollingUpdateDeploymentPatchArgsDict',
     'RollingUpdateDeploymentArgs',
+    'RollingUpdateDeploymentArgsDict',
     'RunAsGroupStrategyOptionsPatchArgs',
+    'RunAsGroupStrategyOptionsPatchArgsDict',
     'RunAsGroupStrategyOptionsArgs',
+    'RunAsGroupStrategyOptionsArgsDict',
     'RunAsUserStrategyOptionsPatchArgs',
+    'RunAsUserStrategyOptionsPatchArgsDict',
     'RunAsUserStrategyOptionsArgs',
+    'RunAsUserStrategyOptionsArgsDict',
     'RuntimeClassStrategyOptionsPatchArgs',
+    'RuntimeClassStrategyOptionsPatchArgsDict',
     'RuntimeClassStrategyOptionsArgs',
+    'RuntimeClassStrategyOptionsArgsDict',
     'SELinuxStrategyOptionsPatchArgs',
+    'SELinuxStrategyOptionsPatchArgsDict',
     'SELinuxStrategyOptionsArgs',
+    'SELinuxStrategyOptionsArgsDict',
     'SupplementalGroupsStrategyOptionsPatchArgs',
+    'SupplementalGroupsStrategyOptionsPatchArgsDict',
     'SupplementalGroupsStrategyOptionsArgs',
+    'SupplementalGroupsStrategyOptionsArgsDict',
 ]
+
+MYPY = False
+
+if not MYPY:
+    class AllowedCSIDriverPatchArgsDict(TypedDict):
+        """
+        AllowedCSIDriver represents a single inline CSI Driver that is allowed to be used.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name is the registered name of the CSI driver
+        """
+elif False:
+    AllowedCSIDriverPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class AllowedCSIDriverPatchArgs:
@@ -115,6 +211,18 @@ class AllowedCSIDriverPatchArgs:
         pulumi.set(self, "name", value)
 
 
+if not MYPY:
+    class AllowedCSIDriverArgsDict(TypedDict):
+        """
+        AllowedCSIDriver represents a single inline CSI Driver that is allowed to be used.
+        """
+        name: pulumi.Input[str]
+        """
+        Name is the registered name of the CSI driver
+        """
+elif False:
+    AllowedCSIDriverArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class AllowedCSIDriverArgs:
     def __init__(__self__, *,
@@ -137,6 +245,18 @@ class AllowedCSIDriverArgs:
     def name(self, value: pulumi.Input[str]):
         pulumi.set(self, "name", value)
 
+
+if not MYPY:
+    class AllowedFlexVolumePatchArgsDict(TypedDict):
+        """
+        AllowedFlexVolume represents a single Flexvolume that is allowed to be used. Deprecated: use AllowedFlexVolume from policy API Group instead.
+        """
+        driver: NotRequired[pulumi.Input[str]]
+        """
+        driver is the name of the Flexvolume driver.
+        """
+elif False:
+    AllowedFlexVolumePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class AllowedFlexVolumePatchArgs:
@@ -162,6 +282,18 @@ class AllowedFlexVolumePatchArgs:
         pulumi.set(self, "driver", value)
 
 
+if not MYPY:
+    class AllowedFlexVolumeArgsDict(TypedDict):
+        """
+        AllowedFlexVolume represents a single Flexvolume that is allowed to be used. Deprecated: use AllowedFlexVolume from policy API Group instead.
+        """
+        driver: pulumi.Input[str]
+        """
+        driver is the name of the Flexvolume driver.
+        """
+elif False:
+    AllowedFlexVolumeArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class AllowedFlexVolumeArgs:
     def __init__(__self__, *,
@@ -184,6 +316,24 @@ class AllowedFlexVolumeArgs:
     def driver(self, value: pulumi.Input[str]):
         pulumi.set(self, "driver", value)
 
+
+if not MYPY:
+    class AllowedHostPathPatchArgsDict(TypedDict):
+        """
+        AllowedHostPath defines the host volume conditions that will be enabled by a policy for pods to use. It requires the path prefix to be defined. Deprecated: use AllowedHostPath from policy API Group instead.
+        """
+        path_prefix: NotRequired[pulumi.Input[str]]
+        """
+        pathPrefix is the path prefix that the host volume must match. It does not support `*`. Trailing slashes are trimmed when validating the path prefix with a host path.
+
+        Examples: `/foo` would allow `/foo`, `/foo/` and `/foo/bar` `/foo` would not allow `/food` or `/etc/foo`
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        when set to true, will allow host volumes matching the pathPrefix only if all volume mounts are readOnly.
+        """
+elif False:
+    AllowedHostPathPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class AllowedHostPathPatchArgs:
@@ -229,6 +379,24 @@ class AllowedHostPathPatchArgs:
         pulumi.set(self, "read_only", value)
 
 
+if not MYPY:
+    class AllowedHostPathArgsDict(TypedDict):
+        """
+        AllowedHostPath defines the host volume conditions that will be enabled by a policy for pods to use. It requires the path prefix to be defined. Deprecated: use AllowedHostPath from policy API Group instead.
+        """
+        path_prefix: NotRequired[pulumi.Input[str]]
+        """
+        pathPrefix is the path prefix that the host volume must match. It does not support `*`. Trailing slashes are trimmed when validating the path prefix with a host path.
+
+        Examples: `/foo` would allow `/foo`, `/foo/` and `/foo/bar` `/foo` would not allow `/food` or `/etc/foo`
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        when set to true, will allow host volumes matching the pathPrefix only if all volume mounts are readOnly.
+        """
+elif False:
+    AllowedHostPathArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class AllowedHostPathArgs:
     def __init__(__self__, *,
@@ -272,6 +440,34 @@ class AllowedHostPathArgs:
     def read_only(self, value: Optional[pulumi.Input[bool]]):
         pulumi.set(self, "read_only", value)
 
+
+if not MYPY:
+    class DaemonSetConditionArgsDict(TypedDict):
+        """
+        DaemonSetCondition describes the state of a DaemonSet at a certain point.
+        """
+        status: pulumi.Input[str]
+        """
+        Status of the condition, one of True, False, Unknown.
+        """
+        type: pulumi.Input[str]
+        """
+        Type of DaemonSet condition.
+        """
+        last_transition_time: NotRequired[pulumi.Input[str]]
+        """
+        Last time the condition transitioned from one status to another.
+        """
+        message: NotRequired[pulumi.Input[str]]
+        """
+        A human readable message indicating details about the transition.
+        """
+        reason: NotRequired[pulumi.Input[str]]
+        """
+        The reason for the condition's last transition.
+        """
+elif False:
+    DaemonSetConditionArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class DaemonSetConditionArgs:
@@ -358,6 +554,38 @@ class DaemonSetConditionArgs:
     def reason(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "reason", value)
 
+
+if not MYPY:
+    class DaemonSetSpecPatchArgsDict(TypedDict):
+        """
+        DaemonSetSpec is the specification of a daemon set.
+        """
+        min_ready_seconds: NotRequired[pulumi.Input[int]]
+        """
+        The minimum number of seconds for which a newly created DaemonSet pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready).
+        """
+        revision_history_limit: NotRequired[pulumi.Input[int]]
+        """
+        The number of old history to retain to allow rollback. This is a pointer to distinguish between explicit zero and not specified. Defaults to 10.
+        """
+        selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorPatchArgsDict']]
+        """
+        A label query over pods that are managed by the daemon set. Must match in order to be controlled. If empty, defaulted to labels on Pod template. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+        """
+        template: NotRequired[pulumi.Input['_core.v1.PodTemplateSpecPatchArgsDict']]
+        """
+        An object that describes the pod that will be created. The DaemonSet will create exactly one copy of this pod on every node that matches the template's node selector (or on every node if no node selector is specified). More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template
+        """
+        template_generation: NotRequired[pulumi.Input[int]]
+        """
+        DEPRECATED. A sequence number representing a specific generation of the template. Populated by the system. It can be set only during the creation.
+        """
+        update_strategy: NotRequired[pulumi.Input['DaemonSetUpdateStrategyPatchArgsDict']]
+        """
+        An update strategy to replace existing DaemonSet pods with new pods.
+        """
+elif False:
+    DaemonSetSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class DaemonSetSpecPatchArgs:
@@ -463,6 +691,38 @@ class DaemonSetSpecPatchArgs:
         pulumi.set(self, "update_strategy", value)
 
 
+if not MYPY:
+    class DaemonSetSpecArgsDict(TypedDict):
+        """
+        DaemonSetSpec is the specification of a daemon set.
+        """
+        template: pulumi.Input['_core.v1.PodTemplateSpecArgsDict']
+        """
+        An object that describes the pod that will be created. The DaemonSet will create exactly one copy of this pod on every node that matches the template's node selector (or on every node if no node selector is specified). More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template
+        """
+        min_ready_seconds: NotRequired[pulumi.Input[int]]
+        """
+        The minimum number of seconds for which a newly created DaemonSet pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready).
+        """
+        revision_history_limit: NotRequired[pulumi.Input[int]]
+        """
+        The number of old history to retain to allow rollback. This is a pointer to distinguish between explicit zero and not specified. Defaults to 10.
+        """
+        selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorArgsDict']]
+        """
+        A label query over pods that are managed by the daemon set. Must match in order to be controlled. If empty, defaulted to labels on Pod template. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+        """
+        template_generation: NotRequired[pulumi.Input[int]]
+        """
+        DEPRECATED. A sequence number representing a specific generation of the template. Populated by the system. It can be set only during the creation.
+        """
+        update_strategy: NotRequired[pulumi.Input['DaemonSetUpdateStrategyArgsDict']]
+        """
+        An update strategy to replace existing DaemonSet pods with new pods.
+        """
+elif False:
+    DaemonSetSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class DaemonSetSpecArgs:
     def __init__(__self__, *,
@@ -565,6 +825,54 @@ class DaemonSetSpecArgs:
     def update_strategy(self, value: Optional[pulumi.Input['DaemonSetUpdateStrategyArgs']]):
         pulumi.set(self, "update_strategy", value)
 
+
+if not MYPY:
+    class DaemonSetStatusArgsDict(TypedDict):
+        """
+        DaemonSetStatus represents the current status of a daemon set.
+        """
+        current_number_scheduled: pulumi.Input[int]
+        """
+        The number of nodes that are running at least 1 daemon pod and are supposed to run the daemon pod. More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
+        """
+        desired_number_scheduled: pulumi.Input[int]
+        """
+        The total number of nodes that should be running the daemon pod (including nodes correctly running the daemon pod). More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
+        """
+        number_misscheduled: pulumi.Input[int]
+        """
+        The number of nodes that are running the daemon pod, but are not supposed to run the daemon pod. More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
+        """
+        number_ready: pulumi.Input[int]
+        """
+        The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready.
+        """
+        collision_count: NotRequired[pulumi.Input[int]]
+        """
+        Count of hash collisions for the DaemonSet. The DaemonSet controller uses this field as a collision avoidance mechanism when it needs to create the name for the newest ControllerRevision.
+        """
+        conditions: NotRequired[pulumi.Input[Sequence[pulumi.Input['DaemonSetConditionArgsDict']]]]
+        """
+        Represents the latest available observations of a DaemonSet's current state.
+        """
+        number_available: NotRequired[pulumi.Input[int]]
+        """
+        The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and available (ready for at least spec.minReadySeconds)
+        """
+        number_unavailable: NotRequired[pulumi.Input[int]]
+        """
+        The number of nodes that should be running the daemon pod and have none of the daemon pod running and available (ready for at least spec.minReadySeconds)
+        """
+        observed_generation: NotRequired[pulumi.Input[int]]
+        """
+        The most recent generation observed by the daemon set controller.
+        """
+        updated_number_scheduled: NotRequired[pulumi.Input[int]]
+        """
+        The total number of nodes that are running updated daemon pod
+        """
+elif False:
+    DaemonSetStatusArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class DaemonSetStatusArgs:
@@ -730,6 +1038,19 @@ class DaemonSetStatusArgs:
         pulumi.set(self, "updated_number_scheduled", value)
 
 
+if not MYPY:
+    class DaemonSetUpdateStrategyPatchArgsDict(TypedDict):
+        rolling_update: NotRequired[pulumi.Input['RollingUpdateDaemonSetPatchArgsDict']]
+        """
+        Rolling update config params. Present only if type = "RollingUpdate".
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        Type of daemon set update. Can be "RollingUpdate" or "OnDelete". Default is OnDelete.
+        """
+elif False:
+    DaemonSetUpdateStrategyPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class DaemonSetUpdateStrategyPatchArgs:
     def __init__(__self__, *,
@@ -769,6 +1090,19 @@ class DaemonSetUpdateStrategyPatchArgs:
         pulumi.set(self, "type", value)
 
 
+if not MYPY:
+    class DaemonSetUpdateStrategyArgsDict(TypedDict):
+        rolling_update: NotRequired[pulumi.Input['RollingUpdateDaemonSetArgsDict']]
+        """
+        Rolling update config params. Present only if type = "RollingUpdate".
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        Type of daemon set update. Can be "RollingUpdate" or "OnDelete". Default is OnDelete.
+        """
+elif False:
+    DaemonSetUpdateStrategyArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class DaemonSetUpdateStrategyArgs:
     def __init__(__self__, *,
@@ -807,6 +1141,34 @@ class DaemonSetUpdateStrategyArgs:
     def type(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "type", value)
 
+
+if not MYPY:
+    class DaemonSetArgsDict(TypedDict):
+        """
+        DaemonSet represents the configuration of a daemon set.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['DaemonSetSpecArgsDict']]
+        """
+        The desired behavior of this daemon set. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+        status: NotRequired[pulumi.Input['DaemonSetStatusArgsDict']]
+        """
+        The current status of this daemon set. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+elif False:
+    DaemonSetArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class DaemonSetArgs:
@@ -895,6 +1257,38 @@ class DaemonSetArgs:
     def status(self, value: Optional[pulumi.Input['DaemonSetStatusArgs']]):
         pulumi.set(self, "status", value)
 
+
+if not MYPY:
+    class DeploymentConditionArgsDict(TypedDict):
+        """
+        DeploymentCondition describes the state of a deployment at a certain point.
+        """
+        status: pulumi.Input[str]
+        """
+        Status of the condition, one of True, False, Unknown.
+        """
+        type: pulumi.Input[str]
+        """
+        Type of deployment condition.
+        """
+        last_transition_time: NotRequired[pulumi.Input[str]]
+        """
+        Last time the condition transitioned from one status to another.
+        """
+        last_update_time: NotRequired[pulumi.Input[str]]
+        """
+        The last time this condition was updated.
+        """
+        message: NotRequired[pulumi.Input[str]]
+        """
+        A human readable message indicating details about the transition.
+        """
+        reason: NotRequired[pulumi.Input[str]]
+        """
+        The reason for the condition's last transition.
+        """
+elif False:
+    DeploymentConditionArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class DeploymentConditionArgs:
@@ -997,6 +1391,50 @@ class DeploymentConditionArgs:
     def reason(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "reason", value)
 
+
+if not MYPY:
+    class DeploymentSpecPatchArgsDict(TypedDict):
+        """
+        DeploymentSpec is the specification of the desired behavior of the Deployment.
+        """
+        min_ready_seconds: NotRequired[pulumi.Input[int]]
+        """
+        Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)
+        """
+        paused: NotRequired[pulumi.Input[bool]]
+        """
+        Indicates that the deployment is paused and will not be processed by the deployment controller.
+        """
+        progress_deadline_seconds: NotRequired[pulumi.Input[int]]
+        """
+        The maximum time in seconds for a deployment to make progress before it is considered to be failed. The deployment controller will continue to process failed deployments and a condition with a ProgressDeadlineExceeded reason will be surfaced in the deployment status. Note that progress will not be estimated during the time a deployment is paused. This is set to the max value of int32 (i.e. 2147483647) by default, which means "no deadline".
+        """
+        replicas: NotRequired[pulumi.Input[int]]
+        """
+        Number of desired pods. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1.
+        """
+        revision_history_limit: NotRequired[pulumi.Input[int]]
+        """
+        The number of old ReplicaSets to retain to allow rollback. This is a pointer to distinguish between explicit zero and not specified. This is set to the max value of int32 (i.e. 2147483647) by default, which means "retaining all old RelicaSets".
+        """
+        rollback_to: NotRequired[pulumi.Input['RollbackConfigPatchArgsDict']]
+        """
+        DEPRECATED. The config this deployment is rolling back to. Will be cleared after rollback is done.
+        """
+        selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorPatchArgsDict']]
+        """
+        Label selector for pods. Existing ReplicaSets whose pods are selected by this will be the ones affected by this deployment.
+        """
+        strategy: NotRequired[pulumi.Input['DeploymentStrategyPatchArgsDict']]
+        """
+        The deployment strategy to use to replace existing pods with new ones.
+        """
+        template: NotRequired[pulumi.Input['_core.v1.PodTemplateSpecPatchArgsDict']]
+        """
+        Template describes the pods that will be created.
+        """
+elif False:
+    DeploymentSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class DeploymentSpecPatchArgs:
@@ -1150,6 +1588,50 @@ class DeploymentSpecPatchArgs:
         pulumi.set(self, "template", value)
 
 
+if not MYPY:
+    class DeploymentSpecArgsDict(TypedDict):
+        """
+        DeploymentSpec is the specification of the desired behavior of the Deployment.
+        """
+        template: pulumi.Input['_core.v1.PodTemplateSpecArgsDict']
+        """
+        Template describes the pods that will be created.
+        """
+        min_ready_seconds: NotRequired[pulumi.Input[int]]
+        """
+        Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)
+        """
+        paused: NotRequired[pulumi.Input[bool]]
+        """
+        Indicates that the deployment is paused and will not be processed by the deployment controller.
+        """
+        progress_deadline_seconds: NotRequired[pulumi.Input[int]]
+        """
+        The maximum time in seconds for a deployment to make progress before it is considered to be failed. The deployment controller will continue to process failed deployments and a condition with a ProgressDeadlineExceeded reason will be surfaced in the deployment status. Note that progress will not be estimated during the time a deployment is paused. This is set to the max value of int32 (i.e. 2147483647) by default, which means "no deadline".
+        """
+        replicas: NotRequired[pulumi.Input[int]]
+        """
+        Number of desired pods. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1.
+        """
+        revision_history_limit: NotRequired[pulumi.Input[int]]
+        """
+        The number of old ReplicaSets to retain to allow rollback. This is a pointer to distinguish between explicit zero and not specified. This is set to the max value of int32 (i.e. 2147483647) by default, which means "retaining all old RelicaSets".
+        """
+        rollback_to: NotRequired[pulumi.Input['RollbackConfigArgsDict']]
+        """
+        DEPRECATED. The config this deployment is rolling back to. Will be cleared after rollback is done.
+        """
+        selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorArgsDict']]
+        """
+        Label selector for pods. Existing ReplicaSets whose pods are selected by this will be the ones affected by this deployment.
+        """
+        strategy: NotRequired[pulumi.Input['DeploymentStrategyArgsDict']]
+        """
+        The deployment strategy to use to replace existing pods with new ones.
+        """
+elif False:
+    DeploymentSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class DeploymentSpecArgs:
     def __init__(__self__, *,
@@ -1301,6 +1783,46 @@ class DeploymentSpecArgs:
         pulumi.set(self, "strategy", value)
 
 
+if not MYPY:
+    class DeploymentStatusArgsDict(TypedDict):
+        """
+        DeploymentStatus is the most recently observed status of the Deployment.
+        """
+        available_replicas: NotRequired[pulumi.Input[int]]
+        """
+        Total number of available pods (ready for at least minReadySeconds) targeted by this deployment.
+        """
+        collision_count: NotRequired[pulumi.Input[int]]
+        """
+        Count of hash collisions for the Deployment. The Deployment controller uses this field as a collision avoidance mechanism when it needs to create the name for the newest ReplicaSet.
+        """
+        conditions: NotRequired[pulumi.Input[Sequence[pulumi.Input['DeploymentConditionArgsDict']]]]
+        """
+        Represents the latest available observations of a deployment's current state.
+        """
+        observed_generation: NotRequired[pulumi.Input[int]]
+        """
+        The generation observed by the deployment controller.
+        """
+        ready_replicas: NotRequired[pulumi.Input[int]]
+        """
+        Total number of ready pods targeted by this deployment.
+        """
+        replicas: NotRequired[pulumi.Input[int]]
+        """
+        Total number of non-terminated pods targeted by this deployment (their labels match the selector).
+        """
+        unavailable_replicas: NotRequired[pulumi.Input[int]]
+        """
+        Total number of unavailable pods targeted by this deployment. This is the total number of pods that are still required for the deployment to have 100% available capacity. They may either be pods that are running but not yet available or pods that still have not been created.
+        """
+        updated_replicas: NotRequired[pulumi.Input[int]]
+        """
+        Total number of non-terminated pods targeted by this deployment that have the desired template spec.
+        """
+elif False:
+    DeploymentStatusArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class DeploymentStatusArgs:
     def __init__(__self__, *,
@@ -1437,6 +1959,22 @@ class DeploymentStatusArgs:
         pulumi.set(self, "updated_replicas", value)
 
 
+if not MYPY:
+    class DeploymentStrategyPatchArgsDict(TypedDict):
+        """
+        DeploymentStrategy describes how to replace existing pods with new ones.
+        """
+        rolling_update: NotRequired[pulumi.Input['RollingUpdateDeploymentPatchArgsDict']]
+        """
+        Rolling update config params. Present only if DeploymentStrategyType = RollingUpdate.
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        Type of deployment. Can be "Recreate" or "RollingUpdate". Default is RollingUpdate.
+        """
+elif False:
+    DeploymentStrategyPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class DeploymentStrategyPatchArgs:
     def __init__(__self__, *,
@@ -1477,6 +2015,22 @@ class DeploymentStrategyPatchArgs:
         pulumi.set(self, "type", value)
 
 
+if not MYPY:
+    class DeploymentStrategyArgsDict(TypedDict):
+        """
+        DeploymentStrategy describes how to replace existing pods with new ones.
+        """
+        rolling_update: NotRequired[pulumi.Input['RollingUpdateDeploymentArgsDict']]
+        """
+        Rolling update config params. Present only if DeploymentStrategyType = RollingUpdate.
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        Type of deployment. Can be "Recreate" or "RollingUpdate". Default is RollingUpdate.
+        """
+elif False:
+    DeploymentStrategyArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class DeploymentStrategyArgs:
     def __init__(__self__, *,
@@ -1516,6 +2070,56 @@ class DeploymentStrategyArgs:
     def type(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "type", value)
 
+
+if not MYPY:
+    class DeploymentArgsDict(TypedDict):
+        """
+        Deployment enables declarative updates for Pods and ReplicaSets.
+
+        This resource waits until its status is ready before registering success
+        for create/update, and populating output properties from the current state of the resource.
+        The following conditions are used to determine whether the resource creation has
+        succeeded or failed:
+
+        1. The Deployment has begun to be updated by the Deployment controller. If the current
+           generation of the Deployment is > 1, then this means that the current generation must
+           be different from the generation reported by the last outputs.
+        2. There exists a ReplicaSet whose revision is equal to the current revision of the
+           Deployment.
+        3. The Deployment's '.status.conditions' has a status of type 'Available' whose 'status'
+           member is set to 'True'.
+        4. If the Deployment has generation > 1, then '.status.conditions' has a status of type
+           'Progressing', whose 'status' member is set to 'True', and whose 'reason' is
+           'NewReplicaSetAvailable'. For generation <= 1, this status field does not exist,
+           because it doesn't do a rollout (i.e., it simply creates the Deployment and
+           corresponding ReplicaSet), and therefore there is no rollout to mark as 'Progressing'.
+
+        If the Deployment has not reached a Ready state after 10 minutes, it will
+        time out and mark the resource update as Failed. You can override the default timeout value
+        by setting the 'customTimeouts' option on the resource.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object metadata.
+        """
+        spec: NotRequired[pulumi.Input['DeploymentSpecArgsDict']]
+        """
+        Specification of the desired behavior of the Deployment.
+        """
+        status: NotRequired[pulumi.Input['DeploymentStatusArgsDict']]
+        """
+        Most recently observed status of the Deployment.
+        """
+elif False:
+    DeploymentArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class DeploymentArgs:
@@ -1627,6 +2231,22 @@ class DeploymentArgs:
         pulumi.set(self, "status", value)
 
 
+if not MYPY:
+    class FSGroupStrategyOptionsPatchArgsDict(TypedDict):
+        """
+        FSGroupStrategyOptions defines the strategy type and options used to create the strategy. Deprecated: use FSGroupStrategyOptions from policy API Group instead.
+        """
+        ranges: NotRequired[pulumi.Input[Sequence[pulumi.Input['IDRangePatchArgsDict']]]]
+        """
+        ranges are the allowed ranges of fs groups.  If you would like to force a single fs group then supply a single range with the same start and end. Required for MustRunAs.
+        """
+        rule: NotRequired[pulumi.Input[str]]
+        """
+        rule is the strategy that will dictate what FSGroup is used in the SecurityContext.
+        """
+elif False:
+    FSGroupStrategyOptionsPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class FSGroupStrategyOptionsPatchArgs:
     def __init__(__self__, *,
@@ -1667,6 +2287,22 @@ class FSGroupStrategyOptionsPatchArgs:
         pulumi.set(self, "rule", value)
 
 
+if not MYPY:
+    class FSGroupStrategyOptionsArgsDict(TypedDict):
+        """
+        FSGroupStrategyOptions defines the strategy type and options used to create the strategy. Deprecated: use FSGroupStrategyOptions from policy API Group instead.
+        """
+        ranges: NotRequired[pulumi.Input[Sequence[pulumi.Input['IDRangeArgsDict']]]]
+        """
+        ranges are the allowed ranges of fs groups.  If you would like to force a single fs group then supply a single range with the same start and end. Required for MustRunAs.
+        """
+        rule: NotRequired[pulumi.Input[str]]
+        """
+        rule is the strategy that will dictate what FSGroup is used in the SecurityContext.
+        """
+elif False:
+    FSGroupStrategyOptionsArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class FSGroupStrategyOptionsArgs:
     def __init__(__self__, *,
@@ -1706,6 +2342,36 @@ class FSGroupStrategyOptionsArgs:
     def rule(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "rule", value)
 
+
+if not MYPY:
+    class HTTPIngressPathPatchArgsDict(TypedDict):
+        """
+        HTTPIngressPath associates a path regex with a backend. Incoming urls matching the path are forwarded to the backend.
+        """
+        backend: NotRequired[pulumi.Input['IngressBackendPatchArgsDict']]
+        """
+        Backend defines the referenced service endpoint to which the traffic will be forwarded to.
+        """
+        path: NotRequired[pulumi.Input[str]]
+        """
+        Path is an extended POSIX regex as defined by IEEE Std 1003.1, (i.e this follows the egrep/unix syntax, not the perl syntax) matched against the path of an incoming request. Currently it can contain characters disallowed from the conventional "path" part of a URL as defined by RFC 3986. Paths must begin with a '/'. If unspecified, the path defaults to a catch all sending traffic to the backend.
+        """
+        path_type: NotRequired[pulumi.Input[str]]
+        """
+        PathType determines the interpretation of the Path matching. PathType can be one of the following values: * Exact: Matches the URL path exactly. * Prefix: Matches based on a URL path prefix split by '/'. Matching is
+          done on a path element by element basis. A path element refers is the
+          list of labels in the path split by the '/' separator. A request is a
+          match for path p if every p is an element-wise prefix of p of the
+          request path. Note that if the last element of the path is a substring
+          of the last element in request path, it is not a match (e.g. /foo/bar
+          matches /foo/bar/baz, but does not match /foo/barbaz).
+        * ImplementationSpecific: Interpretation of the Path matching is up to
+          the IngressClass. Implementations can treat this as a separate PathType
+          or treat it identically to Prefix or Exact path types.
+        Implementations are required to support all path types. Defaults to ImplementationSpecific.
+        """
+elif False:
+    HTTPIngressPathPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class HTTPIngressPathPatchArgs:
@@ -1783,6 +2449,36 @@ class HTTPIngressPathPatchArgs:
         pulumi.set(self, "path_type", value)
 
 
+if not MYPY:
+    class HTTPIngressPathArgsDict(TypedDict):
+        """
+        HTTPIngressPath associates a path regex with a backend. Incoming urls matching the path are forwarded to the backend.
+        """
+        backend: pulumi.Input['IngressBackendArgsDict']
+        """
+        Backend defines the referenced service endpoint to which the traffic will be forwarded to.
+        """
+        path: NotRequired[pulumi.Input[str]]
+        """
+        Path is an extended POSIX regex as defined by IEEE Std 1003.1, (i.e this follows the egrep/unix syntax, not the perl syntax) matched against the path of an incoming request. Currently it can contain characters disallowed from the conventional "path" part of a URL as defined by RFC 3986. Paths must begin with a '/'. If unspecified, the path defaults to a catch all sending traffic to the backend.
+        """
+        path_type: NotRequired[pulumi.Input[str]]
+        """
+        PathType determines the interpretation of the Path matching. PathType can be one of the following values: * Exact: Matches the URL path exactly. * Prefix: Matches based on a URL path prefix split by '/'. Matching is
+          done on a path element by element basis. A path element refers is the
+          list of labels in the path split by the '/' separator. A request is a
+          match for path p if every p is an element-wise prefix of p of the
+          request path. Note that if the last element of the path is a substring
+          of the last element in request path, it is not a match (e.g. /foo/bar
+          matches /foo/bar/baz, but does not match /foo/barbaz).
+        * ImplementationSpecific: Interpretation of the Path matching is up to
+          the IngressClass. Implementations can treat this as a separate PathType
+          or treat it identically to Prefix or Exact path types.
+        Implementations are required to support all path types. Defaults to ImplementationSpecific.
+        """
+elif False:
+    HTTPIngressPathArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class HTTPIngressPathArgs:
     def __init__(__self__, *,
@@ -1858,6 +2554,18 @@ class HTTPIngressPathArgs:
         pulumi.set(self, "path_type", value)
 
 
+if not MYPY:
+    class HTTPIngressRuleValuePatchArgsDict(TypedDict):
+        """
+        HTTPIngressRuleValue is a list of http selectors pointing to backends. In the example: http://<host>/<path>?<searchpart> -> backend where where parts of the url correspond to RFC 3986, this resource will be used to match against everything after the last '/' and before the first '?' or '#'.
+        """
+        paths: NotRequired[pulumi.Input[Sequence[pulumi.Input['HTTPIngressPathPatchArgsDict']]]]
+        """
+        A collection of paths that map requests to backends.
+        """
+elif False:
+    HTTPIngressRuleValuePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class HTTPIngressRuleValuePatchArgs:
     def __init__(__self__, *,
@@ -1882,6 +2590,18 @@ class HTTPIngressRuleValuePatchArgs:
         pulumi.set(self, "paths", value)
 
 
+if not MYPY:
+    class HTTPIngressRuleValueArgsDict(TypedDict):
+        """
+        HTTPIngressRuleValue is a list of http selectors pointing to backends. In the example: http://<host>/<path>?<searchpart> -> backend where where parts of the url correspond to RFC 3986, this resource will be used to match against everything after the last '/' and before the first '?' or '#'.
+        """
+        paths: pulumi.Input[Sequence[pulumi.Input['HTTPIngressPathArgsDict']]]
+        """
+        A collection of paths that map requests to backends.
+        """
+elif False:
+    HTTPIngressRuleValueArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class HTTPIngressRuleValueArgs:
     def __init__(__self__, *,
@@ -1904,6 +2624,22 @@ class HTTPIngressRuleValueArgs:
     def paths(self, value: pulumi.Input[Sequence[pulumi.Input['HTTPIngressPathArgs']]]):
         pulumi.set(self, "paths", value)
 
+
+if not MYPY:
+    class HostPortRangePatchArgsDict(TypedDict):
+        """
+        HostPortRange defines a range of host ports that will be enabled by a policy for pods to use.  It requires both the start and end to be defined. Deprecated: use HostPortRange from policy API Group instead.
+        """
+        max: NotRequired[pulumi.Input[int]]
+        """
+        max is the end of the range, inclusive.
+        """
+        min: NotRequired[pulumi.Input[int]]
+        """
+        min is the start of the range, inclusive.
+        """
+elif False:
+    HostPortRangePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class HostPortRangePatchArgs:
@@ -1945,6 +2681,22 @@ class HostPortRangePatchArgs:
         pulumi.set(self, "min", value)
 
 
+if not MYPY:
+    class HostPortRangeArgsDict(TypedDict):
+        """
+        HostPortRange defines a range of host ports that will be enabled by a policy for pods to use.  It requires both the start and end to be defined. Deprecated: use HostPortRange from policy API Group instead.
+        """
+        max: pulumi.Input[int]
+        """
+        max is the end of the range, inclusive.
+        """
+        min: pulumi.Input[int]
+        """
+        min is the start of the range, inclusive.
+        """
+elif False:
+    HostPortRangeArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class HostPortRangeArgs:
     def __init__(__self__, *,
@@ -1982,6 +2734,22 @@ class HostPortRangeArgs:
     def min(self, value: pulumi.Input[int]):
         pulumi.set(self, "min", value)
 
+
+if not MYPY:
+    class IDRangePatchArgsDict(TypedDict):
+        """
+        IDRange provides a min/max of an allowed range of IDs. Deprecated: use IDRange from policy API Group instead.
+        """
+        max: NotRequired[pulumi.Input[int]]
+        """
+        max is the end of the range, inclusive.
+        """
+        min: NotRequired[pulumi.Input[int]]
+        """
+        min is the start of the range, inclusive.
+        """
+elif False:
+    IDRangePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class IDRangePatchArgs:
@@ -2023,6 +2791,22 @@ class IDRangePatchArgs:
         pulumi.set(self, "min", value)
 
 
+if not MYPY:
+    class IDRangeArgsDict(TypedDict):
+        """
+        IDRange provides a min/max of an allowed range of IDs. Deprecated: use IDRange from policy API Group instead.
+        """
+        max: pulumi.Input[int]
+        """
+        max is the end of the range, inclusive.
+        """
+        min: pulumi.Input[int]
+        """
+        min is the start of the range, inclusive.
+        """
+elif False:
+    IDRangeArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class IDRangeArgs:
     def __init__(__self__, *,
@@ -2060,6 +2844,22 @@ class IDRangeArgs:
     def min(self, value: pulumi.Input[int]):
         pulumi.set(self, "min", value)
 
+
+if not MYPY:
+    class IPBlockPatchArgsDict(TypedDict):
+        """
+        DEPRECATED 1.9 - This group version of IPBlock is deprecated by networking/v1/IPBlock. IPBlock describes a particular CIDR (Ex. "192.168.1.1/24") that is allowed to the pods matched by a NetworkPolicySpec's podSelector. The except entry describes CIDRs that should not be included within this rule.
+        """
+        cidr: NotRequired[pulumi.Input[str]]
+        """
+        CIDR is a string representing the IP Block Valid examples are "192.168.1.1/24"
+        """
+        except_: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Except is a slice of CIDRs that should not be included within an IP Block Valid examples are "192.168.1.1/24" Except values will be rejected if they are outside the CIDR range
+        """
+elif False:
+    IPBlockPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class IPBlockPatchArgs:
@@ -2101,6 +2901,22 @@ class IPBlockPatchArgs:
         pulumi.set(self, "except_", value)
 
 
+if not MYPY:
+    class IPBlockArgsDict(TypedDict):
+        """
+        DEPRECATED 1.9 - This group version of IPBlock is deprecated by networking/v1/IPBlock. IPBlock describes a particular CIDR (Ex. "192.168.1.1/24") that is allowed to the pods matched by a NetworkPolicySpec's podSelector. The except entry describes CIDRs that should not be included within this rule.
+        """
+        cidr: pulumi.Input[str]
+        """
+        CIDR is a string representing the IP Block Valid examples are "192.168.1.1/24"
+        """
+        except_: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Except is a slice of CIDRs that should not be included within an IP Block Valid examples are "192.168.1.1/24" Except values will be rejected if they are outside the CIDR range
+        """
+elif False:
+    IPBlockArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class IPBlockArgs:
     def __init__(__self__, *,
@@ -2139,6 +2955,26 @@ class IPBlockArgs:
     def except_(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]):
         pulumi.set(self, "except_", value)
 
+
+if not MYPY:
+    class IngressBackendPatchArgsDict(TypedDict):
+        """
+        IngressBackend describes all endpoints for a given service and port.
+        """
+        resource: NotRequired[pulumi.Input['_core.v1.TypedLocalObjectReferencePatchArgsDict']]
+        """
+        Resource is an ObjectRef to another Kubernetes resource in the namespace of the Ingress object. If resource is specified, serviceName and servicePort must not be specified.
+        """
+        service_name: NotRequired[pulumi.Input[str]]
+        """
+        Specifies the name of the referenced service.
+        """
+        service_port: NotRequired[pulumi.Input[Union[int, str]]]
+        """
+        Specifies the port of the referenced service.
+        """
+elif False:
+    IngressBackendPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class IngressBackendPatchArgs:
@@ -2196,6 +3032,26 @@ class IngressBackendPatchArgs:
         pulumi.set(self, "service_port", value)
 
 
+if not MYPY:
+    class IngressBackendArgsDict(TypedDict):
+        """
+        IngressBackend describes all endpoints for a given service and port.
+        """
+        service_name: pulumi.Input[str]
+        """
+        Specifies the name of the referenced service.
+        """
+        service_port: pulumi.Input[Union[int, str]]
+        """
+        Specifies the port of the referenced service.
+        """
+        resource: NotRequired[pulumi.Input['_core.v1.TypedLocalObjectReferenceArgsDict']]
+        """
+        Resource is an ObjectRef to another Kubernetes resource in the namespace of the Ingress object. If resource is specified, serviceName and servicePort must not be specified.
+        """
+elif False:
+    IngressBackendArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class IngressBackendArgs:
     def __init__(__self__, *,
@@ -2250,6 +3106,24 @@ class IngressBackendArgs:
         pulumi.set(self, "resource", value)
 
 
+if not MYPY:
+    class IngressRulePatchArgsDict(TypedDict):
+        """
+        IngressRule represents the rules mapping the paths under a specified host to the related backend services. Incoming requests are first evaluated for a host match, then routed to the backend associated with the matching IngressRuleValue.
+        """
+        host: NotRequired[pulumi.Input[str]]
+        """
+        Host is the fully qualified domain name of a network host, as defined by RFC 3986. Note the following deviations from the "host" part of the URI as defined in the RFC: 1. IPs are not allowed. Currently an IngressRuleValue can only apply to the
+        	  IP in the Spec of the parent Ingress.
+        2. The `:` delimiter is not respected because ports are not allowed.
+        	  Currently the port of an Ingress is implicitly :80 for http and
+        	  :443 for https.
+        Both these may change in the future. Incoming requests are matched against the host before the IngressRuleValue. If the host is unspecified, the Ingress routes all traffic based on the specified IngressRuleValue.
+        """
+        http: NotRequired[pulumi.Input['HTTPIngressRuleValuePatchArgsDict']]
+elif False:
+    IngressRulePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class IngressRulePatchArgs:
     def __init__(__self__, *,
@@ -2296,6 +3170,24 @@ class IngressRulePatchArgs:
         pulumi.set(self, "http", value)
 
 
+if not MYPY:
+    class IngressRuleArgsDict(TypedDict):
+        """
+        IngressRule represents the rules mapping the paths under a specified host to the related backend services. Incoming requests are first evaluated for a host match, then routed to the backend associated with the matching IngressRuleValue.
+        """
+        host: NotRequired[pulumi.Input[str]]
+        """
+        Host is the fully qualified domain name of a network host, as defined by RFC 3986. Note the following deviations from the "host" part of the URI as defined in the RFC: 1. IPs are not allowed. Currently an IngressRuleValue can only apply to the
+        	  IP in the Spec of the parent Ingress.
+        2. The `:` delimiter is not respected because ports are not allowed.
+        	  Currently the port of an Ingress is implicitly :80 for http and
+        	  :443 for https.
+        Both these may change in the future. Incoming requests are matched against the host before the IngressRuleValue. If the host is unspecified, the Ingress routes all traffic based on the specified IngressRuleValue.
+        """
+        http: NotRequired[pulumi.Input['HTTPIngressRuleValueArgsDict']]
+elif False:
+    IngressRuleArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class IngressRuleArgs:
     def __init__(__self__, *,
@@ -2341,6 +3233,30 @@ class IngressRuleArgs:
     def http(self, value: Optional[pulumi.Input['HTTPIngressRuleValueArgs']]):
         pulumi.set(self, "http", value)
 
+
+if not MYPY:
+    class IngressSpecPatchArgsDict(TypedDict):
+        """
+        IngressSpec describes the Ingress the user wishes to exist.
+        """
+        backend: NotRequired[pulumi.Input['IngressBackendPatchArgsDict']]
+        """
+        A default backend capable of servicing requests that don't match any rule. At least one of 'backend' or 'rules' must be specified. This field is optional to allow the loadbalancer controller or defaulting logic to specify a global default.
+        """
+        ingress_class_name: NotRequired[pulumi.Input[str]]
+        """
+        IngressClassName is the name of the IngressClass cluster resource. The associated IngressClass defines which controller will implement the resource. This replaces the deprecated `kubernetes.io/ingress.class` annotation. For backwards compatibility, when that annotation is set, it must be given precedence over this field. The controller may emit a warning if the field and annotation have different values. Implementations of this API should ignore Ingresses without a class specified. An IngressClass resource may be marked as default, which can be used to set a default value for this field. For more information, refer to the IngressClass documentation.
+        """
+        rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['IngressRulePatchArgsDict']]]]
+        """
+        A list of host rules used to configure the Ingress. If unspecified, or no rule matches, all traffic is sent to the default backend.
+        """
+        tls: NotRequired[pulumi.Input[Sequence[pulumi.Input['IngressTLSPatchArgsDict']]]]
+        """
+        TLS configuration. Currently the Ingress only supports a single TLS port, 443. If multiple members of this list specify different hosts, they will be multiplexed on the same port according to the hostname specified through the SNI TLS extension, if the ingress controller fulfilling the ingress supports SNI.
+        """
+elif False:
+    IngressSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class IngressSpecPatchArgs:
@@ -2414,6 +3330,30 @@ class IngressSpecPatchArgs:
         pulumi.set(self, "tls", value)
 
 
+if not MYPY:
+    class IngressSpecArgsDict(TypedDict):
+        """
+        IngressSpec describes the Ingress the user wishes to exist.
+        """
+        backend: NotRequired[pulumi.Input['IngressBackendArgsDict']]
+        """
+        A default backend capable of servicing requests that don't match any rule. At least one of 'backend' or 'rules' must be specified. This field is optional to allow the loadbalancer controller or defaulting logic to specify a global default.
+        """
+        ingress_class_name: NotRequired[pulumi.Input[str]]
+        """
+        IngressClassName is the name of the IngressClass cluster resource. The associated IngressClass defines which controller will implement the resource. This replaces the deprecated `kubernetes.io/ingress.class` annotation. For backwards compatibility, when that annotation is set, it must be given precedence over this field. The controller may emit a warning if the field and annotation have different values. Implementations of this API should ignore Ingresses without a class specified. An IngressClass resource may be marked as default, which can be used to set a default value for this field. For more information, refer to the IngressClass documentation.
+        """
+        rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['IngressRuleArgsDict']]]]
+        """
+        A list of host rules used to configure the Ingress. If unspecified, or no rule matches, all traffic is sent to the default backend.
+        """
+        tls: NotRequired[pulumi.Input[Sequence[pulumi.Input['IngressTLSArgsDict']]]]
+        """
+        TLS configuration. Currently the Ingress only supports a single TLS port, 443. If multiple members of this list specify different hosts, they will be multiplexed on the same port according to the hostname specified through the SNI TLS extension, if the ingress controller fulfilling the ingress supports SNI.
+        """
+elif False:
+    IngressSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class IngressSpecArgs:
     def __init__(__self__, *,
@@ -2486,6 +3426,18 @@ class IngressSpecArgs:
         pulumi.set(self, "tls", value)
 
 
+if not MYPY:
+    class IngressStatusArgsDict(TypedDict):
+        """
+        IngressStatus describe the current state of the Ingress.
+        """
+        load_balancer: NotRequired[pulumi.Input['_core.v1.LoadBalancerStatusArgsDict']]
+        """
+        LoadBalancer contains the current status of the load-balancer.
+        """
+elif False:
+    IngressStatusArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class IngressStatusArgs:
     def __init__(__self__, *,
@@ -2509,6 +3461,22 @@ class IngressStatusArgs:
     def load_balancer(self, value: Optional[pulumi.Input['_core.v1.LoadBalancerStatusArgs']]):
         pulumi.set(self, "load_balancer", value)
 
+
+if not MYPY:
+    class IngressTLSPatchArgsDict(TypedDict):
+        """
+        IngressTLS describes the transport layer security associated with an Ingress.
+        """
+        hosts: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Hosts are a list of hosts included in the TLS certificate. The values in this list must match the name/s used in the tlsSecret. Defaults to the wildcard host setting for the loadbalancer controller fulfilling this Ingress, if left unspecified.
+        """
+        secret_name: NotRequired[pulumi.Input[str]]
+        """
+        SecretName is the name of the secret used to terminate SSL traffic on 443. Field is left optional to allow SSL routing based on SNI hostname alone. If the SNI host in a listener conflicts with the "Host" header field used by an IngressRule, the SNI host is used for termination and value of the Host header is used for routing.
+        """
+elif False:
+    IngressTLSPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class IngressTLSPatchArgs:
@@ -2550,6 +3518,22 @@ class IngressTLSPatchArgs:
         pulumi.set(self, "secret_name", value)
 
 
+if not MYPY:
+    class IngressTLSArgsDict(TypedDict):
+        """
+        IngressTLS describes the transport layer security associated with an Ingress.
+        """
+        hosts: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Hosts are a list of hosts included in the TLS certificate. The values in this list must match the name/s used in the tlsSecret. Defaults to the wildcard host setting for the loadbalancer controller fulfilling this Ingress, if left unspecified.
+        """
+        secret_name: NotRequired[pulumi.Input[str]]
+        """
+        SecretName is the name of the secret used to terminate SSL traffic on 443. Field is left optional to allow SSL routing based on SNI hostname alone. If the SNI host in a listener conflicts with the "Host" header field used by an IngressRule, the SNI host is used for termination and value of the Host header is used for routing.
+        """
+elif False:
+    IngressTLSArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class IngressTLSArgs:
     def __init__(__self__, *,
@@ -2589,6 +3573,48 @@ class IngressTLSArgs:
     def secret_name(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "secret_name", value)
 
+
+if not MYPY:
+    class IngressArgsDict(TypedDict):
+        """
+        Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc. 
+
+        This resource waits until its status is ready before registering success
+        for create/update, and populating output properties from the current state of the resource.
+        The following conditions are used to determine whether the resource creation has
+        succeeded or failed:
+
+        1.  Ingress object exists.
+        2.  Endpoint objects exist with matching names for each Ingress path (except when Service
+            type is ExternalName).
+        3.  Ingress entry exists for '.status.loadBalancer.ingress'.
+
+        If the Ingress has not reached a Ready state after 10 minutes, it will
+        time out and mark the resource update as Failed. You can override the default timeout value
+        by setting the 'customTimeouts' option on the resource.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['IngressSpecArgsDict']]
+        """
+        Spec is the desired state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+        status: NotRequired[pulumi.Input['IngressStatusArgsDict']]
+        """
+        Status is the current state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+elif False:
+    IngressArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class IngressArgs:
@@ -2692,6 +3718,22 @@ class IngressArgs:
         pulumi.set(self, "status", value)
 
 
+if not MYPY:
+    class NetworkPolicyEgressRulePatchArgsDict(TypedDict):
+        """
+        DEPRECATED 1.9 - This group version of NetworkPolicyEgressRule is deprecated by networking/v1/NetworkPolicyEgressRule. NetworkPolicyEgressRule describes a particular set of traffic that is allowed out of pods matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and to. This type is beta-level in 1.8
+        """
+        ports: NotRequired[pulumi.Input[Sequence[pulumi.Input['NetworkPolicyPortPatchArgsDict']]]]
+        """
+        List of destination ports for outgoing traffic. Each item in this list is combined using a logical OR. If this field is empty or missing, this rule matches all ports (traffic not restricted by port). If this field is present and contains at least one item, then this rule allows traffic only if the traffic matches at least one port in the list.
+        """
+        to: NotRequired[pulumi.Input[Sequence[pulumi.Input['NetworkPolicyPeerPatchArgsDict']]]]
+        """
+        List of destinations for outgoing traffic of pods selected for this rule. Items in this list are combined using a logical OR operation. If this field is empty or missing, this rule matches all destinations (traffic not restricted by destination). If this field is present and contains at least one item, this rule allows traffic only if the traffic matches at least one item in the to list.
+        """
+elif False:
+    NetworkPolicyEgressRulePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class NetworkPolicyEgressRulePatchArgs:
     def __init__(__self__, *,
@@ -2731,6 +3773,22 @@ class NetworkPolicyEgressRulePatchArgs:
     def to(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['NetworkPolicyPeerPatchArgs']]]]):
         pulumi.set(self, "to", value)
 
+
+if not MYPY:
+    class NetworkPolicyEgressRuleArgsDict(TypedDict):
+        """
+        DEPRECATED 1.9 - This group version of NetworkPolicyEgressRule is deprecated by networking/v1/NetworkPolicyEgressRule. NetworkPolicyEgressRule describes a particular set of traffic that is allowed out of pods matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and to. This type is beta-level in 1.8
+        """
+        ports: NotRequired[pulumi.Input[Sequence[pulumi.Input['NetworkPolicyPortArgsDict']]]]
+        """
+        List of destination ports for outgoing traffic. Each item in this list is combined using a logical OR. If this field is empty or missing, this rule matches all ports (traffic not restricted by port). If this field is present and contains at least one item, then this rule allows traffic only if the traffic matches at least one port in the list.
+        """
+        to: NotRequired[pulumi.Input[Sequence[pulumi.Input['NetworkPolicyPeerArgsDict']]]]
+        """
+        List of destinations for outgoing traffic of pods selected for this rule. Items in this list are combined using a logical OR operation. If this field is empty or missing, this rule matches all destinations (traffic not restricted by destination). If this field is present and contains at least one item, this rule allows traffic only if the traffic matches at least one item in the to list.
+        """
+elif False:
+    NetworkPolicyEgressRuleArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class NetworkPolicyEgressRuleArgs:
@@ -2772,6 +3830,22 @@ class NetworkPolicyEgressRuleArgs:
         pulumi.set(self, "to", value)
 
 
+if not MYPY:
+    class NetworkPolicyIngressRulePatchArgsDict(TypedDict):
+        """
+        DEPRECATED 1.9 - This group version of NetworkPolicyIngressRule is deprecated by networking/v1/NetworkPolicyIngressRule. This NetworkPolicyIngressRule matches traffic if and only if the traffic matches both ports AND from.
+        """
+        from_: NotRequired[pulumi.Input[Sequence[pulumi.Input['NetworkPolicyPeerPatchArgsDict']]]]
+        """
+        List of sources which should be able to access the pods selected for this rule. Items in this list are combined using a logical OR operation. If this field is empty or missing, this rule matches all sources (traffic not restricted by source). If this field is present and contains at least one item, this rule allows traffic only if the traffic matches at least one item in the from list.
+        """
+        ports: NotRequired[pulumi.Input[Sequence[pulumi.Input['NetworkPolicyPortPatchArgsDict']]]]
+        """
+        List of ports which should be made accessible on the pods selected for this rule. Each item in this list is combined using a logical OR. If this field is empty or missing, this rule matches all ports (traffic not restricted by port). If this field is present and contains at least one item, then this rule allows traffic only if the traffic matches at least one port in the list.
+        """
+elif False:
+    NetworkPolicyIngressRulePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class NetworkPolicyIngressRulePatchArgs:
     def __init__(__self__, *,
@@ -2812,6 +3886,22 @@ class NetworkPolicyIngressRulePatchArgs:
         pulumi.set(self, "ports", value)
 
 
+if not MYPY:
+    class NetworkPolicyIngressRuleArgsDict(TypedDict):
+        """
+        DEPRECATED 1.9 - This group version of NetworkPolicyIngressRule is deprecated by networking/v1/NetworkPolicyIngressRule. This NetworkPolicyIngressRule matches traffic if and only if the traffic matches both ports AND from.
+        """
+        from_: NotRequired[pulumi.Input[Sequence[pulumi.Input['NetworkPolicyPeerArgsDict']]]]
+        """
+        List of sources which should be able to access the pods selected for this rule. Items in this list are combined using a logical OR operation. If this field is empty or missing, this rule matches all sources (traffic not restricted by source). If this field is present and contains at least one item, this rule allows traffic only if the traffic matches at least one item in the from list.
+        """
+        ports: NotRequired[pulumi.Input[Sequence[pulumi.Input['NetworkPolicyPortArgsDict']]]]
+        """
+        List of ports which should be made accessible on the pods selected for this rule. Each item in this list is combined using a logical OR. If this field is empty or missing, this rule matches all ports (traffic not restricted by port). If this field is present and contains at least one item, then this rule allows traffic only if the traffic matches at least one port in the list.
+        """
+elif False:
+    NetworkPolicyIngressRuleArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class NetworkPolicyIngressRuleArgs:
     def __init__(__self__, *,
@@ -2851,6 +3941,30 @@ class NetworkPolicyIngressRuleArgs:
     def ports(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['NetworkPolicyPortArgs']]]]):
         pulumi.set(self, "ports", value)
 
+
+if not MYPY:
+    class NetworkPolicyPeerPatchArgsDict(TypedDict):
+        """
+        DEPRECATED 1.9 - This group version of NetworkPolicyPeer is deprecated by networking/v1/NetworkPolicyPeer.
+        """
+        ip_block: NotRequired[pulumi.Input['IPBlockPatchArgsDict']]
+        """
+        IPBlock defines policy on a particular IPBlock. If this field is set then neither of the other fields can be.
+        """
+        namespace_selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorPatchArgsDict']]
+        """
+        Selects Namespaces using cluster-scoped labels. This field follows standard label selector semantics; if present but empty, it selects all namespaces.
+
+        If PodSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects all Pods in the Namespaces selected by NamespaceSelector.
+        """
+        pod_selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorPatchArgsDict']]
+        """
+        This is a label selector which selects Pods. This field follows standard label selector semantics; if present but empty, it selects all pods.
+
+        If NamespaceSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects the Pods matching PodSelector in the policy's own Namespace.
+        """
+elif False:
+    NetworkPolicyPeerPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class NetworkPolicyPeerPatchArgs:
@@ -2916,6 +4030,30 @@ class NetworkPolicyPeerPatchArgs:
         pulumi.set(self, "pod_selector", value)
 
 
+if not MYPY:
+    class NetworkPolicyPeerArgsDict(TypedDict):
+        """
+        DEPRECATED 1.9 - This group version of NetworkPolicyPeer is deprecated by networking/v1/NetworkPolicyPeer.
+        """
+        ip_block: NotRequired[pulumi.Input['IPBlockArgsDict']]
+        """
+        IPBlock defines policy on a particular IPBlock. If this field is set then neither of the other fields can be.
+        """
+        namespace_selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorArgsDict']]
+        """
+        Selects Namespaces using cluster-scoped labels. This field follows standard label selector semantics; if present but empty, it selects all namespaces.
+
+        If PodSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects all Pods in the Namespaces selected by NamespaceSelector.
+        """
+        pod_selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorArgsDict']]
+        """
+        This is a label selector which selects Pods. This field follows standard label selector semantics; if present but empty, it selects all pods.
+
+        If NamespaceSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects the Pods matching PodSelector in the policy's own Namespace.
+        """
+elif False:
+    NetworkPolicyPeerArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class NetworkPolicyPeerArgs:
     def __init__(__self__, *,
@@ -2980,6 +4118,22 @@ class NetworkPolicyPeerArgs:
         pulumi.set(self, "pod_selector", value)
 
 
+if not MYPY:
+    class NetworkPolicyPortPatchArgsDict(TypedDict):
+        """
+        DEPRECATED 1.9 - This group version of NetworkPolicyPort is deprecated by networking/v1/NetworkPolicyPort.
+        """
+        port: NotRequired[pulumi.Input[Union[int, str]]]
+        """
+        If specified, the port on the given protocol.  This can either be a numerical or named port on a pod.  If this field is not provided, this matches all port names and numbers. If present, only traffic on the specified protocol AND port will be matched.
+        """
+        protocol: NotRequired[pulumi.Input[str]]
+        """
+        Optional.  The protocol (TCP, UDP, or SCTP) which traffic must match. If not specified, this field defaults to TCP.
+        """
+elif False:
+    NetworkPolicyPortPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class NetworkPolicyPortPatchArgs:
     def __init__(__self__, *,
@@ -3020,6 +4174,22 @@ class NetworkPolicyPortPatchArgs:
         pulumi.set(self, "protocol", value)
 
 
+if not MYPY:
+    class NetworkPolicyPortArgsDict(TypedDict):
+        """
+        DEPRECATED 1.9 - This group version of NetworkPolicyPort is deprecated by networking/v1/NetworkPolicyPort.
+        """
+        port: NotRequired[pulumi.Input[Union[int, str]]]
+        """
+        If specified, the port on the given protocol.  This can either be a numerical or named port on a pod.  If this field is not provided, this matches all port names and numbers. If present, only traffic on the specified protocol AND port will be matched.
+        """
+        protocol: NotRequired[pulumi.Input[str]]
+        """
+        Optional.  The protocol (TCP, UDP, or SCTP) which traffic must match. If not specified, this field defaults to TCP.
+        """
+elif False:
+    NetworkPolicyPortArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class NetworkPolicyPortArgs:
     def __init__(__self__, *,
@@ -3059,6 +4229,30 @@ class NetworkPolicyPortArgs:
     def protocol(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "protocol", value)
 
+
+if not MYPY:
+    class NetworkPolicySpecPatchArgsDict(TypedDict):
+        """
+        DEPRECATED 1.9 - This group version of NetworkPolicySpec is deprecated by networking/v1/NetworkPolicySpec.
+        """
+        egress: NotRequired[pulumi.Input[Sequence[pulumi.Input['NetworkPolicyEgressRulePatchArgsDict']]]]
+        """
+        List of egress rules to be applied to the selected pods. Outgoing traffic is allowed if there are no NetworkPolicies selecting the pod (and cluster policy otherwise allows the traffic), OR if the traffic matches at least one egress rule across all of the NetworkPolicy objects whose podSelector matches the pod. If this field is empty then this NetworkPolicy limits all outgoing traffic (and serves solely to ensure that the pods it selects are isolated by default). This field is beta-level in 1.8
+        """
+        ingress: NotRequired[pulumi.Input[Sequence[pulumi.Input['NetworkPolicyIngressRulePatchArgsDict']]]]
+        """
+        List of ingress rules to be applied to the selected pods. Traffic is allowed to a pod if there are no NetworkPolicies selecting the pod OR if the traffic source is the pod's local node, OR if the traffic matches at least one ingress rule across all of the NetworkPolicy objects whose podSelector matches the pod. If this field is empty then this NetworkPolicy does not allow any traffic (and serves solely to ensure that the pods it selects are isolated by default).
+        """
+        pod_selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorPatchArgsDict']]
+        """
+        Selects the pods to which this NetworkPolicy object applies.  The array of ingress rules is applied to any pods selected by this field. Multiple network policies can select the same set of pods.  In this case, the ingress rules for each are combined additively. This field is NOT optional and follows standard label selector semantics. An empty podSelector matches all pods in this namespace.
+        """
+        policy_types: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        List of rule types that the NetworkPolicy relates to. Valid options are "Ingress", "Egress", or "Ingress,Egress". If this field is not specified, it will default based on the existence of Ingress or Egress rules; policies that contain an Egress section are assumed to affect Egress, and all policies (whether or not they contain an Ingress section) are assumed to affect Ingress. If you want to write an egress-only policy, you must explicitly specify policyTypes [ "Egress" ]. Likewise, if you want to write a policy that specifies that no egress is allowed, you must specify a policyTypes value that include "Egress" (since such a policy would not include an Egress section and would otherwise default to just [ "Ingress" ]). This field is beta-level in 1.8
+        """
+elif False:
+    NetworkPolicySpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class NetworkPolicySpecPatchArgs:
@@ -3132,6 +4326,30 @@ class NetworkPolicySpecPatchArgs:
         pulumi.set(self, "policy_types", value)
 
 
+if not MYPY:
+    class NetworkPolicySpecArgsDict(TypedDict):
+        """
+        DEPRECATED 1.9 - This group version of NetworkPolicySpec is deprecated by networking/v1/NetworkPolicySpec.
+        """
+        pod_selector: pulumi.Input['_meta.v1.LabelSelectorArgsDict']
+        """
+        Selects the pods to which this NetworkPolicy object applies.  The array of ingress rules is applied to any pods selected by this field. Multiple network policies can select the same set of pods.  In this case, the ingress rules for each are combined additively. This field is NOT optional and follows standard label selector semantics. An empty podSelector matches all pods in this namespace.
+        """
+        egress: NotRequired[pulumi.Input[Sequence[pulumi.Input['NetworkPolicyEgressRuleArgsDict']]]]
+        """
+        List of egress rules to be applied to the selected pods. Outgoing traffic is allowed if there are no NetworkPolicies selecting the pod (and cluster policy otherwise allows the traffic), OR if the traffic matches at least one egress rule across all of the NetworkPolicy objects whose podSelector matches the pod. If this field is empty then this NetworkPolicy limits all outgoing traffic (and serves solely to ensure that the pods it selects are isolated by default). This field is beta-level in 1.8
+        """
+        ingress: NotRequired[pulumi.Input[Sequence[pulumi.Input['NetworkPolicyIngressRuleArgsDict']]]]
+        """
+        List of ingress rules to be applied to the selected pods. Traffic is allowed to a pod if there are no NetworkPolicies selecting the pod OR if the traffic source is the pod's local node, OR if the traffic matches at least one ingress rule across all of the NetworkPolicy objects whose podSelector matches the pod. If this field is empty then this NetworkPolicy does not allow any traffic (and serves solely to ensure that the pods it selects are isolated by default).
+        """
+        policy_types: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        List of rule types that the NetworkPolicy relates to. Valid options are "Ingress", "Egress", or "Ingress,Egress". If this field is not specified, it will default based on the existence of Ingress or Egress rules; policies that contain an Egress section are assumed to affect Egress, and all policies (whether or not they contain an Ingress section) are assumed to affect Ingress. If you want to write an egress-only policy, you must explicitly specify policyTypes [ "Egress" ]. Likewise, if you want to write a policy that specifies that no egress is allowed, you must specify a policyTypes value that include "Egress" (since such a policy would not include an Egress section and would otherwise default to just [ "Ingress" ]). This field is beta-level in 1.8
+        """
+elif False:
+    NetworkPolicySpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class NetworkPolicySpecArgs:
     def __init__(__self__, *,
@@ -3202,6 +4420,30 @@ class NetworkPolicySpecArgs:
     def policy_types(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]):
         pulumi.set(self, "policy_types", value)
 
+
+if not MYPY:
+    class NetworkPolicyArgsDict(TypedDict):
+        """
+        DEPRECATED 1.9 - This group version of NetworkPolicy is deprecated by networking/v1/NetworkPolicy. NetworkPolicy describes what network traffic is allowed for a set of Pods
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['NetworkPolicySpecArgsDict']]
+        """
+        Specification of the desired behavior for this NetworkPolicy.
+        """
+elif False:
+    NetworkPolicyArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class NetworkPolicyArgs:
@@ -3274,6 +4516,114 @@ class NetworkPolicyArgs:
     def spec(self, value: Optional[pulumi.Input['NetworkPolicySpecArgs']]):
         pulumi.set(self, "spec", value)
 
+
+if not MYPY:
+    class PodSecurityPolicySpecPatchArgsDict(TypedDict):
+        """
+        PodSecurityPolicySpec defines the policy enforced. Deprecated: use PodSecurityPolicySpec from policy API Group instead.
+        """
+        allow_privilege_escalation: NotRequired[pulumi.Input[bool]]
+        """
+        allowPrivilegeEscalation determines if a pod can request to allow privilege escalation. If unspecified, defaults to true.
+        """
+        allowed_csi_drivers: NotRequired[pulumi.Input[Sequence[pulumi.Input['AllowedCSIDriverPatchArgsDict']]]]
+        """
+        AllowedCSIDrivers is a whitelist of inline CSI drivers that must be explicitly set to be embedded within a pod spec. An empty value indicates that any CSI driver can be used for inline ephemeral volumes.
+        """
+        allowed_capabilities: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        allowedCapabilities is a list of capabilities that can be requested to add to the container. Capabilities in this field may be added at the pod author's discretion. You must not list a capability in both allowedCapabilities and requiredDropCapabilities.
+        """
+        allowed_flex_volumes: NotRequired[pulumi.Input[Sequence[pulumi.Input['AllowedFlexVolumePatchArgsDict']]]]
+        """
+        allowedFlexVolumes is a whitelist of allowed Flexvolumes.  Empty or nil indicates that all Flexvolumes may be used.  This parameter is effective only when the usage of the Flexvolumes is allowed in the "volumes" field.
+        """
+        allowed_host_paths: NotRequired[pulumi.Input[Sequence[pulumi.Input['AllowedHostPathPatchArgsDict']]]]
+        """
+        allowedHostPaths is a white list of allowed host paths. Empty indicates that all host paths may be used.
+        """
+        allowed_proc_mount_types: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        AllowedProcMountTypes is a whitelist of allowed ProcMountTypes. Empty or nil indicates that only the DefaultProcMountType may be used. This requires the ProcMountType feature flag to be enabled.
+        """
+        allowed_unsafe_sysctls: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        allowedUnsafeSysctls is a list of explicitly allowed unsafe sysctls, defaults to none. Each entry is either a plain sysctl name or ends in "*" in which case it is considered as a prefix of allowed sysctls. Single * means all unsafe sysctls are allowed. Kubelet has to whitelist all allowed unsafe sysctls explicitly to avoid rejection.
+
+        Examples: e.g. "foo/*" allows "foo/bar", "foo/baz", etc. e.g. "foo.*" allows "foo.bar", "foo.baz", etc.
+        """
+        default_add_capabilities: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        defaultAddCapabilities is the default set of capabilities that will be added to the container unless the pod spec specifically drops the capability.  You may not list a capability in both defaultAddCapabilities and requiredDropCapabilities. Capabilities added here are implicitly allowed, and need not be included in the allowedCapabilities list.
+        """
+        default_allow_privilege_escalation: NotRequired[pulumi.Input[bool]]
+        """
+        defaultAllowPrivilegeEscalation controls the default setting for whether a process can gain more privileges than its parent process.
+        """
+        forbidden_sysctls: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        forbiddenSysctls is a list of explicitly forbidden sysctls, defaults to none. Each entry is either a plain sysctl name or ends in "*" in which case it is considered as a prefix of forbidden sysctls. Single * means all sysctls are forbidden.
+
+        Examples: e.g. "foo/*" forbids "foo/bar", "foo/baz", etc. e.g. "foo.*" forbids "foo.bar", "foo.baz", etc.
+        """
+        fs_group: NotRequired[pulumi.Input['FSGroupStrategyOptionsPatchArgsDict']]
+        """
+        fsGroup is the strategy that will dictate what fs group is used by the SecurityContext.
+        """
+        host_ipc: NotRequired[pulumi.Input[bool]]
+        """
+        hostIPC determines if the policy allows the use of HostIPC in the pod spec.
+        """
+        host_network: NotRequired[pulumi.Input[bool]]
+        """
+        hostNetwork determines if the policy allows the use of HostNetwork in the pod spec.
+        """
+        host_pid: NotRequired[pulumi.Input[bool]]
+        """
+        hostPID determines if the policy allows the use of HostPID in the pod spec.
+        """
+        host_ports: NotRequired[pulumi.Input[Sequence[pulumi.Input['HostPortRangePatchArgsDict']]]]
+        """
+        hostPorts determines which host port ranges are allowed to be exposed.
+        """
+        privileged: NotRequired[pulumi.Input[bool]]
+        """
+        privileged determines if a pod can request to be run as privileged.
+        """
+        read_only_root_filesystem: NotRequired[pulumi.Input[bool]]
+        """
+        readOnlyRootFilesystem when set to true will force containers to run with a read only root file system.  If the container specifically requests to run with a non-read only root file system the PSP should deny the pod. If set to false the container may run with a read only root file system if it wishes but it will not be forced to.
+        """
+        required_drop_capabilities: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        requiredDropCapabilities are the capabilities that will be dropped from the container.  These are required to be dropped and cannot be added.
+        """
+        run_as_group: NotRequired[pulumi.Input['RunAsGroupStrategyOptionsPatchArgsDict']]
+        """
+        RunAsGroup is the strategy that will dictate the allowable RunAsGroup values that may be set. If this field is omitted, the pod's RunAsGroup can take any value. This field requires the RunAsGroup feature gate to be enabled.
+        """
+        run_as_user: NotRequired[pulumi.Input['RunAsUserStrategyOptionsPatchArgsDict']]
+        """
+        runAsUser is the strategy that will dictate the allowable RunAsUser values that may be set.
+        """
+        runtime_class: NotRequired[pulumi.Input['RuntimeClassStrategyOptionsPatchArgsDict']]
+        """
+        runtimeClass is the strategy that will dictate the allowable RuntimeClasses for a pod. If this field is omitted, the pod's runtimeClassName field is unrestricted. Enforcement of this field depends on the RuntimeClass feature gate being enabled.
+        """
+        se_linux: NotRequired[pulumi.Input['SELinuxStrategyOptionsPatchArgsDict']]
+        """
+        seLinux is the strategy that will dictate the allowable labels that may be set.
+        """
+        supplemental_groups: NotRequired[pulumi.Input['SupplementalGroupsStrategyOptionsPatchArgsDict']]
+        """
+        supplementalGroups is the strategy that will dictate what supplemental groups are used by the SecurityContext.
+        """
+        volumes: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        volumes is a white list of allowed volume plugins. Empty indicates that no volumes may be used. To allow all volumes you may use '*'.
+        """
+elif False:
+    PodSecurityPolicySpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class PodSecurityPolicySpecPatchArgs:
@@ -3675,6 +5025,114 @@ class PodSecurityPolicySpecPatchArgs:
         pulumi.set(self, "volumes", value)
 
 
+if not MYPY:
+    class PodSecurityPolicySpecArgsDict(TypedDict):
+        """
+        PodSecurityPolicySpec defines the policy enforced. Deprecated: use PodSecurityPolicySpec from policy API Group instead.
+        """
+        fs_group: pulumi.Input['FSGroupStrategyOptionsArgsDict']
+        """
+        fsGroup is the strategy that will dictate what fs group is used by the SecurityContext.
+        """
+        run_as_user: pulumi.Input['RunAsUserStrategyOptionsArgsDict']
+        """
+        runAsUser is the strategy that will dictate the allowable RunAsUser values that may be set.
+        """
+        se_linux: pulumi.Input['SELinuxStrategyOptionsArgsDict']
+        """
+        seLinux is the strategy that will dictate the allowable labels that may be set.
+        """
+        supplemental_groups: pulumi.Input['SupplementalGroupsStrategyOptionsArgsDict']
+        """
+        supplementalGroups is the strategy that will dictate what supplemental groups are used by the SecurityContext.
+        """
+        allow_privilege_escalation: NotRequired[pulumi.Input[bool]]
+        """
+        allowPrivilegeEscalation determines if a pod can request to allow privilege escalation. If unspecified, defaults to true.
+        """
+        allowed_csi_drivers: NotRequired[pulumi.Input[Sequence[pulumi.Input['AllowedCSIDriverArgsDict']]]]
+        """
+        AllowedCSIDrivers is a whitelist of inline CSI drivers that must be explicitly set to be embedded within a pod spec. An empty value indicates that any CSI driver can be used for inline ephemeral volumes.
+        """
+        allowed_capabilities: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        allowedCapabilities is a list of capabilities that can be requested to add to the container. Capabilities in this field may be added at the pod author's discretion. You must not list a capability in both allowedCapabilities and requiredDropCapabilities.
+        """
+        allowed_flex_volumes: NotRequired[pulumi.Input[Sequence[pulumi.Input['AllowedFlexVolumeArgsDict']]]]
+        """
+        allowedFlexVolumes is a whitelist of allowed Flexvolumes.  Empty or nil indicates that all Flexvolumes may be used.  This parameter is effective only when the usage of the Flexvolumes is allowed in the "volumes" field.
+        """
+        allowed_host_paths: NotRequired[pulumi.Input[Sequence[pulumi.Input['AllowedHostPathArgsDict']]]]
+        """
+        allowedHostPaths is a white list of allowed host paths. Empty indicates that all host paths may be used.
+        """
+        allowed_proc_mount_types: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        AllowedProcMountTypes is a whitelist of allowed ProcMountTypes. Empty or nil indicates that only the DefaultProcMountType may be used. This requires the ProcMountType feature flag to be enabled.
+        """
+        allowed_unsafe_sysctls: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        allowedUnsafeSysctls is a list of explicitly allowed unsafe sysctls, defaults to none. Each entry is either a plain sysctl name or ends in "*" in which case it is considered as a prefix of allowed sysctls. Single * means all unsafe sysctls are allowed. Kubelet has to whitelist all allowed unsafe sysctls explicitly to avoid rejection.
+
+        Examples: e.g. "foo/*" allows "foo/bar", "foo/baz", etc. e.g. "foo.*" allows "foo.bar", "foo.baz", etc.
+        """
+        default_add_capabilities: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        defaultAddCapabilities is the default set of capabilities that will be added to the container unless the pod spec specifically drops the capability.  You may not list a capability in both defaultAddCapabilities and requiredDropCapabilities. Capabilities added here are implicitly allowed, and need not be included in the allowedCapabilities list.
+        """
+        default_allow_privilege_escalation: NotRequired[pulumi.Input[bool]]
+        """
+        defaultAllowPrivilegeEscalation controls the default setting for whether a process can gain more privileges than its parent process.
+        """
+        forbidden_sysctls: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        forbiddenSysctls is a list of explicitly forbidden sysctls, defaults to none. Each entry is either a plain sysctl name or ends in "*" in which case it is considered as a prefix of forbidden sysctls. Single * means all sysctls are forbidden.
+
+        Examples: e.g. "foo/*" forbids "foo/bar", "foo/baz", etc. e.g. "foo.*" forbids "foo.bar", "foo.baz", etc.
+        """
+        host_ipc: NotRequired[pulumi.Input[bool]]
+        """
+        hostIPC determines if the policy allows the use of HostIPC in the pod spec.
+        """
+        host_network: NotRequired[pulumi.Input[bool]]
+        """
+        hostNetwork determines if the policy allows the use of HostNetwork in the pod spec.
+        """
+        host_pid: NotRequired[pulumi.Input[bool]]
+        """
+        hostPID determines if the policy allows the use of HostPID in the pod spec.
+        """
+        host_ports: NotRequired[pulumi.Input[Sequence[pulumi.Input['HostPortRangeArgsDict']]]]
+        """
+        hostPorts determines which host port ranges are allowed to be exposed.
+        """
+        privileged: NotRequired[pulumi.Input[bool]]
+        """
+        privileged determines if a pod can request to be run as privileged.
+        """
+        read_only_root_filesystem: NotRequired[pulumi.Input[bool]]
+        """
+        readOnlyRootFilesystem when set to true will force containers to run with a read only root file system.  If the container specifically requests to run with a non-read only root file system the PSP should deny the pod. If set to false the container may run with a read only root file system if it wishes but it will not be forced to.
+        """
+        required_drop_capabilities: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        requiredDropCapabilities are the capabilities that will be dropped from the container.  These are required to be dropped and cannot be added.
+        """
+        run_as_group: NotRequired[pulumi.Input['RunAsGroupStrategyOptionsArgsDict']]
+        """
+        RunAsGroup is the strategy that will dictate the allowable RunAsGroup values that may be set. If this field is omitted, the pod's RunAsGroup can take any value. This field requires the RunAsGroup feature gate to be enabled.
+        """
+        runtime_class: NotRequired[pulumi.Input['RuntimeClassStrategyOptionsArgsDict']]
+        """
+        runtimeClass is the strategy that will dictate the allowable RuntimeClasses for a pod. If this field is omitted, the pod's runtimeClassName field is unrestricted. Enforcement of this field depends on the RuntimeClass feature gate being enabled.
+        """
+        volumes: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        volumes is a white list of allowed volume plugins. Empty indicates that no volumes may be used. To allow all volumes you may use '*'.
+        """
+elif False:
+    PodSecurityPolicySpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PodSecurityPolicySpecArgs:
     def __init__(__self__, *,
@@ -4071,6 +5529,30 @@ class PodSecurityPolicySpecArgs:
         pulumi.set(self, "volumes", value)
 
 
+if not MYPY:
+    class PodSecurityPolicyArgsDict(TypedDict):
+        """
+        PodSecurityPolicy governs the ability to make requests that affect the Security Context that will be applied to a pod and container. Deprecated: use PodSecurityPolicy from policy API Group instead.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['PodSecurityPolicySpecArgsDict']]
+        """
+        spec defines the policy enforced.
+        """
+elif False:
+    PodSecurityPolicyArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PodSecurityPolicyArgs:
     def __init__(__self__, *,
@@ -4142,6 +5624,34 @@ class PodSecurityPolicyArgs:
     def spec(self, value: Optional[pulumi.Input['PodSecurityPolicySpecArgs']]):
         pulumi.set(self, "spec", value)
 
+
+if not MYPY:
+    class ReplicaSetConditionArgsDict(TypedDict):
+        """
+        ReplicaSetCondition describes the state of a replica set at a certain point.
+        """
+        status: pulumi.Input[str]
+        """
+        Status of the condition, one of True, False, Unknown.
+        """
+        type: pulumi.Input[str]
+        """
+        Type of replica set condition.
+        """
+        last_transition_time: NotRequired[pulumi.Input[str]]
+        """
+        The last time the condition transitioned from one status to another.
+        """
+        message: NotRequired[pulumi.Input[str]]
+        """
+        A human readable message indicating details about the transition.
+        """
+        reason: NotRequired[pulumi.Input[str]]
+        """
+        The reason for the condition's last transition.
+        """
+elif False:
+    ReplicaSetConditionArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ReplicaSetConditionArgs:
@@ -4229,6 +5739,30 @@ class ReplicaSetConditionArgs:
         pulumi.set(self, "reason", value)
 
 
+if not MYPY:
+    class ReplicaSetSpecPatchArgsDict(TypedDict):
+        """
+        ReplicaSetSpec is the specification of a ReplicaSet.
+        """
+        min_ready_seconds: NotRequired[pulumi.Input[int]]
+        """
+        Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)
+        """
+        replicas: NotRequired[pulumi.Input[int]]
+        """
+        Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller
+        """
+        selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorPatchArgsDict']]
+        """
+        Selector is a label query over pods that should match the replica count. If the selector is empty, it is defaulted to the labels present on the pod template. Label keys and values that must match in order to be controlled by this replica set. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+        """
+        template: NotRequired[pulumi.Input['_core.v1.PodTemplateSpecPatchArgsDict']]
+        """
+        Template is the object that describes the pod that will be created if insufficient replicas are detected. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template
+        """
+elif False:
+    ReplicaSetSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ReplicaSetSpecPatchArgs:
     def __init__(__self__, *,
@@ -4301,6 +5835,30 @@ class ReplicaSetSpecPatchArgs:
         pulumi.set(self, "template", value)
 
 
+if not MYPY:
+    class ReplicaSetSpecArgsDict(TypedDict):
+        """
+        ReplicaSetSpec is the specification of a ReplicaSet.
+        """
+        min_ready_seconds: NotRequired[pulumi.Input[int]]
+        """
+        Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)
+        """
+        replicas: NotRequired[pulumi.Input[int]]
+        """
+        Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller
+        """
+        selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorArgsDict']]
+        """
+        Selector is a label query over pods that should match the replica count. If the selector is empty, it is defaulted to the labels present on the pod template. Label keys and values that must match in order to be controlled by this replica set. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+        """
+        template: NotRequired[pulumi.Input['_core.v1.PodTemplateSpecArgsDict']]
+        """
+        Template is the object that describes the pod that will be created if insufficient replicas are detected. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template
+        """
+elif False:
+    ReplicaSetSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ReplicaSetSpecArgs:
     def __init__(__self__, *,
@@ -4372,6 +5930,38 @@ class ReplicaSetSpecArgs:
     def template(self, value: Optional[pulumi.Input['_core.v1.PodTemplateSpecArgs']]):
         pulumi.set(self, "template", value)
 
+
+if not MYPY:
+    class ReplicaSetStatusArgsDict(TypedDict):
+        """
+        ReplicaSetStatus represents the current status of a ReplicaSet.
+        """
+        replicas: pulumi.Input[int]
+        """
+        Replicas is the most recently oberved number of replicas. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller
+        """
+        available_replicas: NotRequired[pulumi.Input[int]]
+        """
+        The number of available replicas (ready for at least minReadySeconds) for this replica set.
+        """
+        conditions: NotRequired[pulumi.Input[Sequence[pulumi.Input['ReplicaSetConditionArgsDict']]]]
+        """
+        Represents the latest available observations of a replica set's current state.
+        """
+        fully_labeled_replicas: NotRequired[pulumi.Input[int]]
+        """
+        The number of pods that have labels matching the labels of the pod template of the replicaset.
+        """
+        observed_generation: NotRequired[pulumi.Input[int]]
+        """
+        ObservedGeneration reflects the generation of the most recently observed ReplicaSet.
+        """
+        ready_replicas: NotRequired[pulumi.Input[int]]
+        """
+        The number of ready replicas for this replica set.
+        """
+elif False:
+    ReplicaSetStatusArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ReplicaSetStatusArgs:
@@ -4476,6 +6066,34 @@ class ReplicaSetStatusArgs:
         pulumi.set(self, "ready_replicas", value)
 
 
+if not MYPY:
+    class ReplicaSetArgsDict(TypedDict):
+        """
+        ReplicaSet ensures that a specified number of pod replicas are running at any given time.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        If the Labels of a ReplicaSet are empty, they are defaulted to be the same as the Pod(s) that the ReplicaSet manages. Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['ReplicaSetSpecArgsDict']]
+        """
+        Spec defines the specification of the desired behavior of the ReplicaSet. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+        status: NotRequired[pulumi.Input['ReplicaSetStatusArgsDict']]
+        """
+        Status is the most recently observed status of the ReplicaSet. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+elif False:
+    ReplicaSetArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ReplicaSetArgs:
     def __init__(__self__, *,
@@ -4564,6 +6182,18 @@ class ReplicaSetArgs:
         pulumi.set(self, "status", value)
 
 
+if not MYPY:
+    class RollbackConfigPatchArgsDict(TypedDict):
+        """
+        DEPRECATED.
+        """
+        revision: NotRequired[pulumi.Input[int]]
+        """
+        The revision to rollback to. If set to 0, rollback to the last revision.
+        """
+elif False:
+    RollbackConfigPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class RollbackConfigPatchArgs:
     def __init__(__self__, *,
@@ -4587,6 +6217,18 @@ class RollbackConfigPatchArgs:
     def revision(self, value: Optional[pulumi.Input[int]]):
         pulumi.set(self, "revision", value)
 
+
+if not MYPY:
+    class RollbackConfigArgsDict(TypedDict):
+        """
+        DEPRECATED.
+        """
+        revision: NotRequired[pulumi.Input[int]]
+        """
+        The revision to rollback to. If set to 0, rollback to the last revision.
+        """
+elif False:
+    RollbackConfigArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class RollbackConfigArgs:
@@ -4612,6 +6254,18 @@ class RollbackConfigArgs:
         pulumi.set(self, "revision", value)
 
 
+if not MYPY:
+    class RollingUpdateDaemonSetPatchArgsDict(TypedDict):
+        """
+        Spec to control the desired behavior of daemon set rolling update.
+        """
+        max_unavailable: NotRequired[pulumi.Input[Union[int, str]]]
+        """
+        The maximum number of DaemonSet pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of total number of DaemonSet pods at the start of the update (ex: 10%). Absolute number is calculated from percentage by rounding up. This cannot be 0. Default value is 1. Example: when this is set to 30%, at most 30% of the total number of nodes that should be running the daemon pod (i.e. status.desiredNumberScheduled) can have their pods stopped for an update at any given time. The update starts by stopping at most 30% of those DaemonSet pods and then brings up new DaemonSet pods in their place. Once the new pods are available, it then proceeds onto other DaemonSet pods, thus ensuring that at least 70% of original number of DaemonSet pods are available at all times during the update.
+        """
+elif False:
+    RollingUpdateDaemonSetPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class RollingUpdateDaemonSetPatchArgs:
     def __init__(__self__, *,
@@ -4636,6 +6290,18 @@ class RollingUpdateDaemonSetPatchArgs:
         pulumi.set(self, "max_unavailable", value)
 
 
+if not MYPY:
+    class RollingUpdateDaemonSetArgsDict(TypedDict):
+        """
+        Spec to control the desired behavior of daemon set rolling update.
+        """
+        max_unavailable: NotRequired[pulumi.Input[Union[int, str]]]
+        """
+        The maximum number of DaemonSet pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of total number of DaemonSet pods at the start of the update (ex: 10%). Absolute number is calculated from percentage by rounding up. This cannot be 0. Default value is 1. Example: when this is set to 30%, at most 30% of the total number of nodes that should be running the daemon pod (i.e. status.desiredNumberScheduled) can have their pods stopped for an update at any given time. The update starts by stopping at most 30% of those DaemonSet pods and then brings up new DaemonSet pods in their place. Once the new pods are available, it then proceeds onto other DaemonSet pods, thus ensuring that at least 70% of original number of DaemonSet pods are available at all times during the update.
+        """
+elif False:
+    RollingUpdateDaemonSetArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class RollingUpdateDaemonSetArgs:
     def __init__(__self__, *,
@@ -4659,6 +6325,22 @@ class RollingUpdateDaemonSetArgs:
     def max_unavailable(self, value: Optional[pulumi.Input[Union[int, str]]]):
         pulumi.set(self, "max_unavailable", value)
 
+
+if not MYPY:
+    class RollingUpdateDeploymentPatchArgsDict(TypedDict):
+        """
+        Spec to control the desired behavior of rolling update.
+        """
+        max_surge: NotRequired[pulumi.Input[Union[int, str]]]
+        """
+        The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. By default, a value of 1 is used. Example: when this is set to 30%, the new RC can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new RC can be scaled up further, ensuring that total number of pods running at any time during the update is at most 130% of desired pods.
+        """
+        max_unavailable: NotRequired[pulumi.Input[Union[int, str]]]
+        """
+        The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. By default, a fixed value of 1 is used. Example: when this is set to 30%, the old RC can be scaled down to 70% of desired pods immediately when the rolling update starts. Once new pods are ready, old RC can be scaled down further, followed by scaling up the new RC, ensuring that the total number of pods available at all times during the update is at least 70% of desired pods.
+        """
+elif False:
+    RollingUpdateDeploymentPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class RollingUpdateDeploymentPatchArgs:
@@ -4700,6 +6382,22 @@ class RollingUpdateDeploymentPatchArgs:
         pulumi.set(self, "max_unavailable", value)
 
 
+if not MYPY:
+    class RollingUpdateDeploymentArgsDict(TypedDict):
+        """
+        Spec to control the desired behavior of rolling update.
+        """
+        max_surge: NotRequired[pulumi.Input[Union[int, str]]]
+        """
+        The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. By default, a value of 1 is used. Example: when this is set to 30%, the new RC can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new RC can be scaled up further, ensuring that total number of pods running at any time during the update is at most 130% of desired pods.
+        """
+        max_unavailable: NotRequired[pulumi.Input[Union[int, str]]]
+        """
+        The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. By default, a fixed value of 1 is used. Example: when this is set to 30%, the old RC can be scaled down to 70% of desired pods immediately when the rolling update starts. Once new pods are ready, old RC can be scaled down further, followed by scaling up the new RC, ensuring that the total number of pods available at all times during the update is at least 70% of desired pods.
+        """
+elif False:
+    RollingUpdateDeploymentArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class RollingUpdateDeploymentArgs:
     def __init__(__self__, *,
@@ -4739,6 +6437,22 @@ class RollingUpdateDeploymentArgs:
     def max_unavailable(self, value: Optional[pulumi.Input[Union[int, str]]]):
         pulumi.set(self, "max_unavailable", value)
 
+
+if not MYPY:
+    class RunAsGroupStrategyOptionsPatchArgsDict(TypedDict):
+        """
+        RunAsGroupStrategyOptions defines the strategy type and any options used to create the strategy. Deprecated: use RunAsGroupStrategyOptions from policy API Group instead.
+        """
+        ranges: NotRequired[pulumi.Input[Sequence[pulumi.Input['IDRangePatchArgsDict']]]]
+        """
+        ranges are the allowed ranges of gids that may be used. If you would like to force a single gid then supply a single range with the same start and end. Required for MustRunAs.
+        """
+        rule: NotRequired[pulumi.Input[str]]
+        """
+        rule is the strategy that will dictate the allowable RunAsGroup values that may be set.
+        """
+elif False:
+    RunAsGroupStrategyOptionsPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class RunAsGroupStrategyOptionsPatchArgs:
@@ -4780,6 +6494,22 @@ class RunAsGroupStrategyOptionsPatchArgs:
         pulumi.set(self, "rule", value)
 
 
+if not MYPY:
+    class RunAsGroupStrategyOptionsArgsDict(TypedDict):
+        """
+        RunAsGroupStrategyOptions defines the strategy type and any options used to create the strategy. Deprecated: use RunAsGroupStrategyOptions from policy API Group instead.
+        """
+        rule: pulumi.Input[str]
+        """
+        rule is the strategy that will dictate the allowable RunAsGroup values that may be set.
+        """
+        ranges: NotRequired[pulumi.Input[Sequence[pulumi.Input['IDRangeArgsDict']]]]
+        """
+        ranges are the allowed ranges of gids that may be used. If you would like to force a single gid then supply a single range with the same start and end. Required for MustRunAs.
+        """
+elif False:
+    RunAsGroupStrategyOptionsArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class RunAsGroupStrategyOptionsArgs:
     def __init__(__self__, *,
@@ -4818,6 +6548,22 @@ class RunAsGroupStrategyOptionsArgs:
     def ranges(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['IDRangeArgs']]]]):
         pulumi.set(self, "ranges", value)
 
+
+if not MYPY:
+    class RunAsUserStrategyOptionsPatchArgsDict(TypedDict):
+        """
+        RunAsUserStrategyOptions defines the strategy type and any options used to create the strategy. Deprecated: use RunAsUserStrategyOptions from policy API Group instead.
+        """
+        ranges: NotRequired[pulumi.Input[Sequence[pulumi.Input['IDRangePatchArgsDict']]]]
+        """
+        ranges are the allowed ranges of uids that may be used. If you would like to force a single uid then supply a single range with the same start and end. Required for MustRunAs.
+        """
+        rule: NotRequired[pulumi.Input[str]]
+        """
+        rule is the strategy that will dictate the allowable RunAsUser values that may be set.
+        """
+elif False:
+    RunAsUserStrategyOptionsPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class RunAsUserStrategyOptionsPatchArgs:
@@ -4859,6 +6605,22 @@ class RunAsUserStrategyOptionsPatchArgs:
         pulumi.set(self, "rule", value)
 
 
+if not MYPY:
+    class RunAsUserStrategyOptionsArgsDict(TypedDict):
+        """
+        RunAsUserStrategyOptions defines the strategy type and any options used to create the strategy. Deprecated: use RunAsUserStrategyOptions from policy API Group instead.
+        """
+        rule: pulumi.Input[str]
+        """
+        rule is the strategy that will dictate the allowable RunAsUser values that may be set.
+        """
+        ranges: NotRequired[pulumi.Input[Sequence[pulumi.Input['IDRangeArgsDict']]]]
+        """
+        ranges are the allowed ranges of uids that may be used. If you would like to force a single uid then supply a single range with the same start and end. Required for MustRunAs.
+        """
+elif False:
+    RunAsUserStrategyOptionsArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class RunAsUserStrategyOptionsArgs:
     def __init__(__self__, *,
@@ -4897,6 +6659,22 @@ class RunAsUserStrategyOptionsArgs:
     def ranges(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['IDRangeArgs']]]]):
         pulumi.set(self, "ranges", value)
 
+
+if not MYPY:
+    class RuntimeClassStrategyOptionsPatchArgsDict(TypedDict):
+        """
+        RuntimeClassStrategyOptions define the strategy that will dictate the allowable RuntimeClasses for a pod.
+        """
+        allowed_runtime_class_names: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        allowedRuntimeClassNames is a whitelist of RuntimeClass names that may be specified on a pod. A value of "*" means that any RuntimeClass name is allowed, and must be the only item in the list. An empty list requires the RuntimeClassName field to be unset.
+        """
+        default_runtime_class_name: NotRequired[pulumi.Input[str]]
+        """
+        defaultRuntimeClassName is the default RuntimeClassName to set on the pod. The default MUST be allowed by the allowedRuntimeClassNames list. A value of nil does not mutate the Pod.
+        """
+elif False:
+    RuntimeClassStrategyOptionsPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class RuntimeClassStrategyOptionsPatchArgs:
@@ -4938,6 +6716,22 @@ class RuntimeClassStrategyOptionsPatchArgs:
         pulumi.set(self, "default_runtime_class_name", value)
 
 
+if not MYPY:
+    class RuntimeClassStrategyOptionsArgsDict(TypedDict):
+        """
+        RuntimeClassStrategyOptions define the strategy that will dictate the allowable RuntimeClasses for a pod.
+        """
+        allowed_runtime_class_names: pulumi.Input[Sequence[pulumi.Input[str]]]
+        """
+        allowedRuntimeClassNames is a whitelist of RuntimeClass names that may be specified on a pod. A value of "*" means that any RuntimeClass name is allowed, and must be the only item in the list. An empty list requires the RuntimeClassName field to be unset.
+        """
+        default_runtime_class_name: NotRequired[pulumi.Input[str]]
+        """
+        defaultRuntimeClassName is the default RuntimeClassName to set on the pod. The default MUST be allowed by the allowedRuntimeClassNames list. A value of nil does not mutate the Pod.
+        """
+elif False:
+    RuntimeClassStrategyOptionsArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class RuntimeClassStrategyOptionsArgs:
     def __init__(__self__, *,
@@ -4976,6 +6770,22 @@ class RuntimeClassStrategyOptionsArgs:
     def default_runtime_class_name(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "default_runtime_class_name", value)
 
+
+if not MYPY:
+    class SELinuxStrategyOptionsPatchArgsDict(TypedDict):
+        """
+        SELinuxStrategyOptions defines the strategy type and any options used to create the strategy. Deprecated: use SELinuxStrategyOptions from policy API Group instead.
+        """
+        rule: NotRequired[pulumi.Input[str]]
+        """
+        rule is the strategy that will dictate the allowable labels that may be set.
+        """
+        se_linux_options: NotRequired[pulumi.Input['_core.v1.SELinuxOptionsPatchArgsDict']]
+        """
+        seLinuxOptions required to run as; required for MustRunAs More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+        """
+elif False:
+    SELinuxStrategyOptionsPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class SELinuxStrategyOptionsPatchArgs:
@@ -5017,6 +6827,22 @@ class SELinuxStrategyOptionsPatchArgs:
         pulumi.set(self, "se_linux_options", value)
 
 
+if not MYPY:
+    class SELinuxStrategyOptionsArgsDict(TypedDict):
+        """
+        SELinuxStrategyOptions defines the strategy type and any options used to create the strategy. Deprecated: use SELinuxStrategyOptions from policy API Group instead.
+        """
+        rule: pulumi.Input[str]
+        """
+        rule is the strategy that will dictate the allowable labels that may be set.
+        """
+        se_linux_options: NotRequired[pulumi.Input['_core.v1.SELinuxOptionsArgsDict']]
+        """
+        seLinuxOptions required to run as; required for MustRunAs More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+        """
+elif False:
+    SELinuxStrategyOptionsArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class SELinuxStrategyOptionsArgs:
     def __init__(__self__, *,
@@ -5055,6 +6881,22 @@ class SELinuxStrategyOptionsArgs:
     def se_linux_options(self, value: Optional[pulumi.Input['_core.v1.SELinuxOptionsArgs']]):
         pulumi.set(self, "se_linux_options", value)
 
+
+if not MYPY:
+    class SupplementalGroupsStrategyOptionsPatchArgsDict(TypedDict):
+        """
+        SupplementalGroupsStrategyOptions defines the strategy type and options used to create the strategy. Deprecated: use SupplementalGroupsStrategyOptions from policy API Group instead.
+        """
+        ranges: NotRequired[pulumi.Input[Sequence[pulumi.Input['IDRangePatchArgsDict']]]]
+        """
+        ranges are the allowed ranges of supplemental groups.  If you would like to force a single supplemental group then supply a single range with the same start and end. Required for MustRunAs.
+        """
+        rule: NotRequired[pulumi.Input[str]]
+        """
+        rule is the strategy that will dictate what supplemental groups is used in the SecurityContext.
+        """
+elif False:
+    SupplementalGroupsStrategyOptionsPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class SupplementalGroupsStrategyOptionsPatchArgs:
@@ -5095,6 +6937,22 @@ class SupplementalGroupsStrategyOptionsPatchArgs:
     def rule(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "rule", value)
 
+
+if not MYPY:
+    class SupplementalGroupsStrategyOptionsArgsDict(TypedDict):
+        """
+        SupplementalGroupsStrategyOptions defines the strategy type and options used to create the strategy. Deprecated: use SupplementalGroupsStrategyOptions from policy API Group instead.
+        """
+        ranges: NotRequired[pulumi.Input[Sequence[pulumi.Input['IDRangeArgsDict']]]]
+        """
+        ranges are the allowed ranges of supplemental groups.  If you would like to force a single supplemental group then supply a single range with the same start and end. Required for MustRunAs.
+        """
+        rule: NotRequired[pulumi.Input[str]]
+        """
+        rule is the strategy that will dictate what supplemental groups is used in the SecurityContext.
+        """
+elif False:
+    SupplementalGroupsStrategyOptionsArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class SupplementalGroupsStrategyOptionsArgs:

--- a/sdk/python/pulumi_kubernetes/extensions/v1beta1/outputs.py
+++ b/sdk/python/pulumi_kubernetes/extensions/v1beta1/outputs.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core

--- a/sdk/python/pulumi_kubernetes/flowcontrol/v1/FlowSchema.py
+++ b/sdk/python/pulumi_kubernetes/flowcontrol/v1/FlowSchema.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class FlowSchema(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['FlowSchemaSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['FlowSchemaSpecArgs', 'FlowSchemaSpecArgsDict']]] = None,
                  __props__=None):
         """
         FlowSchema defines the schema of a group of flows. Note that a flow is made up of a set of inbound API requests with similar attributes and is identified by a pair of strings: the name of the FlowSchema and a "flow distinguisher".
@@ -103,8 +108,8 @@ class FlowSchema(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['FlowSchemaSpecArgs']] spec: `spec` is the specification of the desired behavior of a FlowSchema. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['FlowSchemaSpecArgs', 'FlowSchemaSpecArgsDict']] spec: `spec` is the specification of the desired behavior of a FlowSchema. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -132,8 +137,8 @@ class FlowSchema(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['FlowSchemaSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['FlowSchemaSpecArgs', 'FlowSchemaSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/flowcontrol/v1/FlowSchemaList.py
+++ b/sdk/python/pulumi_kubernetes/flowcontrol/v1/FlowSchemaList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class FlowSchemaList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['FlowSchemaArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['FlowSchemaArgs', 'FlowSchemaArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         FlowSchemaList is a list of FlowSchema objects.
@@ -101,9 +106,9 @@ class FlowSchemaList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['FlowSchemaArgs']]]] items: `items` is a list of FlowSchemas.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['FlowSchemaArgs', 'FlowSchemaArgsDict']]]] items: `items` is a list of FlowSchemas.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: `metadata` is the standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: `metadata` is the standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class FlowSchemaList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['FlowSchemaArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['FlowSchemaArgs', 'FlowSchemaArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/flowcontrol/v1/FlowSchemaPatch.py
+++ b/sdk/python/pulumi_kubernetes/flowcontrol/v1/FlowSchemaPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class FlowSchemaPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['FlowSchemaSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['FlowSchemaSpecPatchArgs', 'FlowSchemaSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -109,8 +114,8 @@ class FlowSchemaPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['FlowSchemaSpecPatchArgs']] spec: `spec` is the specification of the desired behavior of a FlowSchema. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['FlowSchemaSpecPatchArgs', 'FlowSchemaSpecPatchArgsDict']] spec: `spec` is the specification of the desired behavior of a FlowSchema. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -144,8 +149,8 @@ class FlowSchemaPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['FlowSchemaSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['FlowSchemaSpecPatchArgs', 'FlowSchemaSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/flowcontrol/v1/PriorityLevelConfiguration.py
+++ b/sdk/python/pulumi_kubernetes/flowcontrol/v1/PriorityLevelConfiguration.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class PriorityLevelConfiguration(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PriorityLevelConfigurationSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PriorityLevelConfigurationSpecArgs', 'PriorityLevelConfigurationSpecArgsDict']]] = None,
                  __props__=None):
         """
         PriorityLevelConfiguration represents the configuration of a priority level.
@@ -103,8 +108,8 @@ class PriorityLevelConfiguration(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['PriorityLevelConfigurationSpecArgs']] spec: `spec` is the specification of the desired behavior of a "request-priority". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['PriorityLevelConfigurationSpecArgs', 'PriorityLevelConfigurationSpecArgsDict']] spec: `spec` is the specification of the desired behavior of a "request-priority". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -132,8 +137,8 @@ class PriorityLevelConfiguration(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PriorityLevelConfigurationSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PriorityLevelConfigurationSpecArgs', 'PriorityLevelConfigurationSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/flowcontrol/v1/PriorityLevelConfigurationList.py
+++ b/sdk/python/pulumi_kubernetes/flowcontrol/v1/PriorityLevelConfigurationList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class PriorityLevelConfigurationList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PriorityLevelConfigurationArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PriorityLevelConfigurationArgs', 'PriorityLevelConfigurationArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         PriorityLevelConfigurationList is a list of PriorityLevelConfiguration objects.
@@ -101,9 +106,9 @@ class PriorityLevelConfigurationList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PriorityLevelConfigurationArgs']]]] items: `items` is a list of request-priorities.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['PriorityLevelConfigurationArgs', 'PriorityLevelConfigurationArgsDict']]]] items: `items` is a list of request-priorities.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class PriorityLevelConfigurationList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PriorityLevelConfigurationArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PriorityLevelConfigurationArgs', 'PriorityLevelConfigurationArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/flowcontrol/v1/PriorityLevelConfigurationPatch.py
+++ b/sdk/python/pulumi_kubernetes/flowcontrol/v1/PriorityLevelConfigurationPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class PriorityLevelConfigurationPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PriorityLevelConfigurationSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PriorityLevelConfigurationSpecPatchArgs', 'PriorityLevelConfigurationSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -109,8 +114,8 @@ class PriorityLevelConfigurationPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['PriorityLevelConfigurationSpecPatchArgs']] spec: `spec` is the specification of the desired behavior of a "request-priority". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['PriorityLevelConfigurationSpecPatchArgs', 'PriorityLevelConfigurationSpecPatchArgsDict']] spec: `spec` is the specification of the desired behavior of a "request-priority". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -144,8 +149,8 @@ class PriorityLevelConfigurationPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PriorityLevelConfigurationSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PriorityLevelConfigurationSpecPatchArgs', 'PriorityLevelConfigurationSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/flowcontrol/v1/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/flowcontrol/v1/_inputs.py
@@ -4,50 +4,115 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import meta as _meta
 
 __all__ = [
     'ExemptPriorityLevelConfigurationPatchArgs',
+    'ExemptPriorityLevelConfigurationPatchArgsDict',
     'ExemptPriorityLevelConfigurationArgs',
+    'ExemptPriorityLevelConfigurationArgsDict',
     'FlowDistinguisherMethodPatchArgs',
+    'FlowDistinguisherMethodPatchArgsDict',
     'FlowDistinguisherMethodArgs',
+    'FlowDistinguisherMethodArgsDict',
     'FlowSchemaConditionArgs',
+    'FlowSchemaConditionArgsDict',
     'FlowSchemaSpecPatchArgs',
+    'FlowSchemaSpecPatchArgsDict',
     'FlowSchemaSpecArgs',
+    'FlowSchemaSpecArgsDict',
     'FlowSchemaStatusArgs',
+    'FlowSchemaStatusArgsDict',
     'FlowSchemaArgs',
+    'FlowSchemaArgsDict',
     'GroupSubjectPatchArgs',
+    'GroupSubjectPatchArgsDict',
     'GroupSubjectArgs',
+    'GroupSubjectArgsDict',
     'LimitResponsePatchArgs',
+    'LimitResponsePatchArgsDict',
     'LimitResponseArgs',
+    'LimitResponseArgsDict',
     'LimitedPriorityLevelConfigurationPatchArgs',
+    'LimitedPriorityLevelConfigurationPatchArgsDict',
     'LimitedPriorityLevelConfigurationArgs',
+    'LimitedPriorityLevelConfigurationArgsDict',
     'NonResourcePolicyRulePatchArgs',
+    'NonResourcePolicyRulePatchArgsDict',
     'NonResourcePolicyRuleArgs',
+    'NonResourcePolicyRuleArgsDict',
     'PolicyRulesWithSubjectsPatchArgs',
+    'PolicyRulesWithSubjectsPatchArgsDict',
     'PolicyRulesWithSubjectsArgs',
+    'PolicyRulesWithSubjectsArgsDict',
     'PriorityLevelConfigurationConditionArgs',
+    'PriorityLevelConfigurationConditionArgsDict',
     'PriorityLevelConfigurationReferencePatchArgs',
+    'PriorityLevelConfigurationReferencePatchArgsDict',
     'PriorityLevelConfigurationReferenceArgs',
+    'PriorityLevelConfigurationReferenceArgsDict',
     'PriorityLevelConfigurationSpecPatchArgs',
+    'PriorityLevelConfigurationSpecPatchArgsDict',
     'PriorityLevelConfigurationSpecArgs',
+    'PriorityLevelConfigurationSpecArgsDict',
     'PriorityLevelConfigurationStatusArgs',
+    'PriorityLevelConfigurationStatusArgsDict',
     'PriorityLevelConfigurationArgs',
+    'PriorityLevelConfigurationArgsDict',
     'QueuingConfigurationPatchArgs',
+    'QueuingConfigurationPatchArgsDict',
     'QueuingConfigurationArgs',
+    'QueuingConfigurationArgsDict',
     'ResourcePolicyRulePatchArgs',
+    'ResourcePolicyRulePatchArgsDict',
     'ResourcePolicyRuleArgs',
+    'ResourcePolicyRuleArgsDict',
     'ServiceAccountSubjectPatchArgs',
+    'ServiceAccountSubjectPatchArgsDict',
     'ServiceAccountSubjectArgs',
+    'ServiceAccountSubjectArgsDict',
     'SubjectPatchArgs',
+    'SubjectPatchArgsDict',
     'SubjectArgs',
+    'SubjectArgsDict',
     'UserSubjectPatchArgs',
+    'UserSubjectPatchArgsDict',
     'UserSubjectArgs',
+    'UserSubjectArgsDict',
 ]
+
+MYPY = False
+
+if not MYPY:
+    class ExemptPriorityLevelConfigurationPatchArgsDict(TypedDict):
+        """
+        ExemptPriorityLevelConfiguration describes the configurable aspects of the handling of exempt requests. In the mandatory exempt configuration object the values in the fields here can be modified by authorized users, unlike the rest of the `spec`.
+        """
+        lendable_percent: NotRequired[pulumi.Input[int]]
+        """
+        `lendablePercent` prescribes the fraction of the level's NominalCL that can be borrowed by other priority levels.  This value of this field must be between 0 and 100, inclusive, and it defaults to 0. The number of seats that other levels can borrow from this level, known as this level's LendableConcurrencyLimit (LendableCL), is defined as follows.
+
+        LendableCL(i) = round( NominalCL(i) * lendablePercent(i)/100.0 )
+        """
+        nominal_concurrency_shares: NotRequired[pulumi.Input[int]]
+        """
+        `nominalConcurrencyShares` (NCS) contributes to the computation of the NominalConcurrencyLimit (NominalCL) of this level. This is the number of execution seats nominally reserved for this priority level. This DOES NOT limit the dispatching from this priority level but affects the other priority levels through the borrowing mechanism. The server's concurrency limit (ServerCL) is divided among all the priority levels in proportion to their NCS values:
+
+        NominalCL(i)  = ceil( ServerCL * NCS(i) / sum_ncs ) sum_ncs = sum[priority level k] NCS(k)
+
+        Bigger numbers mean a larger nominal concurrency limit, at the expense of every other priority level. This field has a default value of zero.
+        """
+elif False:
+    ExemptPriorityLevelConfigurationPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ExemptPriorityLevelConfigurationPatchArgs:
@@ -101,6 +166,28 @@ class ExemptPriorityLevelConfigurationPatchArgs:
         pulumi.set(self, "nominal_concurrency_shares", value)
 
 
+if not MYPY:
+    class ExemptPriorityLevelConfigurationArgsDict(TypedDict):
+        """
+        ExemptPriorityLevelConfiguration describes the configurable aspects of the handling of exempt requests. In the mandatory exempt configuration object the values in the fields here can be modified by authorized users, unlike the rest of the `spec`.
+        """
+        lendable_percent: NotRequired[pulumi.Input[int]]
+        """
+        `lendablePercent` prescribes the fraction of the level's NominalCL that can be borrowed by other priority levels.  This value of this field must be between 0 and 100, inclusive, and it defaults to 0. The number of seats that other levels can borrow from this level, known as this level's LendableConcurrencyLimit (LendableCL), is defined as follows.
+
+        LendableCL(i) = round( NominalCL(i) * lendablePercent(i)/100.0 )
+        """
+        nominal_concurrency_shares: NotRequired[pulumi.Input[int]]
+        """
+        `nominalConcurrencyShares` (NCS) contributes to the computation of the NominalConcurrencyLimit (NominalCL) of this level. This is the number of execution seats nominally reserved for this priority level. This DOES NOT limit the dispatching from this priority level but affects the other priority levels through the borrowing mechanism. The server's concurrency limit (ServerCL) is divided among all the priority levels in proportion to their NCS values:
+
+        NominalCL(i)  = ceil( ServerCL * NCS(i) / sum_ncs ) sum_ncs = sum[priority level k] NCS(k)
+
+        Bigger numbers mean a larger nominal concurrency limit, at the expense of every other priority level. This field has a default value of zero.
+        """
+elif False:
+    ExemptPriorityLevelConfigurationArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ExemptPriorityLevelConfigurationArgs:
     def __init__(__self__, *,
@@ -153,6 +240,18 @@ class ExemptPriorityLevelConfigurationArgs:
         pulumi.set(self, "nominal_concurrency_shares", value)
 
 
+if not MYPY:
+    class FlowDistinguisherMethodPatchArgsDict(TypedDict):
+        """
+        FlowDistinguisherMethod specifies the method of a flow distinguisher.
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        `type` is the type of flow distinguisher method The supported types are "ByUser" and "ByNamespace". Required.
+        """
+elif False:
+    FlowDistinguisherMethodPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class FlowDistinguisherMethodPatchArgs:
     def __init__(__self__, *,
@@ -177,6 +276,18 @@ class FlowDistinguisherMethodPatchArgs:
         pulumi.set(self, "type", value)
 
 
+if not MYPY:
+    class FlowDistinguisherMethodArgsDict(TypedDict):
+        """
+        FlowDistinguisherMethod specifies the method of a flow distinguisher.
+        """
+        type: pulumi.Input[str]
+        """
+        `type` is the type of flow distinguisher method The supported types are "ByUser" and "ByNamespace". Required.
+        """
+elif False:
+    FlowDistinguisherMethodArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class FlowDistinguisherMethodArgs:
     def __init__(__self__, *,
@@ -199,6 +310,34 @@ class FlowDistinguisherMethodArgs:
     def type(self, value: pulumi.Input[str]):
         pulumi.set(self, "type", value)
 
+
+if not MYPY:
+    class FlowSchemaConditionArgsDict(TypedDict):
+        """
+        FlowSchemaCondition describes conditions for a FlowSchema.
+        """
+        last_transition_time: NotRequired[pulumi.Input[str]]
+        """
+        `lastTransitionTime` is the last time the condition transitioned from one status to another.
+        """
+        message: NotRequired[pulumi.Input[str]]
+        """
+        `message` is a human-readable message indicating details about last transition.
+        """
+        reason: NotRequired[pulumi.Input[str]]
+        """
+        `reason` is a unique, one-word, CamelCase reason for the condition's last transition.
+        """
+        status: NotRequired[pulumi.Input[str]]
+        """
+        `status` is the status of the condition. Can be True, False, Unknown. Required.
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        `type` is the type of the condition. Required.
+        """
+elif False:
+    FlowSchemaConditionArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class FlowSchemaConditionArgs:
@@ -288,6 +427,30 @@ class FlowSchemaConditionArgs:
         pulumi.set(self, "type", value)
 
 
+if not MYPY:
+    class FlowSchemaSpecPatchArgsDict(TypedDict):
+        """
+        FlowSchemaSpec describes how the FlowSchema's specification looks like.
+        """
+        distinguisher_method: NotRequired[pulumi.Input['FlowDistinguisherMethodPatchArgsDict']]
+        """
+        `distinguisherMethod` defines how to compute the flow distinguisher for requests that match this schema. `nil` specifies that the distinguisher is disabled and thus will always be the empty string.
+        """
+        matching_precedence: NotRequired[pulumi.Input[int]]
+        """
+        `matchingPrecedence` is used to choose among the FlowSchemas that match a given request. The chosen FlowSchema is among those with the numerically lowest (which we take to be logically highest) MatchingPrecedence.  Each MatchingPrecedence value must be ranged in [1,10000]. Note that if the precedence is not specified, it will be set to 1000 as default.
+        """
+        priority_level_configuration: NotRequired[pulumi.Input['PriorityLevelConfigurationReferencePatchArgsDict']]
+        """
+        `priorityLevelConfiguration` should reference a PriorityLevelConfiguration in the cluster. If the reference cannot be resolved, the FlowSchema will be ignored and marked as invalid in its status. Required.
+        """
+        rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['PolicyRulesWithSubjectsPatchArgsDict']]]]
+        """
+        `rules` describes which requests will match this flow schema. This FlowSchema matches a request if and only if at least one member of rules matches the request. if it is an empty slice, there will be no requests matching the FlowSchema.
+        """
+elif False:
+    FlowSchemaSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class FlowSchemaSpecPatchArgs:
     def __init__(__self__, *,
@@ -360,6 +523,30 @@ class FlowSchemaSpecPatchArgs:
         pulumi.set(self, "rules", value)
 
 
+if not MYPY:
+    class FlowSchemaSpecArgsDict(TypedDict):
+        """
+        FlowSchemaSpec describes how the FlowSchema's specification looks like.
+        """
+        priority_level_configuration: pulumi.Input['PriorityLevelConfigurationReferenceArgsDict']
+        """
+        `priorityLevelConfiguration` should reference a PriorityLevelConfiguration in the cluster. If the reference cannot be resolved, the FlowSchema will be ignored and marked as invalid in its status. Required.
+        """
+        distinguisher_method: NotRequired[pulumi.Input['FlowDistinguisherMethodArgsDict']]
+        """
+        `distinguisherMethod` defines how to compute the flow distinguisher for requests that match this schema. `nil` specifies that the distinguisher is disabled and thus will always be the empty string.
+        """
+        matching_precedence: NotRequired[pulumi.Input[int]]
+        """
+        `matchingPrecedence` is used to choose among the FlowSchemas that match a given request. The chosen FlowSchema is among those with the numerically lowest (which we take to be logically highest) MatchingPrecedence.  Each MatchingPrecedence value must be ranged in [1,10000]. Note that if the precedence is not specified, it will be set to 1000 as default.
+        """
+        rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['PolicyRulesWithSubjectsArgsDict']]]]
+        """
+        `rules` describes which requests will match this flow schema. This FlowSchema matches a request if and only if at least one member of rules matches the request. if it is an empty slice, there will be no requests matching the FlowSchema.
+        """
+elif False:
+    FlowSchemaSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class FlowSchemaSpecArgs:
     def __init__(__self__, *,
@@ -431,6 +618,18 @@ class FlowSchemaSpecArgs:
         pulumi.set(self, "rules", value)
 
 
+if not MYPY:
+    class FlowSchemaStatusArgsDict(TypedDict):
+        """
+        FlowSchemaStatus represents the current state of a FlowSchema.
+        """
+        conditions: NotRequired[pulumi.Input[Sequence[pulumi.Input['FlowSchemaConditionArgsDict']]]]
+        """
+        `conditions` is a list of the current states of FlowSchema.
+        """
+elif False:
+    FlowSchemaStatusArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class FlowSchemaStatusArgs:
     def __init__(__self__, *,
@@ -454,6 +653,34 @@ class FlowSchemaStatusArgs:
     def conditions(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['FlowSchemaConditionArgs']]]]):
         pulumi.set(self, "conditions", value)
 
+
+if not MYPY:
+    class FlowSchemaArgsDict(TypedDict):
+        """
+        FlowSchema defines the schema of a group of flows. Note that a flow is made up of a set of inbound API requests with similar attributes and is identified by a pair of strings: the name of the FlowSchema and a "flow distinguisher".
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['FlowSchemaSpecArgsDict']]
+        """
+        `spec` is the specification of the desired behavior of a FlowSchema. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+        status: NotRequired[pulumi.Input['FlowSchemaStatusArgsDict']]
+        """
+        `status` is the current status of a FlowSchema. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+elif False:
+    FlowSchemaArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class FlowSchemaArgs:
@@ -543,6 +770,18 @@ class FlowSchemaArgs:
         pulumi.set(self, "status", value)
 
 
+if not MYPY:
+    class GroupSubjectPatchArgsDict(TypedDict):
+        """
+        GroupSubject holds detailed information for group-kind subject.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        name is the user group that matches, or "*" to match all user groups. See https://github.com/kubernetes/apiserver/blob/master/pkg/authentication/user/user.go for some well-known group names. Required.
+        """
+elif False:
+    GroupSubjectPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class GroupSubjectPatchArgs:
     def __init__(__self__, *,
@@ -567,6 +806,18 @@ class GroupSubjectPatchArgs:
         pulumi.set(self, "name", value)
 
 
+if not MYPY:
+    class GroupSubjectArgsDict(TypedDict):
+        """
+        GroupSubject holds detailed information for group-kind subject.
+        """
+        name: pulumi.Input[str]
+        """
+        name is the user group that matches, or "*" to match all user groups. See https://github.com/kubernetes/apiserver/blob/master/pkg/authentication/user/user.go for some well-known group names. Required.
+        """
+elif False:
+    GroupSubjectArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class GroupSubjectArgs:
     def __init__(__self__, *,
@@ -589,6 +840,22 @@ class GroupSubjectArgs:
     def name(self, value: pulumi.Input[str]):
         pulumi.set(self, "name", value)
 
+
+if not MYPY:
+    class LimitResponsePatchArgsDict(TypedDict):
+        """
+        LimitResponse defines how to handle requests that can not be executed right now.
+        """
+        queuing: NotRequired[pulumi.Input['QueuingConfigurationPatchArgsDict']]
+        """
+        `queuing` holds the configuration parameters for queuing. This field may be non-empty only if `type` is `"Queue"`.
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        `type` is "Queue" or "Reject". "Queue" means that requests that can not be executed upon arrival are held in a queue until they can be executed or a queuing limit is reached. "Reject" means that requests that can not be executed upon arrival are rejected. Required.
+        """
+elif False:
+    LimitResponsePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class LimitResponsePatchArgs:
@@ -630,6 +897,22 @@ class LimitResponsePatchArgs:
         pulumi.set(self, "type", value)
 
 
+if not MYPY:
+    class LimitResponseArgsDict(TypedDict):
+        """
+        LimitResponse defines how to handle requests that can not be executed right now.
+        """
+        type: pulumi.Input[str]
+        """
+        `type` is "Queue" or "Reject". "Queue" means that requests that can not be executed upon arrival are held in a queue until they can be executed or a queuing limit is reached. "Reject" means that requests that can not be executed upon arrival are rejected. Required.
+        """
+        queuing: NotRequired[pulumi.Input['QueuingConfigurationArgsDict']]
+        """
+        `queuing` holds the configuration parameters for queuing. This field may be non-empty only if `type` is `"Queue"`.
+        """
+elif False:
+    LimitResponseArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class LimitResponseArgs:
     def __init__(__self__, *,
@@ -668,6 +951,46 @@ class LimitResponseArgs:
     def queuing(self, value: Optional[pulumi.Input['QueuingConfigurationArgs']]):
         pulumi.set(self, "queuing", value)
 
+
+if not MYPY:
+    class LimitedPriorityLevelConfigurationPatchArgsDict(TypedDict):
+        """
+        LimitedPriorityLevelConfiguration specifies how to handle requests that are subject to limits. It addresses two issues:
+          - How are requests for this priority level limited?
+          - What should be done with requests that exceed the limit?
+        """
+        borrowing_limit_percent: NotRequired[pulumi.Input[int]]
+        """
+        `borrowingLimitPercent`, if present, configures a limit on how many seats this priority level can borrow from other priority levels. The limit is known as this level's BorrowingConcurrencyLimit (BorrowingCL) and is a limit on the total number of seats that this level may borrow at any one time. This field holds the ratio of that limit to the level's nominal concurrency limit. When this field is non-nil, it must hold a non-negative integer and the limit is calculated as follows.
+
+        BorrowingCL(i) = round( NominalCL(i) * borrowingLimitPercent(i)/100.0 )
+
+        The value of this field can be more than 100, implying that this priority level can borrow a number of seats that is greater than its own nominal concurrency limit (NominalCL). When this field is left `nil`, the limit is effectively infinite.
+        """
+        lendable_percent: NotRequired[pulumi.Input[int]]
+        """
+        `lendablePercent` prescribes the fraction of the level's NominalCL that can be borrowed by other priority levels. The value of this field must be between 0 and 100, inclusive, and it defaults to 0. The number of seats that other levels can borrow from this level, known as this level's LendableConcurrencyLimit (LendableCL), is defined as follows.
+
+        LendableCL(i) = round( NominalCL(i) * lendablePercent(i)/100.0 )
+        """
+        limit_response: NotRequired[pulumi.Input['LimitResponsePatchArgsDict']]
+        """
+        `limitResponse` indicates what to do with requests that can not be executed right now
+        """
+        nominal_concurrency_shares: NotRequired[pulumi.Input[int]]
+        """
+        `nominalConcurrencyShares` (NCS) contributes to the computation of the NominalConcurrencyLimit (NominalCL) of this level. This is the number of execution seats available at this priority level. This is used both for requests dispatched from this priority level as well as requests dispatched from other priority levels borrowing seats from this level. The server's concurrency limit (ServerCL) is divided among the Limited priority levels in proportion to their NCS values:
+
+        NominalCL(i)  = ceil( ServerCL * NCS(i) / sum_ncs ) sum_ncs = sum[priority level k] NCS(k)
+
+        Bigger numbers mean a larger nominal concurrency limit, at the expense of every other priority level.
+
+        If not specified, this field defaults to a value of 30.
+
+        Setting this field to zero supports the construction of a "jail" for this priority level that is used to hold some request(s)
+        """
+elif False:
+    LimitedPriorityLevelConfigurationPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class LimitedPriorityLevelConfigurationPatchArgs:
@@ -771,6 +1094,46 @@ class LimitedPriorityLevelConfigurationPatchArgs:
         pulumi.set(self, "nominal_concurrency_shares", value)
 
 
+if not MYPY:
+    class LimitedPriorityLevelConfigurationArgsDict(TypedDict):
+        """
+        LimitedPriorityLevelConfiguration specifies how to handle requests that are subject to limits. It addresses two issues:
+          - How are requests for this priority level limited?
+          - What should be done with requests that exceed the limit?
+        """
+        borrowing_limit_percent: NotRequired[pulumi.Input[int]]
+        """
+        `borrowingLimitPercent`, if present, configures a limit on how many seats this priority level can borrow from other priority levels. The limit is known as this level's BorrowingConcurrencyLimit (BorrowingCL) and is a limit on the total number of seats that this level may borrow at any one time. This field holds the ratio of that limit to the level's nominal concurrency limit. When this field is non-nil, it must hold a non-negative integer and the limit is calculated as follows.
+
+        BorrowingCL(i) = round( NominalCL(i) * borrowingLimitPercent(i)/100.0 )
+
+        The value of this field can be more than 100, implying that this priority level can borrow a number of seats that is greater than its own nominal concurrency limit (NominalCL). When this field is left `nil`, the limit is effectively infinite.
+        """
+        lendable_percent: NotRequired[pulumi.Input[int]]
+        """
+        `lendablePercent` prescribes the fraction of the level's NominalCL that can be borrowed by other priority levels. The value of this field must be between 0 and 100, inclusive, and it defaults to 0. The number of seats that other levels can borrow from this level, known as this level's LendableConcurrencyLimit (LendableCL), is defined as follows.
+
+        LendableCL(i) = round( NominalCL(i) * lendablePercent(i)/100.0 )
+        """
+        limit_response: NotRequired[pulumi.Input['LimitResponseArgsDict']]
+        """
+        `limitResponse` indicates what to do with requests that can not be executed right now
+        """
+        nominal_concurrency_shares: NotRequired[pulumi.Input[int]]
+        """
+        `nominalConcurrencyShares` (NCS) contributes to the computation of the NominalConcurrencyLimit (NominalCL) of this level. This is the number of execution seats available at this priority level. This is used both for requests dispatched from this priority level as well as requests dispatched from other priority levels borrowing seats from this level. The server's concurrency limit (ServerCL) is divided among the Limited priority levels in proportion to their NCS values:
+
+        NominalCL(i)  = ceil( ServerCL * NCS(i) / sum_ncs ) sum_ncs = sum[priority level k] NCS(k)
+
+        Bigger numbers mean a larger nominal concurrency limit, at the expense of every other priority level.
+
+        If not specified, this field defaults to a value of 30.
+
+        Setting this field to zero supports the construction of a "jail" for this priority level that is used to hold some request(s)
+        """
+elif False:
+    LimitedPriorityLevelConfigurationArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class LimitedPriorityLevelConfigurationArgs:
     def __init__(__self__, *,
@@ -873,6 +1236,28 @@ class LimitedPriorityLevelConfigurationArgs:
         pulumi.set(self, "nominal_concurrency_shares", value)
 
 
+if not MYPY:
+    class NonResourcePolicyRulePatchArgsDict(TypedDict):
+        """
+        NonResourcePolicyRule is a predicate that matches non-resource requests according to their verb and the target non-resource URL. A NonResourcePolicyRule matches a request if and only if both (a) at least one member of verbs matches the request and (b) at least one member of nonResourceURLs matches the request.
+        """
+        non_resource_urls: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        `nonResourceURLs` is a set of url prefixes that a user should have access to and may not be empty. For example:
+          - "/healthz" is legal
+          - "/hea*" is illegal
+          - "/hea" is legal but matches nothing
+          - "/hea/*" also matches nothing
+          - "/healthz/*" matches all per-component health checks.
+        "*" matches all non-resource urls. if it is present, it must be the only entry. Required.
+        """
+        verbs: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        `verbs` is a list of matching verbs and may not be empty. "*" matches all verbs. If it is present, it must be the only entry. Required.
+        """
+elif False:
+    NonResourcePolicyRulePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class NonResourcePolicyRulePatchArgs:
     def __init__(__self__, *,
@@ -925,6 +1310,28 @@ class NonResourcePolicyRulePatchArgs:
         pulumi.set(self, "verbs", value)
 
 
+if not MYPY:
+    class NonResourcePolicyRuleArgsDict(TypedDict):
+        """
+        NonResourcePolicyRule is a predicate that matches non-resource requests according to their verb and the target non-resource URL. A NonResourcePolicyRule matches a request if and only if both (a) at least one member of verbs matches the request and (b) at least one member of nonResourceURLs matches the request.
+        """
+        non_resource_urls: pulumi.Input[Sequence[pulumi.Input[str]]]
+        """
+        `nonResourceURLs` is a set of url prefixes that a user should have access to and may not be empty. For example:
+          - "/healthz" is legal
+          - "/hea*" is illegal
+          - "/hea" is legal but matches nothing
+          - "/hea/*" also matches nothing
+          - "/healthz/*" matches all per-component health checks.
+        "*" matches all non-resource urls. if it is present, it must be the only entry. Required.
+        """
+        verbs: pulumi.Input[Sequence[pulumi.Input[str]]]
+        """
+        `verbs` is a list of matching verbs and may not be empty. "*" matches all verbs. If it is present, it must be the only entry. Required.
+        """
+elif False:
+    NonResourcePolicyRuleArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class NonResourcePolicyRuleArgs:
     def __init__(__self__, *,
@@ -974,6 +1381,26 @@ class NonResourcePolicyRuleArgs:
     def verbs(self, value: pulumi.Input[Sequence[pulumi.Input[str]]]):
         pulumi.set(self, "verbs", value)
 
+
+if not MYPY:
+    class PolicyRulesWithSubjectsPatchArgsDict(TypedDict):
+        """
+        PolicyRulesWithSubjects prescribes a test that applies to a request to an apiserver. The test considers the subject making the request, the verb being requested, and the resource to be acted upon. This PolicyRulesWithSubjects matches a request if and only if both (a) at least one member of subjects matches the request and (b) at least one member of resourceRules or nonResourceRules matches the request.
+        """
+        non_resource_rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['NonResourcePolicyRulePatchArgsDict']]]]
+        """
+        `nonResourceRules` is a list of NonResourcePolicyRules that identify matching requests according to their verb and the target non-resource URL.
+        """
+        resource_rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['ResourcePolicyRulePatchArgsDict']]]]
+        """
+        `resourceRules` is a slice of ResourcePolicyRules that identify matching requests according to their verb and the target resource. At least one of `resourceRules` and `nonResourceRules` has to be non-empty.
+        """
+        subjects: NotRequired[pulumi.Input[Sequence[pulumi.Input['SubjectPatchArgsDict']]]]
+        """
+        subjects is the list of normal user, serviceaccount, or group that this rule cares about. There must be at least one member in this slice. A slice that includes both the system:authenticated and system:unauthenticated user groups matches every request. Required.
+        """
+elif False:
+    PolicyRulesWithSubjectsPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class PolicyRulesWithSubjectsPatchArgs:
@@ -1031,6 +1458,26 @@ class PolicyRulesWithSubjectsPatchArgs:
         pulumi.set(self, "subjects", value)
 
 
+if not MYPY:
+    class PolicyRulesWithSubjectsArgsDict(TypedDict):
+        """
+        PolicyRulesWithSubjects prescribes a test that applies to a request to an apiserver. The test considers the subject making the request, the verb being requested, and the resource to be acted upon. This PolicyRulesWithSubjects matches a request if and only if both (a) at least one member of subjects matches the request and (b) at least one member of resourceRules or nonResourceRules matches the request.
+        """
+        subjects: pulumi.Input[Sequence[pulumi.Input['SubjectArgsDict']]]
+        """
+        subjects is the list of normal user, serviceaccount, or group that this rule cares about. There must be at least one member in this slice. A slice that includes both the system:authenticated and system:unauthenticated user groups matches every request. Required.
+        """
+        non_resource_rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['NonResourcePolicyRuleArgsDict']]]]
+        """
+        `nonResourceRules` is a list of NonResourcePolicyRules that identify matching requests according to their verb and the target non-resource URL.
+        """
+        resource_rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['ResourcePolicyRuleArgsDict']]]]
+        """
+        `resourceRules` is a slice of ResourcePolicyRules that identify matching requests according to their verb and the target resource. At least one of `resourceRules` and `nonResourceRules` has to be non-empty.
+        """
+elif False:
+    PolicyRulesWithSubjectsArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PolicyRulesWithSubjectsArgs:
     def __init__(__self__, *,
@@ -1085,6 +1532,34 @@ class PolicyRulesWithSubjectsArgs:
     def resource_rules(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['ResourcePolicyRuleArgs']]]]):
         pulumi.set(self, "resource_rules", value)
 
+
+if not MYPY:
+    class PriorityLevelConfigurationConditionArgsDict(TypedDict):
+        """
+        PriorityLevelConfigurationCondition defines the condition of priority level.
+        """
+        last_transition_time: NotRequired[pulumi.Input[str]]
+        """
+        `lastTransitionTime` is the last time the condition transitioned from one status to another.
+        """
+        message: NotRequired[pulumi.Input[str]]
+        """
+        `message` is a human-readable message indicating details about last transition.
+        """
+        reason: NotRequired[pulumi.Input[str]]
+        """
+        `reason` is a unique, one-word, CamelCase reason for the condition's last transition.
+        """
+        status: NotRequired[pulumi.Input[str]]
+        """
+        `status` is the status of the condition. Can be True, False, Unknown. Required.
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        `type` is the type of the condition. Required.
+        """
+elif False:
+    PriorityLevelConfigurationConditionArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class PriorityLevelConfigurationConditionArgs:
@@ -1174,6 +1649,18 @@ class PriorityLevelConfigurationConditionArgs:
         pulumi.set(self, "type", value)
 
 
+if not MYPY:
+    class PriorityLevelConfigurationReferencePatchArgsDict(TypedDict):
+        """
+        PriorityLevelConfigurationReference contains information that points to the "request-priority" being used.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        `name` is the name of the priority level configuration being referenced Required.
+        """
+elif False:
+    PriorityLevelConfigurationReferencePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PriorityLevelConfigurationReferencePatchArgs:
     def __init__(__self__, *,
@@ -1198,6 +1685,18 @@ class PriorityLevelConfigurationReferencePatchArgs:
         pulumi.set(self, "name", value)
 
 
+if not MYPY:
+    class PriorityLevelConfigurationReferenceArgsDict(TypedDict):
+        """
+        PriorityLevelConfigurationReference contains information that points to the "request-priority" being used.
+        """
+        name: pulumi.Input[str]
+        """
+        `name` is the name of the priority level configuration being referenced Required.
+        """
+elif False:
+    PriorityLevelConfigurationReferenceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PriorityLevelConfigurationReferenceArgs:
     def __init__(__self__, *,
@@ -1220,6 +1719,26 @@ class PriorityLevelConfigurationReferenceArgs:
     def name(self, value: pulumi.Input[str]):
         pulumi.set(self, "name", value)
 
+
+if not MYPY:
+    class PriorityLevelConfigurationSpecPatchArgsDict(TypedDict):
+        """
+        PriorityLevelConfigurationSpec specifies the configuration of a priority level.
+        """
+        exempt: NotRequired[pulumi.Input['ExemptPriorityLevelConfigurationPatchArgsDict']]
+        """
+        `exempt` specifies how requests are handled for an exempt priority level. This field MUST be empty if `type` is `"Limited"`. This field MAY be non-empty if `type` is `"Exempt"`. If empty and `type` is `"Exempt"` then the default values for `ExemptPriorityLevelConfiguration` apply.
+        """
+        limited: NotRequired[pulumi.Input['LimitedPriorityLevelConfigurationPatchArgsDict']]
+        """
+        `limited` specifies how requests are handled for a Limited priority level. This field must be non-empty if and only if `type` is `"Limited"`.
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        `type` indicates whether this priority level is subject to limitation on request execution.  A value of `"Exempt"` means that requests of this priority level are not subject to a limit (and thus are never queued) and do not detract from the capacity made available to other priority levels.  A value of `"Limited"` means that (a) requests of this priority level _are_ subject to limits and (b) some of the server's limited capacity is made available exclusively to this priority level. Required.
+        """
+elif False:
+    PriorityLevelConfigurationSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class PriorityLevelConfigurationSpecPatchArgs:
@@ -1277,6 +1796,26 @@ class PriorityLevelConfigurationSpecPatchArgs:
         pulumi.set(self, "type", value)
 
 
+if not MYPY:
+    class PriorityLevelConfigurationSpecArgsDict(TypedDict):
+        """
+        PriorityLevelConfigurationSpec specifies the configuration of a priority level.
+        """
+        type: pulumi.Input[str]
+        """
+        `type` indicates whether this priority level is subject to limitation on request execution.  A value of `"Exempt"` means that requests of this priority level are not subject to a limit (and thus are never queued) and do not detract from the capacity made available to other priority levels.  A value of `"Limited"` means that (a) requests of this priority level _are_ subject to limits and (b) some of the server's limited capacity is made available exclusively to this priority level. Required.
+        """
+        exempt: NotRequired[pulumi.Input['ExemptPriorityLevelConfigurationArgsDict']]
+        """
+        `exempt` specifies how requests are handled for an exempt priority level. This field MUST be empty if `type` is `"Limited"`. This field MAY be non-empty if `type` is `"Exempt"`. If empty and `type` is `"Exempt"` then the default values for `ExemptPriorityLevelConfiguration` apply.
+        """
+        limited: NotRequired[pulumi.Input['LimitedPriorityLevelConfigurationArgsDict']]
+        """
+        `limited` specifies how requests are handled for a Limited priority level. This field must be non-empty if and only if `type` is `"Limited"`.
+        """
+elif False:
+    PriorityLevelConfigurationSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PriorityLevelConfigurationSpecArgs:
     def __init__(__self__, *,
@@ -1332,6 +1871,18 @@ class PriorityLevelConfigurationSpecArgs:
         pulumi.set(self, "limited", value)
 
 
+if not MYPY:
+    class PriorityLevelConfigurationStatusArgsDict(TypedDict):
+        """
+        PriorityLevelConfigurationStatus represents the current state of a "request-priority".
+        """
+        conditions: NotRequired[pulumi.Input[Sequence[pulumi.Input['PriorityLevelConfigurationConditionArgsDict']]]]
+        """
+        `conditions` is the current state of "request-priority".
+        """
+elif False:
+    PriorityLevelConfigurationStatusArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PriorityLevelConfigurationStatusArgs:
     def __init__(__self__, *,
@@ -1355,6 +1906,34 @@ class PriorityLevelConfigurationStatusArgs:
     def conditions(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['PriorityLevelConfigurationConditionArgs']]]]):
         pulumi.set(self, "conditions", value)
 
+
+if not MYPY:
+    class PriorityLevelConfigurationArgsDict(TypedDict):
+        """
+        PriorityLevelConfiguration represents the configuration of a priority level.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['PriorityLevelConfigurationSpecArgsDict']]
+        """
+        `spec` is the specification of the desired behavior of a "request-priority". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+        status: NotRequired[pulumi.Input['PriorityLevelConfigurationStatusArgsDict']]
+        """
+        `status` is the current status of a "request-priority". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+elif False:
+    PriorityLevelConfigurationArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class PriorityLevelConfigurationArgs:
@@ -1444,6 +2023,26 @@ class PriorityLevelConfigurationArgs:
         pulumi.set(self, "status", value)
 
 
+if not MYPY:
+    class QueuingConfigurationPatchArgsDict(TypedDict):
+        """
+        QueuingConfiguration holds the configuration parameters for queuing
+        """
+        hand_size: NotRequired[pulumi.Input[int]]
+        """
+        `handSize` is a small positive number that configures the shuffle sharding of requests into queues.  When enqueuing a request at this priority level the request's flow identifier (a string pair) is hashed and the hash value is used to shuffle the list of queues and deal a hand of the size specified here.  The request is put into one of the shortest queues in that hand. `handSize` must be no larger than `queues`, and should be significantly smaller (so that a few heavy flows do not saturate most of the queues).  See the user-facing documentation for more extensive guidance on setting this field.  This field has a default value of 8.
+        """
+        queue_length_limit: NotRequired[pulumi.Input[int]]
+        """
+        `queueLengthLimit` is the maximum number of requests allowed to be waiting in a given queue of this priority level at a time; excess requests are rejected.  This value must be positive.  If not specified, it will be defaulted to 50.
+        """
+        queues: NotRequired[pulumi.Input[int]]
+        """
+        `queues` is the number of queues for this priority level. The queues exist independently at each apiserver. The value must be positive.  Setting it to 1 effectively precludes shufflesharding and thus makes the distinguisher method of associated flow schemas irrelevant.  This field has a default value of 64.
+        """
+elif False:
+    QueuingConfigurationPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class QueuingConfigurationPatchArgs:
     def __init__(__self__, *,
@@ -1500,6 +2099,26 @@ class QueuingConfigurationPatchArgs:
         pulumi.set(self, "queues", value)
 
 
+if not MYPY:
+    class QueuingConfigurationArgsDict(TypedDict):
+        """
+        QueuingConfiguration holds the configuration parameters for queuing
+        """
+        hand_size: NotRequired[pulumi.Input[int]]
+        """
+        `handSize` is a small positive number that configures the shuffle sharding of requests into queues.  When enqueuing a request at this priority level the request's flow identifier (a string pair) is hashed and the hash value is used to shuffle the list of queues and deal a hand of the size specified here.  The request is put into one of the shortest queues in that hand. `handSize` must be no larger than `queues`, and should be significantly smaller (so that a few heavy flows do not saturate most of the queues).  See the user-facing documentation for more extensive guidance on setting this field.  This field has a default value of 8.
+        """
+        queue_length_limit: NotRequired[pulumi.Input[int]]
+        """
+        `queueLengthLimit` is the maximum number of requests allowed to be waiting in a given queue of this priority level at a time; excess requests are rejected.  This value must be positive.  If not specified, it will be defaulted to 50.
+        """
+        queues: NotRequired[pulumi.Input[int]]
+        """
+        `queues` is the number of queues for this priority level. The queues exist independently at each apiserver. The value must be positive.  Setting it to 1 effectively precludes shufflesharding and thus makes the distinguisher method of associated flow schemas irrelevant.  This field has a default value of 64.
+        """
+elif False:
+    QueuingConfigurationArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class QueuingConfigurationArgs:
     def __init__(__self__, *,
@@ -1555,6 +2174,34 @@ class QueuingConfigurationArgs:
     def queues(self, value: Optional[pulumi.Input[int]]):
         pulumi.set(self, "queues", value)
 
+
+if not MYPY:
+    class ResourcePolicyRulePatchArgsDict(TypedDict):
+        """
+        ResourcePolicyRule is a predicate that matches some resource requests, testing the request's verb and the target resource. A ResourcePolicyRule matches a resource request if and only if: (a) at least one member of verbs matches the request, (b) at least one member of apiGroups matches the request, (c) at least one member of resources matches the request, and (d) either (d1) the request does not specify a namespace (i.e., `Namespace==""`) and clusterScope is true or (d2) the request specifies a namespace and least one member of namespaces matches the request's namespace.
+        """
+        api_groups: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        `apiGroups` is a list of matching API groups and may not be empty. "*" matches all API groups and, if present, must be the only entry. Required.
+        """
+        cluster_scope: NotRequired[pulumi.Input[bool]]
+        """
+        `clusterScope` indicates whether to match requests that do not specify a namespace (which happens either because the resource is not namespaced or the request targets all namespaces). If this field is omitted or false then the `namespaces` field must contain a non-empty list.
+        """
+        namespaces: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        `namespaces` is a list of target namespaces that restricts matches.  A request that specifies a target namespace matches only if either (a) this list contains that target namespace or (b) this list contains "*".  Note that "*" matches any specified namespace but does not match a request that _does not specify_ a namespace (see the `clusterScope` field for that). This list may be empty, but only if `clusterScope` is true.
+        """
+        resources: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        `resources` is a list of matching resources (i.e., lowercase and plural) with, if desired, subresource.  For example, [ "services", "nodes/status" ].  This list may not be empty. "*" matches all resources and, if present, must be the only entry. Required.
+        """
+        verbs: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        `verbs` is a list of matching verbs and may not be empty. "*" matches all verbs and, if present, must be the only entry. Required.
+        """
+elif False:
+    ResourcePolicyRulePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ResourcePolicyRulePatchArgs:
@@ -1644,6 +2291,34 @@ class ResourcePolicyRulePatchArgs:
         pulumi.set(self, "verbs", value)
 
 
+if not MYPY:
+    class ResourcePolicyRuleArgsDict(TypedDict):
+        """
+        ResourcePolicyRule is a predicate that matches some resource requests, testing the request's verb and the target resource. A ResourcePolicyRule matches a resource request if and only if: (a) at least one member of verbs matches the request, (b) at least one member of apiGroups matches the request, (c) at least one member of resources matches the request, and (d) either (d1) the request does not specify a namespace (i.e., `Namespace==""`) and clusterScope is true or (d2) the request specifies a namespace and least one member of namespaces matches the request's namespace.
+        """
+        api_groups: pulumi.Input[Sequence[pulumi.Input[str]]]
+        """
+        `apiGroups` is a list of matching API groups and may not be empty. "*" matches all API groups and, if present, must be the only entry. Required.
+        """
+        resources: pulumi.Input[Sequence[pulumi.Input[str]]]
+        """
+        `resources` is a list of matching resources (i.e., lowercase and plural) with, if desired, subresource.  For example, [ "services", "nodes/status" ].  This list may not be empty. "*" matches all resources and, if present, must be the only entry. Required.
+        """
+        verbs: pulumi.Input[Sequence[pulumi.Input[str]]]
+        """
+        `verbs` is a list of matching verbs and may not be empty. "*" matches all verbs and, if present, must be the only entry. Required.
+        """
+        cluster_scope: NotRequired[pulumi.Input[bool]]
+        """
+        `clusterScope` indicates whether to match requests that do not specify a namespace (which happens either because the resource is not namespaced or the request targets all namespaces). If this field is omitted or false then the `namespaces` field must contain a non-empty list.
+        """
+        namespaces: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        `namespaces` is a list of target namespaces that restricts matches.  A request that specifies a target namespace matches only if either (a) this list contains that target namespace or (b) this list contains "*".  Note that "*" matches any specified namespace but does not match a request that _does not specify_ a namespace (see the `clusterScope` field for that). This list may be empty, but only if `clusterScope` is true.
+        """
+elif False:
+    ResourcePolicyRuleArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ResourcePolicyRuleArgs:
     def __init__(__self__, *,
@@ -1729,6 +2404,22 @@ class ResourcePolicyRuleArgs:
         pulumi.set(self, "namespaces", value)
 
 
+if not MYPY:
+    class ServiceAccountSubjectPatchArgsDict(TypedDict):
+        """
+        ServiceAccountSubject holds detailed information for service-account-kind subject.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        `name` is the name of matching ServiceAccount objects, or "*" to match regardless of name. Required.
+        """
+        namespace: NotRequired[pulumi.Input[str]]
+        """
+        `namespace` is the namespace of matching ServiceAccount objects. Required.
+        """
+elif False:
+    ServiceAccountSubjectPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ServiceAccountSubjectPatchArgs:
     def __init__(__self__, *,
@@ -1769,6 +2460,22 @@ class ServiceAccountSubjectPatchArgs:
         pulumi.set(self, "namespace", value)
 
 
+if not MYPY:
+    class ServiceAccountSubjectArgsDict(TypedDict):
+        """
+        ServiceAccountSubject holds detailed information for service-account-kind subject.
+        """
+        name: pulumi.Input[str]
+        """
+        `name` is the name of matching ServiceAccount objects, or "*" to match regardless of name. Required.
+        """
+        namespace: pulumi.Input[str]
+        """
+        `namespace` is the namespace of matching ServiceAccount objects. Required.
+        """
+elif False:
+    ServiceAccountSubjectArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ServiceAccountSubjectArgs:
     def __init__(__self__, *,
@@ -1806,6 +2513,30 @@ class ServiceAccountSubjectArgs:
     def namespace(self, value: pulumi.Input[str]):
         pulumi.set(self, "namespace", value)
 
+
+if not MYPY:
+    class SubjectPatchArgsDict(TypedDict):
+        """
+        Subject matches the originator of a request, as identified by the request authentication system. There are three ways of matching an originator; by user, group, or service account.
+        """
+        group: NotRequired[pulumi.Input['GroupSubjectPatchArgsDict']]
+        """
+        `group` matches based on user group name.
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        `kind` indicates which one of the other fields is non-empty. Required
+        """
+        service_account: NotRequired[pulumi.Input['ServiceAccountSubjectPatchArgsDict']]
+        """
+        `serviceAccount` matches ServiceAccounts.
+        """
+        user: NotRequired[pulumi.Input['UserSubjectPatchArgsDict']]
+        """
+        `user` matches based on username.
+        """
+elif False:
+    SubjectPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class SubjectPatchArgs:
@@ -1879,6 +2610,30 @@ class SubjectPatchArgs:
         pulumi.set(self, "user", value)
 
 
+if not MYPY:
+    class SubjectArgsDict(TypedDict):
+        """
+        Subject matches the originator of a request, as identified by the request authentication system. There are three ways of matching an originator; by user, group, or service account.
+        """
+        kind: pulumi.Input[str]
+        """
+        `kind` indicates which one of the other fields is non-empty. Required
+        """
+        group: NotRequired[pulumi.Input['GroupSubjectArgsDict']]
+        """
+        `group` matches based on user group name.
+        """
+        service_account: NotRequired[pulumi.Input['ServiceAccountSubjectArgsDict']]
+        """
+        `serviceAccount` matches ServiceAccounts.
+        """
+        user: NotRequired[pulumi.Input['UserSubjectArgsDict']]
+        """
+        `user` matches based on username.
+        """
+elif False:
+    SubjectArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class SubjectArgs:
     def __init__(__self__, *,
@@ -1950,6 +2705,18 @@ class SubjectArgs:
         pulumi.set(self, "user", value)
 
 
+if not MYPY:
+    class UserSubjectPatchArgsDict(TypedDict):
+        """
+        UserSubject holds detailed information for user-kind subject.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        `name` is the username that matches, or "*" to match all usernames. Required.
+        """
+elif False:
+    UserSubjectPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class UserSubjectPatchArgs:
     def __init__(__self__, *,
@@ -1973,6 +2740,18 @@ class UserSubjectPatchArgs:
     def name(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "name", value)
 
+
+if not MYPY:
+    class UserSubjectArgsDict(TypedDict):
+        """
+        UserSubject holds detailed information for user-kind subject.
+        """
+        name: pulumi.Input[str]
+        """
+        `name` is the username that matches, or "*" to match all usernames. Required.
+        """
+elif False:
+    UserSubjectArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class UserSubjectArgs:

--- a/sdk/python/pulumi_kubernetes/flowcontrol/v1/outputs.py
+++ b/sdk/python/pulumi_kubernetes/flowcontrol/v1/outputs.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta

--- a/sdk/python/pulumi_kubernetes/flowcontrol/v1alpha1/FlowSchema.py
+++ b/sdk/python/pulumi_kubernetes/flowcontrol/v1alpha1/FlowSchema.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class FlowSchema(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['FlowSchemaSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['FlowSchemaSpecArgs', 'FlowSchemaSpecArgsDict']]] = None,
                  __props__=None):
         """
         FlowSchema defines the schema of a group of flows. Note that a flow is made up of a set of inbound API requests with similar attributes and is identified by a pair of strings: the name of the FlowSchema and a "flow distinguisher".
@@ -103,8 +108,8 @@ class FlowSchema(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['FlowSchemaSpecArgs']] spec: `spec` is the specification of the desired behavior of a FlowSchema. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['FlowSchemaSpecArgs', 'FlowSchemaSpecArgsDict']] spec: `spec` is the specification of the desired behavior of a FlowSchema. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -132,8 +137,8 @@ class FlowSchema(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['FlowSchemaSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['FlowSchemaSpecArgs', 'FlowSchemaSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/flowcontrol/v1alpha1/FlowSchemaList.py
+++ b/sdk/python/pulumi_kubernetes/flowcontrol/v1alpha1/FlowSchemaList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class FlowSchemaList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['FlowSchemaArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['FlowSchemaArgs', 'FlowSchemaArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         FlowSchemaList is a list of FlowSchema objects.
@@ -101,9 +106,9 @@ class FlowSchemaList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['FlowSchemaArgs']]]] items: `items` is a list of FlowSchemas.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['FlowSchemaArgs', 'FlowSchemaArgsDict']]]] items: `items` is a list of FlowSchemas.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: `metadata` is the standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: `metadata` is the standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class FlowSchemaList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['FlowSchemaArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['FlowSchemaArgs', 'FlowSchemaArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/flowcontrol/v1alpha1/FlowSchemaPatch.py
+++ b/sdk/python/pulumi_kubernetes/flowcontrol/v1alpha1/FlowSchemaPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class FlowSchemaPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['FlowSchemaSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['FlowSchemaSpecPatchArgs', 'FlowSchemaSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -109,8 +114,8 @@ class FlowSchemaPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['FlowSchemaSpecPatchArgs']] spec: `spec` is the specification of the desired behavior of a FlowSchema. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['FlowSchemaSpecPatchArgs', 'FlowSchemaSpecPatchArgsDict']] spec: `spec` is the specification of the desired behavior of a FlowSchema. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -144,8 +149,8 @@ class FlowSchemaPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['FlowSchemaSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['FlowSchemaSpecPatchArgs', 'FlowSchemaSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/flowcontrol/v1alpha1/PriorityLevelConfiguration.py
+++ b/sdk/python/pulumi_kubernetes/flowcontrol/v1alpha1/PriorityLevelConfiguration.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class PriorityLevelConfiguration(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PriorityLevelConfigurationSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PriorityLevelConfigurationSpecArgs', 'PriorityLevelConfigurationSpecArgsDict']]] = None,
                  __props__=None):
         """
         PriorityLevelConfiguration represents the configuration of a priority level.
@@ -103,8 +108,8 @@ class PriorityLevelConfiguration(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['PriorityLevelConfigurationSpecArgs']] spec: `spec` is the specification of the desired behavior of a "request-priority". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['PriorityLevelConfigurationSpecArgs', 'PriorityLevelConfigurationSpecArgsDict']] spec: `spec` is the specification of the desired behavior of a "request-priority". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -132,8 +137,8 @@ class PriorityLevelConfiguration(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PriorityLevelConfigurationSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PriorityLevelConfigurationSpecArgs', 'PriorityLevelConfigurationSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/flowcontrol/v1alpha1/PriorityLevelConfigurationList.py
+++ b/sdk/python/pulumi_kubernetes/flowcontrol/v1alpha1/PriorityLevelConfigurationList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class PriorityLevelConfigurationList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PriorityLevelConfigurationArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PriorityLevelConfigurationArgs', 'PriorityLevelConfigurationArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         PriorityLevelConfigurationList is a list of PriorityLevelConfiguration objects.
@@ -101,9 +106,9 @@ class PriorityLevelConfigurationList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PriorityLevelConfigurationArgs']]]] items: `items` is a list of request-priorities.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['PriorityLevelConfigurationArgs', 'PriorityLevelConfigurationArgsDict']]]] items: `items` is a list of request-priorities.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class PriorityLevelConfigurationList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PriorityLevelConfigurationArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PriorityLevelConfigurationArgs', 'PriorityLevelConfigurationArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/flowcontrol/v1alpha1/PriorityLevelConfigurationPatch.py
+++ b/sdk/python/pulumi_kubernetes/flowcontrol/v1alpha1/PriorityLevelConfigurationPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class PriorityLevelConfigurationPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PriorityLevelConfigurationSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PriorityLevelConfigurationSpecPatchArgs', 'PriorityLevelConfigurationSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -109,8 +114,8 @@ class PriorityLevelConfigurationPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['PriorityLevelConfigurationSpecPatchArgs']] spec: `spec` is the specification of the desired behavior of a "request-priority". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['PriorityLevelConfigurationSpecPatchArgs', 'PriorityLevelConfigurationSpecPatchArgsDict']] spec: `spec` is the specification of the desired behavior of a "request-priority". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -144,8 +149,8 @@ class PriorityLevelConfigurationPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PriorityLevelConfigurationSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PriorityLevelConfigurationSpecPatchArgs', 'PriorityLevelConfigurationSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/flowcontrol/v1alpha1/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/flowcontrol/v1alpha1/_inputs.py
@@ -4,48 +4,101 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import meta as _meta
 
 __all__ = [
     'FlowDistinguisherMethodPatchArgs',
+    'FlowDistinguisherMethodPatchArgsDict',
     'FlowDistinguisherMethodArgs',
+    'FlowDistinguisherMethodArgsDict',
     'FlowSchemaConditionArgs',
+    'FlowSchemaConditionArgsDict',
     'FlowSchemaSpecPatchArgs',
+    'FlowSchemaSpecPatchArgsDict',
     'FlowSchemaSpecArgs',
+    'FlowSchemaSpecArgsDict',
     'FlowSchemaStatusArgs',
+    'FlowSchemaStatusArgsDict',
     'FlowSchemaArgs',
+    'FlowSchemaArgsDict',
     'GroupSubjectPatchArgs',
+    'GroupSubjectPatchArgsDict',
     'GroupSubjectArgs',
+    'GroupSubjectArgsDict',
     'LimitResponsePatchArgs',
+    'LimitResponsePatchArgsDict',
     'LimitResponseArgs',
+    'LimitResponseArgsDict',
     'LimitedPriorityLevelConfigurationPatchArgs',
+    'LimitedPriorityLevelConfigurationPatchArgsDict',
     'LimitedPriorityLevelConfigurationArgs',
+    'LimitedPriorityLevelConfigurationArgsDict',
     'NonResourcePolicyRulePatchArgs',
+    'NonResourcePolicyRulePatchArgsDict',
     'NonResourcePolicyRuleArgs',
+    'NonResourcePolicyRuleArgsDict',
     'PolicyRulesWithSubjectsPatchArgs',
+    'PolicyRulesWithSubjectsPatchArgsDict',
     'PolicyRulesWithSubjectsArgs',
+    'PolicyRulesWithSubjectsArgsDict',
     'PriorityLevelConfigurationConditionArgs',
+    'PriorityLevelConfigurationConditionArgsDict',
     'PriorityLevelConfigurationReferencePatchArgs',
+    'PriorityLevelConfigurationReferencePatchArgsDict',
     'PriorityLevelConfigurationReferenceArgs',
+    'PriorityLevelConfigurationReferenceArgsDict',
     'PriorityLevelConfigurationSpecPatchArgs',
+    'PriorityLevelConfigurationSpecPatchArgsDict',
     'PriorityLevelConfigurationSpecArgs',
+    'PriorityLevelConfigurationSpecArgsDict',
     'PriorityLevelConfigurationStatusArgs',
+    'PriorityLevelConfigurationStatusArgsDict',
     'PriorityLevelConfigurationArgs',
+    'PriorityLevelConfigurationArgsDict',
     'QueuingConfigurationPatchArgs',
+    'QueuingConfigurationPatchArgsDict',
     'QueuingConfigurationArgs',
+    'QueuingConfigurationArgsDict',
     'ResourcePolicyRulePatchArgs',
+    'ResourcePolicyRulePatchArgsDict',
     'ResourcePolicyRuleArgs',
+    'ResourcePolicyRuleArgsDict',
     'ServiceAccountSubjectPatchArgs',
+    'ServiceAccountSubjectPatchArgsDict',
     'ServiceAccountSubjectArgs',
+    'ServiceAccountSubjectArgsDict',
     'SubjectPatchArgs',
+    'SubjectPatchArgsDict',
     'SubjectArgs',
+    'SubjectArgsDict',
     'UserSubjectPatchArgs',
+    'UserSubjectPatchArgsDict',
     'UserSubjectArgs',
+    'UserSubjectArgsDict',
 ]
+
+MYPY = False
+
+if not MYPY:
+    class FlowDistinguisherMethodPatchArgsDict(TypedDict):
+        """
+        FlowDistinguisherMethod specifies the method of a flow distinguisher.
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        `type` is the type of flow distinguisher method The supported types are "ByUser" and "ByNamespace". Required.
+        """
+elif False:
+    FlowDistinguisherMethodPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class FlowDistinguisherMethodPatchArgs:
@@ -71,6 +124,18 @@ class FlowDistinguisherMethodPatchArgs:
         pulumi.set(self, "type", value)
 
 
+if not MYPY:
+    class FlowDistinguisherMethodArgsDict(TypedDict):
+        """
+        FlowDistinguisherMethod specifies the method of a flow distinguisher.
+        """
+        type: pulumi.Input[str]
+        """
+        `type` is the type of flow distinguisher method The supported types are "ByUser" and "ByNamespace". Required.
+        """
+elif False:
+    FlowDistinguisherMethodArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class FlowDistinguisherMethodArgs:
     def __init__(__self__, *,
@@ -93,6 +158,34 @@ class FlowDistinguisherMethodArgs:
     def type(self, value: pulumi.Input[str]):
         pulumi.set(self, "type", value)
 
+
+if not MYPY:
+    class FlowSchemaConditionArgsDict(TypedDict):
+        """
+        FlowSchemaCondition describes conditions for a FlowSchema.
+        """
+        last_transition_time: NotRequired[pulumi.Input[str]]
+        """
+        `lastTransitionTime` is the last time the condition transitioned from one status to another.
+        """
+        message: NotRequired[pulumi.Input[str]]
+        """
+        `message` is a human-readable message indicating details about last transition.
+        """
+        reason: NotRequired[pulumi.Input[str]]
+        """
+        `reason` is a unique, one-word, CamelCase reason for the condition's last transition.
+        """
+        status: NotRequired[pulumi.Input[str]]
+        """
+        `status` is the status of the condition. Can be True, False, Unknown. Required.
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        `type` is the type of the condition. Required.
+        """
+elif False:
+    FlowSchemaConditionArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class FlowSchemaConditionArgs:
@@ -182,6 +275,30 @@ class FlowSchemaConditionArgs:
         pulumi.set(self, "type", value)
 
 
+if not MYPY:
+    class FlowSchemaSpecPatchArgsDict(TypedDict):
+        """
+        FlowSchemaSpec describes how the FlowSchema's specification looks like.
+        """
+        distinguisher_method: NotRequired[pulumi.Input['FlowDistinguisherMethodPatchArgsDict']]
+        """
+        `distinguisherMethod` defines how to compute the flow distinguisher for requests that match this schema. `nil` specifies that the distinguisher is disabled and thus will always be the empty string.
+        """
+        matching_precedence: NotRequired[pulumi.Input[int]]
+        """
+        `matchingPrecedence` is used to choose among the FlowSchemas that match a given request. The chosen FlowSchema is among those with the numerically lowest (which we take to be logically highest) MatchingPrecedence.  Each MatchingPrecedence value must be non-negative. Note that if the precedence is not specified or zero, it will be set to 1000 as default.
+        """
+        priority_level_configuration: NotRequired[pulumi.Input['PriorityLevelConfigurationReferencePatchArgsDict']]
+        """
+        `priorityLevelConfiguration` should reference a PriorityLevelConfiguration in the cluster. If the reference cannot be resolved, the FlowSchema will be ignored and marked as invalid in its status. Required.
+        """
+        rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['PolicyRulesWithSubjectsPatchArgsDict']]]]
+        """
+        `rules` describes which requests will match this flow schema. This FlowSchema matches a request if and only if at least one member of rules matches the request. if it is an empty slice, there will be no requests matching the FlowSchema.
+        """
+elif False:
+    FlowSchemaSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class FlowSchemaSpecPatchArgs:
     def __init__(__self__, *,
@@ -254,6 +371,30 @@ class FlowSchemaSpecPatchArgs:
         pulumi.set(self, "rules", value)
 
 
+if not MYPY:
+    class FlowSchemaSpecArgsDict(TypedDict):
+        """
+        FlowSchemaSpec describes how the FlowSchema's specification looks like.
+        """
+        priority_level_configuration: pulumi.Input['PriorityLevelConfigurationReferenceArgsDict']
+        """
+        `priorityLevelConfiguration` should reference a PriorityLevelConfiguration in the cluster. If the reference cannot be resolved, the FlowSchema will be ignored and marked as invalid in its status. Required.
+        """
+        distinguisher_method: NotRequired[pulumi.Input['FlowDistinguisherMethodArgsDict']]
+        """
+        `distinguisherMethod` defines how to compute the flow distinguisher for requests that match this schema. `nil` specifies that the distinguisher is disabled and thus will always be the empty string.
+        """
+        matching_precedence: NotRequired[pulumi.Input[int]]
+        """
+        `matchingPrecedence` is used to choose among the FlowSchemas that match a given request. The chosen FlowSchema is among those with the numerically lowest (which we take to be logically highest) MatchingPrecedence.  Each MatchingPrecedence value must be non-negative. Note that if the precedence is not specified or zero, it will be set to 1000 as default.
+        """
+        rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['PolicyRulesWithSubjectsArgsDict']]]]
+        """
+        `rules` describes which requests will match this flow schema. This FlowSchema matches a request if and only if at least one member of rules matches the request. if it is an empty slice, there will be no requests matching the FlowSchema.
+        """
+elif False:
+    FlowSchemaSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class FlowSchemaSpecArgs:
     def __init__(__self__, *,
@@ -325,6 +466,18 @@ class FlowSchemaSpecArgs:
         pulumi.set(self, "rules", value)
 
 
+if not MYPY:
+    class FlowSchemaStatusArgsDict(TypedDict):
+        """
+        FlowSchemaStatus represents the current state of a FlowSchema.
+        """
+        conditions: NotRequired[pulumi.Input[Sequence[pulumi.Input['FlowSchemaConditionArgsDict']]]]
+        """
+        `conditions` is a list of the current states of FlowSchema.
+        """
+elif False:
+    FlowSchemaStatusArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class FlowSchemaStatusArgs:
     def __init__(__self__, *,
@@ -348,6 +501,34 @@ class FlowSchemaStatusArgs:
     def conditions(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['FlowSchemaConditionArgs']]]]):
         pulumi.set(self, "conditions", value)
 
+
+if not MYPY:
+    class FlowSchemaArgsDict(TypedDict):
+        """
+        FlowSchema defines the schema of a group of flows. Note that a flow is made up of a set of inbound API requests with similar attributes and is identified by a pair of strings: the name of the FlowSchema and a "flow distinguisher".
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['FlowSchemaSpecArgsDict']]
+        """
+        `spec` is the specification of the desired behavior of a FlowSchema. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+        status: NotRequired[pulumi.Input['FlowSchemaStatusArgsDict']]
+        """
+        `status` is the current status of a FlowSchema. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+elif False:
+    FlowSchemaArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class FlowSchemaArgs:
@@ -437,6 +618,18 @@ class FlowSchemaArgs:
         pulumi.set(self, "status", value)
 
 
+if not MYPY:
+    class GroupSubjectPatchArgsDict(TypedDict):
+        """
+        GroupSubject holds detailed information for group-kind subject.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        name is the user group that matches, or "*" to match all user groups. See https://github.com/kubernetes/apiserver/blob/master/pkg/authentication/user/user.go for some well-known group names. Required.
+        """
+elif False:
+    GroupSubjectPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class GroupSubjectPatchArgs:
     def __init__(__self__, *,
@@ -461,6 +654,18 @@ class GroupSubjectPatchArgs:
         pulumi.set(self, "name", value)
 
 
+if not MYPY:
+    class GroupSubjectArgsDict(TypedDict):
+        """
+        GroupSubject holds detailed information for group-kind subject.
+        """
+        name: pulumi.Input[str]
+        """
+        name is the user group that matches, or "*" to match all user groups. See https://github.com/kubernetes/apiserver/blob/master/pkg/authentication/user/user.go for some well-known group names. Required.
+        """
+elif False:
+    GroupSubjectArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class GroupSubjectArgs:
     def __init__(__self__, *,
@@ -483,6 +688,22 @@ class GroupSubjectArgs:
     def name(self, value: pulumi.Input[str]):
         pulumi.set(self, "name", value)
 
+
+if not MYPY:
+    class LimitResponsePatchArgsDict(TypedDict):
+        """
+        LimitResponse defines how to handle requests that can not be executed right now.
+        """
+        queuing: NotRequired[pulumi.Input['QueuingConfigurationPatchArgsDict']]
+        """
+        `queuing` holds the configuration parameters for queuing. This field may be non-empty only if `type` is `"Queue"`.
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        `type` is "Queue" or "Reject". "Queue" means that requests that can not be executed upon arrival are held in a queue until they can be executed or a queuing limit is reached. "Reject" means that requests that can not be executed upon arrival are rejected. Required.
+        """
+elif False:
+    LimitResponsePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class LimitResponsePatchArgs:
@@ -524,6 +745,22 @@ class LimitResponsePatchArgs:
         pulumi.set(self, "type", value)
 
 
+if not MYPY:
+    class LimitResponseArgsDict(TypedDict):
+        """
+        LimitResponse defines how to handle requests that can not be executed right now.
+        """
+        type: pulumi.Input[str]
+        """
+        `type` is "Queue" or "Reject". "Queue" means that requests that can not be executed upon arrival are held in a queue until they can be executed or a queuing limit is reached. "Reject" means that requests that can not be executed upon arrival are rejected. Required.
+        """
+        queuing: NotRequired[pulumi.Input['QueuingConfigurationArgsDict']]
+        """
+        `queuing` holds the configuration parameters for queuing. This field may be non-empty only if `type` is `"Queue"`.
+        """
+elif False:
+    LimitResponseArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class LimitResponseArgs:
     def __init__(__self__, *,
@@ -562,6 +799,28 @@ class LimitResponseArgs:
     def queuing(self, value: Optional[pulumi.Input['QueuingConfigurationArgs']]):
         pulumi.set(self, "queuing", value)
 
+
+if not MYPY:
+    class LimitedPriorityLevelConfigurationPatchArgsDict(TypedDict):
+        """
+        LimitedPriorityLevelConfiguration specifies how to handle requests that are subject to limits. It addresses two issues:
+         * How are requests for this priority level limited?
+         * What should be done with requests that exceed the limit?
+        """
+        assured_concurrency_shares: NotRequired[pulumi.Input[int]]
+        """
+        `assuredConcurrencyShares` (ACS) configures the execution limit, which is a limit on the number of requests of this priority level that may be exeucting at a given time.  ACS must be a positive number. The server's concurrency limit (SCL) is divided among the concurrency-controlled priority levels in proportion to their assured concurrency shares. This produces the assured concurrency value (ACV) --- the number of requests that may be executing at a time --- for each such priority level:
+
+                    ACV(l) = ceil( SCL * ACS(l) / ( sum[priority levels k] ACS(k) ) )
+
+        bigger numbers of ACS mean more reserved concurrent requests (at the expense of every other PL). This field has a default value of 30.
+        """
+        limit_response: NotRequired[pulumi.Input['LimitResponsePatchArgsDict']]
+        """
+        `limitResponse` indicates what to do with requests that can not be executed right now
+        """
+elif False:
+    LimitedPriorityLevelConfigurationPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class LimitedPriorityLevelConfigurationPatchArgs:
@@ -613,6 +872,28 @@ class LimitedPriorityLevelConfigurationPatchArgs:
         pulumi.set(self, "limit_response", value)
 
 
+if not MYPY:
+    class LimitedPriorityLevelConfigurationArgsDict(TypedDict):
+        """
+        LimitedPriorityLevelConfiguration specifies how to handle requests that are subject to limits. It addresses two issues:
+         * How are requests for this priority level limited?
+         * What should be done with requests that exceed the limit?
+        """
+        assured_concurrency_shares: NotRequired[pulumi.Input[int]]
+        """
+        `assuredConcurrencyShares` (ACS) configures the execution limit, which is a limit on the number of requests of this priority level that may be exeucting at a given time.  ACS must be a positive number. The server's concurrency limit (SCL) is divided among the concurrency-controlled priority levels in proportion to their assured concurrency shares. This produces the assured concurrency value (ACV) --- the number of requests that may be executing at a time --- for each such priority level:
+
+                    ACV(l) = ceil( SCL * ACS(l) / ( sum[priority levels k] ACS(k) ) )
+
+        bigger numbers of ACS mean more reserved concurrent requests (at the expense of every other PL). This field has a default value of 30.
+        """
+        limit_response: NotRequired[pulumi.Input['LimitResponseArgsDict']]
+        """
+        `limitResponse` indicates what to do with requests that can not be executed right now
+        """
+elif False:
+    LimitedPriorityLevelConfigurationArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class LimitedPriorityLevelConfigurationArgs:
     def __init__(__self__, *,
@@ -662,6 +943,28 @@ class LimitedPriorityLevelConfigurationArgs:
     def limit_response(self, value: Optional[pulumi.Input['LimitResponseArgs']]):
         pulumi.set(self, "limit_response", value)
 
+
+if not MYPY:
+    class NonResourcePolicyRulePatchArgsDict(TypedDict):
+        """
+        NonResourcePolicyRule is a predicate that matches non-resource requests according to their verb and the target non-resource URL. A NonResourcePolicyRule matches a request if and only if both (a) at least one member of verbs matches the request and (b) at least one member of nonResourceURLs matches the request.
+        """
+        non_resource_urls: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        `nonResourceURLs` is a set of url prefixes that a user should have access to and may not be empty. For example:
+          - "/healthz" is legal
+          - "/hea*" is illegal
+          - "/hea" is legal but matches nothing
+          - "/hea/*" also matches nothing
+          - "/healthz/*" matches all per-component health checks.
+        "*" matches all non-resource urls. if it is present, it must be the only entry. Required.
+        """
+        verbs: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        `verbs` is a list of matching verbs and may not be empty. "*" matches all verbs. If it is present, it must be the only entry. Required.
+        """
+elif False:
+    NonResourcePolicyRulePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class NonResourcePolicyRulePatchArgs:
@@ -715,6 +1018,28 @@ class NonResourcePolicyRulePatchArgs:
         pulumi.set(self, "verbs", value)
 
 
+if not MYPY:
+    class NonResourcePolicyRuleArgsDict(TypedDict):
+        """
+        NonResourcePolicyRule is a predicate that matches non-resource requests according to their verb and the target non-resource URL. A NonResourcePolicyRule matches a request if and only if both (a) at least one member of verbs matches the request and (b) at least one member of nonResourceURLs matches the request.
+        """
+        non_resource_urls: pulumi.Input[Sequence[pulumi.Input[str]]]
+        """
+        `nonResourceURLs` is a set of url prefixes that a user should have access to and may not be empty. For example:
+          - "/healthz" is legal
+          - "/hea*" is illegal
+          - "/hea" is legal but matches nothing
+          - "/hea/*" also matches nothing
+          - "/healthz/*" matches all per-component health checks.
+        "*" matches all non-resource urls. if it is present, it must be the only entry. Required.
+        """
+        verbs: pulumi.Input[Sequence[pulumi.Input[str]]]
+        """
+        `verbs` is a list of matching verbs and may not be empty. "*" matches all verbs. If it is present, it must be the only entry. Required.
+        """
+elif False:
+    NonResourcePolicyRuleArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class NonResourcePolicyRuleArgs:
     def __init__(__self__, *,
@@ -764,6 +1089,26 @@ class NonResourcePolicyRuleArgs:
     def verbs(self, value: pulumi.Input[Sequence[pulumi.Input[str]]]):
         pulumi.set(self, "verbs", value)
 
+
+if not MYPY:
+    class PolicyRulesWithSubjectsPatchArgsDict(TypedDict):
+        """
+        PolicyRulesWithSubjects prescribes a test that applies to a request to an apiserver. The test considers the subject making the request, the verb being requested, and the resource to be acted upon. This PolicyRulesWithSubjects matches a request if and only if both (a) at least one member of subjects matches the request and (b) at least one member of resourceRules or nonResourceRules matches the request.
+        """
+        non_resource_rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['NonResourcePolicyRulePatchArgsDict']]]]
+        """
+        `nonResourceRules` is a list of NonResourcePolicyRules that identify matching requests according to their verb and the target non-resource URL.
+        """
+        resource_rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['ResourcePolicyRulePatchArgsDict']]]]
+        """
+        `resourceRules` is a slice of ResourcePolicyRules that identify matching requests according to their verb and the target resource. At least one of `resourceRules` and `nonResourceRules` has to be non-empty.
+        """
+        subjects: NotRequired[pulumi.Input[Sequence[pulumi.Input['SubjectPatchArgsDict']]]]
+        """
+        subjects is the list of normal user, serviceaccount, or group that this rule cares about. There must be at least one member in this slice. A slice that includes both the system:authenticated and system:unauthenticated user groups matches every request. Required.
+        """
+elif False:
+    PolicyRulesWithSubjectsPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class PolicyRulesWithSubjectsPatchArgs:
@@ -821,6 +1166,26 @@ class PolicyRulesWithSubjectsPatchArgs:
         pulumi.set(self, "subjects", value)
 
 
+if not MYPY:
+    class PolicyRulesWithSubjectsArgsDict(TypedDict):
+        """
+        PolicyRulesWithSubjects prescribes a test that applies to a request to an apiserver. The test considers the subject making the request, the verb being requested, and the resource to be acted upon. This PolicyRulesWithSubjects matches a request if and only if both (a) at least one member of subjects matches the request and (b) at least one member of resourceRules or nonResourceRules matches the request.
+        """
+        subjects: pulumi.Input[Sequence[pulumi.Input['SubjectArgsDict']]]
+        """
+        subjects is the list of normal user, serviceaccount, or group that this rule cares about. There must be at least one member in this slice. A slice that includes both the system:authenticated and system:unauthenticated user groups matches every request. Required.
+        """
+        non_resource_rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['NonResourcePolicyRuleArgsDict']]]]
+        """
+        `nonResourceRules` is a list of NonResourcePolicyRules that identify matching requests according to their verb and the target non-resource URL.
+        """
+        resource_rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['ResourcePolicyRuleArgsDict']]]]
+        """
+        `resourceRules` is a slice of ResourcePolicyRules that identify matching requests according to their verb and the target resource. At least one of `resourceRules` and `nonResourceRules` has to be non-empty.
+        """
+elif False:
+    PolicyRulesWithSubjectsArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PolicyRulesWithSubjectsArgs:
     def __init__(__self__, *,
@@ -875,6 +1240,34 @@ class PolicyRulesWithSubjectsArgs:
     def resource_rules(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['ResourcePolicyRuleArgs']]]]):
         pulumi.set(self, "resource_rules", value)
 
+
+if not MYPY:
+    class PriorityLevelConfigurationConditionArgsDict(TypedDict):
+        """
+        PriorityLevelConfigurationCondition defines the condition of priority level.
+        """
+        last_transition_time: NotRequired[pulumi.Input[str]]
+        """
+        `lastTransitionTime` is the last time the condition transitioned from one status to another.
+        """
+        message: NotRequired[pulumi.Input[str]]
+        """
+        `message` is a human-readable message indicating details about last transition.
+        """
+        reason: NotRequired[pulumi.Input[str]]
+        """
+        `reason` is a unique, one-word, CamelCase reason for the condition's last transition.
+        """
+        status: NotRequired[pulumi.Input[str]]
+        """
+        `status` is the status of the condition. Can be True, False, Unknown. Required.
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        `type` is the type of the condition. Required.
+        """
+elif False:
+    PriorityLevelConfigurationConditionArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class PriorityLevelConfigurationConditionArgs:
@@ -964,6 +1357,18 @@ class PriorityLevelConfigurationConditionArgs:
         pulumi.set(self, "type", value)
 
 
+if not MYPY:
+    class PriorityLevelConfigurationReferencePatchArgsDict(TypedDict):
+        """
+        PriorityLevelConfigurationReference contains information that points to the "request-priority" being used.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        `name` is the name of the priority level configuration being referenced Required.
+        """
+elif False:
+    PriorityLevelConfigurationReferencePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PriorityLevelConfigurationReferencePatchArgs:
     def __init__(__self__, *,
@@ -988,6 +1393,18 @@ class PriorityLevelConfigurationReferencePatchArgs:
         pulumi.set(self, "name", value)
 
 
+if not MYPY:
+    class PriorityLevelConfigurationReferenceArgsDict(TypedDict):
+        """
+        PriorityLevelConfigurationReference contains information that points to the "request-priority" being used.
+        """
+        name: pulumi.Input[str]
+        """
+        `name` is the name of the priority level configuration being referenced Required.
+        """
+elif False:
+    PriorityLevelConfigurationReferenceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PriorityLevelConfigurationReferenceArgs:
     def __init__(__self__, *,
@@ -1010,6 +1427,22 @@ class PriorityLevelConfigurationReferenceArgs:
     def name(self, value: pulumi.Input[str]):
         pulumi.set(self, "name", value)
 
+
+if not MYPY:
+    class PriorityLevelConfigurationSpecPatchArgsDict(TypedDict):
+        """
+        PriorityLevelConfigurationSpec specifies the configuration of a priority level.
+        """
+        limited: NotRequired[pulumi.Input['LimitedPriorityLevelConfigurationPatchArgsDict']]
+        """
+        `limited` specifies how requests are handled for a Limited priority level. This field must be non-empty if and only if `type` is `"Limited"`.
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        `type` indicates whether this priority level is subject to limitation on request execution.  A value of `"Exempt"` means that requests of this priority level are not subject to a limit (and thus are never queued) and do not detract from the capacity made available to other priority levels.  A value of `"Limited"` means that (a) requests of this priority level _are_ subject to limits and (b) some of the server's limited capacity is made available exclusively to this priority level. Required.
+        """
+elif False:
+    PriorityLevelConfigurationSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class PriorityLevelConfigurationSpecPatchArgs:
@@ -1051,6 +1484,22 @@ class PriorityLevelConfigurationSpecPatchArgs:
         pulumi.set(self, "type", value)
 
 
+if not MYPY:
+    class PriorityLevelConfigurationSpecArgsDict(TypedDict):
+        """
+        PriorityLevelConfigurationSpec specifies the configuration of a priority level.
+        """
+        type: pulumi.Input[str]
+        """
+        `type` indicates whether this priority level is subject to limitation on request execution.  A value of `"Exempt"` means that requests of this priority level are not subject to a limit (and thus are never queued) and do not detract from the capacity made available to other priority levels.  A value of `"Limited"` means that (a) requests of this priority level _are_ subject to limits and (b) some of the server's limited capacity is made available exclusively to this priority level. Required.
+        """
+        limited: NotRequired[pulumi.Input['LimitedPriorityLevelConfigurationArgsDict']]
+        """
+        `limited` specifies how requests are handled for a Limited priority level. This field must be non-empty if and only if `type` is `"Limited"`.
+        """
+elif False:
+    PriorityLevelConfigurationSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PriorityLevelConfigurationSpecArgs:
     def __init__(__self__, *,
@@ -1090,6 +1539,18 @@ class PriorityLevelConfigurationSpecArgs:
         pulumi.set(self, "limited", value)
 
 
+if not MYPY:
+    class PriorityLevelConfigurationStatusArgsDict(TypedDict):
+        """
+        PriorityLevelConfigurationStatus represents the current state of a "request-priority".
+        """
+        conditions: NotRequired[pulumi.Input[Sequence[pulumi.Input['PriorityLevelConfigurationConditionArgsDict']]]]
+        """
+        `conditions` is the current state of "request-priority".
+        """
+elif False:
+    PriorityLevelConfigurationStatusArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PriorityLevelConfigurationStatusArgs:
     def __init__(__self__, *,
@@ -1113,6 +1574,34 @@ class PriorityLevelConfigurationStatusArgs:
     def conditions(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['PriorityLevelConfigurationConditionArgs']]]]):
         pulumi.set(self, "conditions", value)
 
+
+if not MYPY:
+    class PriorityLevelConfigurationArgsDict(TypedDict):
+        """
+        PriorityLevelConfiguration represents the configuration of a priority level.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['PriorityLevelConfigurationSpecArgsDict']]
+        """
+        `spec` is the specification of the desired behavior of a "request-priority". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+        status: NotRequired[pulumi.Input['PriorityLevelConfigurationStatusArgsDict']]
+        """
+        `status` is the current status of a "request-priority". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+elif False:
+    PriorityLevelConfigurationArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class PriorityLevelConfigurationArgs:
@@ -1202,6 +1691,26 @@ class PriorityLevelConfigurationArgs:
         pulumi.set(self, "status", value)
 
 
+if not MYPY:
+    class QueuingConfigurationPatchArgsDict(TypedDict):
+        """
+        QueuingConfiguration holds the configuration parameters for queuing
+        """
+        hand_size: NotRequired[pulumi.Input[int]]
+        """
+        `handSize` is a small positive number that configures the shuffle sharding of requests into queues.  When enqueuing a request at this priority level the request's flow identifier (a string pair) is hashed and the hash value is used to shuffle the list of queues and deal a hand of the size specified here.  The request is put into one of the shortest queues in that hand. `handSize` must be no larger than `queues`, and should be significantly smaller (so that a few heavy flows do not saturate most of the queues).  See the user-facing documentation for more extensive guidance on setting this field.  This field has a default value of 8.
+        """
+        queue_length_limit: NotRequired[pulumi.Input[int]]
+        """
+        `queueLengthLimit` is the maximum number of requests allowed to be waiting in a given queue of this priority level at a time; excess requests are rejected.  This value must be positive.  If not specified, it will be defaulted to 50.
+        """
+        queues: NotRequired[pulumi.Input[int]]
+        """
+        `queues` is the number of queues for this priority level. The queues exist independently at each apiserver. The value must be positive.  Setting it to 1 effectively precludes shufflesharding and thus makes the distinguisher method of associated flow schemas irrelevant.  This field has a default value of 64.
+        """
+elif False:
+    QueuingConfigurationPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class QueuingConfigurationPatchArgs:
     def __init__(__self__, *,
@@ -1258,6 +1767,26 @@ class QueuingConfigurationPatchArgs:
         pulumi.set(self, "queues", value)
 
 
+if not MYPY:
+    class QueuingConfigurationArgsDict(TypedDict):
+        """
+        QueuingConfiguration holds the configuration parameters for queuing
+        """
+        hand_size: NotRequired[pulumi.Input[int]]
+        """
+        `handSize` is a small positive number that configures the shuffle sharding of requests into queues.  When enqueuing a request at this priority level the request's flow identifier (a string pair) is hashed and the hash value is used to shuffle the list of queues and deal a hand of the size specified here.  The request is put into one of the shortest queues in that hand. `handSize` must be no larger than `queues`, and should be significantly smaller (so that a few heavy flows do not saturate most of the queues).  See the user-facing documentation for more extensive guidance on setting this field.  This field has a default value of 8.
+        """
+        queue_length_limit: NotRequired[pulumi.Input[int]]
+        """
+        `queueLengthLimit` is the maximum number of requests allowed to be waiting in a given queue of this priority level at a time; excess requests are rejected.  This value must be positive.  If not specified, it will be defaulted to 50.
+        """
+        queues: NotRequired[pulumi.Input[int]]
+        """
+        `queues` is the number of queues for this priority level. The queues exist independently at each apiserver. The value must be positive.  Setting it to 1 effectively precludes shufflesharding and thus makes the distinguisher method of associated flow schemas irrelevant.  This field has a default value of 64.
+        """
+elif False:
+    QueuingConfigurationArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class QueuingConfigurationArgs:
     def __init__(__self__, *,
@@ -1313,6 +1842,34 @@ class QueuingConfigurationArgs:
     def queues(self, value: Optional[pulumi.Input[int]]):
         pulumi.set(self, "queues", value)
 
+
+if not MYPY:
+    class ResourcePolicyRulePatchArgsDict(TypedDict):
+        """
+        ResourcePolicyRule is a predicate that matches some resource requests, testing the request's verb and the target resource. A ResourcePolicyRule matches a resource request if and only if: (a) at least one member of verbs matches the request, (b) at least one member of apiGroups matches the request, (c) at least one member of resources matches the request, and (d) least one member of namespaces matches the request.
+        """
+        api_groups: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        `apiGroups` is a list of matching API groups and may not be empty. "*" matches all API groups and, if present, must be the only entry. Required.
+        """
+        cluster_scope: NotRequired[pulumi.Input[bool]]
+        """
+        `clusterScope` indicates whether to match requests that do not specify a namespace (which happens either because the resource is not namespaced or the request targets all namespaces). If this field is omitted or false then the `namespaces` field must contain a non-empty list.
+        """
+        namespaces: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        `namespaces` is a list of target namespaces that restricts matches.  A request that specifies a target namespace matches only if either (a) this list contains that target namespace or (b) this list contains "*".  Note that "*" matches any specified namespace but does not match a request that _does not specify_ a namespace (see the `clusterScope` field for that). This list may be empty, but only if `clusterScope` is true.
+        """
+        resources: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        `resources` is a list of matching resources (i.e., lowercase and plural) with, if desired, subresource.  For example, [ "services", "nodes/status" ].  This list may not be empty. "*" matches all resources and, if present, must be the only entry. Required.
+        """
+        verbs: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        `verbs` is a list of matching verbs and may not be empty. "*" matches all verbs and, if present, must be the only entry. Required.
+        """
+elif False:
+    ResourcePolicyRulePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ResourcePolicyRulePatchArgs:
@@ -1402,6 +1959,34 @@ class ResourcePolicyRulePatchArgs:
         pulumi.set(self, "verbs", value)
 
 
+if not MYPY:
+    class ResourcePolicyRuleArgsDict(TypedDict):
+        """
+        ResourcePolicyRule is a predicate that matches some resource requests, testing the request's verb and the target resource. A ResourcePolicyRule matches a resource request if and only if: (a) at least one member of verbs matches the request, (b) at least one member of apiGroups matches the request, (c) at least one member of resources matches the request, and (d) least one member of namespaces matches the request.
+        """
+        api_groups: pulumi.Input[Sequence[pulumi.Input[str]]]
+        """
+        `apiGroups` is a list of matching API groups and may not be empty. "*" matches all API groups and, if present, must be the only entry. Required.
+        """
+        resources: pulumi.Input[Sequence[pulumi.Input[str]]]
+        """
+        `resources` is a list of matching resources (i.e., lowercase and plural) with, if desired, subresource.  For example, [ "services", "nodes/status" ].  This list may not be empty. "*" matches all resources and, if present, must be the only entry. Required.
+        """
+        verbs: pulumi.Input[Sequence[pulumi.Input[str]]]
+        """
+        `verbs` is a list of matching verbs and may not be empty. "*" matches all verbs and, if present, must be the only entry. Required.
+        """
+        cluster_scope: NotRequired[pulumi.Input[bool]]
+        """
+        `clusterScope` indicates whether to match requests that do not specify a namespace (which happens either because the resource is not namespaced or the request targets all namespaces). If this field is omitted or false then the `namespaces` field must contain a non-empty list.
+        """
+        namespaces: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        `namespaces` is a list of target namespaces that restricts matches.  A request that specifies a target namespace matches only if either (a) this list contains that target namespace or (b) this list contains "*".  Note that "*" matches any specified namespace but does not match a request that _does not specify_ a namespace (see the `clusterScope` field for that). This list may be empty, but only if `clusterScope` is true.
+        """
+elif False:
+    ResourcePolicyRuleArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ResourcePolicyRuleArgs:
     def __init__(__self__, *,
@@ -1487,6 +2072,22 @@ class ResourcePolicyRuleArgs:
         pulumi.set(self, "namespaces", value)
 
 
+if not MYPY:
+    class ServiceAccountSubjectPatchArgsDict(TypedDict):
+        """
+        ServiceAccountSubject holds detailed information for service-account-kind subject.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        `name` is the name of matching ServiceAccount objects, or "*" to match regardless of name. Required.
+        """
+        namespace: NotRequired[pulumi.Input[str]]
+        """
+        `namespace` is the namespace of matching ServiceAccount objects. Required.
+        """
+elif False:
+    ServiceAccountSubjectPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ServiceAccountSubjectPatchArgs:
     def __init__(__self__, *,
@@ -1527,6 +2128,22 @@ class ServiceAccountSubjectPatchArgs:
         pulumi.set(self, "namespace", value)
 
 
+if not MYPY:
+    class ServiceAccountSubjectArgsDict(TypedDict):
+        """
+        ServiceAccountSubject holds detailed information for service-account-kind subject.
+        """
+        name: pulumi.Input[str]
+        """
+        `name` is the name of matching ServiceAccount objects, or "*" to match regardless of name. Required.
+        """
+        namespace: pulumi.Input[str]
+        """
+        `namespace` is the namespace of matching ServiceAccount objects. Required.
+        """
+elif False:
+    ServiceAccountSubjectArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ServiceAccountSubjectArgs:
     def __init__(__self__, *,
@@ -1564,6 +2181,21 @@ class ServiceAccountSubjectArgs:
     def namespace(self, value: pulumi.Input[str]):
         pulumi.set(self, "namespace", value)
 
+
+if not MYPY:
+    class SubjectPatchArgsDict(TypedDict):
+        """
+        Subject matches the originator of a request, as identified by the request authentication system. There are three ways of matching an originator; by user, group, or service account.
+        """
+        group: NotRequired[pulumi.Input['GroupSubjectPatchArgsDict']]
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Required
+        """
+        service_account: NotRequired[pulumi.Input['ServiceAccountSubjectPatchArgsDict']]
+        user: NotRequired[pulumi.Input['UserSubjectPatchArgsDict']]
+elif False:
+    SubjectPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class SubjectPatchArgs:
@@ -1625,6 +2257,21 @@ class SubjectPatchArgs:
         pulumi.set(self, "user", value)
 
 
+if not MYPY:
+    class SubjectArgsDict(TypedDict):
+        """
+        Subject matches the originator of a request, as identified by the request authentication system. There are three ways of matching an originator; by user, group, or service account.
+        """
+        kind: pulumi.Input[str]
+        """
+        Required
+        """
+        group: NotRequired[pulumi.Input['GroupSubjectArgsDict']]
+        service_account: NotRequired[pulumi.Input['ServiceAccountSubjectArgsDict']]
+        user: NotRequired[pulumi.Input['UserSubjectArgsDict']]
+elif False:
+    SubjectArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class SubjectArgs:
     def __init__(__self__, *,
@@ -1684,6 +2331,18 @@ class SubjectArgs:
         pulumi.set(self, "user", value)
 
 
+if not MYPY:
+    class UserSubjectPatchArgsDict(TypedDict):
+        """
+        UserSubject holds detailed information for user-kind subject.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        `name` is the username that matches, or "*" to match all usernames. Required.
+        """
+elif False:
+    UserSubjectPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class UserSubjectPatchArgs:
     def __init__(__self__, *,
@@ -1707,6 +2366,18 @@ class UserSubjectPatchArgs:
     def name(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "name", value)
 
+
+if not MYPY:
+    class UserSubjectArgsDict(TypedDict):
+        """
+        UserSubject holds detailed information for user-kind subject.
+        """
+        name: pulumi.Input[str]
+        """
+        `name` is the username that matches, or "*" to match all usernames. Required.
+        """
+elif False:
+    UserSubjectArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class UserSubjectArgs:

--- a/sdk/python/pulumi_kubernetes/flowcontrol/v1alpha1/outputs.py
+++ b/sdk/python/pulumi_kubernetes/flowcontrol/v1alpha1/outputs.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta

--- a/sdk/python/pulumi_kubernetes/flowcontrol/v1beta1/FlowSchema.py
+++ b/sdk/python/pulumi_kubernetes/flowcontrol/v1beta1/FlowSchema.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class FlowSchema(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['FlowSchemaSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['FlowSchemaSpecArgs', 'FlowSchemaSpecArgsDict']]] = None,
                  __props__=None):
         """
         FlowSchema defines the schema of a group of flows. Note that a flow is made up of a set of inbound API requests with similar attributes and is identified by a pair of strings: the name of the FlowSchema and a "flow distinguisher".
@@ -103,8 +108,8 @@ class FlowSchema(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['FlowSchemaSpecArgs']] spec: `spec` is the specification of the desired behavior of a FlowSchema. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['FlowSchemaSpecArgs', 'FlowSchemaSpecArgsDict']] spec: `spec` is the specification of the desired behavior of a FlowSchema. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -132,8 +137,8 @@ class FlowSchema(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['FlowSchemaSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['FlowSchemaSpecArgs', 'FlowSchemaSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/flowcontrol/v1beta1/FlowSchemaList.py
+++ b/sdk/python/pulumi_kubernetes/flowcontrol/v1beta1/FlowSchemaList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class FlowSchemaList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['FlowSchemaArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['FlowSchemaArgs', 'FlowSchemaArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         FlowSchemaList is a list of FlowSchema objects.
@@ -101,9 +106,9 @@ class FlowSchemaList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['FlowSchemaArgs']]]] items: `items` is a list of FlowSchemas.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['FlowSchemaArgs', 'FlowSchemaArgsDict']]]] items: `items` is a list of FlowSchemas.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: `metadata` is the standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: `metadata` is the standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class FlowSchemaList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['FlowSchemaArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['FlowSchemaArgs', 'FlowSchemaArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/flowcontrol/v1beta1/FlowSchemaPatch.py
+++ b/sdk/python/pulumi_kubernetes/flowcontrol/v1beta1/FlowSchemaPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class FlowSchemaPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['FlowSchemaSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['FlowSchemaSpecPatchArgs', 'FlowSchemaSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -109,8 +114,8 @@ class FlowSchemaPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['FlowSchemaSpecPatchArgs']] spec: `spec` is the specification of the desired behavior of a FlowSchema. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['FlowSchemaSpecPatchArgs', 'FlowSchemaSpecPatchArgsDict']] spec: `spec` is the specification of the desired behavior of a FlowSchema. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -144,8 +149,8 @@ class FlowSchemaPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['FlowSchemaSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['FlowSchemaSpecPatchArgs', 'FlowSchemaSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/flowcontrol/v1beta1/PriorityLevelConfiguration.py
+++ b/sdk/python/pulumi_kubernetes/flowcontrol/v1beta1/PriorityLevelConfiguration.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class PriorityLevelConfiguration(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PriorityLevelConfigurationSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PriorityLevelConfigurationSpecArgs', 'PriorityLevelConfigurationSpecArgsDict']]] = None,
                  __props__=None):
         """
         PriorityLevelConfiguration represents the configuration of a priority level.
@@ -103,8 +108,8 @@ class PriorityLevelConfiguration(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['PriorityLevelConfigurationSpecArgs']] spec: `spec` is the specification of the desired behavior of a "request-priority". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['PriorityLevelConfigurationSpecArgs', 'PriorityLevelConfigurationSpecArgsDict']] spec: `spec` is the specification of the desired behavior of a "request-priority". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -132,8 +137,8 @@ class PriorityLevelConfiguration(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PriorityLevelConfigurationSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PriorityLevelConfigurationSpecArgs', 'PriorityLevelConfigurationSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/flowcontrol/v1beta1/PriorityLevelConfigurationList.py
+++ b/sdk/python/pulumi_kubernetes/flowcontrol/v1beta1/PriorityLevelConfigurationList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class PriorityLevelConfigurationList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PriorityLevelConfigurationArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PriorityLevelConfigurationArgs', 'PriorityLevelConfigurationArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         PriorityLevelConfigurationList is a list of PriorityLevelConfiguration objects.
@@ -101,9 +106,9 @@ class PriorityLevelConfigurationList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PriorityLevelConfigurationArgs']]]] items: `items` is a list of request-priorities.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['PriorityLevelConfigurationArgs', 'PriorityLevelConfigurationArgsDict']]]] items: `items` is a list of request-priorities.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class PriorityLevelConfigurationList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PriorityLevelConfigurationArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PriorityLevelConfigurationArgs', 'PriorityLevelConfigurationArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/flowcontrol/v1beta1/PriorityLevelConfigurationPatch.py
+++ b/sdk/python/pulumi_kubernetes/flowcontrol/v1beta1/PriorityLevelConfigurationPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class PriorityLevelConfigurationPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PriorityLevelConfigurationSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PriorityLevelConfigurationSpecPatchArgs', 'PriorityLevelConfigurationSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -109,8 +114,8 @@ class PriorityLevelConfigurationPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['PriorityLevelConfigurationSpecPatchArgs']] spec: `spec` is the specification of the desired behavior of a "request-priority". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['PriorityLevelConfigurationSpecPatchArgs', 'PriorityLevelConfigurationSpecPatchArgsDict']] spec: `spec` is the specification of the desired behavior of a "request-priority". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -144,8 +149,8 @@ class PriorityLevelConfigurationPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PriorityLevelConfigurationSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PriorityLevelConfigurationSpecPatchArgs', 'PriorityLevelConfigurationSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/flowcontrol/v1beta1/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/flowcontrol/v1beta1/_inputs.py
@@ -4,48 +4,101 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import meta as _meta
 
 __all__ = [
     'FlowDistinguisherMethodPatchArgs',
+    'FlowDistinguisherMethodPatchArgsDict',
     'FlowDistinguisherMethodArgs',
+    'FlowDistinguisherMethodArgsDict',
     'FlowSchemaConditionArgs',
+    'FlowSchemaConditionArgsDict',
     'FlowSchemaSpecPatchArgs',
+    'FlowSchemaSpecPatchArgsDict',
     'FlowSchemaSpecArgs',
+    'FlowSchemaSpecArgsDict',
     'FlowSchemaStatusArgs',
+    'FlowSchemaStatusArgsDict',
     'FlowSchemaArgs',
+    'FlowSchemaArgsDict',
     'GroupSubjectPatchArgs',
+    'GroupSubjectPatchArgsDict',
     'GroupSubjectArgs',
+    'GroupSubjectArgsDict',
     'LimitResponsePatchArgs',
+    'LimitResponsePatchArgsDict',
     'LimitResponseArgs',
+    'LimitResponseArgsDict',
     'LimitedPriorityLevelConfigurationPatchArgs',
+    'LimitedPriorityLevelConfigurationPatchArgsDict',
     'LimitedPriorityLevelConfigurationArgs',
+    'LimitedPriorityLevelConfigurationArgsDict',
     'NonResourcePolicyRulePatchArgs',
+    'NonResourcePolicyRulePatchArgsDict',
     'NonResourcePolicyRuleArgs',
+    'NonResourcePolicyRuleArgsDict',
     'PolicyRulesWithSubjectsPatchArgs',
+    'PolicyRulesWithSubjectsPatchArgsDict',
     'PolicyRulesWithSubjectsArgs',
+    'PolicyRulesWithSubjectsArgsDict',
     'PriorityLevelConfigurationConditionArgs',
+    'PriorityLevelConfigurationConditionArgsDict',
     'PriorityLevelConfigurationReferencePatchArgs',
+    'PriorityLevelConfigurationReferencePatchArgsDict',
     'PriorityLevelConfigurationReferenceArgs',
+    'PriorityLevelConfigurationReferenceArgsDict',
     'PriorityLevelConfigurationSpecPatchArgs',
+    'PriorityLevelConfigurationSpecPatchArgsDict',
     'PriorityLevelConfigurationSpecArgs',
+    'PriorityLevelConfigurationSpecArgsDict',
     'PriorityLevelConfigurationStatusArgs',
+    'PriorityLevelConfigurationStatusArgsDict',
     'PriorityLevelConfigurationArgs',
+    'PriorityLevelConfigurationArgsDict',
     'QueuingConfigurationPatchArgs',
+    'QueuingConfigurationPatchArgsDict',
     'QueuingConfigurationArgs',
+    'QueuingConfigurationArgsDict',
     'ResourcePolicyRulePatchArgs',
+    'ResourcePolicyRulePatchArgsDict',
     'ResourcePolicyRuleArgs',
+    'ResourcePolicyRuleArgsDict',
     'ServiceAccountSubjectPatchArgs',
+    'ServiceAccountSubjectPatchArgsDict',
     'ServiceAccountSubjectArgs',
+    'ServiceAccountSubjectArgsDict',
     'SubjectPatchArgs',
+    'SubjectPatchArgsDict',
     'SubjectArgs',
+    'SubjectArgsDict',
     'UserSubjectPatchArgs',
+    'UserSubjectPatchArgsDict',
     'UserSubjectArgs',
+    'UserSubjectArgsDict',
 ]
+
+MYPY = False
+
+if not MYPY:
+    class FlowDistinguisherMethodPatchArgsDict(TypedDict):
+        """
+        FlowDistinguisherMethod specifies the method of a flow distinguisher.
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        `type` is the type of flow distinguisher method The supported types are "ByUser" and "ByNamespace". Required.
+        """
+elif False:
+    FlowDistinguisherMethodPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class FlowDistinguisherMethodPatchArgs:
@@ -71,6 +124,18 @@ class FlowDistinguisherMethodPatchArgs:
         pulumi.set(self, "type", value)
 
 
+if not MYPY:
+    class FlowDistinguisherMethodArgsDict(TypedDict):
+        """
+        FlowDistinguisherMethod specifies the method of a flow distinguisher.
+        """
+        type: pulumi.Input[str]
+        """
+        `type` is the type of flow distinguisher method The supported types are "ByUser" and "ByNamespace". Required.
+        """
+elif False:
+    FlowDistinguisherMethodArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class FlowDistinguisherMethodArgs:
     def __init__(__self__, *,
@@ -93,6 +158,34 @@ class FlowDistinguisherMethodArgs:
     def type(self, value: pulumi.Input[str]):
         pulumi.set(self, "type", value)
 
+
+if not MYPY:
+    class FlowSchemaConditionArgsDict(TypedDict):
+        """
+        FlowSchemaCondition describes conditions for a FlowSchema.
+        """
+        last_transition_time: NotRequired[pulumi.Input[str]]
+        """
+        `lastTransitionTime` is the last time the condition transitioned from one status to another.
+        """
+        message: NotRequired[pulumi.Input[str]]
+        """
+        `message` is a human-readable message indicating details about last transition.
+        """
+        reason: NotRequired[pulumi.Input[str]]
+        """
+        `reason` is a unique, one-word, CamelCase reason for the condition's last transition.
+        """
+        status: NotRequired[pulumi.Input[str]]
+        """
+        `status` is the status of the condition. Can be True, False, Unknown. Required.
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        `type` is the type of the condition. Required.
+        """
+elif False:
+    FlowSchemaConditionArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class FlowSchemaConditionArgs:
@@ -182,6 +275,30 @@ class FlowSchemaConditionArgs:
         pulumi.set(self, "type", value)
 
 
+if not MYPY:
+    class FlowSchemaSpecPatchArgsDict(TypedDict):
+        """
+        FlowSchemaSpec describes how the FlowSchema's specification looks like.
+        """
+        distinguisher_method: NotRequired[pulumi.Input['FlowDistinguisherMethodPatchArgsDict']]
+        """
+        `distinguisherMethod` defines how to compute the flow distinguisher for requests that match this schema. `nil` specifies that the distinguisher is disabled and thus will always be the empty string.
+        """
+        matching_precedence: NotRequired[pulumi.Input[int]]
+        """
+        `matchingPrecedence` is used to choose among the FlowSchemas that match a given request. The chosen FlowSchema is among those with the numerically lowest (which we take to be logically highest) MatchingPrecedence.  Each MatchingPrecedence value must be ranged in [1,10000]. Note that if the precedence is not specified, it will be set to 1000 as default.
+        """
+        priority_level_configuration: NotRequired[pulumi.Input['PriorityLevelConfigurationReferencePatchArgsDict']]
+        """
+        `priorityLevelConfiguration` should reference a PriorityLevelConfiguration in the cluster. If the reference cannot be resolved, the FlowSchema will be ignored and marked as invalid in its status. Required.
+        """
+        rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['PolicyRulesWithSubjectsPatchArgsDict']]]]
+        """
+        `rules` describes which requests will match this flow schema. This FlowSchema matches a request if and only if at least one member of rules matches the request. if it is an empty slice, there will be no requests matching the FlowSchema.
+        """
+elif False:
+    FlowSchemaSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class FlowSchemaSpecPatchArgs:
     def __init__(__self__, *,
@@ -254,6 +371,30 @@ class FlowSchemaSpecPatchArgs:
         pulumi.set(self, "rules", value)
 
 
+if not MYPY:
+    class FlowSchemaSpecArgsDict(TypedDict):
+        """
+        FlowSchemaSpec describes how the FlowSchema's specification looks like.
+        """
+        priority_level_configuration: pulumi.Input['PriorityLevelConfigurationReferenceArgsDict']
+        """
+        `priorityLevelConfiguration` should reference a PriorityLevelConfiguration in the cluster. If the reference cannot be resolved, the FlowSchema will be ignored and marked as invalid in its status. Required.
+        """
+        distinguisher_method: NotRequired[pulumi.Input['FlowDistinguisherMethodArgsDict']]
+        """
+        `distinguisherMethod` defines how to compute the flow distinguisher for requests that match this schema. `nil` specifies that the distinguisher is disabled and thus will always be the empty string.
+        """
+        matching_precedence: NotRequired[pulumi.Input[int]]
+        """
+        `matchingPrecedence` is used to choose among the FlowSchemas that match a given request. The chosen FlowSchema is among those with the numerically lowest (which we take to be logically highest) MatchingPrecedence.  Each MatchingPrecedence value must be ranged in [1,10000]. Note that if the precedence is not specified, it will be set to 1000 as default.
+        """
+        rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['PolicyRulesWithSubjectsArgsDict']]]]
+        """
+        `rules` describes which requests will match this flow schema. This FlowSchema matches a request if and only if at least one member of rules matches the request. if it is an empty slice, there will be no requests matching the FlowSchema.
+        """
+elif False:
+    FlowSchemaSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class FlowSchemaSpecArgs:
     def __init__(__self__, *,
@@ -325,6 +466,18 @@ class FlowSchemaSpecArgs:
         pulumi.set(self, "rules", value)
 
 
+if not MYPY:
+    class FlowSchemaStatusArgsDict(TypedDict):
+        """
+        FlowSchemaStatus represents the current state of a FlowSchema.
+        """
+        conditions: NotRequired[pulumi.Input[Sequence[pulumi.Input['FlowSchemaConditionArgsDict']]]]
+        """
+        `conditions` is a list of the current states of FlowSchema.
+        """
+elif False:
+    FlowSchemaStatusArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class FlowSchemaStatusArgs:
     def __init__(__self__, *,
@@ -348,6 +501,34 @@ class FlowSchemaStatusArgs:
     def conditions(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['FlowSchemaConditionArgs']]]]):
         pulumi.set(self, "conditions", value)
 
+
+if not MYPY:
+    class FlowSchemaArgsDict(TypedDict):
+        """
+        FlowSchema defines the schema of a group of flows. Note that a flow is made up of a set of inbound API requests with similar attributes and is identified by a pair of strings: the name of the FlowSchema and a "flow distinguisher".
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['FlowSchemaSpecArgsDict']]
+        """
+        `spec` is the specification of the desired behavior of a FlowSchema. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+        status: NotRequired[pulumi.Input['FlowSchemaStatusArgsDict']]
+        """
+        `status` is the current status of a FlowSchema. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+elif False:
+    FlowSchemaArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class FlowSchemaArgs:
@@ -437,6 +618,18 @@ class FlowSchemaArgs:
         pulumi.set(self, "status", value)
 
 
+if not MYPY:
+    class GroupSubjectPatchArgsDict(TypedDict):
+        """
+        GroupSubject holds detailed information for group-kind subject.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        name is the user group that matches, or "*" to match all user groups. See https://github.com/kubernetes/apiserver/blob/master/pkg/authentication/user/user.go for some well-known group names. Required.
+        """
+elif False:
+    GroupSubjectPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class GroupSubjectPatchArgs:
     def __init__(__self__, *,
@@ -461,6 +654,18 @@ class GroupSubjectPatchArgs:
         pulumi.set(self, "name", value)
 
 
+if not MYPY:
+    class GroupSubjectArgsDict(TypedDict):
+        """
+        GroupSubject holds detailed information for group-kind subject.
+        """
+        name: pulumi.Input[str]
+        """
+        name is the user group that matches, or "*" to match all user groups. See https://github.com/kubernetes/apiserver/blob/master/pkg/authentication/user/user.go for some well-known group names. Required.
+        """
+elif False:
+    GroupSubjectArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class GroupSubjectArgs:
     def __init__(__self__, *,
@@ -483,6 +688,22 @@ class GroupSubjectArgs:
     def name(self, value: pulumi.Input[str]):
         pulumi.set(self, "name", value)
 
+
+if not MYPY:
+    class LimitResponsePatchArgsDict(TypedDict):
+        """
+        LimitResponse defines how to handle requests that can not be executed right now.
+        """
+        queuing: NotRequired[pulumi.Input['QueuingConfigurationPatchArgsDict']]
+        """
+        `queuing` holds the configuration parameters for queuing. This field may be non-empty only if `type` is `"Queue"`.
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        `type` is "Queue" or "Reject". "Queue" means that requests that can not be executed upon arrival are held in a queue until they can be executed or a queuing limit is reached. "Reject" means that requests that can not be executed upon arrival are rejected. Required.
+        """
+elif False:
+    LimitResponsePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class LimitResponsePatchArgs:
@@ -524,6 +745,22 @@ class LimitResponsePatchArgs:
         pulumi.set(self, "type", value)
 
 
+if not MYPY:
+    class LimitResponseArgsDict(TypedDict):
+        """
+        LimitResponse defines how to handle requests that can not be executed right now.
+        """
+        type: pulumi.Input[str]
+        """
+        `type` is "Queue" or "Reject". "Queue" means that requests that can not be executed upon arrival are held in a queue until they can be executed or a queuing limit is reached. "Reject" means that requests that can not be executed upon arrival are rejected. Required.
+        """
+        queuing: NotRequired[pulumi.Input['QueuingConfigurationArgsDict']]
+        """
+        `queuing` holds the configuration parameters for queuing. This field may be non-empty only if `type` is `"Queue"`.
+        """
+elif False:
+    LimitResponseArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class LimitResponseArgs:
     def __init__(__self__, *,
@@ -562,6 +799,28 @@ class LimitResponseArgs:
     def queuing(self, value: Optional[pulumi.Input['QueuingConfigurationArgs']]):
         pulumi.set(self, "queuing", value)
 
+
+if not MYPY:
+    class LimitedPriorityLevelConfigurationPatchArgsDict(TypedDict):
+        """
+        LimitedPriorityLevelConfiguration specifies how to handle requests that are subject to limits. It addresses two issues:
+         * How are requests for this priority level limited?
+         * What should be done with requests that exceed the limit?
+        """
+        assured_concurrency_shares: NotRequired[pulumi.Input[int]]
+        """
+        `assuredConcurrencyShares` (ACS) configures the execution limit, which is a limit on the number of requests of this priority level that may be exeucting at a given time.  ACS must be a positive number. The server's concurrency limit (SCL) is divided among the concurrency-controlled priority levels in proportion to their assured concurrency shares. This produces the assured concurrency value (ACV) --- the number of requests that may be executing at a time --- for each such priority level:
+
+                    ACV(l) = ceil( SCL * ACS(l) / ( sum[priority levels k] ACS(k) ) )
+
+        bigger numbers of ACS mean more reserved concurrent requests (at the expense of every other PL). This field has a default value of 30.
+        """
+        limit_response: NotRequired[pulumi.Input['LimitResponsePatchArgsDict']]
+        """
+        `limitResponse` indicates what to do with requests that can not be executed right now
+        """
+elif False:
+    LimitedPriorityLevelConfigurationPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class LimitedPriorityLevelConfigurationPatchArgs:
@@ -613,6 +872,28 @@ class LimitedPriorityLevelConfigurationPatchArgs:
         pulumi.set(self, "limit_response", value)
 
 
+if not MYPY:
+    class LimitedPriorityLevelConfigurationArgsDict(TypedDict):
+        """
+        LimitedPriorityLevelConfiguration specifies how to handle requests that are subject to limits. It addresses two issues:
+         * How are requests for this priority level limited?
+         * What should be done with requests that exceed the limit?
+        """
+        assured_concurrency_shares: NotRequired[pulumi.Input[int]]
+        """
+        `assuredConcurrencyShares` (ACS) configures the execution limit, which is a limit on the number of requests of this priority level that may be exeucting at a given time.  ACS must be a positive number. The server's concurrency limit (SCL) is divided among the concurrency-controlled priority levels in proportion to their assured concurrency shares. This produces the assured concurrency value (ACV) --- the number of requests that may be executing at a time --- for each such priority level:
+
+                    ACV(l) = ceil( SCL * ACS(l) / ( sum[priority levels k] ACS(k) ) )
+
+        bigger numbers of ACS mean more reserved concurrent requests (at the expense of every other PL). This field has a default value of 30.
+        """
+        limit_response: NotRequired[pulumi.Input['LimitResponseArgsDict']]
+        """
+        `limitResponse` indicates what to do with requests that can not be executed right now
+        """
+elif False:
+    LimitedPriorityLevelConfigurationArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class LimitedPriorityLevelConfigurationArgs:
     def __init__(__self__, *,
@@ -662,6 +943,28 @@ class LimitedPriorityLevelConfigurationArgs:
     def limit_response(self, value: Optional[pulumi.Input['LimitResponseArgs']]):
         pulumi.set(self, "limit_response", value)
 
+
+if not MYPY:
+    class NonResourcePolicyRulePatchArgsDict(TypedDict):
+        """
+        NonResourcePolicyRule is a predicate that matches non-resource requests according to their verb and the target non-resource URL. A NonResourcePolicyRule matches a request if and only if both (a) at least one member of verbs matches the request and (b) at least one member of nonResourceURLs matches the request.
+        """
+        non_resource_urls: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        `nonResourceURLs` is a set of url prefixes that a user should have access to and may not be empty. For example:
+          - "/healthz" is legal
+          - "/hea*" is illegal
+          - "/hea" is legal but matches nothing
+          - "/hea/*" also matches nothing
+          - "/healthz/*" matches all per-component health checks.
+        "*" matches all non-resource urls. if it is present, it must be the only entry. Required.
+        """
+        verbs: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        `verbs` is a list of matching verbs and may not be empty. "*" matches all verbs. If it is present, it must be the only entry. Required.
+        """
+elif False:
+    NonResourcePolicyRulePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class NonResourcePolicyRulePatchArgs:
@@ -715,6 +1018,28 @@ class NonResourcePolicyRulePatchArgs:
         pulumi.set(self, "verbs", value)
 
 
+if not MYPY:
+    class NonResourcePolicyRuleArgsDict(TypedDict):
+        """
+        NonResourcePolicyRule is a predicate that matches non-resource requests according to their verb and the target non-resource URL. A NonResourcePolicyRule matches a request if and only if both (a) at least one member of verbs matches the request and (b) at least one member of nonResourceURLs matches the request.
+        """
+        non_resource_urls: pulumi.Input[Sequence[pulumi.Input[str]]]
+        """
+        `nonResourceURLs` is a set of url prefixes that a user should have access to and may not be empty. For example:
+          - "/healthz" is legal
+          - "/hea*" is illegal
+          - "/hea" is legal but matches nothing
+          - "/hea/*" also matches nothing
+          - "/healthz/*" matches all per-component health checks.
+        "*" matches all non-resource urls. if it is present, it must be the only entry. Required.
+        """
+        verbs: pulumi.Input[Sequence[pulumi.Input[str]]]
+        """
+        `verbs` is a list of matching verbs and may not be empty. "*" matches all verbs. If it is present, it must be the only entry. Required.
+        """
+elif False:
+    NonResourcePolicyRuleArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class NonResourcePolicyRuleArgs:
     def __init__(__self__, *,
@@ -764,6 +1089,26 @@ class NonResourcePolicyRuleArgs:
     def verbs(self, value: pulumi.Input[Sequence[pulumi.Input[str]]]):
         pulumi.set(self, "verbs", value)
 
+
+if not MYPY:
+    class PolicyRulesWithSubjectsPatchArgsDict(TypedDict):
+        """
+        PolicyRulesWithSubjects prescribes a test that applies to a request to an apiserver. The test considers the subject making the request, the verb being requested, and the resource to be acted upon. This PolicyRulesWithSubjects matches a request if and only if both (a) at least one member of subjects matches the request and (b) at least one member of resourceRules or nonResourceRules matches the request.
+        """
+        non_resource_rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['NonResourcePolicyRulePatchArgsDict']]]]
+        """
+        `nonResourceRules` is a list of NonResourcePolicyRules that identify matching requests according to their verb and the target non-resource URL.
+        """
+        resource_rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['ResourcePolicyRulePatchArgsDict']]]]
+        """
+        `resourceRules` is a slice of ResourcePolicyRules that identify matching requests according to their verb and the target resource. At least one of `resourceRules` and `nonResourceRules` has to be non-empty.
+        """
+        subjects: NotRequired[pulumi.Input[Sequence[pulumi.Input['SubjectPatchArgsDict']]]]
+        """
+        subjects is the list of normal user, serviceaccount, or group that this rule cares about. There must be at least one member in this slice. A slice that includes both the system:authenticated and system:unauthenticated user groups matches every request. Required.
+        """
+elif False:
+    PolicyRulesWithSubjectsPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class PolicyRulesWithSubjectsPatchArgs:
@@ -821,6 +1166,26 @@ class PolicyRulesWithSubjectsPatchArgs:
         pulumi.set(self, "subjects", value)
 
 
+if not MYPY:
+    class PolicyRulesWithSubjectsArgsDict(TypedDict):
+        """
+        PolicyRulesWithSubjects prescribes a test that applies to a request to an apiserver. The test considers the subject making the request, the verb being requested, and the resource to be acted upon. This PolicyRulesWithSubjects matches a request if and only if both (a) at least one member of subjects matches the request and (b) at least one member of resourceRules or nonResourceRules matches the request.
+        """
+        subjects: pulumi.Input[Sequence[pulumi.Input['SubjectArgsDict']]]
+        """
+        subjects is the list of normal user, serviceaccount, or group that this rule cares about. There must be at least one member in this slice. A slice that includes both the system:authenticated and system:unauthenticated user groups matches every request. Required.
+        """
+        non_resource_rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['NonResourcePolicyRuleArgsDict']]]]
+        """
+        `nonResourceRules` is a list of NonResourcePolicyRules that identify matching requests according to their verb and the target non-resource URL.
+        """
+        resource_rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['ResourcePolicyRuleArgsDict']]]]
+        """
+        `resourceRules` is a slice of ResourcePolicyRules that identify matching requests according to their verb and the target resource. At least one of `resourceRules` and `nonResourceRules` has to be non-empty.
+        """
+elif False:
+    PolicyRulesWithSubjectsArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PolicyRulesWithSubjectsArgs:
     def __init__(__self__, *,
@@ -875,6 +1240,34 @@ class PolicyRulesWithSubjectsArgs:
     def resource_rules(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['ResourcePolicyRuleArgs']]]]):
         pulumi.set(self, "resource_rules", value)
 
+
+if not MYPY:
+    class PriorityLevelConfigurationConditionArgsDict(TypedDict):
+        """
+        PriorityLevelConfigurationCondition defines the condition of priority level.
+        """
+        last_transition_time: NotRequired[pulumi.Input[str]]
+        """
+        `lastTransitionTime` is the last time the condition transitioned from one status to another.
+        """
+        message: NotRequired[pulumi.Input[str]]
+        """
+        `message` is a human-readable message indicating details about last transition.
+        """
+        reason: NotRequired[pulumi.Input[str]]
+        """
+        `reason` is a unique, one-word, CamelCase reason for the condition's last transition.
+        """
+        status: NotRequired[pulumi.Input[str]]
+        """
+        `status` is the status of the condition. Can be True, False, Unknown. Required.
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        `type` is the type of the condition. Required.
+        """
+elif False:
+    PriorityLevelConfigurationConditionArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class PriorityLevelConfigurationConditionArgs:
@@ -964,6 +1357,18 @@ class PriorityLevelConfigurationConditionArgs:
         pulumi.set(self, "type", value)
 
 
+if not MYPY:
+    class PriorityLevelConfigurationReferencePatchArgsDict(TypedDict):
+        """
+        PriorityLevelConfigurationReference contains information that points to the "request-priority" being used.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        `name` is the name of the priority level configuration being referenced Required.
+        """
+elif False:
+    PriorityLevelConfigurationReferencePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PriorityLevelConfigurationReferencePatchArgs:
     def __init__(__self__, *,
@@ -988,6 +1393,18 @@ class PriorityLevelConfigurationReferencePatchArgs:
         pulumi.set(self, "name", value)
 
 
+if not MYPY:
+    class PriorityLevelConfigurationReferenceArgsDict(TypedDict):
+        """
+        PriorityLevelConfigurationReference contains information that points to the "request-priority" being used.
+        """
+        name: pulumi.Input[str]
+        """
+        `name` is the name of the priority level configuration being referenced Required.
+        """
+elif False:
+    PriorityLevelConfigurationReferenceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PriorityLevelConfigurationReferenceArgs:
     def __init__(__self__, *,
@@ -1010,6 +1427,22 @@ class PriorityLevelConfigurationReferenceArgs:
     def name(self, value: pulumi.Input[str]):
         pulumi.set(self, "name", value)
 
+
+if not MYPY:
+    class PriorityLevelConfigurationSpecPatchArgsDict(TypedDict):
+        """
+        PriorityLevelConfigurationSpec specifies the configuration of a priority level.
+        """
+        limited: NotRequired[pulumi.Input['LimitedPriorityLevelConfigurationPatchArgsDict']]
+        """
+        `limited` specifies how requests are handled for a Limited priority level. This field must be non-empty if and only if `type` is `"Limited"`.
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        `type` indicates whether this priority level is subject to limitation on request execution.  A value of `"Exempt"` means that requests of this priority level are not subject to a limit (and thus are never queued) and do not detract from the capacity made available to other priority levels.  A value of `"Limited"` means that (a) requests of this priority level _are_ subject to limits and (b) some of the server's limited capacity is made available exclusively to this priority level. Required.
+        """
+elif False:
+    PriorityLevelConfigurationSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class PriorityLevelConfigurationSpecPatchArgs:
@@ -1051,6 +1484,22 @@ class PriorityLevelConfigurationSpecPatchArgs:
         pulumi.set(self, "type", value)
 
 
+if not MYPY:
+    class PriorityLevelConfigurationSpecArgsDict(TypedDict):
+        """
+        PriorityLevelConfigurationSpec specifies the configuration of a priority level.
+        """
+        type: pulumi.Input[str]
+        """
+        `type` indicates whether this priority level is subject to limitation on request execution.  A value of `"Exempt"` means that requests of this priority level are not subject to a limit (and thus are never queued) and do not detract from the capacity made available to other priority levels.  A value of `"Limited"` means that (a) requests of this priority level _are_ subject to limits and (b) some of the server's limited capacity is made available exclusively to this priority level. Required.
+        """
+        limited: NotRequired[pulumi.Input['LimitedPriorityLevelConfigurationArgsDict']]
+        """
+        `limited` specifies how requests are handled for a Limited priority level. This field must be non-empty if and only if `type` is `"Limited"`.
+        """
+elif False:
+    PriorityLevelConfigurationSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PriorityLevelConfigurationSpecArgs:
     def __init__(__self__, *,
@@ -1090,6 +1539,18 @@ class PriorityLevelConfigurationSpecArgs:
         pulumi.set(self, "limited", value)
 
 
+if not MYPY:
+    class PriorityLevelConfigurationStatusArgsDict(TypedDict):
+        """
+        PriorityLevelConfigurationStatus represents the current state of a "request-priority".
+        """
+        conditions: NotRequired[pulumi.Input[Sequence[pulumi.Input['PriorityLevelConfigurationConditionArgsDict']]]]
+        """
+        `conditions` is the current state of "request-priority".
+        """
+elif False:
+    PriorityLevelConfigurationStatusArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PriorityLevelConfigurationStatusArgs:
     def __init__(__self__, *,
@@ -1113,6 +1574,34 @@ class PriorityLevelConfigurationStatusArgs:
     def conditions(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['PriorityLevelConfigurationConditionArgs']]]]):
         pulumi.set(self, "conditions", value)
 
+
+if not MYPY:
+    class PriorityLevelConfigurationArgsDict(TypedDict):
+        """
+        PriorityLevelConfiguration represents the configuration of a priority level.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['PriorityLevelConfigurationSpecArgsDict']]
+        """
+        `spec` is the specification of the desired behavior of a "request-priority". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+        status: NotRequired[pulumi.Input['PriorityLevelConfigurationStatusArgsDict']]
+        """
+        `status` is the current status of a "request-priority". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+elif False:
+    PriorityLevelConfigurationArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class PriorityLevelConfigurationArgs:
@@ -1202,6 +1691,26 @@ class PriorityLevelConfigurationArgs:
         pulumi.set(self, "status", value)
 
 
+if not MYPY:
+    class QueuingConfigurationPatchArgsDict(TypedDict):
+        """
+        QueuingConfiguration holds the configuration parameters for queuing
+        """
+        hand_size: NotRequired[pulumi.Input[int]]
+        """
+        `handSize` is a small positive number that configures the shuffle sharding of requests into queues.  When enqueuing a request at this priority level the request's flow identifier (a string pair) is hashed and the hash value is used to shuffle the list of queues and deal a hand of the size specified here.  The request is put into one of the shortest queues in that hand. `handSize` must be no larger than `queues`, and should be significantly smaller (so that a few heavy flows do not saturate most of the queues).  See the user-facing documentation for more extensive guidance on setting this field.  This field has a default value of 8.
+        """
+        queue_length_limit: NotRequired[pulumi.Input[int]]
+        """
+        `queueLengthLimit` is the maximum number of requests allowed to be waiting in a given queue of this priority level at a time; excess requests are rejected.  This value must be positive.  If not specified, it will be defaulted to 50.
+        """
+        queues: NotRequired[pulumi.Input[int]]
+        """
+        `queues` is the number of queues for this priority level. The queues exist independently at each apiserver. The value must be positive.  Setting it to 1 effectively precludes shufflesharding and thus makes the distinguisher method of associated flow schemas irrelevant.  This field has a default value of 64.
+        """
+elif False:
+    QueuingConfigurationPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class QueuingConfigurationPatchArgs:
     def __init__(__self__, *,
@@ -1258,6 +1767,26 @@ class QueuingConfigurationPatchArgs:
         pulumi.set(self, "queues", value)
 
 
+if not MYPY:
+    class QueuingConfigurationArgsDict(TypedDict):
+        """
+        QueuingConfiguration holds the configuration parameters for queuing
+        """
+        hand_size: NotRequired[pulumi.Input[int]]
+        """
+        `handSize` is a small positive number that configures the shuffle sharding of requests into queues.  When enqueuing a request at this priority level the request's flow identifier (a string pair) is hashed and the hash value is used to shuffle the list of queues and deal a hand of the size specified here.  The request is put into one of the shortest queues in that hand. `handSize` must be no larger than `queues`, and should be significantly smaller (so that a few heavy flows do not saturate most of the queues).  See the user-facing documentation for more extensive guidance on setting this field.  This field has a default value of 8.
+        """
+        queue_length_limit: NotRequired[pulumi.Input[int]]
+        """
+        `queueLengthLimit` is the maximum number of requests allowed to be waiting in a given queue of this priority level at a time; excess requests are rejected.  This value must be positive.  If not specified, it will be defaulted to 50.
+        """
+        queues: NotRequired[pulumi.Input[int]]
+        """
+        `queues` is the number of queues for this priority level. The queues exist independently at each apiserver. The value must be positive.  Setting it to 1 effectively precludes shufflesharding and thus makes the distinguisher method of associated flow schemas irrelevant.  This field has a default value of 64.
+        """
+elif False:
+    QueuingConfigurationArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class QueuingConfigurationArgs:
     def __init__(__self__, *,
@@ -1313,6 +1842,34 @@ class QueuingConfigurationArgs:
     def queues(self, value: Optional[pulumi.Input[int]]):
         pulumi.set(self, "queues", value)
 
+
+if not MYPY:
+    class ResourcePolicyRulePatchArgsDict(TypedDict):
+        """
+        ResourcePolicyRule is a predicate that matches some resource requests, testing the request's verb and the target resource. A ResourcePolicyRule matches a resource request if and only if: (a) at least one member of verbs matches the request, (b) at least one member of apiGroups matches the request, (c) at least one member of resources matches the request, and (d) least one member of namespaces matches the request.
+        """
+        api_groups: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        `apiGroups` is a list of matching API groups and may not be empty. "*" matches all API groups and, if present, must be the only entry. Required.
+        """
+        cluster_scope: NotRequired[pulumi.Input[bool]]
+        """
+        `clusterScope` indicates whether to match requests that do not specify a namespace (which happens either because the resource is not namespaced or the request targets all namespaces). If this field is omitted or false then the `namespaces` field must contain a non-empty list.
+        """
+        namespaces: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        `namespaces` is a list of target namespaces that restricts matches.  A request that specifies a target namespace matches only if either (a) this list contains that target namespace or (b) this list contains "*".  Note that "*" matches any specified namespace but does not match a request that _does not specify_ a namespace (see the `clusterScope` field for that). This list may be empty, but only if `clusterScope` is true.
+        """
+        resources: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        `resources` is a list of matching resources (i.e., lowercase and plural) with, if desired, subresource.  For example, [ "services", "nodes/status" ].  This list may not be empty. "*" matches all resources and, if present, must be the only entry. Required.
+        """
+        verbs: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        `verbs` is a list of matching verbs and may not be empty. "*" matches all verbs and, if present, must be the only entry. Required.
+        """
+elif False:
+    ResourcePolicyRulePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ResourcePolicyRulePatchArgs:
@@ -1402,6 +1959,34 @@ class ResourcePolicyRulePatchArgs:
         pulumi.set(self, "verbs", value)
 
 
+if not MYPY:
+    class ResourcePolicyRuleArgsDict(TypedDict):
+        """
+        ResourcePolicyRule is a predicate that matches some resource requests, testing the request's verb and the target resource. A ResourcePolicyRule matches a resource request if and only if: (a) at least one member of verbs matches the request, (b) at least one member of apiGroups matches the request, (c) at least one member of resources matches the request, and (d) least one member of namespaces matches the request.
+        """
+        api_groups: pulumi.Input[Sequence[pulumi.Input[str]]]
+        """
+        `apiGroups` is a list of matching API groups and may not be empty. "*" matches all API groups and, if present, must be the only entry. Required.
+        """
+        resources: pulumi.Input[Sequence[pulumi.Input[str]]]
+        """
+        `resources` is a list of matching resources (i.e., lowercase and plural) with, if desired, subresource.  For example, [ "services", "nodes/status" ].  This list may not be empty. "*" matches all resources and, if present, must be the only entry. Required.
+        """
+        verbs: pulumi.Input[Sequence[pulumi.Input[str]]]
+        """
+        `verbs` is a list of matching verbs and may not be empty. "*" matches all verbs and, if present, must be the only entry. Required.
+        """
+        cluster_scope: NotRequired[pulumi.Input[bool]]
+        """
+        `clusterScope` indicates whether to match requests that do not specify a namespace (which happens either because the resource is not namespaced or the request targets all namespaces). If this field is omitted or false then the `namespaces` field must contain a non-empty list.
+        """
+        namespaces: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        `namespaces` is a list of target namespaces that restricts matches.  A request that specifies a target namespace matches only if either (a) this list contains that target namespace or (b) this list contains "*".  Note that "*" matches any specified namespace but does not match a request that _does not specify_ a namespace (see the `clusterScope` field for that). This list may be empty, but only if `clusterScope` is true.
+        """
+elif False:
+    ResourcePolicyRuleArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ResourcePolicyRuleArgs:
     def __init__(__self__, *,
@@ -1487,6 +2072,22 @@ class ResourcePolicyRuleArgs:
         pulumi.set(self, "namespaces", value)
 
 
+if not MYPY:
+    class ServiceAccountSubjectPatchArgsDict(TypedDict):
+        """
+        ServiceAccountSubject holds detailed information for service-account-kind subject.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        `name` is the name of matching ServiceAccount objects, or "*" to match regardless of name. Required.
+        """
+        namespace: NotRequired[pulumi.Input[str]]
+        """
+        `namespace` is the namespace of matching ServiceAccount objects. Required.
+        """
+elif False:
+    ServiceAccountSubjectPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ServiceAccountSubjectPatchArgs:
     def __init__(__self__, *,
@@ -1527,6 +2128,22 @@ class ServiceAccountSubjectPatchArgs:
         pulumi.set(self, "namespace", value)
 
 
+if not MYPY:
+    class ServiceAccountSubjectArgsDict(TypedDict):
+        """
+        ServiceAccountSubject holds detailed information for service-account-kind subject.
+        """
+        name: pulumi.Input[str]
+        """
+        `name` is the name of matching ServiceAccount objects, or "*" to match regardless of name. Required.
+        """
+        namespace: pulumi.Input[str]
+        """
+        `namespace` is the namespace of matching ServiceAccount objects. Required.
+        """
+elif False:
+    ServiceAccountSubjectArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ServiceAccountSubjectArgs:
     def __init__(__self__, *,
@@ -1564,6 +2181,21 @@ class ServiceAccountSubjectArgs:
     def namespace(self, value: pulumi.Input[str]):
         pulumi.set(self, "namespace", value)
 
+
+if not MYPY:
+    class SubjectPatchArgsDict(TypedDict):
+        """
+        Subject matches the originator of a request, as identified by the request authentication system. There are three ways of matching an originator; by user, group, or service account.
+        """
+        group: NotRequired[pulumi.Input['GroupSubjectPatchArgsDict']]
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Required
+        """
+        service_account: NotRequired[pulumi.Input['ServiceAccountSubjectPatchArgsDict']]
+        user: NotRequired[pulumi.Input['UserSubjectPatchArgsDict']]
+elif False:
+    SubjectPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class SubjectPatchArgs:
@@ -1625,6 +2257,21 @@ class SubjectPatchArgs:
         pulumi.set(self, "user", value)
 
 
+if not MYPY:
+    class SubjectArgsDict(TypedDict):
+        """
+        Subject matches the originator of a request, as identified by the request authentication system. There are three ways of matching an originator; by user, group, or service account.
+        """
+        kind: pulumi.Input[str]
+        """
+        Required
+        """
+        group: NotRequired[pulumi.Input['GroupSubjectArgsDict']]
+        service_account: NotRequired[pulumi.Input['ServiceAccountSubjectArgsDict']]
+        user: NotRequired[pulumi.Input['UserSubjectArgsDict']]
+elif False:
+    SubjectArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class SubjectArgs:
     def __init__(__self__, *,
@@ -1684,6 +2331,18 @@ class SubjectArgs:
         pulumi.set(self, "user", value)
 
 
+if not MYPY:
+    class UserSubjectPatchArgsDict(TypedDict):
+        """
+        UserSubject holds detailed information for user-kind subject.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        `name` is the username that matches, or "*" to match all usernames. Required.
+        """
+elif False:
+    UserSubjectPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class UserSubjectPatchArgs:
     def __init__(__self__, *,
@@ -1707,6 +2366,18 @@ class UserSubjectPatchArgs:
     def name(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "name", value)
 
+
+if not MYPY:
+    class UserSubjectArgsDict(TypedDict):
+        """
+        UserSubject holds detailed information for user-kind subject.
+        """
+        name: pulumi.Input[str]
+        """
+        `name` is the username that matches, or "*" to match all usernames. Required.
+        """
+elif False:
+    UserSubjectArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class UserSubjectArgs:

--- a/sdk/python/pulumi_kubernetes/flowcontrol/v1beta1/outputs.py
+++ b/sdk/python/pulumi_kubernetes/flowcontrol/v1beta1/outputs.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta

--- a/sdk/python/pulumi_kubernetes/flowcontrol/v1beta2/FlowSchema.py
+++ b/sdk/python/pulumi_kubernetes/flowcontrol/v1beta2/FlowSchema.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class FlowSchema(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['FlowSchemaSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['FlowSchemaSpecArgs', 'FlowSchemaSpecArgsDict']]] = None,
                  __props__=None):
         """
         FlowSchema defines the schema of a group of flows. Note that a flow is made up of a set of inbound API requests with similar attributes and is identified by a pair of strings: the name of the FlowSchema and a "flow distinguisher".
@@ -103,8 +108,8 @@ class FlowSchema(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['FlowSchemaSpecArgs']] spec: `spec` is the specification of the desired behavior of a FlowSchema. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['FlowSchemaSpecArgs', 'FlowSchemaSpecArgsDict']] spec: `spec` is the specification of the desired behavior of a FlowSchema. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -132,8 +137,8 @@ class FlowSchema(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['FlowSchemaSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['FlowSchemaSpecArgs', 'FlowSchemaSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/flowcontrol/v1beta2/FlowSchemaList.py
+++ b/sdk/python/pulumi_kubernetes/flowcontrol/v1beta2/FlowSchemaList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class FlowSchemaList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['FlowSchemaArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['FlowSchemaArgs', 'FlowSchemaArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         FlowSchemaList is a list of FlowSchema objects.
@@ -101,9 +106,9 @@ class FlowSchemaList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['FlowSchemaArgs']]]] items: `items` is a list of FlowSchemas.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['FlowSchemaArgs', 'FlowSchemaArgsDict']]]] items: `items` is a list of FlowSchemas.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: `metadata` is the standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: `metadata` is the standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class FlowSchemaList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['FlowSchemaArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['FlowSchemaArgs', 'FlowSchemaArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/flowcontrol/v1beta2/FlowSchemaPatch.py
+++ b/sdk/python/pulumi_kubernetes/flowcontrol/v1beta2/FlowSchemaPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class FlowSchemaPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['FlowSchemaSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['FlowSchemaSpecPatchArgs', 'FlowSchemaSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -109,8 +114,8 @@ class FlowSchemaPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['FlowSchemaSpecPatchArgs']] spec: `spec` is the specification of the desired behavior of a FlowSchema. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['FlowSchemaSpecPatchArgs', 'FlowSchemaSpecPatchArgsDict']] spec: `spec` is the specification of the desired behavior of a FlowSchema. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -144,8 +149,8 @@ class FlowSchemaPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['FlowSchemaSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['FlowSchemaSpecPatchArgs', 'FlowSchemaSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/flowcontrol/v1beta2/PriorityLevelConfiguration.py
+++ b/sdk/python/pulumi_kubernetes/flowcontrol/v1beta2/PriorityLevelConfiguration.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class PriorityLevelConfiguration(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PriorityLevelConfigurationSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PriorityLevelConfigurationSpecArgs', 'PriorityLevelConfigurationSpecArgsDict']]] = None,
                  __props__=None):
         """
         PriorityLevelConfiguration represents the configuration of a priority level.
@@ -103,8 +108,8 @@ class PriorityLevelConfiguration(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['PriorityLevelConfigurationSpecArgs']] spec: `spec` is the specification of the desired behavior of a "request-priority". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['PriorityLevelConfigurationSpecArgs', 'PriorityLevelConfigurationSpecArgsDict']] spec: `spec` is the specification of the desired behavior of a "request-priority". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -132,8 +137,8 @@ class PriorityLevelConfiguration(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PriorityLevelConfigurationSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PriorityLevelConfigurationSpecArgs', 'PriorityLevelConfigurationSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/flowcontrol/v1beta2/PriorityLevelConfigurationList.py
+++ b/sdk/python/pulumi_kubernetes/flowcontrol/v1beta2/PriorityLevelConfigurationList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class PriorityLevelConfigurationList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PriorityLevelConfigurationArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PriorityLevelConfigurationArgs', 'PriorityLevelConfigurationArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         PriorityLevelConfigurationList is a list of PriorityLevelConfiguration objects.
@@ -101,9 +106,9 @@ class PriorityLevelConfigurationList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PriorityLevelConfigurationArgs']]]] items: `items` is a list of request-priorities.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['PriorityLevelConfigurationArgs', 'PriorityLevelConfigurationArgsDict']]]] items: `items` is a list of request-priorities.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class PriorityLevelConfigurationList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PriorityLevelConfigurationArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PriorityLevelConfigurationArgs', 'PriorityLevelConfigurationArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/flowcontrol/v1beta2/PriorityLevelConfigurationPatch.py
+++ b/sdk/python/pulumi_kubernetes/flowcontrol/v1beta2/PriorityLevelConfigurationPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class PriorityLevelConfigurationPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PriorityLevelConfigurationSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PriorityLevelConfigurationSpecPatchArgs', 'PriorityLevelConfigurationSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -109,8 +114,8 @@ class PriorityLevelConfigurationPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['PriorityLevelConfigurationSpecPatchArgs']] spec: `spec` is the specification of the desired behavior of a "request-priority". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['PriorityLevelConfigurationSpecPatchArgs', 'PriorityLevelConfigurationSpecPatchArgsDict']] spec: `spec` is the specification of the desired behavior of a "request-priority". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -144,8 +149,8 @@ class PriorityLevelConfigurationPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PriorityLevelConfigurationSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PriorityLevelConfigurationSpecPatchArgs', 'PriorityLevelConfigurationSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/flowcontrol/v1beta2/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/flowcontrol/v1beta2/_inputs.py
@@ -4,50 +4,115 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import meta as _meta
 
 __all__ = [
     'ExemptPriorityLevelConfigurationPatchArgs',
+    'ExemptPriorityLevelConfigurationPatchArgsDict',
     'ExemptPriorityLevelConfigurationArgs',
+    'ExemptPriorityLevelConfigurationArgsDict',
     'FlowDistinguisherMethodPatchArgs',
+    'FlowDistinguisherMethodPatchArgsDict',
     'FlowDistinguisherMethodArgs',
+    'FlowDistinguisherMethodArgsDict',
     'FlowSchemaConditionArgs',
+    'FlowSchemaConditionArgsDict',
     'FlowSchemaSpecPatchArgs',
+    'FlowSchemaSpecPatchArgsDict',
     'FlowSchemaSpecArgs',
+    'FlowSchemaSpecArgsDict',
     'FlowSchemaStatusArgs',
+    'FlowSchemaStatusArgsDict',
     'FlowSchemaArgs',
+    'FlowSchemaArgsDict',
     'GroupSubjectPatchArgs',
+    'GroupSubjectPatchArgsDict',
     'GroupSubjectArgs',
+    'GroupSubjectArgsDict',
     'LimitResponsePatchArgs',
+    'LimitResponsePatchArgsDict',
     'LimitResponseArgs',
+    'LimitResponseArgsDict',
     'LimitedPriorityLevelConfigurationPatchArgs',
+    'LimitedPriorityLevelConfigurationPatchArgsDict',
     'LimitedPriorityLevelConfigurationArgs',
+    'LimitedPriorityLevelConfigurationArgsDict',
     'NonResourcePolicyRulePatchArgs',
+    'NonResourcePolicyRulePatchArgsDict',
     'NonResourcePolicyRuleArgs',
+    'NonResourcePolicyRuleArgsDict',
     'PolicyRulesWithSubjectsPatchArgs',
+    'PolicyRulesWithSubjectsPatchArgsDict',
     'PolicyRulesWithSubjectsArgs',
+    'PolicyRulesWithSubjectsArgsDict',
     'PriorityLevelConfigurationConditionArgs',
+    'PriorityLevelConfigurationConditionArgsDict',
     'PriorityLevelConfigurationReferencePatchArgs',
+    'PriorityLevelConfigurationReferencePatchArgsDict',
     'PriorityLevelConfigurationReferenceArgs',
+    'PriorityLevelConfigurationReferenceArgsDict',
     'PriorityLevelConfigurationSpecPatchArgs',
+    'PriorityLevelConfigurationSpecPatchArgsDict',
     'PriorityLevelConfigurationSpecArgs',
+    'PriorityLevelConfigurationSpecArgsDict',
     'PriorityLevelConfigurationStatusArgs',
+    'PriorityLevelConfigurationStatusArgsDict',
     'PriorityLevelConfigurationArgs',
+    'PriorityLevelConfigurationArgsDict',
     'QueuingConfigurationPatchArgs',
+    'QueuingConfigurationPatchArgsDict',
     'QueuingConfigurationArgs',
+    'QueuingConfigurationArgsDict',
     'ResourcePolicyRulePatchArgs',
+    'ResourcePolicyRulePatchArgsDict',
     'ResourcePolicyRuleArgs',
+    'ResourcePolicyRuleArgsDict',
     'ServiceAccountSubjectPatchArgs',
+    'ServiceAccountSubjectPatchArgsDict',
     'ServiceAccountSubjectArgs',
+    'ServiceAccountSubjectArgsDict',
     'SubjectPatchArgs',
+    'SubjectPatchArgsDict',
     'SubjectArgs',
+    'SubjectArgsDict',
     'UserSubjectPatchArgs',
+    'UserSubjectPatchArgsDict',
     'UserSubjectArgs',
+    'UserSubjectArgsDict',
 ]
+
+MYPY = False
+
+if not MYPY:
+    class ExemptPriorityLevelConfigurationPatchArgsDict(TypedDict):
+        """
+        ExemptPriorityLevelConfiguration describes the configurable aspects of the handling of exempt requests. In the mandatory exempt configuration object the values in the fields here can be modified by authorized users, unlike the rest of the `spec`.
+        """
+        lendable_percent: NotRequired[pulumi.Input[int]]
+        """
+        `lendablePercent` prescribes the fraction of the level's NominalCL that can be borrowed by other priority levels.  This value of this field must be between 0 and 100, inclusive, and it defaults to 0. The number of seats that other levels can borrow from this level, known as this level's LendableConcurrencyLimit (LendableCL), is defined as follows.
+
+        LendableCL(i) = round( NominalCL(i) * lendablePercent(i)/100.0 )
+        """
+        nominal_concurrency_shares: NotRequired[pulumi.Input[int]]
+        """
+        `nominalConcurrencyShares` (NCS) contributes to the computation of the NominalConcurrencyLimit (NominalCL) of this level. This is the number of execution seats nominally reserved for this priority level. This DOES NOT limit the dispatching from this priority level but affects the other priority levels through the borrowing mechanism. The server's concurrency limit (ServerCL) is divided among all the priority levels in proportion to their NCS values:
+
+        NominalCL(i)  = ceil( ServerCL * NCS(i) / sum_ncs ) sum_ncs = sum[priority level k] NCS(k)
+
+        Bigger numbers mean a larger nominal concurrency limit, at the expense of every other priority level. This field has a default value of zero.
+        """
+elif False:
+    ExemptPriorityLevelConfigurationPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ExemptPriorityLevelConfigurationPatchArgs:
@@ -101,6 +166,28 @@ class ExemptPriorityLevelConfigurationPatchArgs:
         pulumi.set(self, "nominal_concurrency_shares", value)
 
 
+if not MYPY:
+    class ExemptPriorityLevelConfigurationArgsDict(TypedDict):
+        """
+        ExemptPriorityLevelConfiguration describes the configurable aspects of the handling of exempt requests. In the mandatory exempt configuration object the values in the fields here can be modified by authorized users, unlike the rest of the `spec`.
+        """
+        lendable_percent: NotRequired[pulumi.Input[int]]
+        """
+        `lendablePercent` prescribes the fraction of the level's NominalCL that can be borrowed by other priority levels.  This value of this field must be between 0 and 100, inclusive, and it defaults to 0. The number of seats that other levels can borrow from this level, known as this level's LendableConcurrencyLimit (LendableCL), is defined as follows.
+
+        LendableCL(i) = round( NominalCL(i) * lendablePercent(i)/100.0 )
+        """
+        nominal_concurrency_shares: NotRequired[pulumi.Input[int]]
+        """
+        `nominalConcurrencyShares` (NCS) contributes to the computation of the NominalConcurrencyLimit (NominalCL) of this level. This is the number of execution seats nominally reserved for this priority level. This DOES NOT limit the dispatching from this priority level but affects the other priority levels through the borrowing mechanism. The server's concurrency limit (ServerCL) is divided among all the priority levels in proportion to their NCS values:
+
+        NominalCL(i)  = ceil( ServerCL * NCS(i) / sum_ncs ) sum_ncs = sum[priority level k] NCS(k)
+
+        Bigger numbers mean a larger nominal concurrency limit, at the expense of every other priority level. This field has a default value of zero.
+        """
+elif False:
+    ExemptPriorityLevelConfigurationArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ExemptPriorityLevelConfigurationArgs:
     def __init__(__self__, *,
@@ -153,6 +240,18 @@ class ExemptPriorityLevelConfigurationArgs:
         pulumi.set(self, "nominal_concurrency_shares", value)
 
 
+if not MYPY:
+    class FlowDistinguisherMethodPatchArgsDict(TypedDict):
+        """
+        FlowDistinguisherMethod specifies the method of a flow distinguisher.
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        `type` is the type of flow distinguisher method The supported types are "ByUser" and "ByNamespace". Required.
+        """
+elif False:
+    FlowDistinguisherMethodPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class FlowDistinguisherMethodPatchArgs:
     def __init__(__self__, *,
@@ -177,6 +276,18 @@ class FlowDistinguisherMethodPatchArgs:
         pulumi.set(self, "type", value)
 
 
+if not MYPY:
+    class FlowDistinguisherMethodArgsDict(TypedDict):
+        """
+        FlowDistinguisherMethod specifies the method of a flow distinguisher.
+        """
+        type: pulumi.Input[str]
+        """
+        `type` is the type of flow distinguisher method The supported types are "ByUser" and "ByNamespace". Required.
+        """
+elif False:
+    FlowDistinguisherMethodArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class FlowDistinguisherMethodArgs:
     def __init__(__self__, *,
@@ -199,6 +310,34 @@ class FlowDistinguisherMethodArgs:
     def type(self, value: pulumi.Input[str]):
         pulumi.set(self, "type", value)
 
+
+if not MYPY:
+    class FlowSchemaConditionArgsDict(TypedDict):
+        """
+        FlowSchemaCondition describes conditions for a FlowSchema.
+        """
+        last_transition_time: NotRequired[pulumi.Input[str]]
+        """
+        `lastTransitionTime` is the last time the condition transitioned from one status to another.
+        """
+        message: NotRequired[pulumi.Input[str]]
+        """
+        `message` is a human-readable message indicating details about last transition.
+        """
+        reason: NotRequired[pulumi.Input[str]]
+        """
+        `reason` is a unique, one-word, CamelCase reason for the condition's last transition.
+        """
+        status: NotRequired[pulumi.Input[str]]
+        """
+        `status` is the status of the condition. Can be True, False, Unknown. Required.
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        `type` is the type of the condition. Required.
+        """
+elif False:
+    FlowSchemaConditionArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class FlowSchemaConditionArgs:
@@ -288,6 +427,30 @@ class FlowSchemaConditionArgs:
         pulumi.set(self, "type", value)
 
 
+if not MYPY:
+    class FlowSchemaSpecPatchArgsDict(TypedDict):
+        """
+        FlowSchemaSpec describes how the FlowSchema's specification looks like.
+        """
+        distinguisher_method: NotRequired[pulumi.Input['FlowDistinguisherMethodPatchArgsDict']]
+        """
+        `distinguisherMethod` defines how to compute the flow distinguisher for requests that match this schema. `nil` specifies that the distinguisher is disabled and thus will always be the empty string.
+        """
+        matching_precedence: NotRequired[pulumi.Input[int]]
+        """
+        `matchingPrecedence` is used to choose among the FlowSchemas that match a given request. The chosen FlowSchema is among those with the numerically lowest (which we take to be logically highest) MatchingPrecedence.  Each MatchingPrecedence value must be ranged in [1,10000]. Note that if the precedence is not specified, it will be set to 1000 as default.
+        """
+        priority_level_configuration: NotRequired[pulumi.Input['PriorityLevelConfigurationReferencePatchArgsDict']]
+        """
+        `priorityLevelConfiguration` should reference a PriorityLevelConfiguration in the cluster. If the reference cannot be resolved, the FlowSchema will be ignored and marked as invalid in its status. Required.
+        """
+        rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['PolicyRulesWithSubjectsPatchArgsDict']]]]
+        """
+        `rules` describes which requests will match this flow schema. This FlowSchema matches a request if and only if at least one member of rules matches the request. if it is an empty slice, there will be no requests matching the FlowSchema.
+        """
+elif False:
+    FlowSchemaSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class FlowSchemaSpecPatchArgs:
     def __init__(__self__, *,
@@ -360,6 +523,30 @@ class FlowSchemaSpecPatchArgs:
         pulumi.set(self, "rules", value)
 
 
+if not MYPY:
+    class FlowSchemaSpecArgsDict(TypedDict):
+        """
+        FlowSchemaSpec describes how the FlowSchema's specification looks like.
+        """
+        priority_level_configuration: pulumi.Input['PriorityLevelConfigurationReferenceArgsDict']
+        """
+        `priorityLevelConfiguration` should reference a PriorityLevelConfiguration in the cluster. If the reference cannot be resolved, the FlowSchema will be ignored and marked as invalid in its status. Required.
+        """
+        distinguisher_method: NotRequired[pulumi.Input['FlowDistinguisherMethodArgsDict']]
+        """
+        `distinguisherMethod` defines how to compute the flow distinguisher for requests that match this schema. `nil` specifies that the distinguisher is disabled and thus will always be the empty string.
+        """
+        matching_precedence: NotRequired[pulumi.Input[int]]
+        """
+        `matchingPrecedence` is used to choose among the FlowSchemas that match a given request. The chosen FlowSchema is among those with the numerically lowest (which we take to be logically highest) MatchingPrecedence.  Each MatchingPrecedence value must be ranged in [1,10000]. Note that if the precedence is not specified, it will be set to 1000 as default.
+        """
+        rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['PolicyRulesWithSubjectsArgsDict']]]]
+        """
+        `rules` describes which requests will match this flow schema. This FlowSchema matches a request if and only if at least one member of rules matches the request. if it is an empty slice, there will be no requests matching the FlowSchema.
+        """
+elif False:
+    FlowSchemaSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class FlowSchemaSpecArgs:
     def __init__(__self__, *,
@@ -431,6 +618,18 @@ class FlowSchemaSpecArgs:
         pulumi.set(self, "rules", value)
 
 
+if not MYPY:
+    class FlowSchemaStatusArgsDict(TypedDict):
+        """
+        FlowSchemaStatus represents the current state of a FlowSchema.
+        """
+        conditions: NotRequired[pulumi.Input[Sequence[pulumi.Input['FlowSchemaConditionArgsDict']]]]
+        """
+        `conditions` is a list of the current states of FlowSchema.
+        """
+elif False:
+    FlowSchemaStatusArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class FlowSchemaStatusArgs:
     def __init__(__self__, *,
@@ -454,6 +653,34 @@ class FlowSchemaStatusArgs:
     def conditions(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['FlowSchemaConditionArgs']]]]):
         pulumi.set(self, "conditions", value)
 
+
+if not MYPY:
+    class FlowSchemaArgsDict(TypedDict):
+        """
+        FlowSchema defines the schema of a group of flows. Note that a flow is made up of a set of inbound API requests with similar attributes and is identified by a pair of strings: the name of the FlowSchema and a "flow distinguisher".
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['FlowSchemaSpecArgsDict']]
+        """
+        `spec` is the specification of the desired behavior of a FlowSchema. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+        status: NotRequired[pulumi.Input['FlowSchemaStatusArgsDict']]
+        """
+        `status` is the current status of a FlowSchema. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+elif False:
+    FlowSchemaArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class FlowSchemaArgs:
@@ -543,6 +770,18 @@ class FlowSchemaArgs:
         pulumi.set(self, "status", value)
 
 
+if not MYPY:
+    class GroupSubjectPatchArgsDict(TypedDict):
+        """
+        GroupSubject holds detailed information for group-kind subject.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        name is the user group that matches, or "*" to match all user groups. See https://github.com/kubernetes/apiserver/blob/master/pkg/authentication/user/user.go for some well-known group names. Required.
+        """
+elif False:
+    GroupSubjectPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class GroupSubjectPatchArgs:
     def __init__(__self__, *,
@@ -567,6 +806,18 @@ class GroupSubjectPatchArgs:
         pulumi.set(self, "name", value)
 
 
+if not MYPY:
+    class GroupSubjectArgsDict(TypedDict):
+        """
+        GroupSubject holds detailed information for group-kind subject.
+        """
+        name: pulumi.Input[str]
+        """
+        name is the user group that matches, or "*" to match all user groups. See https://github.com/kubernetes/apiserver/blob/master/pkg/authentication/user/user.go for some well-known group names. Required.
+        """
+elif False:
+    GroupSubjectArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class GroupSubjectArgs:
     def __init__(__self__, *,
@@ -589,6 +840,22 @@ class GroupSubjectArgs:
     def name(self, value: pulumi.Input[str]):
         pulumi.set(self, "name", value)
 
+
+if not MYPY:
+    class LimitResponsePatchArgsDict(TypedDict):
+        """
+        LimitResponse defines how to handle requests that can not be executed right now.
+        """
+        queuing: NotRequired[pulumi.Input['QueuingConfigurationPatchArgsDict']]
+        """
+        `queuing` holds the configuration parameters for queuing. This field may be non-empty only if `type` is `"Queue"`.
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        `type` is "Queue" or "Reject". "Queue" means that requests that can not be executed upon arrival are held in a queue until they can be executed or a queuing limit is reached. "Reject" means that requests that can not be executed upon arrival are rejected. Required.
+        """
+elif False:
+    LimitResponsePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class LimitResponsePatchArgs:
@@ -630,6 +897,22 @@ class LimitResponsePatchArgs:
         pulumi.set(self, "type", value)
 
 
+if not MYPY:
+    class LimitResponseArgsDict(TypedDict):
+        """
+        LimitResponse defines how to handle requests that can not be executed right now.
+        """
+        type: pulumi.Input[str]
+        """
+        `type` is "Queue" or "Reject". "Queue" means that requests that can not be executed upon arrival are held in a queue until they can be executed or a queuing limit is reached. "Reject" means that requests that can not be executed upon arrival are rejected. Required.
+        """
+        queuing: NotRequired[pulumi.Input['QueuingConfigurationArgsDict']]
+        """
+        `queuing` holds the configuration parameters for queuing. This field may be non-empty only if `type` is `"Queue"`.
+        """
+elif False:
+    LimitResponseArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class LimitResponseArgs:
     def __init__(__self__, *,
@@ -668,6 +951,42 @@ class LimitResponseArgs:
     def queuing(self, value: Optional[pulumi.Input['QueuingConfigurationArgs']]):
         pulumi.set(self, "queuing", value)
 
+
+if not MYPY:
+    class LimitedPriorityLevelConfigurationPatchArgsDict(TypedDict):
+        """
+        LimitedPriorityLevelConfiguration specifies how to handle requests that are subject to limits. It addresses two issues:
+          - How are requests for this priority level limited?
+          - What should be done with requests that exceed the limit?
+        """
+        assured_concurrency_shares: NotRequired[pulumi.Input[int]]
+        """
+        `assuredConcurrencyShares` (ACS) configures the execution limit, which is a limit on the number of requests of this priority level that may be exeucting at a given time.  ACS must be a positive number. The server's concurrency limit (SCL) is divided among the concurrency-controlled priority levels in proportion to their assured concurrency shares. This produces the assured concurrency value (ACV) --- the number of requests that may be executing at a time --- for each such priority level:
+
+                    ACV(l) = ceil( SCL * ACS(l) / ( sum[priority levels k] ACS(k) ) )
+
+        bigger numbers of ACS mean more reserved concurrent requests (at the expense of every other PL). This field has a default value of 30.
+        """
+        borrowing_limit_percent: NotRequired[pulumi.Input[int]]
+        """
+        `borrowingLimitPercent`, if present, configures a limit on how many seats this priority level can borrow from other priority levels. The limit is known as this level's BorrowingConcurrencyLimit (BorrowingCL) and is a limit on the total number of seats that this level may borrow at any one time. This field holds the ratio of that limit to the level's nominal concurrency limit. When this field is non-nil, it must hold a non-negative integer and the limit is calculated as follows.
+
+        BorrowingCL(i) = round( NominalCL(i) * borrowingLimitPercent(i)/100.0 )
+
+        The value of this field can be more than 100, implying that this priority level can borrow a number of seats that is greater than its own nominal concurrency limit (NominalCL). When this field is left `nil`, the limit is effectively infinite.
+        """
+        lendable_percent: NotRequired[pulumi.Input[int]]
+        """
+        `lendablePercent` prescribes the fraction of the level's NominalCL that can be borrowed by other priority levels. The value of this field must be between 0 and 100, inclusive, and it defaults to 0. The number of seats that other levels can borrow from this level, known as this level's LendableConcurrencyLimit (LendableCL), is defined as follows.
+
+        LendableCL(i) = round( NominalCL(i) * lendablePercent(i)/100.0 )
+        """
+        limit_response: NotRequired[pulumi.Input['LimitResponsePatchArgsDict']]
+        """
+        `limitResponse` indicates what to do with requests that can not be executed right now
+        """
+elif False:
+    LimitedPriorityLevelConfigurationPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class LimitedPriorityLevelConfigurationPatchArgs:
@@ -763,6 +1082,42 @@ class LimitedPriorityLevelConfigurationPatchArgs:
         pulumi.set(self, "limit_response", value)
 
 
+if not MYPY:
+    class LimitedPriorityLevelConfigurationArgsDict(TypedDict):
+        """
+        LimitedPriorityLevelConfiguration specifies how to handle requests that are subject to limits. It addresses two issues:
+          - How are requests for this priority level limited?
+          - What should be done with requests that exceed the limit?
+        """
+        assured_concurrency_shares: NotRequired[pulumi.Input[int]]
+        """
+        `assuredConcurrencyShares` (ACS) configures the execution limit, which is a limit on the number of requests of this priority level that may be exeucting at a given time.  ACS must be a positive number. The server's concurrency limit (SCL) is divided among the concurrency-controlled priority levels in proportion to their assured concurrency shares. This produces the assured concurrency value (ACV) --- the number of requests that may be executing at a time --- for each such priority level:
+
+                    ACV(l) = ceil( SCL * ACS(l) / ( sum[priority levels k] ACS(k) ) )
+
+        bigger numbers of ACS mean more reserved concurrent requests (at the expense of every other PL). This field has a default value of 30.
+        """
+        borrowing_limit_percent: NotRequired[pulumi.Input[int]]
+        """
+        `borrowingLimitPercent`, if present, configures a limit on how many seats this priority level can borrow from other priority levels. The limit is known as this level's BorrowingConcurrencyLimit (BorrowingCL) and is a limit on the total number of seats that this level may borrow at any one time. This field holds the ratio of that limit to the level's nominal concurrency limit. When this field is non-nil, it must hold a non-negative integer and the limit is calculated as follows.
+
+        BorrowingCL(i) = round( NominalCL(i) * borrowingLimitPercent(i)/100.0 )
+
+        The value of this field can be more than 100, implying that this priority level can borrow a number of seats that is greater than its own nominal concurrency limit (NominalCL). When this field is left `nil`, the limit is effectively infinite.
+        """
+        lendable_percent: NotRequired[pulumi.Input[int]]
+        """
+        `lendablePercent` prescribes the fraction of the level's NominalCL that can be borrowed by other priority levels. The value of this field must be between 0 and 100, inclusive, and it defaults to 0. The number of seats that other levels can borrow from this level, known as this level's LendableConcurrencyLimit (LendableCL), is defined as follows.
+
+        LendableCL(i) = round( NominalCL(i) * lendablePercent(i)/100.0 )
+        """
+        limit_response: NotRequired[pulumi.Input['LimitResponseArgsDict']]
+        """
+        `limitResponse` indicates what to do with requests that can not be executed right now
+        """
+elif False:
+    LimitedPriorityLevelConfigurationArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class LimitedPriorityLevelConfigurationArgs:
     def __init__(__self__, *,
@@ -857,6 +1212,28 @@ class LimitedPriorityLevelConfigurationArgs:
         pulumi.set(self, "limit_response", value)
 
 
+if not MYPY:
+    class NonResourcePolicyRulePatchArgsDict(TypedDict):
+        """
+        NonResourcePolicyRule is a predicate that matches non-resource requests according to their verb and the target non-resource URL. A NonResourcePolicyRule matches a request if and only if both (a) at least one member of verbs matches the request and (b) at least one member of nonResourceURLs matches the request.
+        """
+        non_resource_urls: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        `nonResourceURLs` is a set of url prefixes that a user should have access to and may not be empty. For example:
+          - "/healthz" is legal
+          - "/hea*" is illegal
+          - "/hea" is legal but matches nothing
+          - "/hea/*" also matches nothing
+          - "/healthz/*" matches all per-component health checks.
+        "*" matches all non-resource urls. if it is present, it must be the only entry. Required.
+        """
+        verbs: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        `verbs` is a list of matching verbs and may not be empty. "*" matches all verbs. If it is present, it must be the only entry. Required.
+        """
+elif False:
+    NonResourcePolicyRulePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class NonResourcePolicyRulePatchArgs:
     def __init__(__self__, *,
@@ -909,6 +1286,28 @@ class NonResourcePolicyRulePatchArgs:
         pulumi.set(self, "verbs", value)
 
 
+if not MYPY:
+    class NonResourcePolicyRuleArgsDict(TypedDict):
+        """
+        NonResourcePolicyRule is a predicate that matches non-resource requests according to their verb and the target non-resource URL. A NonResourcePolicyRule matches a request if and only if both (a) at least one member of verbs matches the request and (b) at least one member of nonResourceURLs matches the request.
+        """
+        non_resource_urls: pulumi.Input[Sequence[pulumi.Input[str]]]
+        """
+        `nonResourceURLs` is a set of url prefixes that a user should have access to and may not be empty. For example:
+          - "/healthz" is legal
+          - "/hea*" is illegal
+          - "/hea" is legal but matches nothing
+          - "/hea/*" also matches nothing
+          - "/healthz/*" matches all per-component health checks.
+        "*" matches all non-resource urls. if it is present, it must be the only entry. Required.
+        """
+        verbs: pulumi.Input[Sequence[pulumi.Input[str]]]
+        """
+        `verbs` is a list of matching verbs and may not be empty. "*" matches all verbs. If it is present, it must be the only entry. Required.
+        """
+elif False:
+    NonResourcePolicyRuleArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class NonResourcePolicyRuleArgs:
     def __init__(__self__, *,
@@ -958,6 +1357,26 @@ class NonResourcePolicyRuleArgs:
     def verbs(self, value: pulumi.Input[Sequence[pulumi.Input[str]]]):
         pulumi.set(self, "verbs", value)
 
+
+if not MYPY:
+    class PolicyRulesWithSubjectsPatchArgsDict(TypedDict):
+        """
+        PolicyRulesWithSubjects prescribes a test that applies to a request to an apiserver. The test considers the subject making the request, the verb being requested, and the resource to be acted upon. This PolicyRulesWithSubjects matches a request if and only if both (a) at least one member of subjects matches the request and (b) at least one member of resourceRules or nonResourceRules matches the request.
+        """
+        non_resource_rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['NonResourcePolicyRulePatchArgsDict']]]]
+        """
+        `nonResourceRules` is a list of NonResourcePolicyRules that identify matching requests according to their verb and the target non-resource URL.
+        """
+        resource_rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['ResourcePolicyRulePatchArgsDict']]]]
+        """
+        `resourceRules` is a slice of ResourcePolicyRules that identify matching requests according to their verb and the target resource. At least one of `resourceRules` and `nonResourceRules` has to be non-empty.
+        """
+        subjects: NotRequired[pulumi.Input[Sequence[pulumi.Input['SubjectPatchArgsDict']]]]
+        """
+        subjects is the list of normal user, serviceaccount, or group that this rule cares about. There must be at least one member in this slice. A slice that includes both the system:authenticated and system:unauthenticated user groups matches every request. Required.
+        """
+elif False:
+    PolicyRulesWithSubjectsPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class PolicyRulesWithSubjectsPatchArgs:
@@ -1015,6 +1434,26 @@ class PolicyRulesWithSubjectsPatchArgs:
         pulumi.set(self, "subjects", value)
 
 
+if not MYPY:
+    class PolicyRulesWithSubjectsArgsDict(TypedDict):
+        """
+        PolicyRulesWithSubjects prescribes a test that applies to a request to an apiserver. The test considers the subject making the request, the verb being requested, and the resource to be acted upon. This PolicyRulesWithSubjects matches a request if and only if both (a) at least one member of subjects matches the request and (b) at least one member of resourceRules or nonResourceRules matches the request.
+        """
+        subjects: pulumi.Input[Sequence[pulumi.Input['SubjectArgsDict']]]
+        """
+        subjects is the list of normal user, serviceaccount, or group that this rule cares about. There must be at least one member in this slice. A slice that includes both the system:authenticated and system:unauthenticated user groups matches every request. Required.
+        """
+        non_resource_rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['NonResourcePolicyRuleArgsDict']]]]
+        """
+        `nonResourceRules` is a list of NonResourcePolicyRules that identify matching requests according to their verb and the target non-resource URL.
+        """
+        resource_rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['ResourcePolicyRuleArgsDict']]]]
+        """
+        `resourceRules` is a slice of ResourcePolicyRules that identify matching requests according to their verb and the target resource. At least one of `resourceRules` and `nonResourceRules` has to be non-empty.
+        """
+elif False:
+    PolicyRulesWithSubjectsArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PolicyRulesWithSubjectsArgs:
     def __init__(__self__, *,
@@ -1069,6 +1508,34 @@ class PolicyRulesWithSubjectsArgs:
     def resource_rules(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['ResourcePolicyRuleArgs']]]]):
         pulumi.set(self, "resource_rules", value)
 
+
+if not MYPY:
+    class PriorityLevelConfigurationConditionArgsDict(TypedDict):
+        """
+        PriorityLevelConfigurationCondition defines the condition of priority level.
+        """
+        last_transition_time: NotRequired[pulumi.Input[str]]
+        """
+        `lastTransitionTime` is the last time the condition transitioned from one status to another.
+        """
+        message: NotRequired[pulumi.Input[str]]
+        """
+        `message` is a human-readable message indicating details about last transition.
+        """
+        reason: NotRequired[pulumi.Input[str]]
+        """
+        `reason` is a unique, one-word, CamelCase reason for the condition's last transition.
+        """
+        status: NotRequired[pulumi.Input[str]]
+        """
+        `status` is the status of the condition. Can be True, False, Unknown. Required.
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        `type` is the type of the condition. Required.
+        """
+elif False:
+    PriorityLevelConfigurationConditionArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class PriorityLevelConfigurationConditionArgs:
@@ -1158,6 +1625,18 @@ class PriorityLevelConfigurationConditionArgs:
         pulumi.set(self, "type", value)
 
 
+if not MYPY:
+    class PriorityLevelConfigurationReferencePatchArgsDict(TypedDict):
+        """
+        PriorityLevelConfigurationReference contains information that points to the "request-priority" being used.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        `name` is the name of the priority level configuration being referenced Required.
+        """
+elif False:
+    PriorityLevelConfigurationReferencePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PriorityLevelConfigurationReferencePatchArgs:
     def __init__(__self__, *,
@@ -1182,6 +1661,18 @@ class PriorityLevelConfigurationReferencePatchArgs:
         pulumi.set(self, "name", value)
 
 
+if not MYPY:
+    class PriorityLevelConfigurationReferenceArgsDict(TypedDict):
+        """
+        PriorityLevelConfigurationReference contains information that points to the "request-priority" being used.
+        """
+        name: pulumi.Input[str]
+        """
+        `name` is the name of the priority level configuration being referenced Required.
+        """
+elif False:
+    PriorityLevelConfigurationReferenceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PriorityLevelConfigurationReferenceArgs:
     def __init__(__self__, *,
@@ -1204,6 +1695,26 @@ class PriorityLevelConfigurationReferenceArgs:
     def name(self, value: pulumi.Input[str]):
         pulumi.set(self, "name", value)
 
+
+if not MYPY:
+    class PriorityLevelConfigurationSpecPatchArgsDict(TypedDict):
+        """
+        PriorityLevelConfigurationSpec specifies the configuration of a priority level.
+        """
+        exempt: NotRequired[pulumi.Input['ExemptPriorityLevelConfigurationPatchArgsDict']]
+        """
+        `exempt` specifies how requests are handled for an exempt priority level. This field MUST be empty if `type` is `"Limited"`. This field MAY be non-empty if `type` is `"Exempt"`. If empty and `type` is `"Exempt"` then the default values for `ExemptPriorityLevelConfiguration` apply.
+        """
+        limited: NotRequired[pulumi.Input['LimitedPriorityLevelConfigurationPatchArgsDict']]
+        """
+        `limited` specifies how requests are handled for a Limited priority level. This field must be non-empty if and only if `type` is `"Limited"`.
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        `type` indicates whether this priority level is subject to limitation on request execution.  A value of `"Exempt"` means that requests of this priority level are not subject to a limit (and thus are never queued) and do not detract from the capacity made available to other priority levels.  A value of `"Limited"` means that (a) requests of this priority level _are_ subject to limits and (b) some of the server's limited capacity is made available exclusively to this priority level. Required.
+        """
+elif False:
+    PriorityLevelConfigurationSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class PriorityLevelConfigurationSpecPatchArgs:
@@ -1261,6 +1772,26 @@ class PriorityLevelConfigurationSpecPatchArgs:
         pulumi.set(self, "type", value)
 
 
+if not MYPY:
+    class PriorityLevelConfigurationSpecArgsDict(TypedDict):
+        """
+        PriorityLevelConfigurationSpec specifies the configuration of a priority level.
+        """
+        type: pulumi.Input[str]
+        """
+        `type` indicates whether this priority level is subject to limitation on request execution.  A value of `"Exempt"` means that requests of this priority level are not subject to a limit (and thus are never queued) and do not detract from the capacity made available to other priority levels.  A value of `"Limited"` means that (a) requests of this priority level _are_ subject to limits and (b) some of the server's limited capacity is made available exclusively to this priority level. Required.
+        """
+        exempt: NotRequired[pulumi.Input['ExemptPriorityLevelConfigurationArgsDict']]
+        """
+        `exempt` specifies how requests are handled for an exempt priority level. This field MUST be empty if `type` is `"Limited"`. This field MAY be non-empty if `type` is `"Exempt"`. If empty and `type` is `"Exempt"` then the default values for `ExemptPriorityLevelConfiguration` apply.
+        """
+        limited: NotRequired[pulumi.Input['LimitedPriorityLevelConfigurationArgsDict']]
+        """
+        `limited` specifies how requests are handled for a Limited priority level. This field must be non-empty if and only if `type` is `"Limited"`.
+        """
+elif False:
+    PriorityLevelConfigurationSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PriorityLevelConfigurationSpecArgs:
     def __init__(__self__, *,
@@ -1316,6 +1847,18 @@ class PriorityLevelConfigurationSpecArgs:
         pulumi.set(self, "limited", value)
 
 
+if not MYPY:
+    class PriorityLevelConfigurationStatusArgsDict(TypedDict):
+        """
+        PriorityLevelConfigurationStatus represents the current state of a "request-priority".
+        """
+        conditions: NotRequired[pulumi.Input[Sequence[pulumi.Input['PriorityLevelConfigurationConditionArgsDict']]]]
+        """
+        `conditions` is the current state of "request-priority".
+        """
+elif False:
+    PriorityLevelConfigurationStatusArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PriorityLevelConfigurationStatusArgs:
     def __init__(__self__, *,
@@ -1339,6 +1882,34 @@ class PriorityLevelConfigurationStatusArgs:
     def conditions(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['PriorityLevelConfigurationConditionArgs']]]]):
         pulumi.set(self, "conditions", value)
 
+
+if not MYPY:
+    class PriorityLevelConfigurationArgsDict(TypedDict):
+        """
+        PriorityLevelConfiguration represents the configuration of a priority level.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['PriorityLevelConfigurationSpecArgsDict']]
+        """
+        `spec` is the specification of the desired behavior of a "request-priority". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+        status: NotRequired[pulumi.Input['PriorityLevelConfigurationStatusArgsDict']]
+        """
+        `status` is the current status of a "request-priority". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+elif False:
+    PriorityLevelConfigurationArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class PriorityLevelConfigurationArgs:
@@ -1428,6 +1999,26 @@ class PriorityLevelConfigurationArgs:
         pulumi.set(self, "status", value)
 
 
+if not MYPY:
+    class QueuingConfigurationPatchArgsDict(TypedDict):
+        """
+        QueuingConfiguration holds the configuration parameters for queuing
+        """
+        hand_size: NotRequired[pulumi.Input[int]]
+        """
+        `handSize` is a small positive number that configures the shuffle sharding of requests into queues.  When enqueuing a request at this priority level the request's flow identifier (a string pair) is hashed and the hash value is used to shuffle the list of queues and deal a hand of the size specified here.  The request is put into one of the shortest queues in that hand. `handSize` must be no larger than `queues`, and should be significantly smaller (so that a few heavy flows do not saturate most of the queues).  See the user-facing documentation for more extensive guidance on setting this field.  This field has a default value of 8.
+        """
+        queue_length_limit: NotRequired[pulumi.Input[int]]
+        """
+        `queueLengthLimit` is the maximum number of requests allowed to be waiting in a given queue of this priority level at a time; excess requests are rejected.  This value must be positive.  If not specified, it will be defaulted to 50.
+        """
+        queues: NotRequired[pulumi.Input[int]]
+        """
+        `queues` is the number of queues for this priority level. The queues exist independently at each apiserver. The value must be positive.  Setting it to 1 effectively precludes shufflesharding and thus makes the distinguisher method of associated flow schemas irrelevant.  This field has a default value of 64.
+        """
+elif False:
+    QueuingConfigurationPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class QueuingConfigurationPatchArgs:
     def __init__(__self__, *,
@@ -1484,6 +2075,26 @@ class QueuingConfigurationPatchArgs:
         pulumi.set(self, "queues", value)
 
 
+if not MYPY:
+    class QueuingConfigurationArgsDict(TypedDict):
+        """
+        QueuingConfiguration holds the configuration parameters for queuing
+        """
+        hand_size: NotRequired[pulumi.Input[int]]
+        """
+        `handSize` is a small positive number that configures the shuffle sharding of requests into queues.  When enqueuing a request at this priority level the request's flow identifier (a string pair) is hashed and the hash value is used to shuffle the list of queues and deal a hand of the size specified here.  The request is put into one of the shortest queues in that hand. `handSize` must be no larger than `queues`, and should be significantly smaller (so that a few heavy flows do not saturate most of the queues).  See the user-facing documentation for more extensive guidance on setting this field.  This field has a default value of 8.
+        """
+        queue_length_limit: NotRequired[pulumi.Input[int]]
+        """
+        `queueLengthLimit` is the maximum number of requests allowed to be waiting in a given queue of this priority level at a time; excess requests are rejected.  This value must be positive.  If not specified, it will be defaulted to 50.
+        """
+        queues: NotRequired[pulumi.Input[int]]
+        """
+        `queues` is the number of queues for this priority level. The queues exist independently at each apiserver. The value must be positive.  Setting it to 1 effectively precludes shufflesharding and thus makes the distinguisher method of associated flow schemas irrelevant.  This field has a default value of 64.
+        """
+elif False:
+    QueuingConfigurationArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class QueuingConfigurationArgs:
     def __init__(__self__, *,
@@ -1539,6 +2150,34 @@ class QueuingConfigurationArgs:
     def queues(self, value: Optional[pulumi.Input[int]]):
         pulumi.set(self, "queues", value)
 
+
+if not MYPY:
+    class ResourcePolicyRulePatchArgsDict(TypedDict):
+        """
+        ResourcePolicyRule is a predicate that matches some resource requests, testing the request's verb and the target resource. A ResourcePolicyRule matches a resource request if and only if: (a) at least one member of verbs matches the request, (b) at least one member of apiGroups matches the request, (c) at least one member of resources matches the request, and (d) either (d1) the request does not specify a namespace (i.e., `Namespace==""`) and clusterScope is true or (d2) the request specifies a namespace and least one member of namespaces matches the request's namespace.
+        """
+        api_groups: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        `apiGroups` is a list of matching API groups and may not be empty. "*" matches all API groups and, if present, must be the only entry. Required.
+        """
+        cluster_scope: NotRequired[pulumi.Input[bool]]
+        """
+        `clusterScope` indicates whether to match requests that do not specify a namespace (which happens either because the resource is not namespaced or the request targets all namespaces). If this field is omitted or false then the `namespaces` field must contain a non-empty list.
+        """
+        namespaces: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        `namespaces` is a list of target namespaces that restricts matches.  A request that specifies a target namespace matches only if either (a) this list contains that target namespace or (b) this list contains "*".  Note that "*" matches any specified namespace but does not match a request that _does not specify_ a namespace (see the `clusterScope` field for that). This list may be empty, but only if `clusterScope` is true.
+        """
+        resources: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        `resources` is a list of matching resources (i.e., lowercase and plural) with, if desired, subresource.  For example, [ "services", "nodes/status" ].  This list may not be empty. "*" matches all resources and, if present, must be the only entry. Required.
+        """
+        verbs: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        `verbs` is a list of matching verbs and may not be empty. "*" matches all verbs and, if present, must be the only entry. Required.
+        """
+elif False:
+    ResourcePolicyRulePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ResourcePolicyRulePatchArgs:
@@ -1628,6 +2267,34 @@ class ResourcePolicyRulePatchArgs:
         pulumi.set(self, "verbs", value)
 
 
+if not MYPY:
+    class ResourcePolicyRuleArgsDict(TypedDict):
+        """
+        ResourcePolicyRule is a predicate that matches some resource requests, testing the request's verb and the target resource. A ResourcePolicyRule matches a resource request if and only if: (a) at least one member of verbs matches the request, (b) at least one member of apiGroups matches the request, (c) at least one member of resources matches the request, and (d) either (d1) the request does not specify a namespace (i.e., `Namespace==""`) and clusterScope is true or (d2) the request specifies a namespace and least one member of namespaces matches the request's namespace.
+        """
+        api_groups: pulumi.Input[Sequence[pulumi.Input[str]]]
+        """
+        `apiGroups` is a list of matching API groups and may not be empty. "*" matches all API groups and, if present, must be the only entry. Required.
+        """
+        resources: pulumi.Input[Sequence[pulumi.Input[str]]]
+        """
+        `resources` is a list of matching resources (i.e., lowercase and plural) with, if desired, subresource.  For example, [ "services", "nodes/status" ].  This list may not be empty. "*" matches all resources and, if present, must be the only entry. Required.
+        """
+        verbs: pulumi.Input[Sequence[pulumi.Input[str]]]
+        """
+        `verbs` is a list of matching verbs and may not be empty. "*" matches all verbs and, if present, must be the only entry. Required.
+        """
+        cluster_scope: NotRequired[pulumi.Input[bool]]
+        """
+        `clusterScope` indicates whether to match requests that do not specify a namespace (which happens either because the resource is not namespaced or the request targets all namespaces). If this field is omitted or false then the `namespaces` field must contain a non-empty list.
+        """
+        namespaces: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        `namespaces` is a list of target namespaces that restricts matches.  A request that specifies a target namespace matches only if either (a) this list contains that target namespace or (b) this list contains "*".  Note that "*" matches any specified namespace but does not match a request that _does not specify_ a namespace (see the `clusterScope` field for that). This list may be empty, but only if `clusterScope` is true.
+        """
+elif False:
+    ResourcePolicyRuleArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ResourcePolicyRuleArgs:
     def __init__(__self__, *,
@@ -1713,6 +2380,22 @@ class ResourcePolicyRuleArgs:
         pulumi.set(self, "namespaces", value)
 
 
+if not MYPY:
+    class ServiceAccountSubjectPatchArgsDict(TypedDict):
+        """
+        ServiceAccountSubject holds detailed information for service-account-kind subject.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        `name` is the name of matching ServiceAccount objects, or "*" to match regardless of name. Required.
+        """
+        namespace: NotRequired[pulumi.Input[str]]
+        """
+        `namespace` is the namespace of matching ServiceAccount objects. Required.
+        """
+elif False:
+    ServiceAccountSubjectPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ServiceAccountSubjectPatchArgs:
     def __init__(__self__, *,
@@ -1753,6 +2436,22 @@ class ServiceAccountSubjectPatchArgs:
         pulumi.set(self, "namespace", value)
 
 
+if not MYPY:
+    class ServiceAccountSubjectArgsDict(TypedDict):
+        """
+        ServiceAccountSubject holds detailed information for service-account-kind subject.
+        """
+        name: pulumi.Input[str]
+        """
+        `name` is the name of matching ServiceAccount objects, or "*" to match regardless of name. Required.
+        """
+        namespace: pulumi.Input[str]
+        """
+        `namespace` is the namespace of matching ServiceAccount objects. Required.
+        """
+elif False:
+    ServiceAccountSubjectArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ServiceAccountSubjectArgs:
     def __init__(__self__, *,
@@ -1790,6 +2489,30 @@ class ServiceAccountSubjectArgs:
     def namespace(self, value: pulumi.Input[str]):
         pulumi.set(self, "namespace", value)
 
+
+if not MYPY:
+    class SubjectPatchArgsDict(TypedDict):
+        """
+        Subject matches the originator of a request, as identified by the request authentication system. There are three ways of matching an originator; by user, group, or service account.
+        """
+        group: NotRequired[pulumi.Input['GroupSubjectPatchArgsDict']]
+        """
+        `group` matches based on user group name.
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        `kind` indicates which one of the other fields is non-empty. Required
+        """
+        service_account: NotRequired[pulumi.Input['ServiceAccountSubjectPatchArgsDict']]
+        """
+        `serviceAccount` matches ServiceAccounts.
+        """
+        user: NotRequired[pulumi.Input['UserSubjectPatchArgsDict']]
+        """
+        `user` matches based on username.
+        """
+elif False:
+    SubjectPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class SubjectPatchArgs:
@@ -1863,6 +2586,30 @@ class SubjectPatchArgs:
         pulumi.set(self, "user", value)
 
 
+if not MYPY:
+    class SubjectArgsDict(TypedDict):
+        """
+        Subject matches the originator of a request, as identified by the request authentication system. There are three ways of matching an originator; by user, group, or service account.
+        """
+        kind: pulumi.Input[str]
+        """
+        `kind` indicates which one of the other fields is non-empty. Required
+        """
+        group: NotRequired[pulumi.Input['GroupSubjectArgsDict']]
+        """
+        `group` matches based on user group name.
+        """
+        service_account: NotRequired[pulumi.Input['ServiceAccountSubjectArgsDict']]
+        """
+        `serviceAccount` matches ServiceAccounts.
+        """
+        user: NotRequired[pulumi.Input['UserSubjectArgsDict']]
+        """
+        `user` matches based on username.
+        """
+elif False:
+    SubjectArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class SubjectArgs:
     def __init__(__self__, *,
@@ -1934,6 +2681,18 @@ class SubjectArgs:
         pulumi.set(self, "user", value)
 
 
+if not MYPY:
+    class UserSubjectPatchArgsDict(TypedDict):
+        """
+        UserSubject holds detailed information for user-kind subject.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        `name` is the username that matches, or "*" to match all usernames. Required.
+        """
+elif False:
+    UserSubjectPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class UserSubjectPatchArgs:
     def __init__(__self__, *,
@@ -1957,6 +2716,18 @@ class UserSubjectPatchArgs:
     def name(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "name", value)
 
+
+if not MYPY:
+    class UserSubjectArgsDict(TypedDict):
+        """
+        UserSubject holds detailed information for user-kind subject.
+        """
+        name: pulumi.Input[str]
+        """
+        `name` is the username that matches, or "*" to match all usernames. Required.
+        """
+elif False:
+    UserSubjectArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class UserSubjectArgs:

--- a/sdk/python/pulumi_kubernetes/flowcontrol/v1beta2/outputs.py
+++ b/sdk/python/pulumi_kubernetes/flowcontrol/v1beta2/outputs.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta

--- a/sdk/python/pulumi_kubernetes/flowcontrol/v1beta3/FlowSchema.py
+++ b/sdk/python/pulumi_kubernetes/flowcontrol/v1beta3/FlowSchema.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class FlowSchema(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['FlowSchemaSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['FlowSchemaSpecArgs', 'FlowSchemaSpecArgsDict']]] = None,
                  __props__=None):
         """
         FlowSchema defines the schema of a group of flows. Note that a flow is made up of a set of inbound API requests with similar attributes and is identified by a pair of strings: the name of the FlowSchema and a "flow distinguisher".
@@ -103,8 +108,8 @@ class FlowSchema(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['FlowSchemaSpecArgs']] spec: `spec` is the specification of the desired behavior of a FlowSchema. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['FlowSchemaSpecArgs', 'FlowSchemaSpecArgsDict']] spec: `spec` is the specification of the desired behavior of a FlowSchema. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -132,8 +137,8 @@ class FlowSchema(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['FlowSchemaSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['FlowSchemaSpecArgs', 'FlowSchemaSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/flowcontrol/v1beta3/FlowSchemaList.py
+++ b/sdk/python/pulumi_kubernetes/flowcontrol/v1beta3/FlowSchemaList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class FlowSchemaList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['FlowSchemaArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['FlowSchemaArgs', 'FlowSchemaArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         FlowSchemaList is a list of FlowSchema objects.
@@ -101,9 +106,9 @@ class FlowSchemaList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['FlowSchemaArgs']]]] items: `items` is a list of FlowSchemas.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['FlowSchemaArgs', 'FlowSchemaArgsDict']]]] items: `items` is a list of FlowSchemas.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: `metadata` is the standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: `metadata` is the standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class FlowSchemaList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['FlowSchemaArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['FlowSchemaArgs', 'FlowSchemaArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/flowcontrol/v1beta3/FlowSchemaPatch.py
+++ b/sdk/python/pulumi_kubernetes/flowcontrol/v1beta3/FlowSchemaPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class FlowSchemaPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['FlowSchemaSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['FlowSchemaSpecPatchArgs', 'FlowSchemaSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -109,8 +114,8 @@ class FlowSchemaPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['FlowSchemaSpecPatchArgs']] spec: `spec` is the specification of the desired behavior of a FlowSchema. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['FlowSchemaSpecPatchArgs', 'FlowSchemaSpecPatchArgsDict']] spec: `spec` is the specification of the desired behavior of a FlowSchema. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -144,8 +149,8 @@ class FlowSchemaPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['FlowSchemaSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['FlowSchemaSpecPatchArgs', 'FlowSchemaSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/flowcontrol/v1beta3/PriorityLevelConfiguration.py
+++ b/sdk/python/pulumi_kubernetes/flowcontrol/v1beta3/PriorityLevelConfiguration.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class PriorityLevelConfiguration(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PriorityLevelConfigurationSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PriorityLevelConfigurationSpecArgs', 'PriorityLevelConfigurationSpecArgsDict']]] = None,
                  __props__=None):
         """
         PriorityLevelConfiguration represents the configuration of a priority level.
@@ -103,8 +108,8 @@ class PriorityLevelConfiguration(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['PriorityLevelConfigurationSpecArgs']] spec: `spec` is the specification of the desired behavior of a "request-priority". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['PriorityLevelConfigurationSpecArgs', 'PriorityLevelConfigurationSpecArgsDict']] spec: `spec` is the specification of the desired behavior of a "request-priority". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -132,8 +137,8 @@ class PriorityLevelConfiguration(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PriorityLevelConfigurationSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PriorityLevelConfigurationSpecArgs', 'PriorityLevelConfigurationSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/flowcontrol/v1beta3/PriorityLevelConfigurationList.py
+++ b/sdk/python/pulumi_kubernetes/flowcontrol/v1beta3/PriorityLevelConfigurationList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class PriorityLevelConfigurationList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PriorityLevelConfigurationArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PriorityLevelConfigurationArgs', 'PriorityLevelConfigurationArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         PriorityLevelConfigurationList is a list of PriorityLevelConfiguration objects.
@@ -101,9 +106,9 @@ class PriorityLevelConfigurationList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PriorityLevelConfigurationArgs']]]] items: `items` is a list of request-priorities.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['PriorityLevelConfigurationArgs', 'PriorityLevelConfigurationArgsDict']]]] items: `items` is a list of request-priorities.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class PriorityLevelConfigurationList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PriorityLevelConfigurationArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PriorityLevelConfigurationArgs', 'PriorityLevelConfigurationArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/flowcontrol/v1beta3/PriorityLevelConfigurationPatch.py
+++ b/sdk/python/pulumi_kubernetes/flowcontrol/v1beta3/PriorityLevelConfigurationPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class PriorityLevelConfigurationPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PriorityLevelConfigurationSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PriorityLevelConfigurationSpecPatchArgs', 'PriorityLevelConfigurationSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -109,8 +114,8 @@ class PriorityLevelConfigurationPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['PriorityLevelConfigurationSpecPatchArgs']] spec: `spec` is the specification of the desired behavior of a "request-priority". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['PriorityLevelConfigurationSpecPatchArgs', 'PriorityLevelConfigurationSpecPatchArgsDict']] spec: `spec` is the specification of the desired behavior of a "request-priority". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -144,8 +149,8 @@ class PriorityLevelConfigurationPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PriorityLevelConfigurationSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PriorityLevelConfigurationSpecPatchArgs', 'PriorityLevelConfigurationSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/flowcontrol/v1beta3/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/flowcontrol/v1beta3/_inputs.py
@@ -4,50 +4,115 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import meta as _meta
 
 __all__ = [
     'ExemptPriorityLevelConfigurationPatchArgs',
+    'ExemptPriorityLevelConfigurationPatchArgsDict',
     'ExemptPriorityLevelConfigurationArgs',
+    'ExemptPriorityLevelConfigurationArgsDict',
     'FlowDistinguisherMethodPatchArgs',
+    'FlowDistinguisherMethodPatchArgsDict',
     'FlowDistinguisherMethodArgs',
+    'FlowDistinguisherMethodArgsDict',
     'FlowSchemaConditionArgs',
+    'FlowSchemaConditionArgsDict',
     'FlowSchemaSpecPatchArgs',
+    'FlowSchemaSpecPatchArgsDict',
     'FlowSchemaSpecArgs',
+    'FlowSchemaSpecArgsDict',
     'FlowSchemaStatusArgs',
+    'FlowSchemaStatusArgsDict',
     'FlowSchemaArgs',
+    'FlowSchemaArgsDict',
     'GroupSubjectPatchArgs',
+    'GroupSubjectPatchArgsDict',
     'GroupSubjectArgs',
+    'GroupSubjectArgsDict',
     'LimitResponsePatchArgs',
+    'LimitResponsePatchArgsDict',
     'LimitResponseArgs',
+    'LimitResponseArgsDict',
     'LimitedPriorityLevelConfigurationPatchArgs',
+    'LimitedPriorityLevelConfigurationPatchArgsDict',
     'LimitedPriorityLevelConfigurationArgs',
+    'LimitedPriorityLevelConfigurationArgsDict',
     'NonResourcePolicyRulePatchArgs',
+    'NonResourcePolicyRulePatchArgsDict',
     'NonResourcePolicyRuleArgs',
+    'NonResourcePolicyRuleArgsDict',
     'PolicyRulesWithSubjectsPatchArgs',
+    'PolicyRulesWithSubjectsPatchArgsDict',
     'PolicyRulesWithSubjectsArgs',
+    'PolicyRulesWithSubjectsArgsDict',
     'PriorityLevelConfigurationConditionArgs',
+    'PriorityLevelConfigurationConditionArgsDict',
     'PriorityLevelConfigurationReferencePatchArgs',
+    'PriorityLevelConfigurationReferencePatchArgsDict',
     'PriorityLevelConfigurationReferenceArgs',
+    'PriorityLevelConfigurationReferenceArgsDict',
     'PriorityLevelConfigurationSpecPatchArgs',
+    'PriorityLevelConfigurationSpecPatchArgsDict',
     'PriorityLevelConfigurationSpecArgs',
+    'PriorityLevelConfigurationSpecArgsDict',
     'PriorityLevelConfigurationStatusArgs',
+    'PriorityLevelConfigurationStatusArgsDict',
     'PriorityLevelConfigurationArgs',
+    'PriorityLevelConfigurationArgsDict',
     'QueuingConfigurationPatchArgs',
+    'QueuingConfigurationPatchArgsDict',
     'QueuingConfigurationArgs',
+    'QueuingConfigurationArgsDict',
     'ResourcePolicyRulePatchArgs',
+    'ResourcePolicyRulePatchArgsDict',
     'ResourcePolicyRuleArgs',
+    'ResourcePolicyRuleArgsDict',
     'ServiceAccountSubjectPatchArgs',
+    'ServiceAccountSubjectPatchArgsDict',
     'ServiceAccountSubjectArgs',
+    'ServiceAccountSubjectArgsDict',
     'SubjectPatchArgs',
+    'SubjectPatchArgsDict',
     'SubjectArgs',
+    'SubjectArgsDict',
     'UserSubjectPatchArgs',
+    'UserSubjectPatchArgsDict',
     'UserSubjectArgs',
+    'UserSubjectArgsDict',
 ]
+
+MYPY = False
+
+if not MYPY:
+    class ExemptPriorityLevelConfigurationPatchArgsDict(TypedDict):
+        """
+        ExemptPriorityLevelConfiguration describes the configurable aspects of the handling of exempt requests. In the mandatory exempt configuration object the values in the fields here can be modified by authorized users, unlike the rest of the `spec`.
+        """
+        lendable_percent: NotRequired[pulumi.Input[int]]
+        """
+        `lendablePercent` prescribes the fraction of the level's NominalCL that can be borrowed by other priority levels.  This value of this field must be between 0 and 100, inclusive, and it defaults to 0. The number of seats that other levels can borrow from this level, known as this level's LendableConcurrencyLimit (LendableCL), is defined as follows.
+
+        LendableCL(i) = round( NominalCL(i) * lendablePercent(i)/100.0 )
+        """
+        nominal_concurrency_shares: NotRequired[pulumi.Input[int]]
+        """
+        `nominalConcurrencyShares` (NCS) contributes to the computation of the NominalConcurrencyLimit (NominalCL) of this level. This is the number of execution seats nominally reserved for this priority level. This DOES NOT limit the dispatching from this priority level but affects the other priority levels through the borrowing mechanism. The server's concurrency limit (ServerCL) is divided among all the priority levels in proportion to their NCS values:
+
+        NominalCL(i)  = ceil( ServerCL * NCS(i) / sum_ncs ) sum_ncs = sum[priority level k] NCS(k)
+
+        Bigger numbers mean a larger nominal concurrency limit, at the expense of every other priority level. This field has a default value of zero.
+        """
+elif False:
+    ExemptPriorityLevelConfigurationPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ExemptPriorityLevelConfigurationPatchArgs:
@@ -101,6 +166,28 @@ class ExemptPriorityLevelConfigurationPatchArgs:
         pulumi.set(self, "nominal_concurrency_shares", value)
 
 
+if not MYPY:
+    class ExemptPriorityLevelConfigurationArgsDict(TypedDict):
+        """
+        ExemptPriorityLevelConfiguration describes the configurable aspects of the handling of exempt requests. In the mandatory exempt configuration object the values in the fields here can be modified by authorized users, unlike the rest of the `spec`.
+        """
+        lendable_percent: NotRequired[pulumi.Input[int]]
+        """
+        `lendablePercent` prescribes the fraction of the level's NominalCL that can be borrowed by other priority levels.  This value of this field must be between 0 and 100, inclusive, and it defaults to 0. The number of seats that other levels can borrow from this level, known as this level's LendableConcurrencyLimit (LendableCL), is defined as follows.
+
+        LendableCL(i) = round( NominalCL(i) * lendablePercent(i)/100.0 )
+        """
+        nominal_concurrency_shares: NotRequired[pulumi.Input[int]]
+        """
+        `nominalConcurrencyShares` (NCS) contributes to the computation of the NominalConcurrencyLimit (NominalCL) of this level. This is the number of execution seats nominally reserved for this priority level. This DOES NOT limit the dispatching from this priority level but affects the other priority levels through the borrowing mechanism. The server's concurrency limit (ServerCL) is divided among all the priority levels in proportion to their NCS values:
+
+        NominalCL(i)  = ceil( ServerCL * NCS(i) / sum_ncs ) sum_ncs = sum[priority level k] NCS(k)
+
+        Bigger numbers mean a larger nominal concurrency limit, at the expense of every other priority level. This field has a default value of zero.
+        """
+elif False:
+    ExemptPriorityLevelConfigurationArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ExemptPriorityLevelConfigurationArgs:
     def __init__(__self__, *,
@@ -153,6 +240,18 @@ class ExemptPriorityLevelConfigurationArgs:
         pulumi.set(self, "nominal_concurrency_shares", value)
 
 
+if not MYPY:
+    class FlowDistinguisherMethodPatchArgsDict(TypedDict):
+        """
+        FlowDistinguisherMethod specifies the method of a flow distinguisher.
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        `type` is the type of flow distinguisher method The supported types are "ByUser" and "ByNamespace". Required.
+        """
+elif False:
+    FlowDistinguisherMethodPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class FlowDistinguisherMethodPatchArgs:
     def __init__(__self__, *,
@@ -177,6 +276,18 @@ class FlowDistinguisherMethodPatchArgs:
         pulumi.set(self, "type", value)
 
 
+if not MYPY:
+    class FlowDistinguisherMethodArgsDict(TypedDict):
+        """
+        FlowDistinguisherMethod specifies the method of a flow distinguisher.
+        """
+        type: pulumi.Input[str]
+        """
+        `type` is the type of flow distinguisher method The supported types are "ByUser" and "ByNamespace". Required.
+        """
+elif False:
+    FlowDistinguisherMethodArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class FlowDistinguisherMethodArgs:
     def __init__(__self__, *,
@@ -199,6 +310,34 @@ class FlowDistinguisherMethodArgs:
     def type(self, value: pulumi.Input[str]):
         pulumi.set(self, "type", value)
 
+
+if not MYPY:
+    class FlowSchemaConditionArgsDict(TypedDict):
+        """
+        FlowSchemaCondition describes conditions for a FlowSchema.
+        """
+        last_transition_time: NotRequired[pulumi.Input[str]]
+        """
+        `lastTransitionTime` is the last time the condition transitioned from one status to another.
+        """
+        message: NotRequired[pulumi.Input[str]]
+        """
+        `message` is a human-readable message indicating details about last transition.
+        """
+        reason: NotRequired[pulumi.Input[str]]
+        """
+        `reason` is a unique, one-word, CamelCase reason for the condition's last transition.
+        """
+        status: NotRequired[pulumi.Input[str]]
+        """
+        `status` is the status of the condition. Can be True, False, Unknown. Required.
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        `type` is the type of the condition. Required.
+        """
+elif False:
+    FlowSchemaConditionArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class FlowSchemaConditionArgs:
@@ -288,6 +427,30 @@ class FlowSchemaConditionArgs:
         pulumi.set(self, "type", value)
 
 
+if not MYPY:
+    class FlowSchemaSpecPatchArgsDict(TypedDict):
+        """
+        FlowSchemaSpec describes how the FlowSchema's specification looks like.
+        """
+        distinguisher_method: NotRequired[pulumi.Input['FlowDistinguisherMethodPatchArgsDict']]
+        """
+        `distinguisherMethod` defines how to compute the flow distinguisher for requests that match this schema. `nil` specifies that the distinguisher is disabled and thus will always be the empty string.
+        """
+        matching_precedence: NotRequired[pulumi.Input[int]]
+        """
+        `matchingPrecedence` is used to choose among the FlowSchemas that match a given request. The chosen FlowSchema is among those with the numerically lowest (which we take to be logically highest) MatchingPrecedence.  Each MatchingPrecedence value must be ranged in [1,10000]. Note that if the precedence is not specified, it will be set to 1000 as default.
+        """
+        priority_level_configuration: NotRequired[pulumi.Input['PriorityLevelConfigurationReferencePatchArgsDict']]
+        """
+        `priorityLevelConfiguration` should reference a PriorityLevelConfiguration in the cluster. If the reference cannot be resolved, the FlowSchema will be ignored and marked as invalid in its status. Required.
+        """
+        rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['PolicyRulesWithSubjectsPatchArgsDict']]]]
+        """
+        `rules` describes which requests will match this flow schema. This FlowSchema matches a request if and only if at least one member of rules matches the request. if it is an empty slice, there will be no requests matching the FlowSchema.
+        """
+elif False:
+    FlowSchemaSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class FlowSchemaSpecPatchArgs:
     def __init__(__self__, *,
@@ -360,6 +523,30 @@ class FlowSchemaSpecPatchArgs:
         pulumi.set(self, "rules", value)
 
 
+if not MYPY:
+    class FlowSchemaSpecArgsDict(TypedDict):
+        """
+        FlowSchemaSpec describes how the FlowSchema's specification looks like.
+        """
+        priority_level_configuration: pulumi.Input['PriorityLevelConfigurationReferenceArgsDict']
+        """
+        `priorityLevelConfiguration` should reference a PriorityLevelConfiguration in the cluster. If the reference cannot be resolved, the FlowSchema will be ignored and marked as invalid in its status. Required.
+        """
+        distinguisher_method: NotRequired[pulumi.Input['FlowDistinguisherMethodArgsDict']]
+        """
+        `distinguisherMethod` defines how to compute the flow distinguisher for requests that match this schema. `nil` specifies that the distinguisher is disabled and thus will always be the empty string.
+        """
+        matching_precedence: NotRequired[pulumi.Input[int]]
+        """
+        `matchingPrecedence` is used to choose among the FlowSchemas that match a given request. The chosen FlowSchema is among those with the numerically lowest (which we take to be logically highest) MatchingPrecedence.  Each MatchingPrecedence value must be ranged in [1,10000]. Note that if the precedence is not specified, it will be set to 1000 as default.
+        """
+        rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['PolicyRulesWithSubjectsArgsDict']]]]
+        """
+        `rules` describes which requests will match this flow schema. This FlowSchema matches a request if and only if at least one member of rules matches the request. if it is an empty slice, there will be no requests matching the FlowSchema.
+        """
+elif False:
+    FlowSchemaSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class FlowSchemaSpecArgs:
     def __init__(__self__, *,
@@ -431,6 +618,18 @@ class FlowSchemaSpecArgs:
         pulumi.set(self, "rules", value)
 
 
+if not MYPY:
+    class FlowSchemaStatusArgsDict(TypedDict):
+        """
+        FlowSchemaStatus represents the current state of a FlowSchema.
+        """
+        conditions: NotRequired[pulumi.Input[Sequence[pulumi.Input['FlowSchemaConditionArgsDict']]]]
+        """
+        `conditions` is a list of the current states of FlowSchema.
+        """
+elif False:
+    FlowSchemaStatusArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class FlowSchemaStatusArgs:
     def __init__(__self__, *,
@@ -454,6 +653,34 @@ class FlowSchemaStatusArgs:
     def conditions(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['FlowSchemaConditionArgs']]]]):
         pulumi.set(self, "conditions", value)
 
+
+if not MYPY:
+    class FlowSchemaArgsDict(TypedDict):
+        """
+        FlowSchema defines the schema of a group of flows. Note that a flow is made up of a set of inbound API requests with similar attributes and is identified by a pair of strings: the name of the FlowSchema and a "flow distinguisher".
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['FlowSchemaSpecArgsDict']]
+        """
+        `spec` is the specification of the desired behavior of a FlowSchema. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+        status: NotRequired[pulumi.Input['FlowSchemaStatusArgsDict']]
+        """
+        `status` is the current status of a FlowSchema. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+elif False:
+    FlowSchemaArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class FlowSchemaArgs:
@@ -543,6 +770,18 @@ class FlowSchemaArgs:
         pulumi.set(self, "status", value)
 
 
+if not MYPY:
+    class GroupSubjectPatchArgsDict(TypedDict):
+        """
+        GroupSubject holds detailed information for group-kind subject.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        name is the user group that matches, or "*" to match all user groups. See https://github.com/kubernetes/apiserver/blob/master/pkg/authentication/user/user.go for some well-known group names. Required.
+        """
+elif False:
+    GroupSubjectPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class GroupSubjectPatchArgs:
     def __init__(__self__, *,
@@ -567,6 +806,18 @@ class GroupSubjectPatchArgs:
         pulumi.set(self, "name", value)
 
 
+if not MYPY:
+    class GroupSubjectArgsDict(TypedDict):
+        """
+        GroupSubject holds detailed information for group-kind subject.
+        """
+        name: pulumi.Input[str]
+        """
+        name is the user group that matches, or "*" to match all user groups. See https://github.com/kubernetes/apiserver/blob/master/pkg/authentication/user/user.go for some well-known group names. Required.
+        """
+elif False:
+    GroupSubjectArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class GroupSubjectArgs:
     def __init__(__self__, *,
@@ -589,6 +840,22 @@ class GroupSubjectArgs:
     def name(self, value: pulumi.Input[str]):
         pulumi.set(self, "name", value)
 
+
+if not MYPY:
+    class LimitResponsePatchArgsDict(TypedDict):
+        """
+        LimitResponse defines how to handle requests that can not be executed right now.
+        """
+        queuing: NotRequired[pulumi.Input['QueuingConfigurationPatchArgsDict']]
+        """
+        `queuing` holds the configuration parameters for queuing. This field may be non-empty only if `type` is `"Queue"`.
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        `type` is "Queue" or "Reject". "Queue" means that requests that can not be executed upon arrival are held in a queue until they can be executed or a queuing limit is reached. "Reject" means that requests that can not be executed upon arrival are rejected. Required.
+        """
+elif False:
+    LimitResponsePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class LimitResponsePatchArgs:
@@ -630,6 +897,22 @@ class LimitResponsePatchArgs:
         pulumi.set(self, "type", value)
 
 
+if not MYPY:
+    class LimitResponseArgsDict(TypedDict):
+        """
+        LimitResponse defines how to handle requests that can not be executed right now.
+        """
+        type: pulumi.Input[str]
+        """
+        `type` is "Queue" or "Reject". "Queue" means that requests that can not be executed upon arrival are held in a queue until they can be executed or a queuing limit is reached. "Reject" means that requests that can not be executed upon arrival are rejected. Required.
+        """
+        queuing: NotRequired[pulumi.Input['QueuingConfigurationArgsDict']]
+        """
+        `queuing` holds the configuration parameters for queuing. This field may be non-empty only if `type` is `"Queue"`.
+        """
+elif False:
+    LimitResponseArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class LimitResponseArgs:
     def __init__(__self__, *,
@@ -668,6 +951,42 @@ class LimitResponseArgs:
     def queuing(self, value: Optional[pulumi.Input['QueuingConfigurationArgs']]):
         pulumi.set(self, "queuing", value)
 
+
+if not MYPY:
+    class LimitedPriorityLevelConfigurationPatchArgsDict(TypedDict):
+        """
+        LimitedPriorityLevelConfiguration specifies how to handle requests that are subject to limits. It addresses two issues:
+          - How are requests for this priority level limited?
+          - What should be done with requests that exceed the limit?
+        """
+        borrowing_limit_percent: NotRequired[pulumi.Input[int]]
+        """
+        `borrowingLimitPercent`, if present, configures a limit on how many seats this priority level can borrow from other priority levels. The limit is known as this level's BorrowingConcurrencyLimit (BorrowingCL) and is a limit on the total number of seats that this level may borrow at any one time. This field holds the ratio of that limit to the level's nominal concurrency limit. When this field is non-nil, it must hold a non-negative integer and the limit is calculated as follows.
+
+        BorrowingCL(i) = round( NominalCL(i) * borrowingLimitPercent(i)/100.0 )
+
+        The value of this field can be more than 100, implying that this priority level can borrow a number of seats that is greater than its own nominal concurrency limit (NominalCL). When this field is left `nil`, the limit is effectively infinite.
+        """
+        lendable_percent: NotRequired[pulumi.Input[int]]
+        """
+        `lendablePercent` prescribes the fraction of the level's NominalCL that can be borrowed by other priority levels. The value of this field must be between 0 and 100, inclusive, and it defaults to 0. The number of seats that other levels can borrow from this level, known as this level's LendableConcurrencyLimit (LendableCL), is defined as follows.
+
+        LendableCL(i) = round( NominalCL(i) * lendablePercent(i)/100.0 )
+        """
+        limit_response: NotRequired[pulumi.Input['LimitResponsePatchArgsDict']]
+        """
+        `limitResponse` indicates what to do with requests that can not be executed right now
+        """
+        nominal_concurrency_shares: NotRequired[pulumi.Input[int]]
+        """
+        `nominalConcurrencyShares` (NCS) contributes to the computation of the NominalConcurrencyLimit (NominalCL) of this level. This is the number of execution seats available at this priority level. This is used both for requests dispatched from this priority level as well as requests dispatched from other priority levels borrowing seats from this level. The server's concurrency limit (ServerCL) is divided among the Limited priority levels in proportion to their NCS values:
+
+        NominalCL(i)  = ceil( ServerCL * NCS(i) / sum_ncs ) sum_ncs = sum[priority level k] NCS(k)
+
+        Bigger numbers mean a larger nominal concurrency limit, at the expense of every other priority level. This field has a default value of 30.
+        """
+elif False:
+    LimitedPriorityLevelConfigurationPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class LimitedPriorityLevelConfigurationPatchArgs:
@@ -763,6 +1082,42 @@ class LimitedPriorityLevelConfigurationPatchArgs:
         pulumi.set(self, "nominal_concurrency_shares", value)
 
 
+if not MYPY:
+    class LimitedPriorityLevelConfigurationArgsDict(TypedDict):
+        """
+        LimitedPriorityLevelConfiguration specifies how to handle requests that are subject to limits. It addresses two issues:
+          - How are requests for this priority level limited?
+          - What should be done with requests that exceed the limit?
+        """
+        borrowing_limit_percent: NotRequired[pulumi.Input[int]]
+        """
+        `borrowingLimitPercent`, if present, configures a limit on how many seats this priority level can borrow from other priority levels. The limit is known as this level's BorrowingConcurrencyLimit (BorrowingCL) and is a limit on the total number of seats that this level may borrow at any one time. This field holds the ratio of that limit to the level's nominal concurrency limit. When this field is non-nil, it must hold a non-negative integer and the limit is calculated as follows.
+
+        BorrowingCL(i) = round( NominalCL(i) * borrowingLimitPercent(i)/100.0 )
+
+        The value of this field can be more than 100, implying that this priority level can borrow a number of seats that is greater than its own nominal concurrency limit (NominalCL). When this field is left `nil`, the limit is effectively infinite.
+        """
+        lendable_percent: NotRequired[pulumi.Input[int]]
+        """
+        `lendablePercent` prescribes the fraction of the level's NominalCL that can be borrowed by other priority levels. The value of this field must be between 0 and 100, inclusive, and it defaults to 0. The number of seats that other levels can borrow from this level, known as this level's LendableConcurrencyLimit (LendableCL), is defined as follows.
+
+        LendableCL(i) = round( NominalCL(i) * lendablePercent(i)/100.0 )
+        """
+        limit_response: NotRequired[pulumi.Input['LimitResponseArgsDict']]
+        """
+        `limitResponse` indicates what to do with requests that can not be executed right now
+        """
+        nominal_concurrency_shares: NotRequired[pulumi.Input[int]]
+        """
+        `nominalConcurrencyShares` (NCS) contributes to the computation of the NominalConcurrencyLimit (NominalCL) of this level. This is the number of execution seats available at this priority level. This is used both for requests dispatched from this priority level as well as requests dispatched from other priority levels borrowing seats from this level. The server's concurrency limit (ServerCL) is divided among the Limited priority levels in proportion to their NCS values:
+
+        NominalCL(i)  = ceil( ServerCL * NCS(i) / sum_ncs ) sum_ncs = sum[priority level k] NCS(k)
+
+        Bigger numbers mean a larger nominal concurrency limit, at the expense of every other priority level. This field has a default value of 30.
+        """
+elif False:
+    LimitedPriorityLevelConfigurationArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class LimitedPriorityLevelConfigurationArgs:
     def __init__(__self__, *,
@@ -857,6 +1212,28 @@ class LimitedPriorityLevelConfigurationArgs:
         pulumi.set(self, "nominal_concurrency_shares", value)
 
 
+if not MYPY:
+    class NonResourcePolicyRulePatchArgsDict(TypedDict):
+        """
+        NonResourcePolicyRule is a predicate that matches non-resource requests according to their verb and the target non-resource URL. A NonResourcePolicyRule matches a request if and only if both (a) at least one member of verbs matches the request and (b) at least one member of nonResourceURLs matches the request.
+        """
+        non_resource_urls: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        `nonResourceURLs` is a set of url prefixes that a user should have access to and may not be empty. For example:
+          - "/healthz" is legal
+          - "/hea*" is illegal
+          - "/hea" is legal but matches nothing
+          - "/hea/*" also matches nothing
+          - "/healthz/*" matches all per-component health checks.
+        "*" matches all non-resource urls. if it is present, it must be the only entry. Required.
+        """
+        verbs: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        `verbs` is a list of matching verbs and may not be empty. "*" matches all verbs. If it is present, it must be the only entry. Required.
+        """
+elif False:
+    NonResourcePolicyRulePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class NonResourcePolicyRulePatchArgs:
     def __init__(__self__, *,
@@ -909,6 +1286,28 @@ class NonResourcePolicyRulePatchArgs:
         pulumi.set(self, "verbs", value)
 
 
+if not MYPY:
+    class NonResourcePolicyRuleArgsDict(TypedDict):
+        """
+        NonResourcePolicyRule is a predicate that matches non-resource requests according to their verb and the target non-resource URL. A NonResourcePolicyRule matches a request if and only if both (a) at least one member of verbs matches the request and (b) at least one member of nonResourceURLs matches the request.
+        """
+        non_resource_urls: pulumi.Input[Sequence[pulumi.Input[str]]]
+        """
+        `nonResourceURLs` is a set of url prefixes that a user should have access to and may not be empty. For example:
+          - "/healthz" is legal
+          - "/hea*" is illegal
+          - "/hea" is legal but matches nothing
+          - "/hea/*" also matches nothing
+          - "/healthz/*" matches all per-component health checks.
+        "*" matches all non-resource urls. if it is present, it must be the only entry. Required.
+        """
+        verbs: pulumi.Input[Sequence[pulumi.Input[str]]]
+        """
+        `verbs` is a list of matching verbs and may not be empty. "*" matches all verbs. If it is present, it must be the only entry. Required.
+        """
+elif False:
+    NonResourcePolicyRuleArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class NonResourcePolicyRuleArgs:
     def __init__(__self__, *,
@@ -958,6 +1357,26 @@ class NonResourcePolicyRuleArgs:
     def verbs(self, value: pulumi.Input[Sequence[pulumi.Input[str]]]):
         pulumi.set(self, "verbs", value)
 
+
+if not MYPY:
+    class PolicyRulesWithSubjectsPatchArgsDict(TypedDict):
+        """
+        PolicyRulesWithSubjects prescribes a test that applies to a request to an apiserver. The test considers the subject making the request, the verb being requested, and the resource to be acted upon. This PolicyRulesWithSubjects matches a request if and only if both (a) at least one member of subjects matches the request and (b) at least one member of resourceRules or nonResourceRules matches the request.
+        """
+        non_resource_rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['NonResourcePolicyRulePatchArgsDict']]]]
+        """
+        `nonResourceRules` is a list of NonResourcePolicyRules that identify matching requests according to their verb and the target non-resource URL.
+        """
+        resource_rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['ResourcePolicyRulePatchArgsDict']]]]
+        """
+        `resourceRules` is a slice of ResourcePolicyRules that identify matching requests according to their verb and the target resource. At least one of `resourceRules` and `nonResourceRules` has to be non-empty.
+        """
+        subjects: NotRequired[pulumi.Input[Sequence[pulumi.Input['SubjectPatchArgsDict']]]]
+        """
+        subjects is the list of normal user, serviceaccount, or group that this rule cares about. There must be at least one member in this slice. A slice that includes both the system:authenticated and system:unauthenticated user groups matches every request. Required.
+        """
+elif False:
+    PolicyRulesWithSubjectsPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class PolicyRulesWithSubjectsPatchArgs:
@@ -1015,6 +1434,26 @@ class PolicyRulesWithSubjectsPatchArgs:
         pulumi.set(self, "subjects", value)
 
 
+if not MYPY:
+    class PolicyRulesWithSubjectsArgsDict(TypedDict):
+        """
+        PolicyRulesWithSubjects prescribes a test that applies to a request to an apiserver. The test considers the subject making the request, the verb being requested, and the resource to be acted upon. This PolicyRulesWithSubjects matches a request if and only if both (a) at least one member of subjects matches the request and (b) at least one member of resourceRules or nonResourceRules matches the request.
+        """
+        subjects: pulumi.Input[Sequence[pulumi.Input['SubjectArgsDict']]]
+        """
+        subjects is the list of normal user, serviceaccount, or group that this rule cares about. There must be at least one member in this slice. A slice that includes both the system:authenticated and system:unauthenticated user groups matches every request. Required.
+        """
+        non_resource_rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['NonResourcePolicyRuleArgsDict']]]]
+        """
+        `nonResourceRules` is a list of NonResourcePolicyRules that identify matching requests according to their verb and the target non-resource URL.
+        """
+        resource_rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['ResourcePolicyRuleArgsDict']]]]
+        """
+        `resourceRules` is a slice of ResourcePolicyRules that identify matching requests according to their verb and the target resource. At least one of `resourceRules` and `nonResourceRules` has to be non-empty.
+        """
+elif False:
+    PolicyRulesWithSubjectsArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PolicyRulesWithSubjectsArgs:
     def __init__(__self__, *,
@@ -1069,6 +1508,34 @@ class PolicyRulesWithSubjectsArgs:
     def resource_rules(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['ResourcePolicyRuleArgs']]]]):
         pulumi.set(self, "resource_rules", value)
 
+
+if not MYPY:
+    class PriorityLevelConfigurationConditionArgsDict(TypedDict):
+        """
+        PriorityLevelConfigurationCondition defines the condition of priority level.
+        """
+        last_transition_time: NotRequired[pulumi.Input[str]]
+        """
+        `lastTransitionTime` is the last time the condition transitioned from one status to another.
+        """
+        message: NotRequired[pulumi.Input[str]]
+        """
+        `message` is a human-readable message indicating details about last transition.
+        """
+        reason: NotRequired[pulumi.Input[str]]
+        """
+        `reason` is a unique, one-word, CamelCase reason for the condition's last transition.
+        """
+        status: NotRequired[pulumi.Input[str]]
+        """
+        `status` is the status of the condition. Can be True, False, Unknown. Required.
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        `type` is the type of the condition. Required.
+        """
+elif False:
+    PriorityLevelConfigurationConditionArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class PriorityLevelConfigurationConditionArgs:
@@ -1158,6 +1625,18 @@ class PriorityLevelConfigurationConditionArgs:
         pulumi.set(self, "type", value)
 
 
+if not MYPY:
+    class PriorityLevelConfigurationReferencePatchArgsDict(TypedDict):
+        """
+        PriorityLevelConfigurationReference contains information that points to the "request-priority" being used.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        `name` is the name of the priority level configuration being referenced Required.
+        """
+elif False:
+    PriorityLevelConfigurationReferencePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PriorityLevelConfigurationReferencePatchArgs:
     def __init__(__self__, *,
@@ -1182,6 +1661,18 @@ class PriorityLevelConfigurationReferencePatchArgs:
         pulumi.set(self, "name", value)
 
 
+if not MYPY:
+    class PriorityLevelConfigurationReferenceArgsDict(TypedDict):
+        """
+        PriorityLevelConfigurationReference contains information that points to the "request-priority" being used.
+        """
+        name: pulumi.Input[str]
+        """
+        `name` is the name of the priority level configuration being referenced Required.
+        """
+elif False:
+    PriorityLevelConfigurationReferenceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PriorityLevelConfigurationReferenceArgs:
     def __init__(__self__, *,
@@ -1204,6 +1695,26 @@ class PriorityLevelConfigurationReferenceArgs:
     def name(self, value: pulumi.Input[str]):
         pulumi.set(self, "name", value)
 
+
+if not MYPY:
+    class PriorityLevelConfigurationSpecPatchArgsDict(TypedDict):
+        """
+        PriorityLevelConfigurationSpec specifies the configuration of a priority level.
+        """
+        exempt: NotRequired[pulumi.Input['ExemptPriorityLevelConfigurationPatchArgsDict']]
+        """
+        `exempt` specifies how requests are handled for an exempt priority level. This field MUST be empty if `type` is `"Limited"`. This field MAY be non-empty if `type` is `"Exempt"`. If empty and `type` is `"Exempt"` then the default values for `ExemptPriorityLevelConfiguration` apply.
+        """
+        limited: NotRequired[pulumi.Input['LimitedPriorityLevelConfigurationPatchArgsDict']]
+        """
+        `limited` specifies how requests are handled for a Limited priority level. This field must be non-empty if and only if `type` is `"Limited"`.
+        """
+        type: NotRequired[pulumi.Input[str]]
+        """
+        `type` indicates whether this priority level is subject to limitation on request execution.  A value of `"Exempt"` means that requests of this priority level are not subject to a limit (and thus are never queued) and do not detract from the capacity made available to other priority levels.  A value of `"Limited"` means that (a) requests of this priority level _are_ subject to limits and (b) some of the server's limited capacity is made available exclusively to this priority level. Required.
+        """
+elif False:
+    PriorityLevelConfigurationSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class PriorityLevelConfigurationSpecPatchArgs:
@@ -1261,6 +1772,26 @@ class PriorityLevelConfigurationSpecPatchArgs:
         pulumi.set(self, "type", value)
 
 
+if not MYPY:
+    class PriorityLevelConfigurationSpecArgsDict(TypedDict):
+        """
+        PriorityLevelConfigurationSpec specifies the configuration of a priority level.
+        """
+        type: pulumi.Input[str]
+        """
+        `type` indicates whether this priority level is subject to limitation on request execution.  A value of `"Exempt"` means that requests of this priority level are not subject to a limit (and thus are never queued) and do not detract from the capacity made available to other priority levels.  A value of `"Limited"` means that (a) requests of this priority level _are_ subject to limits and (b) some of the server's limited capacity is made available exclusively to this priority level. Required.
+        """
+        exempt: NotRequired[pulumi.Input['ExemptPriorityLevelConfigurationArgsDict']]
+        """
+        `exempt` specifies how requests are handled for an exempt priority level. This field MUST be empty if `type` is `"Limited"`. This field MAY be non-empty if `type` is `"Exempt"`. If empty and `type` is `"Exempt"` then the default values for `ExemptPriorityLevelConfiguration` apply.
+        """
+        limited: NotRequired[pulumi.Input['LimitedPriorityLevelConfigurationArgsDict']]
+        """
+        `limited` specifies how requests are handled for a Limited priority level. This field must be non-empty if and only if `type` is `"Limited"`.
+        """
+elif False:
+    PriorityLevelConfigurationSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PriorityLevelConfigurationSpecArgs:
     def __init__(__self__, *,
@@ -1316,6 +1847,18 @@ class PriorityLevelConfigurationSpecArgs:
         pulumi.set(self, "limited", value)
 
 
+if not MYPY:
+    class PriorityLevelConfigurationStatusArgsDict(TypedDict):
+        """
+        PriorityLevelConfigurationStatus represents the current state of a "request-priority".
+        """
+        conditions: NotRequired[pulumi.Input[Sequence[pulumi.Input['PriorityLevelConfigurationConditionArgsDict']]]]
+        """
+        `conditions` is the current state of "request-priority".
+        """
+elif False:
+    PriorityLevelConfigurationStatusArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PriorityLevelConfigurationStatusArgs:
     def __init__(__self__, *,
@@ -1339,6 +1882,34 @@ class PriorityLevelConfigurationStatusArgs:
     def conditions(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['PriorityLevelConfigurationConditionArgs']]]]):
         pulumi.set(self, "conditions", value)
 
+
+if not MYPY:
+    class PriorityLevelConfigurationArgsDict(TypedDict):
+        """
+        PriorityLevelConfiguration represents the configuration of a priority level.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        `metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['PriorityLevelConfigurationSpecArgsDict']]
+        """
+        `spec` is the specification of the desired behavior of a "request-priority". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+        status: NotRequired[pulumi.Input['PriorityLevelConfigurationStatusArgsDict']]
+        """
+        `status` is the current status of a "request-priority". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+elif False:
+    PriorityLevelConfigurationArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class PriorityLevelConfigurationArgs:
@@ -1428,6 +1999,26 @@ class PriorityLevelConfigurationArgs:
         pulumi.set(self, "status", value)
 
 
+if not MYPY:
+    class QueuingConfigurationPatchArgsDict(TypedDict):
+        """
+        QueuingConfiguration holds the configuration parameters for queuing
+        """
+        hand_size: NotRequired[pulumi.Input[int]]
+        """
+        `handSize` is a small positive number that configures the shuffle sharding of requests into queues.  When enqueuing a request at this priority level the request's flow identifier (a string pair) is hashed and the hash value is used to shuffle the list of queues and deal a hand of the size specified here.  The request is put into one of the shortest queues in that hand. `handSize` must be no larger than `queues`, and should be significantly smaller (so that a few heavy flows do not saturate most of the queues).  See the user-facing documentation for more extensive guidance on setting this field.  This field has a default value of 8.
+        """
+        queue_length_limit: NotRequired[pulumi.Input[int]]
+        """
+        `queueLengthLimit` is the maximum number of requests allowed to be waiting in a given queue of this priority level at a time; excess requests are rejected.  This value must be positive.  If not specified, it will be defaulted to 50.
+        """
+        queues: NotRequired[pulumi.Input[int]]
+        """
+        `queues` is the number of queues for this priority level. The queues exist independently at each apiserver. The value must be positive.  Setting it to 1 effectively precludes shufflesharding and thus makes the distinguisher method of associated flow schemas irrelevant.  This field has a default value of 64.
+        """
+elif False:
+    QueuingConfigurationPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class QueuingConfigurationPatchArgs:
     def __init__(__self__, *,
@@ -1484,6 +2075,26 @@ class QueuingConfigurationPatchArgs:
         pulumi.set(self, "queues", value)
 
 
+if not MYPY:
+    class QueuingConfigurationArgsDict(TypedDict):
+        """
+        QueuingConfiguration holds the configuration parameters for queuing
+        """
+        hand_size: NotRequired[pulumi.Input[int]]
+        """
+        `handSize` is a small positive number that configures the shuffle sharding of requests into queues.  When enqueuing a request at this priority level the request's flow identifier (a string pair) is hashed and the hash value is used to shuffle the list of queues and deal a hand of the size specified here.  The request is put into one of the shortest queues in that hand. `handSize` must be no larger than `queues`, and should be significantly smaller (so that a few heavy flows do not saturate most of the queues).  See the user-facing documentation for more extensive guidance on setting this field.  This field has a default value of 8.
+        """
+        queue_length_limit: NotRequired[pulumi.Input[int]]
+        """
+        `queueLengthLimit` is the maximum number of requests allowed to be waiting in a given queue of this priority level at a time; excess requests are rejected.  This value must be positive.  If not specified, it will be defaulted to 50.
+        """
+        queues: NotRequired[pulumi.Input[int]]
+        """
+        `queues` is the number of queues for this priority level. The queues exist independently at each apiserver. The value must be positive.  Setting it to 1 effectively precludes shufflesharding and thus makes the distinguisher method of associated flow schemas irrelevant.  This field has a default value of 64.
+        """
+elif False:
+    QueuingConfigurationArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class QueuingConfigurationArgs:
     def __init__(__self__, *,
@@ -1539,6 +2150,34 @@ class QueuingConfigurationArgs:
     def queues(self, value: Optional[pulumi.Input[int]]):
         pulumi.set(self, "queues", value)
 
+
+if not MYPY:
+    class ResourcePolicyRulePatchArgsDict(TypedDict):
+        """
+        ResourcePolicyRule is a predicate that matches some resource requests, testing the request's verb and the target resource. A ResourcePolicyRule matches a resource request if and only if: (a) at least one member of verbs matches the request, (b) at least one member of apiGroups matches the request, (c) at least one member of resources matches the request, and (d) either (d1) the request does not specify a namespace (i.e., `Namespace==""`) and clusterScope is true or (d2) the request specifies a namespace and least one member of namespaces matches the request's namespace.
+        """
+        api_groups: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        `apiGroups` is a list of matching API groups and may not be empty. "*" matches all API groups and, if present, must be the only entry. Required.
+        """
+        cluster_scope: NotRequired[pulumi.Input[bool]]
+        """
+        `clusterScope` indicates whether to match requests that do not specify a namespace (which happens either because the resource is not namespaced or the request targets all namespaces). If this field is omitted or false then the `namespaces` field must contain a non-empty list.
+        """
+        namespaces: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        `namespaces` is a list of target namespaces that restricts matches.  A request that specifies a target namespace matches only if either (a) this list contains that target namespace or (b) this list contains "*".  Note that "*" matches any specified namespace but does not match a request that _does not specify_ a namespace (see the `clusterScope` field for that). This list may be empty, but only if `clusterScope` is true.
+        """
+        resources: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        `resources` is a list of matching resources (i.e., lowercase and plural) with, if desired, subresource.  For example, [ "services", "nodes/status" ].  This list may not be empty. "*" matches all resources and, if present, must be the only entry. Required.
+        """
+        verbs: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        `verbs` is a list of matching verbs and may not be empty. "*" matches all verbs and, if present, must be the only entry. Required.
+        """
+elif False:
+    ResourcePolicyRulePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ResourcePolicyRulePatchArgs:
@@ -1628,6 +2267,34 @@ class ResourcePolicyRulePatchArgs:
         pulumi.set(self, "verbs", value)
 
 
+if not MYPY:
+    class ResourcePolicyRuleArgsDict(TypedDict):
+        """
+        ResourcePolicyRule is a predicate that matches some resource requests, testing the request's verb and the target resource. A ResourcePolicyRule matches a resource request if and only if: (a) at least one member of verbs matches the request, (b) at least one member of apiGroups matches the request, (c) at least one member of resources matches the request, and (d) either (d1) the request does not specify a namespace (i.e., `Namespace==""`) and clusterScope is true or (d2) the request specifies a namespace and least one member of namespaces matches the request's namespace.
+        """
+        api_groups: pulumi.Input[Sequence[pulumi.Input[str]]]
+        """
+        `apiGroups` is a list of matching API groups and may not be empty. "*" matches all API groups and, if present, must be the only entry. Required.
+        """
+        resources: pulumi.Input[Sequence[pulumi.Input[str]]]
+        """
+        `resources` is a list of matching resources (i.e., lowercase and plural) with, if desired, subresource.  For example, [ "services", "nodes/status" ].  This list may not be empty. "*" matches all resources and, if present, must be the only entry. Required.
+        """
+        verbs: pulumi.Input[Sequence[pulumi.Input[str]]]
+        """
+        `verbs` is a list of matching verbs and may not be empty. "*" matches all verbs and, if present, must be the only entry. Required.
+        """
+        cluster_scope: NotRequired[pulumi.Input[bool]]
+        """
+        `clusterScope` indicates whether to match requests that do not specify a namespace (which happens either because the resource is not namespaced or the request targets all namespaces). If this field is omitted or false then the `namespaces` field must contain a non-empty list.
+        """
+        namespaces: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        `namespaces` is a list of target namespaces that restricts matches.  A request that specifies a target namespace matches only if either (a) this list contains that target namespace or (b) this list contains "*".  Note that "*" matches any specified namespace but does not match a request that _does not specify_ a namespace (see the `clusterScope` field for that). This list may be empty, but only if `clusterScope` is true.
+        """
+elif False:
+    ResourcePolicyRuleArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ResourcePolicyRuleArgs:
     def __init__(__self__, *,
@@ -1713,6 +2380,22 @@ class ResourcePolicyRuleArgs:
         pulumi.set(self, "namespaces", value)
 
 
+if not MYPY:
+    class ServiceAccountSubjectPatchArgsDict(TypedDict):
+        """
+        ServiceAccountSubject holds detailed information for service-account-kind subject.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        `name` is the name of matching ServiceAccount objects, or "*" to match regardless of name. Required.
+        """
+        namespace: NotRequired[pulumi.Input[str]]
+        """
+        `namespace` is the namespace of matching ServiceAccount objects. Required.
+        """
+elif False:
+    ServiceAccountSubjectPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ServiceAccountSubjectPatchArgs:
     def __init__(__self__, *,
@@ -1753,6 +2436,22 @@ class ServiceAccountSubjectPatchArgs:
         pulumi.set(self, "namespace", value)
 
 
+if not MYPY:
+    class ServiceAccountSubjectArgsDict(TypedDict):
+        """
+        ServiceAccountSubject holds detailed information for service-account-kind subject.
+        """
+        name: pulumi.Input[str]
+        """
+        `name` is the name of matching ServiceAccount objects, or "*" to match regardless of name. Required.
+        """
+        namespace: pulumi.Input[str]
+        """
+        `namespace` is the namespace of matching ServiceAccount objects. Required.
+        """
+elif False:
+    ServiceAccountSubjectArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ServiceAccountSubjectArgs:
     def __init__(__self__, *,
@@ -1790,6 +2489,30 @@ class ServiceAccountSubjectArgs:
     def namespace(self, value: pulumi.Input[str]):
         pulumi.set(self, "namespace", value)
 
+
+if not MYPY:
+    class SubjectPatchArgsDict(TypedDict):
+        """
+        Subject matches the originator of a request, as identified by the request authentication system. There are three ways of matching an originator; by user, group, or service account.
+        """
+        group: NotRequired[pulumi.Input['GroupSubjectPatchArgsDict']]
+        """
+        `group` matches based on user group name.
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        `kind` indicates which one of the other fields is non-empty. Required
+        """
+        service_account: NotRequired[pulumi.Input['ServiceAccountSubjectPatchArgsDict']]
+        """
+        `serviceAccount` matches ServiceAccounts.
+        """
+        user: NotRequired[pulumi.Input['UserSubjectPatchArgsDict']]
+        """
+        `user` matches based on username.
+        """
+elif False:
+    SubjectPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class SubjectPatchArgs:
@@ -1863,6 +2586,30 @@ class SubjectPatchArgs:
         pulumi.set(self, "user", value)
 
 
+if not MYPY:
+    class SubjectArgsDict(TypedDict):
+        """
+        Subject matches the originator of a request, as identified by the request authentication system. There are three ways of matching an originator; by user, group, or service account.
+        """
+        kind: pulumi.Input[str]
+        """
+        `kind` indicates which one of the other fields is non-empty. Required
+        """
+        group: NotRequired[pulumi.Input['GroupSubjectArgsDict']]
+        """
+        `group` matches based on user group name.
+        """
+        service_account: NotRequired[pulumi.Input['ServiceAccountSubjectArgsDict']]
+        """
+        `serviceAccount` matches ServiceAccounts.
+        """
+        user: NotRequired[pulumi.Input['UserSubjectArgsDict']]
+        """
+        `user` matches based on username.
+        """
+elif False:
+    SubjectArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class SubjectArgs:
     def __init__(__self__, *,
@@ -1934,6 +2681,18 @@ class SubjectArgs:
         pulumi.set(self, "user", value)
 
 
+if not MYPY:
+    class UserSubjectPatchArgsDict(TypedDict):
+        """
+        UserSubject holds detailed information for user-kind subject.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        `name` is the username that matches, or "*" to match all usernames. Required.
+        """
+elif False:
+    UserSubjectPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class UserSubjectPatchArgs:
     def __init__(__self__, *,
@@ -1957,6 +2716,18 @@ class UserSubjectPatchArgs:
     def name(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "name", value)
 
+
+if not MYPY:
+    class UserSubjectArgsDict(TypedDict):
+        """
+        UserSubject holds detailed information for user-kind subject.
+        """
+        name: pulumi.Input[str]
+        """
+        `name` is the username that matches, or "*" to match all usernames. Required.
+        """
+elif False:
+    UserSubjectArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class UserSubjectArgs:

--- a/sdk/python/pulumi_kubernetes/flowcontrol/v1beta3/outputs.py
+++ b/sdk/python/pulumi_kubernetes/flowcontrol/v1beta3/outputs.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta

--- a/sdk/python/pulumi_kubernetes/helm/v3/Release.py
+++ b/sdk/python/pulumi_kubernetes/helm/v3/Release.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ._inputs import *
@@ -604,7 +609,7 @@ class Release(pulumi.CustomResource):
                  recreate_pods: Optional[pulumi.Input[bool]] = None,
                  render_subchart_notes: Optional[pulumi.Input[bool]] = None,
                  replace: Optional[pulumi.Input[bool]] = None,
-                 repository_opts: Optional[pulumi.Input[pulumi.InputType['RepositoryOptsArgs']]] = None,
+                 repository_opts: Optional[pulumi.Input[Union['RepositoryOptsArgs', 'RepositoryOptsArgsDict']]] = None,
                  reset_values: Optional[pulumi.Input[bool]] = None,
                  resource_names: Optional[pulumi.Input[Mapping[str, pulumi.Input[Sequence[pulumi.Input[str]]]]]] = None,
                  reuse_values: Optional[pulumi.Input[bool]] = None,
@@ -806,7 +811,7 @@ class Release(pulumi.CustomResource):
         :param pulumi.Input[bool] recreate_pods: Perform pods restart during upgrade/rollback.
         :param pulumi.Input[bool] render_subchart_notes: If set, render subchart notes along with the parent.
         :param pulumi.Input[bool] replace: Re-use the given name, even if that name is already used. This is unsafe in production
-        :param pulumi.Input[pulumi.InputType['RepositoryOptsArgs']] repository_opts: Specification defining the Helm chart repository to use.
+        :param pulumi.Input[Union['RepositoryOptsArgs', 'RepositoryOptsArgsDict']] repository_opts: Specification defining the Helm chart repository to use.
         :param pulumi.Input[bool] reset_values: When upgrading, reset the values to the ones built into the chart.
         :param pulumi.Input[Mapping[str, pulumi.Input[Sequence[pulumi.Input[str]]]]] resource_names: Names of resources created by the release grouped by "kind/version".
         :param pulumi.Input[bool] reuse_values: When upgrading, reuse the last release's values and merge in any overrides. If 'resetValues' is specified, this is ignored
@@ -1028,7 +1033,7 @@ class Release(pulumi.CustomResource):
                  recreate_pods: Optional[pulumi.Input[bool]] = None,
                  render_subchart_notes: Optional[pulumi.Input[bool]] = None,
                  replace: Optional[pulumi.Input[bool]] = None,
-                 repository_opts: Optional[pulumi.Input[pulumi.InputType['RepositoryOptsArgs']]] = None,
+                 repository_opts: Optional[pulumi.Input[Union['RepositoryOptsArgs', 'RepositoryOptsArgsDict']]] = None,
                  reset_values: Optional[pulumi.Input[bool]] = None,
                  resource_names: Optional[pulumi.Input[Mapping[str, pulumi.Input[Sequence[pulumi.Input[str]]]]]] = None,
                  reuse_values: Optional[pulumi.Input[bool]] = None,

--- a/sdk/python/pulumi_kubernetes/helm/v3/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/helm/v3/_inputs.py
@@ -4,14 +4,54 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 
 __all__ = [
     'RepositoryOptsArgs',
+    'RepositoryOptsArgsDict',
 ]
+
+MYPY = False
+
+if not MYPY:
+    class RepositoryOptsArgsDict(TypedDict):
+        """
+        Specification defining the Helm chart repository to use.
+        """
+        ca_file: NotRequired[pulumi.Input[str]]
+        """
+        The Repository's CA File
+        """
+        cert_file: NotRequired[pulumi.Input[str]]
+        """
+        The repository's cert file
+        """
+        key_file: NotRequired[pulumi.Input[str]]
+        """
+        The repository's cert key file
+        """
+        password: NotRequired[pulumi.Input[str]]
+        """
+        Password for HTTP basic authentication
+        """
+        repo: NotRequired[pulumi.Input[str]]
+        """
+        Repository where to locate the requested chart. If is a URL the chart is installed without installing the repository.
+        """
+        username: NotRequired[pulumi.Input[str]]
+        """
+        Username for HTTP basic authentication
+        """
+elif False:
+    RepositoryOptsArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class RepositoryOptsArgs:

--- a/sdk/python/pulumi_kubernetes/helm/v3/outputs.py
+++ b/sdk/python/pulumi_kubernetes/helm/v3/outputs.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 
 __all__ = [

--- a/sdk/python/pulumi_kubernetes/helm/v4/Chart.py
+++ b/sdk/python/pulumi_kubernetes/helm/v4/Chart.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ._inputs import *
 
@@ -270,8 +275,8 @@ class Chart(pulumi.ComponentResource):
                  keyring: Optional[pulumi.Input[Union[pulumi.Asset, pulumi.Archive]]] = None,
                  name: Optional[pulumi.Input[str]] = None,
                  namespace: Optional[pulumi.Input[str]] = None,
-                 post_renderer: Optional[pulumi.Input[pulumi.InputType['PostRendererArgs']]] = None,
-                 repository_opts: Optional[pulumi.Input[pulumi.InputType['RepositoryOptsArgs']]] = None,
+                 post_renderer: Optional[pulumi.Input[Union['PostRendererArgs', 'PostRendererArgsDict']]] = None,
+                 repository_opts: Optional[pulumi.Input[Union['RepositoryOptsArgs', 'RepositoryOptsArgsDict']]] = None,
                  resource_prefix: Optional[pulumi.Input[str]] = None,
                  skip_await: Optional[pulumi.Input[bool]] = None,
                  skip_crds: Optional[pulumi.Input[bool]] = None,
@@ -453,8 +458,8 @@ class Chart(pulumi.ComponentResource):
         :param pulumi.Input[Union[pulumi.Asset, pulumi.Archive]] keyring: Location of public keys used for verification. Used only if `verify` is true
         :param pulumi.Input[str] name: Release name.
         :param pulumi.Input[str] namespace: Namespace for the release.
-        :param pulumi.Input[pulumi.InputType['PostRendererArgs']] post_renderer: Specification defining the post-renderer to use.
-        :param pulumi.Input[pulumi.InputType['RepositoryOptsArgs']] repository_opts: Specification defining the Helm chart repository to use.
+        :param pulumi.Input[Union['PostRendererArgs', 'PostRendererArgsDict']] post_renderer: Specification defining the post-renderer to use.
+        :param pulumi.Input[Union['RepositoryOptsArgs', 'RepositoryOptsArgsDict']] repository_opts: Specification defining the Helm chart repository to use.
         :param pulumi.Input[str] resource_prefix: An optional prefix for the auto-generated resource names. Example: A resource created with resourcePrefix="foo" would produce a resource named "foo:resourceName".
         :param pulumi.Input[bool] skip_await: By default, the provider waits until all resources are in a ready state before marking the release as successful. Setting this to true will skip such await logic.
         :param pulumi.Input[bool] skip_crds: If set, no CRDs will be installed. By default, CRDs are installed if not already present.
@@ -655,8 +660,8 @@ class Chart(pulumi.ComponentResource):
                  keyring: Optional[pulumi.Input[Union[pulumi.Asset, pulumi.Archive]]] = None,
                  name: Optional[pulumi.Input[str]] = None,
                  namespace: Optional[pulumi.Input[str]] = None,
-                 post_renderer: Optional[pulumi.Input[pulumi.InputType['PostRendererArgs']]] = None,
-                 repository_opts: Optional[pulumi.Input[pulumi.InputType['RepositoryOptsArgs']]] = None,
+                 post_renderer: Optional[pulumi.Input[Union['PostRendererArgs', 'PostRendererArgsDict']]] = None,
+                 repository_opts: Optional[pulumi.Input[Union['RepositoryOptsArgs', 'RepositoryOptsArgsDict']]] = None,
                  resource_prefix: Optional[pulumi.Input[str]] = None,
                  skip_await: Optional[pulumi.Input[bool]] = None,
                  skip_crds: Optional[pulumi.Input[bool]] = None,

--- a/sdk/python/pulumi_kubernetes/helm/v4/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/helm/v4/_inputs.py
@@ -4,15 +4,40 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 
 __all__ = [
     'PostRendererArgs',
+    'PostRendererArgsDict',
     'RepositoryOptsArgs',
+    'RepositoryOptsArgsDict',
 ]
+
+MYPY = False
+
+if not MYPY:
+    class PostRendererArgsDict(TypedDict):
+        """
+        Specification defining the post-renderer to use.
+        """
+        command: pulumi.Input[str]
+        """
+        Path to an executable to be used for post rendering.
+        """
+        args: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Arguments to pass to the post-renderer command.
+        """
+elif False:
+    PostRendererArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class PostRendererArgs:
@@ -52,6 +77,38 @@ class PostRendererArgs:
     def args(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]):
         pulumi.set(self, "args", value)
 
+
+if not MYPY:
+    class RepositoryOptsArgsDict(TypedDict):
+        """
+        Specification defining the Helm chart repository to use.
+        """
+        ca_file: NotRequired[pulumi.Input[Union[pulumi.Asset, pulumi.Archive]]]
+        """
+        The Repository's CA File
+        """
+        cert_file: NotRequired[pulumi.Input[Union[pulumi.Asset, pulumi.Archive]]]
+        """
+        The repository's cert file
+        """
+        key_file: NotRequired[pulumi.Input[Union[pulumi.Asset, pulumi.Archive]]]
+        """
+        The repository's cert key file
+        """
+        password: NotRequired[pulumi.Input[str]]
+        """
+        Password for HTTP basic authentication
+        """
+        repo: NotRequired[pulumi.Input[str]]
+        """
+        Repository where to locate the requested chart. If is a URL the chart is installed without installing the repository.
+        """
+        username: NotRequired[pulumi.Input[str]]
+        """
+        Username for HTTP basic authentication
+        """
+elif False:
+    RepositoryOptsArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class RepositoryOptsArgs:

--- a/sdk/python/pulumi_kubernetes/kustomize/v2/Directory.py
+++ b/sdk/python/pulumi_kubernetes/kustomize/v2/Directory.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 
 __all__ = ['DirectoryArgs', 'Directory']

--- a/sdk/python/pulumi_kubernetes/meta/v1/Status.py
+++ b/sdk/python/pulumi_kubernetes/meta/v1/Status.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ._inputs import *
@@ -140,10 +145,10 @@ class Status(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  code: Optional[pulumi.Input[int]] = None,
-                 details: Optional[pulumi.Input[pulumi.InputType['StatusDetailsArgs']]] = None,
+                 details: Optional[pulumi.Input[Union['StatusDetailsArgs', 'StatusDetailsArgsDict']]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
                  message: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['ListMetaArgs', 'ListMetaArgsDict']]] = None,
                  reason: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         """
@@ -153,10 +158,10 @@ class Status(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[int] code: Suggested HTTP return code for this status, 0 if not set.
-        :param pulumi.Input[pulumi.InputType['StatusDetailsArgs']] details: Extended data associated with the reason.  Each reason may define its own extended details. This field is optional and the data returned is not guaranteed to conform to any schema except that defined by the reason type.
+        :param pulumi.Input[Union['StatusDetailsArgs', 'StatusDetailsArgsDict']] details: Extended data associated with the reason.  Each reason may define its own extended details. This field is optional and the data returned is not guaranteed to conform to any schema except that defined by the reason type.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
         :param pulumi.Input[str] message: A human-readable description of the status of this operation.
-        :param pulumi.Input[pulumi.InputType['ListMetaArgs']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        :param pulumi.Input[Union['ListMetaArgs', 'ListMetaArgsDict']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
         :param pulumi.Input[str] reason: A machine-readable description of why this operation is in the "Failure" status. If this value is empty there is no information available. A Reason clarifies an HTTP status code but does not override it.
         """
         ...
@@ -185,10 +190,10 @@ class Status(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  code: Optional[pulumi.Input[int]] = None,
-                 details: Optional[pulumi.Input[pulumi.InputType['StatusDetailsArgs']]] = None,
+                 details: Optional[pulumi.Input[Union['StatusDetailsArgs', 'StatusDetailsArgsDict']]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
                  message: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['ListMetaArgs', 'ListMetaArgsDict']]] = None,
                  reason: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)

--- a/sdk/python/pulumi_kubernetes/meta/v1/StatusPatch.py
+++ b/sdk/python/pulumi_kubernetes/meta/v1/StatusPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ._inputs import *
@@ -140,10 +145,10 @@ class StatusPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  code: Optional[pulumi.Input[int]] = None,
-                 details: Optional[pulumi.Input[pulumi.InputType['StatusDetailsPatchArgs']]] = None,
+                 details: Optional[pulumi.Input[Union['StatusDetailsPatchArgs', 'StatusDetailsPatchArgsDict']]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
                  message: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['ListMetaPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['ListMetaPatchArgs', 'ListMetaPatchArgsDict']]] = None,
                  reason: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         """
@@ -159,10 +164,10 @@ class StatusPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[int] code: Suggested HTTP return code for this status, 0 if not set.
-        :param pulumi.Input[pulumi.InputType['StatusDetailsPatchArgs']] details: Extended data associated with the reason.  Each reason may define its own extended details. This field is optional and the data returned is not guaranteed to conform to any schema except that defined by the reason type.
+        :param pulumi.Input[Union['StatusDetailsPatchArgs', 'StatusDetailsPatchArgsDict']] details: Extended data associated with the reason.  Each reason may define its own extended details. This field is optional and the data returned is not guaranteed to conform to any schema except that defined by the reason type.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
         :param pulumi.Input[str] message: A human-readable description of the status of this operation.
-        :param pulumi.Input[pulumi.InputType['ListMetaPatchArgs']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        :param pulumi.Input[Union['ListMetaPatchArgs', 'ListMetaPatchArgsDict']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
         :param pulumi.Input[str] reason: A machine-readable description of why this operation is in the "Failure" status. If this value is empty there is no information available. A Reason clarifies an HTTP status code but does not override it.
         """
         ...
@@ -197,10 +202,10 @@ class StatusPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  code: Optional[pulumi.Input[int]] = None,
-                 details: Optional[pulumi.Input[pulumi.InputType['StatusDetailsPatchArgs']]] = None,
+                 details: Optional[pulumi.Input[Union['StatusDetailsPatchArgs', 'StatusDetailsPatchArgsDict']]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
                  message: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['ListMetaPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['ListMetaPatchArgs', 'ListMetaPatchArgsDict']]] = None,
                  reason: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)

--- a/sdk/python/pulumi_kubernetes/meta/v1/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/meta/v1/_inputs.py
@@ -4,30 +4,86 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 
 __all__ = [
     'ConditionArgs',
+    'ConditionArgsDict',
     'LabelSelectorPatchArgs',
+    'LabelSelectorPatchArgsDict',
     'LabelSelectorRequirementPatchArgs',
+    'LabelSelectorRequirementPatchArgsDict',
     'LabelSelectorRequirementArgs',
+    'LabelSelectorRequirementArgsDict',
     'LabelSelectorArgs',
+    'LabelSelectorArgsDict',
     'ListMetaPatchArgs',
+    'ListMetaPatchArgsDict',
     'ListMetaArgs',
+    'ListMetaArgsDict',
     'ManagedFieldsEntryPatchArgs',
+    'ManagedFieldsEntryPatchArgsDict',
     'ManagedFieldsEntryArgs',
+    'ManagedFieldsEntryArgsDict',
     'ObjectMetaPatchArgs',
+    'ObjectMetaPatchArgsDict',
     'ObjectMetaArgs',
+    'ObjectMetaArgsDict',
     'OwnerReferencePatchArgs',
+    'OwnerReferencePatchArgsDict',
     'OwnerReferenceArgs',
+    'OwnerReferenceArgsDict',
     'StatusCausePatchArgs',
+    'StatusCausePatchArgsDict',
     'StatusCauseArgs',
+    'StatusCauseArgsDict',
     'StatusDetailsPatchArgs',
+    'StatusDetailsPatchArgsDict',
     'StatusDetailsArgs',
+    'StatusDetailsArgsDict',
 ]
+
+MYPY = False
+
+if not MYPY:
+    class ConditionArgsDict(TypedDict):
+        """
+        Condition contains details for one aspect of the current state of this API Resource.
+        """
+        last_transition_time: pulumi.Input[str]
+        """
+        lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+        """
+        message: pulumi.Input[str]
+        """
+        message is a human readable message indicating details about the transition. This may be an empty string.
+        """
+        reason: pulumi.Input[str]
+        """
+        reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+        """
+        status: pulumi.Input[str]
+        """
+        status of the condition, one of True, False, Unknown.
+        """
+        type: pulumi.Input[str]
+        """
+        type of condition in CamelCase or in foo.example.com/CamelCase.
+        """
+        observed_generation: NotRequired[pulumi.Input[int]]
+        """
+        observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+        """
+elif False:
+    ConditionArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ConditionArgs:
@@ -128,6 +184,22 @@ class ConditionArgs:
         pulumi.set(self, "observed_generation", value)
 
 
+if not MYPY:
+    class LabelSelectorPatchArgsDict(TypedDict):
+        """
+        A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+        """
+        match_expressions: NotRequired[pulumi.Input[Sequence[pulumi.Input['LabelSelectorRequirementPatchArgsDict']]]]
+        """
+        matchExpressions is a list of label selector requirements. The requirements are ANDed.
+        """
+        match_labels: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+        """
+elif False:
+    LabelSelectorPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class LabelSelectorPatchArgs:
     def __init__(__self__, *,
@@ -167,6 +239,26 @@ class LabelSelectorPatchArgs:
     def match_labels(self, value: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]):
         pulumi.set(self, "match_labels", value)
 
+
+if not MYPY:
+    class LabelSelectorRequirementPatchArgsDict(TypedDict):
+        """
+        A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+        """
+        key: NotRequired[pulumi.Input[str]]
+        """
+        key is the label key that the selector applies to.
+        """
+        operator: NotRequired[pulumi.Input[str]]
+        """
+        operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+        """
+        values: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+        """
+elif False:
+    LabelSelectorRequirementPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class LabelSelectorRequirementPatchArgs:
@@ -224,6 +316,26 @@ class LabelSelectorRequirementPatchArgs:
         pulumi.set(self, "values", value)
 
 
+if not MYPY:
+    class LabelSelectorRequirementArgsDict(TypedDict):
+        """
+        A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+        """
+        key: pulumi.Input[str]
+        """
+        key is the label key that the selector applies to.
+        """
+        operator: pulumi.Input[str]
+        """
+        operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+        """
+        values: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+        """
+elif False:
+    LabelSelectorRequirementArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class LabelSelectorRequirementArgs:
     def __init__(__self__, *,
@@ -278,6 +390,22 @@ class LabelSelectorRequirementArgs:
         pulumi.set(self, "values", value)
 
 
+if not MYPY:
+    class LabelSelectorArgsDict(TypedDict):
+        """
+        A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+        """
+        match_expressions: NotRequired[pulumi.Input[Sequence[pulumi.Input['LabelSelectorRequirementArgsDict']]]]
+        """
+        matchExpressions is a list of label selector requirements. The requirements are ANDed.
+        """
+        match_labels: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+        """
+elif False:
+    LabelSelectorArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class LabelSelectorArgs:
     def __init__(__self__, *,
@@ -317,6 +445,30 @@ class LabelSelectorArgs:
     def match_labels(self, value: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]):
         pulumi.set(self, "match_labels", value)
 
+
+if not MYPY:
+    class ListMetaPatchArgsDict(TypedDict):
+        """
+        ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.
+        """
+        continue_: NotRequired[pulumi.Input[str]]
+        """
+        continue may be set if the user set a limit on the number of items returned, and indicates that the server has more data available. The value is opaque and may be used to issue another request to the endpoint that served this list to retrieve the next set of available objects. Continuing a consistent list may not be possible if the server configuration has changed or more than a few minutes have passed. The resourceVersion field returned when using this continue value will be identical to the value in the first response, unless you have received this token from an error message.
+        """
+        remaining_item_count: NotRequired[pulumi.Input[int]]
+        """
+        remainingItemCount is the number of subsequent items in the list which are not included in this list response. If the list request contained label or field selectors, then the number of remaining items is unknown and the field will be left unset and omitted during serialization. If the list is complete (either because it is not chunking or because this is the last chunk), then there are no more remaining items and this field will be left unset and omitted during serialization. Servers older than v1.15 do not set this field. The intended use of the remainingItemCount is *estimating* the size of a collection. Clients should not rely on the remainingItemCount to be set or to be exact.
+        """
+        resource_version: NotRequired[pulumi.Input[str]]
+        """
+        String that identifies the server's internal version of this object that can be used by clients to determine when objects have changed. Value must be treated as opaque by clients and passed unmodified back to the server. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+        """
+        self_link: NotRequired[pulumi.Input[str]]
+        """
+        Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.
+        """
+elif False:
+    ListMetaPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ListMetaPatchArgs:
@@ -390,6 +542,30 @@ class ListMetaPatchArgs:
         pulumi.set(self, "self_link", value)
 
 
+if not MYPY:
+    class ListMetaArgsDict(TypedDict):
+        """
+        ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.
+        """
+        continue_: NotRequired[pulumi.Input[str]]
+        """
+        continue may be set if the user set a limit on the number of items returned, and indicates that the server has more data available. The value is opaque and may be used to issue another request to the endpoint that served this list to retrieve the next set of available objects. Continuing a consistent list may not be possible if the server configuration has changed or more than a few minutes have passed. The resourceVersion field returned when using this continue value will be identical to the value in the first response, unless you have received this token from an error message.
+        """
+        remaining_item_count: NotRequired[pulumi.Input[int]]
+        """
+        remainingItemCount is the number of subsequent items in the list which are not included in this list response. If the list request contained label or field selectors, then the number of remaining items is unknown and the field will be left unset and omitted during serialization. If the list is complete (either because it is not chunking or because this is the last chunk), then there are no more remaining items and this field will be left unset and omitted during serialization. Servers older than v1.15 do not set this field. The intended use of the remainingItemCount is *estimating* the size of a collection. Clients should not rely on the remainingItemCount to be set or to be exact.
+        """
+        resource_version: NotRequired[pulumi.Input[str]]
+        """
+        String that identifies the server's internal version of this object that can be used by clients to determine when objects have changed. Value must be treated as opaque by clients and passed unmodified back to the server. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+        """
+        self_link: NotRequired[pulumi.Input[str]]
+        """
+        Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.
+        """
+elif False:
+    ListMetaArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ListMetaArgs:
     def __init__(__self__, *,
@@ -461,6 +637,42 @@ class ListMetaArgs:
     def self_link(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "self_link", value)
 
+
+if not MYPY:
+    class ManagedFieldsEntryPatchArgsDict(TypedDict):
+        """
+        ManagedFieldsEntry is a workflow-id, a FieldSet and the group version of the resource that the fieldset applies to.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the version of this resource that this field set applies to. The format is "group/version" just like the top-level APIVersion field. It is necessary to track the version of a field set because it cannot be automatically converted.
+        """
+        fields_type: NotRequired[pulumi.Input[str]]
+        """
+        FieldsType is the discriminator for the different fields format and version. There is currently only one possible value: "FieldsV1"
+        """
+        fields_v1: NotRequired[Any]
+        """
+        FieldsV1 holds the first JSON version format as described in the "FieldsV1" type.
+        """
+        manager: NotRequired[pulumi.Input[str]]
+        """
+        Manager is an identifier of the workflow managing these fields.
+        """
+        operation: NotRequired[pulumi.Input[str]]
+        """
+        Operation is the type of operation which lead to this ManagedFieldsEntry being created. The only valid values for this field are 'Apply' and 'Update'.
+        """
+        subresource: NotRequired[pulumi.Input[str]]
+        """
+        Subresource is the name of the subresource used to update that object, or empty string if the object was updated through the main resource. The value of this field is used to distinguish between managers, even if they share the same name. For example, a status update will be distinct from a regular update using the same manager name. Note that the APIVersion field is not related to the Subresource field and it always corresponds to the version of the main resource.
+        """
+        time: NotRequired[pulumi.Input[str]]
+        """
+        Time is the timestamp of when the ManagedFields entry was added. The timestamp will also be updated if a field is added, the manager changes any of the owned fields value or removes a field. The timestamp does not update when a field is removed from the entry because another manager took it over.
+        """
+elif False:
+    ManagedFieldsEntryPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ManagedFieldsEntryPatchArgs:
@@ -582,6 +794,42 @@ class ManagedFieldsEntryPatchArgs:
         pulumi.set(self, "time", value)
 
 
+if not MYPY:
+    class ManagedFieldsEntryArgsDict(TypedDict):
+        """
+        ManagedFieldsEntry is a workflow-id, a FieldSet and the group version of the resource that the fieldset applies to.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the version of this resource that this field set applies to. The format is "group/version" just like the top-level APIVersion field. It is necessary to track the version of a field set because it cannot be automatically converted.
+        """
+        fields_type: NotRequired[pulumi.Input[str]]
+        """
+        FieldsType is the discriminator for the different fields format and version. There is currently only one possible value: "FieldsV1"
+        """
+        fields_v1: NotRequired[Any]
+        """
+        FieldsV1 holds the first JSON version format as described in the "FieldsV1" type.
+        """
+        manager: NotRequired[pulumi.Input[str]]
+        """
+        Manager is an identifier of the workflow managing these fields.
+        """
+        operation: NotRequired[pulumi.Input[str]]
+        """
+        Operation is the type of operation which lead to this ManagedFieldsEntry being created. The only valid values for this field are 'Apply' and 'Update'.
+        """
+        subresource: NotRequired[pulumi.Input[str]]
+        """
+        Subresource is the name of the subresource used to update that object, or empty string if the object was updated through the main resource. The value of this field is used to distinguish between managers, even if they share the same name. For example, a status update will be distinct from a regular update using the same manager name. Note that the APIVersion field is not related to the Subresource field and it always corresponds to the version of the main resource.
+        """
+        time: NotRequired[pulumi.Input[str]]
+        """
+        Time is the timestamp of when the ManagedFields entry was added. The timestamp will also be updated if a field is added, the manager changes any of the owned fields value or removes a field. The timestamp does not update when a field is removed from the entry because another manager took it over.
+        """
+elif False:
+    ManagedFieldsEntryArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ManagedFieldsEntryArgs:
     def __init__(__self__, *,
@@ -701,6 +949,92 @@ class ManagedFieldsEntryArgs:
     def time(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "time", value)
 
+
+if not MYPY:
+    class ObjectMetaPatchArgsDict(TypedDict):
+        """
+        ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create.
+        """
+        annotations: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
+        """
+        cluster_name: NotRequired[pulumi.Input[str]]
+        """
+        The name of the cluster which the object belongs to. This is used to distinguish resources with same name and namespace in different clusters. This field is not set anywhere right now and apiserver is going to ignore it if set in create or update request.
+        """
+        creation_timestamp: NotRequired[pulumi.Input[str]]
+        """
+        CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+
+        Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        deletion_grace_period_seconds: NotRequired[pulumi.Input[int]]
+        """
+        Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only.
+        """
+        deletion_timestamp: NotRequired[pulumi.Input[str]]
+        """
+        DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource is expected to be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field, once the finalizers list is empty. As long as the finalizers list contains items, deletion is blocked. Once the deletionTimestamp is set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. After that 30 seconds, the Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup, remove the pod from the API. In the presence of network partitions, this object may still exist after this timestamp, until an administrator or automated process can determine the resource is fully terminated. If not set, graceful deletion of the object has not been requested.
+
+        Populated by the system when a graceful deletion is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        finalizers: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed. Finalizers may be processed and removed in any order.  Order is NOT enforced because it introduces significant risk of stuck finalizers. finalizers is a shared field, any actor with permission can reorder it. If the finalizer list is processed in order, then this can lead to a situation in which the component responsible for the first finalizer in the list is waiting for a signal (field value, external system, or other) produced by a component responsible for a finalizer later in the list, resulting in a deadlock. Without enforced ordering finalizers are free to order amongst themselves and are not vulnerable to ordering changes in the list.
+        """
+        generate_name: NotRequired[pulumi.Input[str]]
+        """
+        GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
+
+        If this field is specified and the generated name exists, the server will return a 409.
+
+        Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency
+        """
+        generation: NotRequired[pulumi.Input[int]]
+        """
+        A sequence number representing a specific generation of the desired state. Populated by the system. Read-only.
+        """
+        labels: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
+        """
+        managed_fields: NotRequired[pulumi.Input[Sequence[pulumi.Input['ManagedFieldsEntryPatchArgsDict']]]]
+        """
+        ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like "ci-cd". The set of fields is always in the version that the workflow used when modifying the object.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names
+        """
+        namespace: NotRequired[pulumi.Input[str]]
+        """
+        Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+
+        Must be a DNS_LABEL. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces
+        """
+        owner_references: NotRequired[pulumi.Input[Sequence[pulumi.Input['OwnerReferencePatchArgsDict']]]]
+        """
+        List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.
+        """
+        resource_version: NotRequired[pulumi.Input[str]]
+        """
+        An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
+
+        Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+        """
+        self_link: NotRequired[pulumi.Input[str]]
+        """
+        Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.
+        """
+        uid: NotRequired[pulumi.Input[str]]
+        """
+        UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
+
+        Populated by the system. Read-only. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids
+        """
+elif False:
+    ObjectMetaPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ObjectMetaPatchArgs:
@@ -994,6 +1328,92 @@ class ObjectMetaPatchArgs:
         pulumi.set(self, "uid", value)
 
 
+if not MYPY:
+    class ObjectMetaArgsDict(TypedDict):
+        """
+        ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create.
+        """
+        annotations: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations
+        """
+        cluster_name: NotRequired[pulumi.Input[str]]
+        """
+        The name of the cluster which the object belongs to. This is used to distinguish resources with same name and namespace in different clusters. This field is not set anywhere right now and apiserver is going to ignore it if set in create or update request.
+        """
+        creation_timestamp: NotRequired[pulumi.Input[str]]
+        """
+        CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+
+        Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        deletion_grace_period_seconds: NotRequired[pulumi.Input[int]]
+        """
+        Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only.
+        """
+        deletion_timestamp: NotRequired[pulumi.Input[str]]
+        """
+        DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource is expected to be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field, once the finalizers list is empty. As long as the finalizers list contains items, deletion is blocked. Once the deletionTimestamp is set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. After that 30 seconds, the Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup, remove the pod from the API. In the presence of network partitions, this object may still exist after this timestamp, until an administrator or automated process can determine the resource is fully terminated. If not set, graceful deletion of the object has not been requested.
+
+        Populated by the system when a graceful deletion is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        finalizers: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed. Finalizers may be processed and removed in any order.  Order is NOT enforced because it introduces significant risk of stuck finalizers. finalizers is a shared field, any actor with permission can reorder it. If the finalizer list is processed in order, then this can lead to a situation in which the component responsible for the first finalizer in the list is waiting for a signal (field value, external system, or other) produced by a component responsible for a finalizer later in the list, resulting in a deadlock. Without enforced ordering finalizers are free to order amongst themselves and are not vulnerable to ordering changes in the list.
+        """
+        generate_name: NotRequired[pulumi.Input[str]]
+        """
+        GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
+
+        If this field is specified and the generated name exists, the server will return a 409.
+
+        Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency
+        """
+        generation: NotRequired[pulumi.Input[int]]
+        """
+        A sequence number representing a specific generation of the desired state. Populated by the system. Read-only.
+        """
+        labels: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
+        """
+        managed_fields: NotRequired[pulumi.Input[Sequence[pulumi.Input['ManagedFieldsEntryArgsDict']]]]
+        """
+        ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like "ci-cd". The set of fields is always in the version that the workflow used when modifying the object.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names
+        """
+        namespace: NotRequired[pulumi.Input[str]]
+        """
+        Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+
+        Must be a DNS_LABEL. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces
+        """
+        owner_references: NotRequired[pulumi.Input[Sequence[pulumi.Input['OwnerReferenceArgsDict']]]]
+        """
+        List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.
+        """
+        resource_version: NotRequired[pulumi.Input[str]]
+        """
+        An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
+
+        Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+        """
+        self_link: NotRequired[pulumi.Input[str]]
+        """
+        Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.
+        """
+        uid: NotRequired[pulumi.Input[str]]
+        """
+        UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
+
+        Populated by the system. Read-only. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids
+        """
+elif False:
+    ObjectMetaArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ObjectMetaArgs:
     def __init__(__self__, *,
@@ -1286,6 +1706,38 @@ class ObjectMetaArgs:
         pulumi.set(self, "uid", value)
 
 
+if not MYPY:
+    class OwnerReferencePatchArgsDict(TypedDict):
+        """
+        OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        API version of the referent.
+        """
+        block_owner_deletion: NotRequired[pulumi.Input[bool]]
+        """
+        If true, AND if the owner has the "foregroundDeletion" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. See https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion for how the garbage collector interacts with this field and enforces the foreground deletion. Defaults to false. To set this field, a user needs "delete" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.
+        """
+        controller: NotRequired[pulumi.Input[bool]]
+        """
+        If true, this reference points to the managing controller.
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names
+        """
+        uid: NotRequired[pulumi.Input[str]]
+        """
+        UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids
+        """
+elif False:
+    OwnerReferencePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class OwnerReferencePatchArgs:
     def __init__(__self__, *,
@@ -1390,6 +1842,38 @@ class OwnerReferencePatchArgs:
         pulumi.set(self, "uid", value)
 
 
+if not MYPY:
+    class OwnerReferenceArgsDict(TypedDict):
+        """
+        OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.
+        """
+        api_version: pulumi.Input[str]
+        """
+        API version of the referent.
+        """
+        kind: pulumi.Input[str]
+        """
+        Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        name: pulumi.Input[str]
+        """
+        Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names
+        """
+        uid: pulumi.Input[str]
+        """
+        UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids
+        """
+        block_owner_deletion: NotRequired[pulumi.Input[bool]]
+        """
+        If true, AND if the owner has the "foregroundDeletion" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. See https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion for how the garbage collector interacts with this field and enforces the foreground deletion. Defaults to false. To set this field, a user needs "delete" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.
+        """
+        controller: NotRequired[pulumi.Input[bool]]
+        """
+        If true, this reference points to the managing controller.
+        """
+elif False:
+    OwnerReferenceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class OwnerReferenceArgs:
     def __init__(__self__, *,
@@ -1490,6 +1974,30 @@ class OwnerReferenceArgs:
         pulumi.set(self, "controller", value)
 
 
+if not MYPY:
+    class StatusCausePatchArgsDict(TypedDict):
+        """
+        StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.
+        """
+        field: NotRequired[pulumi.Input[str]]
+        """
+        The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.
+
+        Examples:
+          "name" - the field "name" on the current resource
+          "items[0].name" - the field "name" on the first array entry in "items"
+        """
+        message: NotRequired[pulumi.Input[str]]
+        """
+        A human-readable description of the cause of the error.  This field may be presented as-is to a reader.
+        """
+        reason: NotRequired[pulumi.Input[str]]
+        """
+        A machine-readable description of the cause of the error. If this value is empty there is no information available.
+        """
+elif False:
+    StatusCausePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class StatusCausePatchArgs:
     def __init__(__self__, *,
@@ -1554,6 +2062,30 @@ class StatusCausePatchArgs:
         pulumi.set(self, "reason", value)
 
 
+if not MYPY:
+    class StatusCauseArgsDict(TypedDict):
+        """
+        StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.
+        """
+        field: NotRequired[pulumi.Input[str]]
+        """
+        The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.
+
+        Examples:
+          "name" - the field "name" on the current resource
+          "items[0].name" - the field "name" on the first array entry in "items"
+        """
+        message: NotRequired[pulumi.Input[str]]
+        """
+        A human-readable description of the cause of the error.  This field may be presented as-is to a reader.
+        """
+        reason: NotRequired[pulumi.Input[str]]
+        """
+        A machine-readable description of the cause of the error. If this value is empty there is no information available.
+        """
+elif False:
+    StatusCauseArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class StatusCauseArgs:
     def __init__(__self__, *,
@@ -1617,6 +2149,38 @@ class StatusCauseArgs:
     def reason(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "reason", value)
 
+
+if not MYPY:
+    class StatusDetailsPatchArgsDict(TypedDict):
+        """
+        StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.
+        """
+        causes: NotRequired[pulumi.Input[Sequence[pulumi.Input['StatusCausePatchArgsDict']]]]
+        """
+        The Causes array includes more details associated with the StatusReason failure. Not all StatusReasons may provide detailed causes.
+        """
+        group: NotRequired[pulumi.Input[str]]
+        """
+        The group attribute of the resource associated with the status StatusReason.
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        The kind attribute of the resource associated with the status StatusReason. On some operations may differ from the requested resource Kind. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        The name attribute of the resource associated with the status StatusReason (when there is a single name which can be described).
+        """
+        retry_after_seconds: NotRequired[pulumi.Input[int]]
+        """
+        If specified, the time in seconds before the operation should be retried. Some errors may indicate the client must take an alternate action - for those errors this field may indicate how long to wait before taking the alternate action.
+        """
+        uid: NotRequired[pulumi.Input[str]]
+        """
+        UID of the resource. (when there is a single resource which can be described). More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids
+        """
+elif False:
+    StatusDetailsPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class StatusDetailsPatchArgs:
@@ -1721,6 +2285,38 @@ class StatusDetailsPatchArgs:
     def uid(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "uid", value)
 
+
+if not MYPY:
+    class StatusDetailsArgsDict(TypedDict):
+        """
+        StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.
+        """
+        causes: NotRequired[pulumi.Input[Sequence[pulumi.Input['StatusCauseArgsDict']]]]
+        """
+        The Causes array includes more details associated with the StatusReason failure. Not all StatusReasons may provide detailed causes.
+        """
+        group: NotRequired[pulumi.Input[str]]
+        """
+        The group attribute of the resource associated with the status StatusReason.
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        The kind attribute of the resource associated with the status StatusReason. On some operations may differ from the requested resource Kind. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        The name attribute of the resource associated with the status StatusReason (when there is a single name which can be described).
+        """
+        retry_after_seconds: NotRequired[pulumi.Input[int]]
+        """
+        If specified, the time in seconds before the operation should be retried. Some errors may indicate the client must take an alternate action - for those errors this field may indicate how long to wait before taking the alternate action.
+        """
+        uid: NotRequired[pulumi.Input[str]]
+        """
+        UID of the resource. (when there is a single resource which can be described). More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids
+        """
+elif False:
+    StatusDetailsArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class StatusDetailsArgs:

--- a/sdk/python/pulumi_kubernetes/meta/v1/outputs.py
+++ b/sdk/python/pulumi_kubernetes/meta/v1/outputs.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 

--- a/sdk/python/pulumi_kubernetes/networking/v1/Ingress.py
+++ b/sdk/python/pulumi_kubernetes/networking/v1/Ingress.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -94,8 +99,8 @@ class Ingress(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['IngressSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['IngressSpecArgs', 'IngressSpecArgsDict']]] = None,
                  __props__=None):
         """
         Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.
@@ -181,8 +186,8 @@ class Ingress(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['IngressSpecArgs']] spec: spec is the desired state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['IngressSpecArgs', 'IngressSpecArgsDict']] spec: spec is the desired state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -287,8 +292,8 @@ class Ingress(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['IngressSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['IngressSpecArgs', 'IngressSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/networking/v1/IngressClass.py
+++ b/sdk/python/pulumi_kubernetes/networking/v1/IngressClass.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class IngressClass(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['IngressClassSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['IngressClassSpecArgs', 'IngressClassSpecArgsDict']]] = None,
                  __props__=None):
         """
         IngressClass represents the class of the Ingress, referenced by the Ingress Spec. The `ingressclass.kubernetes.io/is-default-class` annotation can be used to indicate that an IngressClass should be considered default. When a single IngressClass resource has this annotation set to true, new Ingress resources without a class specified will be assigned this default class.
@@ -103,8 +108,8 @@ class IngressClass(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['IngressClassSpecArgs']] spec: spec is the desired state of the IngressClass. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['IngressClassSpecArgs', 'IngressClassSpecArgsDict']] spec: spec is the desired state of the IngressClass. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -132,8 +137,8 @@ class IngressClass(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['IngressClassSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['IngressClassSpecArgs', 'IngressClassSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/networking/v1/IngressClassList.py
+++ b/sdk/python/pulumi_kubernetes/networking/v1/IngressClassList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class IngressClassList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['IngressClassArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['IngressClassArgs', 'IngressClassArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         IngressClassList is a collection of IngressClasses.
@@ -101,9 +106,9 @@ class IngressClassList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['IngressClassArgs']]]] items: items is the list of IngressClasses.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['IngressClassArgs', 'IngressClassArgsDict']]]] items: items is the list of IngressClasses.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata.
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata.
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class IngressClassList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['IngressClassArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['IngressClassArgs', 'IngressClassArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/networking/v1/IngressClassPatch.py
+++ b/sdk/python/pulumi_kubernetes/networking/v1/IngressClassPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class IngressClassPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['IngressClassSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['IngressClassSpecPatchArgs', 'IngressClassSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -109,8 +114,8 @@ class IngressClassPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['IngressClassSpecPatchArgs']] spec: spec is the desired state of the IngressClass. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['IngressClassSpecPatchArgs', 'IngressClassSpecPatchArgsDict']] spec: spec is the desired state of the IngressClass. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -144,8 +149,8 @@ class IngressClassPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['IngressClassSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['IngressClassSpecPatchArgs', 'IngressClassSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/networking/v1/IngressList.py
+++ b/sdk/python/pulumi_kubernetes/networking/v1/IngressList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -92,9 +97,9 @@ class IngressList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['IngressArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['IngressArgs', 'IngressArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         IngressList is a collection of Ingress.
@@ -102,9 +107,9 @@ class IngressList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['IngressArgs']]]] items: items is the list of Ingress.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['IngressArgs', 'IngressArgsDict']]]] items: items is the list of Ingress.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -131,9 +136,9 @@ class IngressList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['IngressArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['IngressArgs', 'IngressArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/networking/v1/IngressPatch.py
+++ b/sdk/python/pulumi_kubernetes/networking/v1/IngressPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -94,8 +99,8 @@ class IngressPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['IngressSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['IngressSpecPatchArgs', 'IngressSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -124,8 +129,8 @@ class IngressPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['IngressSpecPatchArgs']] spec: spec is the desired state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['IngressSpecPatchArgs', 'IngressSpecPatchArgsDict']] spec: spec is the desired state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -173,8 +178,8 @@ class IngressPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['IngressSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['IngressSpecPatchArgs', 'IngressSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/networking/v1/NetworkPolicy.py
+++ b/sdk/python/pulumi_kubernetes/networking/v1/NetworkPolicy.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class NetworkPolicy(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['NetworkPolicySpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['NetworkPolicySpecArgs', 'NetworkPolicySpecArgsDict']]] = None,
                  __props__=None):
         """
         NetworkPolicy describes what network traffic is allowed for a set of Pods
@@ -103,8 +108,8 @@ class NetworkPolicy(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['NetworkPolicySpecArgs']] spec: spec represents the specification of the desired behavior for this NetworkPolicy.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['NetworkPolicySpecArgs', 'NetworkPolicySpecArgsDict']] spec: spec represents the specification of the desired behavior for this NetworkPolicy.
         """
         ...
     @overload
@@ -132,8 +137,8 @@ class NetworkPolicy(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['NetworkPolicySpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['NetworkPolicySpecArgs', 'NetworkPolicySpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/networking/v1/NetworkPolicyList.py
+++ b/sdk/python/pulumi_kubernetes/networking/v1/NetworkPolicyList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class NetworkPolicyList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['NetworkPolicyArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['NetworkPolicyArgs', 'NetworkPolicyArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         NetworkPolicyList is a list of NetworkPolicy objects.
@@ -101,9 +106,9 @@ class NetworkPolicyList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['NetworkPolicyArgs']]]] items: items is a list of schema objects.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['NetworkPolicyArgs', 'NetworkPolicyArgsDict']]]] items: items is a list of schema objects.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class NetworkPolicyList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['NetworkPolicyArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['NetworkPolicyArgs', 'NetworkPolicyArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/networking/v1/NetworkPolicyPatch.py
+++ b/sdk/python/pulumi_kubernetes/networking/v1/NetworkPolicyPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class NetworkPolicyPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['NetworkPolicySpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['NetworkPolicySpecPatchArgs', 'NetworkPolicySpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -109,8 +114,8 @@ class NetworkPolicyPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['NetworkPolicySpecPatchArgs']] spec: spec represents the specification of the desired behavior for this NetworkPolicy.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['NetworkPolicySpecPatchArgs', 'NetworkPolicySpecPatchArgsDict']] spec: spec represents the specification of the desired behavior for this NetworkPolicy.
         """
         ...
     @overload
@@ -144,8 +149,8 @@ class NetworkPolicyPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['NetworkPolicySpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['NetworkPolicySpecPatchArgs', 'NetworkPolicySpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/networking/v1/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/networking/v1/_inputs.py
@@ -4,55 +4,132 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import core as _core
 from ... import meta as _meta
 
 __all__ = [
     'HTTPIngressPathPatchArgs',
+    'HTTPIngressPathPatchArgsDict',
     'HTTPIngressPathArgs',
+    'HTTPIngressPathArgsDict',
     'HTTPIngressRuleValuePatchArgs',
+    'HTTPIngressRuleValuePatchArgsDict',
     'HTTPIngressRuleValueArgs',
+    'HTTPIngressRuleValueArgsDict',
     'IPBlockPatchArgs',
+    'IPBlockPatchArgsDict',
     'IPBlockArgs',
+    'IPBlockArgsDict',
     'IngressBackendPatchArgs',
+    'IngressBackendPatchArgsDict',
     'IngressBackendArgs',
+    'IngressBackendArgsDict',
     'IngressClassParametersReferencePatchArgs',
+    'IngressClassParametersReferencePatchArgsDict',
     'IngressClassParametersReferenceArgs',
+    'IngressClassParametersReferenceArgsDict',
     'IngressClassSpecPatchArgs',
+    'IngressClassSpecPatchArgsDict',
     'IngressClassSpecArgs',
+    'IngressClassSpecArgsDict',
     'IngressClassArgs',
+    'IngressClassArgsDict',
     'IngressLoadBalancerIngressArgs',
+    'IngressLoadBalancerIngressArgsDict',
     'IngressLoadBalancerStatusArgs',
+    'IngressLoadBalancerStatusArgsDict',
     'IngressPortStatusArgs',
+    'IngressPortStatusArgsDict',
     'IngressRulePatchArgs',
+    'IngressRulePatchArgsDict',
     'IngressRuleArgs',
+    'IngressRuleArgsDict',
     'IngressServiceBackendPatchArgs',
+    'IngressServiceBackendPatchArgsDict',
     'IngressServiceBackendArgs',
+    'IngressServiceBackendArgsDict',
     'IngressSpecPatchArgs',
+    'IngressSpecPatchArgsDict',
     'IngressSpecArgs',
+    'IngressSpecArgsDict',
     'IngressStatusArgs',
+    'IngressStatusArgsDict',
     'IngressTLSPatchArgs',
+    'IngressTLSPatchArgsDict',
     'IngressTLSArgs',
+    'IngressTLSArgsDict',
     'IngressArgs',
+    'IngressArgsDict',
     'NetworkPolicyEgressRulePatchArgs',
+    'NetworkPolicyEgressRulePatchArgsDict',
     'NetworkPolicyEgressRuleArgs',
+    'NetworkPolicyEgressRuleArgsDict',
     'NetworkPolicyIngressRulePatchArgs',
+    'NetworkPolicyIngressRulePatchArgsDict',
     'NetworkPolicyIngressRuleArgs',
+    'NetworkPolicyIngressRuleArgsDict',
     'NetworkPolicyPeerPatchArgs',
+    'NetworkPolicyPeerPatchArgsDict',
     'NetworkPolicyPeerArgs',
+    'NetworkPolicyPeerArgsDict',
     'NetworkPolicyPortPatchArgs',
+    'NetworkPolicyPortPatchArgsDict',
     'NetworkPolicyPortArgs',
+    'NetworkPolicyPortArgsDict',
     'NetworkPolicySpecPatchArgs',
+    'NetworkPolicySpecPatchArgsDict',
     'NetworkPolicySpecArgs',
+    'NetworkPolicySpecArgsDict',
     'NetworkPolicyStatusArgs',
+    'NetworkPolicyStatusArgsDict',
     'NetworkPolicyArgs',
+    'NetworkPolicyArgsDict',
     'ServiceBackendPortPatchArgs',
+    'ServiceBackendPortPatchArgsDict',
     'ServiceBackendPortArgs',
+    'ServiceBackendPortArgsDict',
 ]
+
+MYPY = False
+
+if not MYPY:
+    class HTTPIngressPathPatchArgsDict(TypedDict):
+        """
+        HTTPIngressPath associates a path with a backend. Incoming urls matching the path are forwarded to the backend.
+        """
+        backend: NotRequired[pulumi.Input['IngressBackendPatchArgsDict']]
+        """
+        backend defines the referenced service endpoint to which the traffic will be forwarded to.
+        """
+        path: NotRequired[pulumi.Input[str]]
+        """
+        path is matched against the path of an incoming request. Currently it can contain characters disallowed from the conventional "path" part of a URL as defined by RFC 3986. Paths must begin with a '/' and must be present when using PathType with value "Exact" or "Prefix".
+        """
+        path_type: NotRequired[pulumi.Input[str]]
+        """
+        pathType determines the interpretation of the path matching. PathType can be one of the following values: * Exact: Matches the URL path exactly. * Prefix: Matches based on a URL path prefix split by '/'. Matching is
+          done on a path element by element basis. A path element refers is the
+          list of labels in the path split by the '/' separator. A request is a
+          match for path p if every p is an element-wise prefix of p of the
+          request path. Note that if the last element of the path is a substring
+          of the last element in request path, it is not a match (e.g. /foo/bar
+          matches /foo/bar/baz, but does not match /foo/barbaz).
+        * ImplementationSpecific: Interpretation of the Path matching is up to
+          the IngressClass. Implementations can treat this as a separate PathType
+          or treat it identically to Prefix or Exact path types.
+        Implementations are required to support all path types.
+        """
+elif False:
+    HTTPIngressPathPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class HTTPIngressPathPatchArgs:
@@ -130,6 +207,36 @@ class HTTPIngressPathPatchArgs:
         pulumi.set(self, "path_type", value)
 
 
+if not MYPY:
+    class HTTPIngressPathArgsDict(TypedDict):
+        """
+        HTTPIngressPath associates a path with a backend. Incoming urls matching the path are forwarded to the backend.
+        """
+        backend: pulumi.Input['IngressBackendArgsDict']
+        """
+        backend defines the referenced service endpoint to which the traffic will be forwarded to.
+        """
+        path_type: pulumi.Input[str]
+        """
+        pathType determines the interpretation of the path matching. PathType can be one of the following values: * Exact: Matches the URL path exactly. * Prefix: Matches based on a URL path prefix split by '/'. Matching is
+          done on a path element by element basis. A path element refers is the
+          list of labels in the path split by the '/' separator. A request is a
+          match for path p if every p is an element-wise prefix of p of the
+          request path. Note that if the last element of the path is a substring
+          of the last element in request path, it is not a match (e.g. /foo/bar
+          matches /foo/bar/baz, but does not match /foo/barbaz).
+        * ImplementationSpecific: Interpretation of the Path matching is up to
+          the IngressClass. Implementations can treat this as a separate PathType
+          or treat it identically to Prefix or Exact path types.
+        Implementations are required to support all path types.
+        """
+        path: NotRequired[pulumi.Input[str]]
+        """
+        path is matched against the path of an incoming request. Currently it can contain characters disallowed from the conventional "path" part of a URL as defined by RFC 3986. Paths must begin with a '/' and must be present when using PathType with value "Exact" or "Prefix".
+        """
+elif False:
+    HTTPIngressPathArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class HTTPIngressPathArgs:
     def __init__(__self__, *,
@@ -204,6 +311,18 @@ class HTTPIngressPathArgs:
         pulumi.set(self, "path", value)
 
 
+if not MYPY:
+    class HTTPIngressRuleValuePatchArgsDict(TypedDict):
+        """
+        HTTPIngressRuleValue is a list of http selectors pointing to backends. In the example: http://<host>/<path>?<searchpart> -> backend where where parts of the url correspond to RFC 3986, this resource will be used to match against everything after the last '/' and before the first '?' or '#'.
+        """
+        paths: NotRequired[pulumi.Input[Sequence[pulumi.Input['HTTPIngressPathPatchArgsDict']]]]
+        """
+        paths is a collection of paths that map requests to backends.
+        """
+elif False:
+    HTTPIngressRuleValuePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class HTTPIngressRuleValuePatchArgs:
     def __init__(__self__, *,
@@ -228,6 +347,18 @@ class HTTPIngressRuleValuePatchArgs:
         pulumi.set(self, "paths", value)
 
 
+if not MYPY:
+    class HTTPIngressRuleValueArgsDict(TypedDict):
+        """
+        HTTPIngressRuleValue is a list of http selectors pointing to backends. In the example: http://<host>/<path>?<searchpart> -> backend where where parts of the url correspond to RFC 3986, this resource will be used to match against everything after the last '/' and before the first '?' or '#'.
+        """
+        paths: pulumi.Input[Sequence[pulumi.Input['HTTPIngressPathArgsDict']]]
+        """
+        paths is a collection of paths that map requests to backends.
+        """
+elif False:
+    HTTPIngressRuleValueArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class HTTPIngressRuleValueArgs:
     def __init__(__self__, *,
@@ -250,6 +381,22 @@ class HTTPIngressRuleValueArgs:
     def paths(self, value: pulumi.Input[Sequence[pulumi.Input['HTTPIngressPathArgs']]]):
         pulumi.set(self, "paths", value)
 
+
+if not MYPY:
+    class IPBlockPatchArgsDict(TypedDict):
+        """
+        IPBlock describes a particular CIDR (Ex. "192.168.1.0/24","2001:db8::/64") that is allowed to the pods matched by a NetworkPolicySpec's podSelector. The except entry describes CIDRs that should not be included within this rule.
+        """
+        cidr: NotRequired[pulumi.Input[str]]
+        """
+        cidr is a string representing the IPBlock Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+        """
+        except_: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        except is a slice of CIDRs that should not be included within an IPBlock Valid examples are "192.168.1.0/24" or "2001:db8::/64" Except values will be rejected if they are outside the cidr range
+        """
+elif False:
+    IPBlockPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class IPBlockPatchArgs:
@@ -291,6 +438,22 @@ class IPBlockPatchArgs:
         pulumi.set(self, "except_", value)
 
 
+if not MYPY:
+    class IPBlockArgsDict(TypedDict):
+        """
+        IPBlock describes a particular CIDR (Ex. "192.168.1.0/24","2001:db8::/64") that is allowed to the pods matched by a NetworkPolicySpec's podSelector. The except entry describes CIDRs that should not be included within this rule.
+        """
+        cidr: pulumi.Input[str]
+        """
+        cidr is a string representing the IPBlock Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+        """
+        except_: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        except is a slice of CIDRs that should not be included within an IPBlock Valid examples are "192.168.1.0/24" or "2001:db8::/64" Except values will be rejected if they are outside the cidr range
+        """
+elif False:
+    IPBlockArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class IPBlockArgs:
     def __init__(__self__, *,
@@ -329,6 +492,22 @@ class IPBlockArgs:
     def except_(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]):
         pulumi.set(self, "except_", value)
 
+
+if not MYPY:
+    class IngressBackendPatchArgsDict(TypedDict):
+        """
+        IngressBackend describes all endpoints for a given service and port.
+        """
+        resource: NotRequired[pulumi.Input['_core.v1.TypedLocalObjectReferencePatchArgsDict']]
+        """
+        resource is an ObjectRef to another Kubernetes resource in the namespace of the Ingress object. If resource is specified, a service.Name and service.Port must not be specified. This is a mutually exclusive setting with "Service".
+        """
+        service: NotRequired[pulumi.Input['IngressServiceBackendPatchArgsDict']]
+        """
+        service references a service as a backend. This is a mutually exclusive setting with "Resource".
+        """
+elif False:
+    IngressBackendPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class IngressBackendPatchArgs:
@@ -370,6 +549,22 @@ class IngressBackendPatchArgs:
         pulumi.set(self, "service", value)
 
 
+if not MYPY:
+    class IngressBackendArgsDict(TypedDict):
+        """
+        IngressBackend describes all endpoints for a given service and port.
+        """
+        resource: NotRequired[pulumi.Input['_core.v1.TypedLocalObjectReferenceArgsDict']]
+        """
+        resource is an ObjectRef to another Kubernetes resource in the namespace of the Ingress object. If resource is specified, a service.Name and service.Port must not be specified. This is a mutually exclusive setting with "Service".
+        """
+        service: NotRequired[pulumi.Input['IngressServiceBackendArgsDict']]
+        """
+        service references a service as a backend. This is a mutually exclusive setting with "Resource".
+        """
+elif False:
+    IngressBackendArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class IngressBackendArgs:
     def __init__(__self__, *,
@@ -409,6 +604,34 @@ class IngressBackendArgs:
     def service(self, value: Optional[pulumi.Input['IngressServiceBackendArgs']]):
         pulumi.set(self, "service", value)
 
+
+if not MYPY:
+    class IngressClassParametersReferencePatchArgsDict(TypedDict):
+        """
+        IngressClassParametersReference identifies an API object. This can be used to specify a cluster or namespace-scoped resource.
+        """
+        api_group: NotRequired[pulumi.Input[str]]
+        """
+        apiGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        kind is the type of resource being referenced.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        name is the name of resource being referenced.
+        """
+        namespace: NotRequired[pulumi.Input[str]]
+        """
+        namespace is the namespace of the resource being referenced. This field is required when scope is set to "Namespace" and must be unset when scope is set to "Cluster".
+        """
+        scope: NotRequired[pulumi.Input[str]]
+        """
+        scope represents if this refers to a cluster or namespace scoped resource. This may be set to "Cluster" (default) or "Namespace".
+        """
+elif False:
+    IngressClassParametersReferencePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class IngressClassParametersReferencePatchArgs:
@@ -498,6 +721,34 @@ class IngressClassParametersReferencePatchArgs:
         pulumi.set(self, "scope", value)
 
 
+if not MYPY:
+    class IngressClassParametersReferenceArgsDict(TypedDict):
+        """
+        IngressClassParametersReference identifies an API object. This can be used to specify a cluster or namespace-scoped resource.
+        """
+        kind: pulumi.Input[str]
+        """
+        kind is the type of resource being referenced.
+        """
+        name: pulumi.Input[str]
+        """
+        name is the name of resource being referenced.
+        """
+        api_group: NotRequired[pulumi.Input[str]]
+        """
+        apiGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+        """
+        namespace: NotRequired[pulumi.Input[str]]
+        """
+        namespace is the namespace of the resource being referenced. This field is required when scope is set to "Namespace" and must be unset when scope is set to "Cluster".
+        """
+        scope: NotRequired[pulumi.Input[str]]
+        """
+        scope represents if this refers to a cluster or namespace scoped resource. This may be set to "Cluster" (default) or "Namespace".
+        """
+elif False:
+    IngressClassParametersReferenceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class IngressClassParametersReferenceArgs:
     def __init__(__self__, *,
@@ -584,6 +835,22 @@ class IngressClassParametersReferenceArgs:
         pulumi.set(self, "scope", value)
 
 
+if not MYPY:
+    class IngressClassSpecPatchArgsDict(TypedDict):
+        """
+        IngressClassSpec provides information about the class of an Ingress.
+        """
+        controller: NotRequired[pulumi.Input[str]]
+        """
+        controller refers to the name of the controller that should handle this class. This allows for different "flavors" that are controlled by the same controller. For example, you may have different parameters for the same implementing controller. This should be specified as a domain-prefixed path no more than 250 characters in length, e.g. "acme.io/ingress-controller". This field is immutable.
+        """
+        parameters: NotRequired[pulumi.Input['IngressClassParametersReferencePatchArgsDict']]
+        """
+        parameters is a link to a custom resource containing additional configuration for the controller. This is optional if the controller does not require extra parameters.
+        """
+elif False:
+    IngressClassSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class IngressClassSpecPatchArgs:
     def __init__(__self__, *,
@@ -624,6 +891,22 @@ class IngressClassSpecPatchArgs:
         pulumi.set(self, "parameters", value)
 
 
+if not MYPY:
+    class IngressClassSpecArgsDict(TypedDict):
+        """
+        IngressClassSpec provides information about the class of an Ingress.
+        """
+        controller: NotRequired[pulumi.Input[str]]
+        """
+        controller refers to the name of the controller that should handle this class. This allows for different "flavors" that are controlled by the same controller. For example, you may have different parameters for the same implementing controller. This should be specified as a domain-prefixed path no more than 250 characters in length, e.g. "acme.io/ingress-controller". This field is immutable.
+        """
+        parameters: NotRequired[pulumi.Input['IngressClassParametersReferenceArgsDict']]
+        """
+        parameters is a link to a custom resource containing additional configuration for the controller. This is optional if the controller does not require extra parameters.
+        """
+elif False:
+    IngressClassSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class IngressClassSpecArgs:
     def __init__(__self__, *,
@@ -663,6 +946,30 @@ class IngressClassSpecArgs:
     def parameters(self, value: Optional[pulumi.Input['IngressClassParametersReferenceArgs']]):
         pulumi.set(self, "parameters", value)
 
+
+if not MYPY:
+    class IngressClassArgsDict(TypedDict):
+        """
+        IngressClass represents the class of the Ingress, referenced by the Ingress Spec. The `ingressclass.kubernetes.io/is-default-class` annotation can be used to indicate that an IngressClass should be considered default. When a single IngressClass resource has this annotation set to true, new Ingress resources without a class specified will be assigned this default class.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['IngressClassSpecArgsDict']]
+        """
+        spec is the desired state of the IngressClass. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+elif False:
+    IngressClassArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class IngressClassArgs:
@@ -736,6 +1043,26 @@ class IngressClassArgs:
         pulumi.set(self, "spec", value)
 
 
+if not MYPY:
+    class IngressLoadBalancerIngressArgsDict(TypedDict):
+        """
+        IngressLoadBalancerIngress represents the status of a load-balancer ingress point.
+        """
+        hostname: NotRequired[pulumi.Input[str]]
+        """
+        hostname is set for load-balancer ingress points that are DNS based.
+        """
+        ip: NotRequired[pulumi.Input[str]]
+        """
+        ip is set for load-balancer ingress points that are IP based.
+        """
+        ports: NotRequired[pulumi.Input[Sequence[pulumi.Input['IngressPortStatusArgsDict']]]]
+        """
+        ports provides information about the ports exposed by this LoadBalancer.
+        """
+elif False:
+    IngressLoadBalancerIngressArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class IngressLoadBalancerIngressArgs:
     def __init__(__self__, *,
@@ -792,6 +1119,18 @@ class IngressLoadBalancerIngressArgs:
         pulumi.set(self, "ports", value)
 
 
+if not MYPY:
+    class IngressLoadBalancerStatusArgsDict(TypedDict):
+        """
+        IngressLoadBalancerStatus represents the status of a load-balancer.
+        """
+        ingress: NotRequired[pulumi.Input[Sequence[pulumi.Input['IngressLoadBalancerIngressArgsDict']]]]
+        """
+        ingress is a list containing ingress points for the load-balancer.
+        """
+elif False:
+    IngressLoadBalancerStatusArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class IngressLoadBalancerStatusArgs:
     def __init__(__self__, *,
@@ -815,6 +1154,29 @@ class IngressLoadBalancerStatusArgs:
     def ingress(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['IngressLoadBalancerIngressArgs']]]]):
         pulumi.set(self, "ingress", value)
 
+
+if not MYPY:
+    class IngressPortStatusArgsDict(TypedDict):
+        """
+        IngressPortStatus represents the error condition of a service port
+        """
+        port: pulumi.Input[int]
+        """
+        port is the port number of the ingress port.
+        """
+        protocol: pulumi.Input[str]
+        """
+        protocol is the protocol of the ingress port. The supported values are: "TCP", "UDP", "SCTP"
+        """
+        error: NotRequired[pulumi.Input[str]]
+        """
+        error is to record the problem with the service port The format of the error shall comply with the following rules: - built-in error values shall be specified in this file and those shall use
+          CamelCase names
+        - cloud provider specific error values must have names that comply with the
+          format foo.example.com/CamelCase.
+        """
+elif False:
+    IngressPortStatusArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class IngressPortStatusArgs:
@@ -876,6 +1238,26 @@ class IngressPortStatusArgs:
         pulumi.set(self, "error", value)
 
 
+if not MYPY:
+    class IngressRulePatchArgsDict(TypedDict):
+        """
+        IngressRule represents the rules mapping the paths under a specified host to the related backend services. Incoming requests are first evaluated for a host match, then routed to the backend associated with the matching IngressRuleValue.
+        """
+        host: NotRequired[pulumi.Input[str]]
+        """
+        host is the fully qualified domain name of a network host, as defined by RFC 3986. Note the following deviations from the "host" part of the URI as defined in RFC 3986: 1. IPs are not allowed. Currently an IngressRuleValue can only apply to
+           the IP in the Spec of the parent Ingress.
+        2. The `:` delimiter is not respected because ports are not allowed.
+        	  Currently the port of an Ingress is implicitly :80 for http and
+        	  :443 for https.
+        Both these may change in the future. Incoming requests are matched against the host before the IngressRuleValue. If the host is unspecified, the Ingress routes all traffic based on the specified IngressRuleValue.
+
+        host can be "precise" which is a domain name without the terminating dot of a network host (e.g. "foo.bar.com") or "wildcard", which is a domain name prefixed with a single wildcard label (e.g. "*.foo.com"). The wildcard character '*' must appear by itself as the first DNS label and matches only a single label. You cannot have a wildcard label by itself (e.g. Host == "*"). Requests will be matched against the Host field in the following way: 1. If host is precise, the request matches this rule if the http host header is equal to Host. 2. If host is a wildcard, then the request matches this rule if the http host header is to equal to the suffix (removing the first label) of the wildcard rule.
+        """
+        http: NotRequired[pulumi.Input['HTTPIngressRuleValuePatchArgsDict']]
+elif False:
+    IngressRulePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class IngressRulePatchArgs:
     def __init__(__self__, *,
@@ -925,6 +1307,26 @@ class IngressRulePatchArgs:
     def http(self, value: Optional[pulumi.Input['HTTPIngressRuleValuePatchArgs']]):
         pulumi.set(self, "http", value)
 
+
+if not MYPY:
+    class IngressRuleArgsDict(TypedDict):
+        """
+        IngressRule represents the rules mapping the paths under a specified host to the related backend services. Incoming requests are first evaluated for a host match, then routed to the backend associated with the matching IngressRuleValue.
+        """
+        host: NotRequired[pulumi.Input[str]]
+        """
+        host is the fully qualified domain name of a network host, as defined by RFC 3986. Note the following deviations from the "host" part of the URI as defined in RFC 3986: 1. IPs are not allowed. Currently an IngressRuleValue can only apply to
+           the IP in the Spec of the parent Ingress.
+        2. The `:` delimiter is not respected because ports are not allowed.
+        	  Currently the port of an Ingress is implicitly :80 for http and
+        	  :443 for https.
+        Both these may change in the future. Incoming requests are matched against the host before the IngressRuleValue. If the host is unspecified, the Ingress routes all traffic based on the specified IngressRuleValue.
+
+        host can be "precise" which is a domain name without the terminating dot of a network host (e.g. "foo.bar.com") or "wildcard", which is a domain name prefixed with a single wildcard label (e.g. "*.foo.com"). The wildcard character '*' must appear by itself as the first DNS label and matches only a single label. You cannot have a wildcard label by itself (e.g. Host == "*"). Requests will be matched against the Host field in the following way: 1. If host is precise, the request matches this rule if the http host header is equal to Host. 2. If host is a wildcard, then the request matches this rule if the http host header is to equal to the suffix (removing the first label) of the wildcard rule.
+        """
+        http: NotRequired[pulumi.Input['HTTPIngressRuleValueArgsDict']]
+elif False:
+    IngressRuleArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class IngressRuleArgs:
@@ -976,6 +1378,22 @@ class IngressRuleArgs:
         pulumi.set(self, "http", value)
 
 
+if not MYPY:
+    class IngressServiceBackendPatchArgsDict(TypedDict):
+        """
+        IngressServiceBackend references a Kubernetes Service as a Backend.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        name is the referenced service. The service must exist in the same namespace as the Ingress object.
+        """
+        port: NotRequired[pulumi.Input['ServiceBackendPortPatchArgsDict']]
+        """
+        port of the referenced service. A port name or port number is required for a IngressServiceBackend.
+        """
+elif False:
+    IngressServiceBackendPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class IngressServiceBackendPatchArgs:
     def __init__(__self__, *,
@@ -1016,6 +1434,22 @@ class IngressServiceBackendPatchArgs:
         pulumi.set(self, "port", value)
 
 
+if not MYPY:
+    class IngressServiceBackendArgsDict(TypedDict):
+        """
+        IngressServiceBackend references a Kubernetes Service as a Backend.
+        """
+        name: pulumi.Input[str]
+        """
+        name is the referenced service. The service must exist in the same namespace as the Ingress object.
+        """
+        port: NotRequired[pulumi.Input['ServiceBackendPortArgsDict']]
+        """
+        port of the referenced service. A port name or port number is required for a IngressServiceBackend.
+        """
+elif False:
+    IngressServiceBackendArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class IngressServiceBackendArgs:
     def __init__(__self__, *,
@@ -1054,6 +1488,30 @@ class IngressServiceBackendArgs:
     def port(self, value: Optional[pulumi.Input['ServiceBackendPortArgs']]):
         pulumi.set(self, "port", value)
 
+
+if not MYPY:
+    class IngressSpecPatchArgsDict(TypedDict):
+        """
+        IngressSpec describes the Ingress the user wishes to exist.
+        """
+        default_backend: NotRequired[pulumi.Input['IngressBackendPatchArgsDict']]
+        """
+        defaultBackend is the backend that should handle requests that don't match any rule. If Rules are not specified, DefaultBackend must be specified. If DefaultBackend is not set, the handling of requests that do not match any of the rules will be up to the Ingress controller.
+        """
+        ingress_class_name: NotRequired[pulumi.Input[str]]
+        """
+        ingressClassName is the name of an IngressClass cluster resource. Ingress controller implementations use this field to know whether they should be serving this Ingress resource, by a transitive connection (controller -> IngressClass -> Ingress resource). Although the `kubernetes.io/ingress.class` annotation (simple constant name) was never formally defined, it was widely supported by Ingress controllers to create a direct binding between Ingress controller and Ingress resources. Newly created Ingress resources should prefer using the field. However, even though the annotation is officially deprecated, for backwards compatibility reasons, ingress controllers should still honor that annotation if present.
+        """
+        rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['IngressRulePatchArgsDict']]]]
+        """
+        rules is a list of host rules used to configure the Ingress. If unspecified, or no rule matches, all traffic is sent to the default backend.
+        """
+        tls: NotRequired[pulumi.Input[Sequence[pulumi.Input['IngressTLSPatchArgsDict']]]]
+        """
+        tls represents the TLS configuration. Currently the Ingress only supports a single TLS port, 443. If multiple members of this list specify different hosts, they will be multiplexed on the same port according to the hostname specified through the SNI TLS extension, if the ingress controller fulfilling the ingress supports SNI.
+        """
+elif False:
+    IngressSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class IngressSpecPatchArgs:
@@ -1127,6 +1585,30 @@ class IngressSpecPatchArgs:
         pulumi.set(self, "tls", value)
 
 
+if not MYPY:
+    class IngressSpecArgsDict(TypedDict):
+        """
+        IngressSpec describes the Ingress the user wishes to exist.
+        """
+        default_backend: NotRequired[pulumi.Input['IngressBackendArgsDict']]
+        """
+        defaultBackend is the backend that should handle requests that don't match any rule. If Rules are not specified, DefaultBackend must be specified. If DefaultBackend is not set, the handling of requests that do not match any of the rules will be up to the Ingress controller.
+        """
+        ingress_class_name: NotRequired[pulumi.Input[str]]
+        """
+        ingressClassName is the name of an IngressClass cluster resource. Ingress controller implementations use this field to know whether they should be serving this Ingress resource, by a transitive connection (controller -> IngressClass -> Ingress resource). Although the `kubernetes.io/ingress.class` annotation (simple constant name) was never formally defined, it was widely supported by Ingress controllers to create a direct binding between Ingress controller and Ingress resources. Newly created Ingress resources should prefer using the field. However, even though the annotation is officially deprecated, for backwards compatibility reasons, ingress controllers should still honor that annotation if present.
+        """
+        rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['IngressRuleArgsDict']]]]
+        """
+        rules is a list of host rules used to configure the Ingress. If unspecified, or no rule matches, all traffic is sent to the default backend.
+        """
+        tls: NotRequired[pulumi.Input[Sequence[pulumi.Input['IngressTLSArgsDict']]]]
+        """
+        tls represents the TLS configuration. Currently the Ingress only supports a single TLS port, 443. If multiple members of this list specify different hosts, they will be multiplexed on the same port according to the hostname specified through the SNI TLS extension, if the ingress controller fulfilling the ingress supports SNI.
+        """
+elif False:
+    IngressSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class IngressSpecArgs:
     def __init__(__self__, *,
@@ -1199,6 +1681,18 @@ class IngressSpecArgs:
         pulumi.set(self, "tls", value)
 
 
+if not MYPY:
+    class IngressStatusArgsDict(TypedDict):
+        """
+        IngressStatus describe the current state of the Ingress.
+        """
+        load_balancer: NotRequired[pulumi.Input['IngressLoadBalancerStatusArgsDict']]
+        """
+        loadBalancer contains the current status of the load-balancer.
+        """
+elif False:
+    IngressStatusArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class IngressStatusArgs:
     def __init__(__self__, *,
@@ -1222,6 +1716,22 @@ class IngressStatusArgs:
     def load_balancer(self, value: Optional[pulumi.Input['IngressLoadBalancerStatusArgs']]):
         pulumi.set(self, "load_balancer", value)
 
+
+if not MYPY:
+    class IngressTLSPatchArgsDict(TypedDict):
+        """
+        IngressTLS describes the transport layer security associated with an ingress.
+        """
+        hosts: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        hosts is a list of hosts included in the TLS certificate. The values in this list must match the name/s used in the tlsSecret. Defaults to the wildcard host setting for the loadbalancer controller fulfilling this Ingress, if left unspecified.
+        """
+        secret_name: NotRequired[pulumi.Input[str]]
+        """
+        secretName is the name of the secret used to terminate TLS traffic on port 443. Field is left optional to allow TLS routing based on SNI hostname alone. If the SNI host in a listener conflicts with the "Host" header field used by an IngressRule, the SNI host is used for termination and value of the "Host" header is used for routing.
+        """
+elif False:
+    IngressTLSPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class IngressTLSPatchArgs:
@@ -1263,6 +1773,22 @@ class IngressTLSPatchArgs:
         pulumi.set(self, "secret_name", value)
 
 
+if not MYPY:
+    class IngressTLSArgsDict(TypedDict):
+        """
+        IngressTLS describes the transport layer security associated with an ingress.
+        """
+        hosts: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        hosts is a list of hosts included in the TLS certificate. The values in this list must match the name/s used in the tlsSecret. Defaults to the wildcard host setting for the loadbalancer controller fulfilling this Ingress, if left unspecified.
+        """
+        secret_name: NotRequired[pulumi.Input[str]]
+        """
+        secretName is the name of the secret used to terminate TLS traffic on port 443. Field is left optional to allow TLS routing based on SNI hostname alone. If the SNI host in a listener conflicts with the "Host" header field used by an IngressRule, the SNI host is used for termination and value of the "Host" header is used for routing.
+        """
+elif False:
+    IngressTLSArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class IngressTLSArgs:
     def __init__(__self__, *,
@@ -1302,6 +1828,48 @@ class IngressTLSArgs:
     def secret_name(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "secret_name", value)
 
+
+if not MYPY:
+    class IngressArgsDict(TypedDict):
+        """
+        Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.
+
+        This resource waits until its status is ready before registering success
+        for create/update, and populating output properties from the current state of the resource.
+        The following conditions are used to determine whether the resource creation has
+        succeeded or failed:
+
+        1.  Ingress object exists.
+        2.  Endpoint objects exist with matching names for each Ingress path (except when Service
+            type is ExternalName).
+        3.  Ingress entry exists for '.status.loadBalancer.ingress'.
+
+        If the Ingress has not reached a Ready state after 10 minutes, it will
+        time out and mark the resource update as Failed. You can override the default timeout value
+        by setting the 'customTimeouts' option on the resource.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['IngressSpecArgsDict']]
+        """
+        spec is the desired state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+        status: NotRequired[pulumi.Input['IngressStatusArgsDict']]
+        """
+        status is the current state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+elif False:
+    IngressArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class IngressArgs:
@@ -1405,6 +1973,22 @@ class IngressArgs:
         pulumi.set(self, "status", value)
 
 
+if not MYPY:
+    class NetworkPolicyEgressRulePatchArgsDict(TypedDict):
+        """
+        NetworkPolicyEgressRule describes a particular set of traffic that is allowed out of pods matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and to. This type is beta-level in 1.8
+        """
+        ports: NotRequired[pulumi.Input[Sequence[pulumi.Input['NetworkPolicyPortPatchArgsDict']]]]
+        """
+        ports is a list of destination ports for outgoing traffic. Each item in this list is combined using a logical OR. If this field is empty or missing, this rule matches all ports (traffic not restricted by port). If this field is present and contains at least one item, then this rule allows traffic only if the traffic matches at least one port in the list.
+        """
+        to: NotRequired[pulumi.Input[Sequence[pulumi.Input['NetworkPolicyPeerPatchArgsDict']]]]
+        """
+        to is a list of destinations for outgoing traffic of pods selected for this rule. Items in this list are combined using a logical OR operation. If this field is empty or missing, this rule matches all destinations (traffic not restricted by destination). If this field is present and contains at least one item, this rule allows traffic only if the traffic matches at least one item in the to list.
+        """
+elif False:
+    NetworkPolicyEgressRulePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class NetworkPolicyEgressRulePatchArgs:
     def __init__(__self__, *,
@@ -1444,6 +2028,22 @@ class NetworkPolicyEgressRulePatchArgs:
     def to(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['NetworkPolicyPeerPatchArgs']]]]):
         pulumi.set(self, "to", value)
 
+
+if not MYPY:
+    class NetworkPolicyEgressRuleArgsDict(TypedDict):
+        """
+        NetworkPolicyEgressRule describes a particular set of traffic that is allowed out of pods matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and to. This type is beta-level in 1.8
+        """
+        ports: NotRequired[pulumi.Input[Sequence[pulumi.Input['NetworkPolicyPortArgsDict']]]]
+        """
+        ports is a list of destination ports for outgoing traffic. Each item in this list is combined using a logical OR. If this field is empty or missing, this rule matches all ports (traffic not restricted by port). If this field is present and contains at least one item, then this rule allows traffic only if the traffic matches at least one port in the list.
+        """
+        to: NotRequired[pulumi.Input[Sequence[pulumi.Input['NetworkPolicyPeerArgsDict']]]]
+        """
+        to is a list of destinations for outgoing traffic of pods selected for this rule. Items in this list are combined using a logical OR operation. If this field is empty or missing, this rule matches all destinations (traffic not restricted by destination). If this field is present and contains at least one item, this rule allows traffic only if the traffic matches at least one item in the to list.
+        """
+elif False:
+    NetworkPolicyEgressRuleArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class NetworkPolicyEgressRuleArgs:
@@ -1485,6 +2085,22 @@ class NetworkPolicyEgressRuleArgs:
         pulumi.set(self, "to", value)
 
 
+if not MYPY:
+    class NetworkPolicyIngressRulePatchArgsDict(TypedDict):
+        """
+        NetworkPolicyIngressRule describes a particular set of traffic that is allowed to the pods matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and from.
+        """
+        from_: NotRequired[pulumi.Input[Sequence[pulumi.Input['NetworkPolicyPeerPatchArgsDict']]]]
+        """
+        from is a list of sources which should be able to access the pods selected for this rule. Items in this list are combined using a logical OR operation. If this field is empty or missing, this rule matches all sources (traffic not restricted by source). If this field is present and contains at least one item, this rule allows traffic only if the traffic matches at least one item in the from list.
+        """
+        ports: NotRequired[pulumi.Input[Sequence[pulumi.Input['NetworkPolicyPortPatchArgsDict']]]]
+        """
+        ports is a list of ports which should be made accessible on the pods selected for this rule. Each item in this list is combined using a logical OR. If this field is empty or missing, this rule matches all ports (traffic not restricted by port). If this field is present and contains at least one item, then this rule allows traffic only if the traffic matches at least one port in the list.
+        """
+elif False:
+    NetworkPolicyIngressRulePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class NetworkPolicyIngressRulePatchArgs:
     def __init__(__self__, *,
@@ -1525,6 +2141,22 @@ class NetworkPolicyIngressRulePatchArgs:
         pulumi.set(self, "ports", value)
 
 
+if not MYPY:
+    class NetworkPolicyIngressRuleArgsDict(TypedDict):
+        """
+        NetworkPolicyIngressRule describes a particular set of traffic that is allowed to the pods matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and from.
+        """
+        from_: NotRequired[pulumi.Input[Sequence[pulumi.Input['NetworkPolicyPeerArgsDict']]]]
+        """
+        from is a list of sources which should be able to access the pods selected for this rule. Items in this list are combined using a logical OR operation. If this field is empty or missing, this rule matches all sources (traffic not restricted by source). If this field is present and contains at least one item, this rule allows traffic only if the traffic matches at least one item in the from list.
+        """
+        ports: NotRequired[pulumi.Input[Sequence[pulumi.Input['NetworkPolicyPortArgsDict']]]]
+        """
+        ports is a list of ports which should be made accessible on the pods selected for this rule. Each item in this list is combined using a logical OR. If this field is empty or missing, this rule matches all ports (traffic not restricted by port). If this field is present and contains at least one item, then this rule allows traffic only if the traffic matches at least one port in the list.
+        """
+elif False:
+    NetworkPolicyIngressRuleArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class NetworkPolicyIngressRuleArgs:
     def __init__(__self__, *,
@@ -1564,6 +2196,30 @@ class NetworkPolicyIngressRuleArgs:
     def ports(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['NetworkPolicyPortArgs']]]]):
         pulumi.set(self, "ports", value)
 
+
+if not MYPY:
+    class NetworkPolicyPeerPatchArgsDict(TypedDict):
+        """
+        NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of fields are allowed
+        """
+        ip_block: NotRequired[pulumi.Input['IPBlockPatchArgsDict']]
+        """
+        ipBlock defines policy on a particular IPBlock. If this field is set then neither of the other fields can be.
+        """
+        namespace_selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorPatchArgsDict']]
+        """
+        namespaceSelector selects namespaces using cluster-scoped labels. This field follows standard label selector semantics; if present but empty, it selects all namespaces.
+
+        If podSelector is also set, then the NetworkPolicyPeer as a whole selects the pods matching podSelector in the namespaces selected by namespaceSelector. Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+        """
+        pod_selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorPatchArgsDict']]
+        """
+        podSelector is a label selector which selects pods. This field follows standard label selector semantics; if present but empty, it selects all pods.
+
+        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects the pods matching podSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects the pods matching podSelector in the policy's own namespace.
+        """
+elif False:
+    NetworkPolicyPeerPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class NetworkPolicyPeerPatchArgs:
@@ -1629,6 +2285,30 @@ class NetworkPolicyPeerPatchArgs:
         pulumi.set(self, "pod_selector", value)
 
 
+if not MYPY:
+    class NetworkPolicyPeerArgsDict(TypedDict):
+        """
+        NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of fields are allowed
+        """
+        ip_block: NotRequired[pulumi.Input['IPBlockArgsDict']]
+        """
+        ipBlock defines policy on a particular IPBlock. If this field is set then neither of the other fields can be.
+        """
+        namespace_selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorArgsDict']]
+        """
+        namespaceSelector selects namespaces using cluster-scoped labels. This field follows standard label selector semantics; if present but empty, it selects all namespaces.
+
+        If podSelector is also set, then the NetworkPolicyPeer as a whole selects the pods matching podSelector in the namespaces selected by namespaceSelector. Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+        """
+        pod_selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorArgsDict']]
+        """
+        podSelector is a label selector which selects pods. This field follows standard label selector semantics; if present but empty, it selects all pods.
+
+        If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects the pods matching podSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects the pods matching podSelector in the policy's own namespace.
+        """
+elif False:
+    NetworkPolicyPeerArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class NetworkPolicyPeerArgs:
     def __init__(__self__, *,
@@ -1693,6 +2373,26 @@ class NetworkPolicyPeerArgs:
         pulumi.set(self, "pod_selector", value)
 
 
+if not MYPY:
+    class NetworkPolicyPortPatchArgsDict(TypedDict):
+        """
+        NetworkPolicyPort describes a port to allow traffic on
+        """
+        end_port: NotRequired[pulumi.Input[int]]
+        """
+        endPort indicates that the range of ports from port to endPort if set, inclusive, should be allowed by the policy. This field cannot be defined if the port field is not defined or if the port field is defined as a named (string) port. The endPort must be equal or greater than port.
+        """
+        port: NotRequired[pulumi.Input[Union[int, str]]]
+        """
+        port represents the port on the given protocol. This can either be a numerical or named port on a pod. If this field is not provided, this matches all port names and numbers. If present, only traffic on the specified protocol AND port will be matched.
+        """
+        protocol: NotRequired[pulumi.Input[str]]
+        """
+        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match. If not specified, this field defaults to TCP.
+        """
+elif False:
+    NetworkPolicyPortPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class NetworkPolicyPortPatchArgs:
     def __init__(__self__, *,
@@ -1749,6 +2449,26 @@ class NetworkPolicyPortPatchArgs:
         pulumi.set(self, "protocol", value)
 
 
+if not MYPY:
+    class NetworkPolicyPortArgsDict(TypedDict):
+        """
+        NetworkPolicyPort describes a port to allow traffic on
+        """
+        end_port: NotRequired[pulumi.Input[int]]
+        """
+        endPort indicates that the range of ports from port to endPort if set, inclusive, should be allowed by the policy. This field cannot be defined if the port field is not defined or if the port field is defined as a named (string) port. The endPort must be equal or greater than port.
+        """
+        port: NotRequired[pulumi.Input[Union[int, str]]]
+        """
+        port represents the port on the given protocol. This can either be a numerical or named port on a pod. If this field is not provided, this matches all port names and numbers. If present, only traffic on the specified protocol AND port will be matched.
+        """
+        protocol: NotRequired[pulumi.Input[str]]
+        """
+        protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match. If not specified, this field defaults to TCP.
+        """
+elif False:
+    NetworkPolicyPortArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class NetworkPolicyPortArgs:
     def __init__(__self__, *,
@@ -1804,6 +2524,30 @@ class NetworkPolicyPortArgs:
     def protocol(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "protocol", value)
 
+
+if not MYPY:
+    class NetworkPolicySpecPatchArgsDict(TypedDict):
+        """
+        NetworkPolicySpec provides the specification of a NetworkPolicy
+        """
+        egress: NotRequired[pulumi.Input[Sequence[pulumi.Input['NetworkPolicyEgressRulePatchArgsDict']]]]
+        """
+        egress is a list of egress rules to be applied to the selected pods. Outgoing traffic is allowed if there are no NetworkPolicies selecting the pod (and cluster policy otherwise allows the traffic), OR if the traffic matches at least one egress rule across all of the NetworkPolicy objects whose podSelector matches the pod. If this field is empty then this NetworkPolicy limits all outgoing traffic (and serves solely to ensure that the pods it selects are isolated by default). This field is beta-level in 1.8
+        """
+        ingress: NotRequired[pulumi.Input[Sequence[pulumi.Input['NetworkPolicyIngressRulePatchArgsDict']]]]
+        """
+        ingress is a list of ingress rules to be applied to the selected pods. Traffic is allowed to a pod if there are no NetworkPolicies selecting the pod (and cluster policy otherwise allows the traffic), OR if the traffic source is the pod's local node, OR if the traffic matches at least one ingress rule across all of the NetworkPolicy objects whose podSelector matches the pod. If this field is empty then this NetworkPolicy does not allow any traffic (and serves solely to ensure that the pods it selects are isolated by default)
+        """
+        pod_selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorPatchArgsDict']]
+        """
+        podSelector selects the pods to which this NetworkPolicy object applies. The array of ingress rules is applied to any pods selected by this field. Multiple network policies can select the same set of pods. In this case, the ingress rules for each are combined additively. This field is NOT optional and follows standard label selector semantics. An empty podSelector matches all pods in this namespace.
+        """
+        policy_types: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        policyTypes is a list of rule types that the NetworkPolicy relates to. Valid options are ["Ingress"], ["Egress"], or ["Ingress", "Egress"]. If this field is not specified, it will default based on the existence of ingress or egress rules; policies that contain an egress section are assumed to affect egress, and all policies (whether or not they contain an ingress section) are assumed to affect ingress. If you want to write an egress-only policy, you must explicitly specify policyTypes [ "Egress" ]. Likewise, if you want to write a policy that specifies that no egress is allowed, you must specify a policyTypes value that include "Egress" (since such a policy would not include an egress section and would otherwise default to just [ "Ingress" ]). This field is beta-level in 1.8
+        """
+elif False:
+    NetworkPolicySpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class NetworkPolicySpecPatchArgs:
@@ -1877,6 +2621,30 @@ class NetworkPolicySpecPatchArgs:
         pulumi.set(self, "policy_types", value)
 
 
+if not MYPY:
+    class NetworkPolicySpecArgsDict(TypedDict):
+        """
+        NetworkPolicySpec provides the specification of a NetworkPolicy
+        """
+        pod_selector: pulumi.Input['_meta.v1.LabelSelectorArgsDict']
+        """
+        podSelector selects the pods to which this NetworkPolicy object applies. The array of ingress rules is applied to any pods selected by this field. Multiple network policies can select the same set of pods. In this case, the ingress rules for each are combined additively. This field is NOT optional and follows standard label selector semantics. An empty podSelector matches all pods in this namespace.
+        """
+        egress: NotRequired[pulumi.Input[Sequence[pulumi.Input['NetworkPolicyEgressRuleArgsDict']]]]
+        """
+        egress is a list of egress rules to be applied to the selected pods. Outgoing traffic is allowed if there are no NetworkPolicies selecting the pod (and cluster policy otherwise allows the traffic), OR if the traffic matches at least one egress rule across all of the NetworkPolicy objects whose podSelector matches the pod. If this field is empty then this NetworkPolicy limits all outgoing traffic (and serves solely to ensure that the pods it selects are isolated by default). This field is beta-level in 1.8
+        """
+        ingress: NotRequired[pulumi.Input[Sequence[pulumi.Input['NetworkPolicyIngressRuleArgsDict']]]]
+        """
+        ingress is a list of ingress rules to be applied to the selected pods. Traffic is allowed to a pod if there are no NetworkPolicies selecting the pod (and cluster policy otherwise allows the traffic), OR if the traffic source is the pod's local node, OR if the traffic matches at least one ingress rule across all of the NetworkPolicy objects whose podSelector matches the pod. If this field is empty then this NetworkPolicy does not allow any traffic (and serves solely to ensure that the pods it selects are isolated by default)
+        """
+        policy_types: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        policyTypes is a list of rule types that the NetworkPolicy relates to. Valid options are ["Ingress"], ["Egress"], or ["Ingress", "Egress"]. If this field is not specified, it will default based on the existence of ingress or egress rules; policies that contain an egress section are assumed to affect egress, and all policies (whether or not they contain an ingress section) are assumed to affect ingress. If you want to write an egress-only policy, you must explicitly specify policyTypes [ "Egress" ]. Likewise, if you want to write a policy that specifies that no egress is allowed, you must specify a policyTypes value that include "Egress" (since such a policy would not include an egress section and would otherwise default to just [ "Ingress" ]). This field is beta-level in 1.8
+        """
+elif False:
+    NetworkPolicySpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class NetworkPolicySpecArgs:
     def __init__(__self__, *,
@@ -1948,6 +2716,18 @@ class NetworkPolicySpecArgs:
         pulumi.set(self, "policy_types", value)
 
 
+if not MYPY:
+    class NetworkPolicyStatusArgsDict(TypedDict):
+        """
+        NetworkPolicyStatus describe the current state of the NetworkPolicy.
+        """
+        conditions: NotRequired[pulumi.Input[Sequence[pulumi.Input['_meta.v1.ConditionArgsDict']]]]
+        """
+        Conditions holds an array of metav1.Condition that describe the state of the NetworkPolicy. Current service state
+        """
+elif False:
+    NetworkPolicyStatusArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class NetworkPolicyStatusArgs:
     def __init__(__self__, *,
@@ -1971,6 +2751,34 @@ class NetworkPolicyStatusArgs:
     def conditions(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['_meta.v1.ConditionArgs']]]]):
         pulumi.set(self, "conditions", value)
 
+
+if not MYPY:
+    class NetworkPolicyArgsDict(TypedDict):
+        """
+        NetworkPolicy describes what network traffic is allowed for a set of Pods
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['NetworkPolicySpecArgsDict']]
+        """
+        spec represents the specification of the desired behavior for this NetworkPolicy.
+        """
+        status: NotRequired[pulumi.Input['NetworkPolicyStatusArgsDict']]
+        """
+        Status is the current state of the NetworkPolicy. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+elif False:
+    NetworkPolicyArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class NetworkPolicyArgs:
@@ -2060,6 +2868,22 @@ class NetworkPolicyArgs:
         pulumi.set(self, "status", value)
 
 
+if not MYPY:
+    class ServiceBackendPortPatchArgsDict(TypedDict):
+        """
+        ServiceBackendPort is the service port being referenced.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        name is the name of the port on the Service. This is a mutually exclusive setting with "Number".
+        """
+        number: NotRequired[pulumi.Input[int]]
+        """
+        number is the numerical port number (e.g. 80) on the Service. This is a mutually exclusive setting with "Name".
+        """
+elif False:
+    ServiceBackendPortPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ServiceBackendPortPatchArgs:
     def __init__(__self__, *,
@@ -2099,6 +2923,22 @@ class ServiceBackendPortPatchArgs:
     def number(self, value: Optional[pulumi.Input[int]]):
         pulumi.set(self, "number", value)
 
+
+if not MYPY:
+    class ServiceBackendPortArgsDict(TypedDict):
+        """
+        ServiceBackendPort is the service port being referenced.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        name is the name of the port on the Service. This is a mutually exclusive setting with "Number".
+        """
+        number: NotRequired[pulumi.Input[int]]
+        """
+        number is the numerical port number (e.g. 80) on the Service. This is a mutually exclusive setting with "Name".
+        """
+elif False:
+    ServiceBackendPortArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ServiceBackendPortArgs:

--- a/sdk/python/pulumi_kubernetes/networking/v1/outputs.py
+++ b/sdk/python/pulumi_kubernetes/networking/v1/outputs.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core

--- a/sdk/python/pulumi_kubernetes/networking/v1alpha1/ClusterCIDR.py
+++ b/sdk/python/pulumi_kubernetes/networking/v1alpha1/ClusterCIDR.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -94,8 +99,8 @@ class ClusterCIDR(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ClusterCIDRSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ClusterCIDRSpecArgs', 'ClusterCIDRSpecArgsDict']]] = None,
                  __props__=None):
         """
         ClusterCIDR represents a single configuration for per-Node Pod CIDR allocations when the MultiCIDRRangeAllocator is enabled (see the config for kube-controller-manager).  A cluster may have any number of ClusterCIDR resources, all of which will be considered when allocating a CIDR for a Node.  A ClusterCIDR is eligible to be used for a given Node when the node selector matches the node in question and has free CIDRs to allocate.  In case of multiple matching ClusterCIDR resources, the allocator will attempt to break ties using internal heuristics, but any ClusterCIDR whose node selector matches the Node may be used.
@@ -104,8 +109,8 @@ class ClusterCIDR(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['ClusterCIDRSpecArgs']] spec: Spec is the desired state of the ClusterCIDR. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['ClusterCIDRSpecArgs', 'ClusterCIDRSpecArgsDict']] spec: Spec is the desired state of the ClusterCIDR. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -133,8 +138,8 @@ class ClusterCIDR(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ClusterCIDRSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ClusterCIDRSpecArgs', 'ClusterCIDRSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/networking/v1alpha1/ClusterCIDRList.py
+++ b/sdk/python/pulumi_kubernetes/networking/v1alpha1/ClusterCIDRList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -92,9 +97,9 @@ class ClusterCIDRList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ClusterCIDRArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ClusterCIDRArgs', 'ClusterCIDRArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         ClusterCIDRList contains a list of ClusterCIDR.
@@ -102,9 +107,9 @@ class ClusterCIDRList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ClusterCIDRArgs']]]] items: Items is the list of ClusterCIDRs.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['ClusterCIDRArgs', 'ClusterCIDRArgsDict']]]] items: Items is the list of ClusterCIDRs.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -131,9 +136,9 @@ class ClusterCIDRList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ClusterCIDRArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ClusterCIDRArgs', 'ClusterCIDRArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/networking/v1alpha1/ClusterCIDRPatch.py
+++ b/sdk/python/pulumi_kubernetes/networking/v1alpha1/ClusterCIDRPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -94,8 +99,8 @@ class ClusterCIDRPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ClusterCIDRSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ClusterCIDRSpecPatchArgs', 'ClusterCIDRSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -110,8 +115,8 @@ class ClusterCIDRPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['ClusterCIDRSpecPatchArgs']] spec: Spec is the desired state of the ClusterCIDR. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['ClusterCIDRSpecPatchArgs', 'ClusterCIDRSpecPatchArgsDict']] spec: Spec is the desired state of the ClusterCIDR. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -145,8 +150,8 @@ class ClusterCIDRPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ClusterCIDRSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ClusterCIDRSpecPatchArgs', 'ClusterCIDRSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/networking/v1alpha1/IPAddress.py
+++ b/sdk/python/pulumi_kubernetes/networking/v1alpha1/IPAddress.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class IPAddress(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['IPAddressSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['IPAddressSpecArgs', 'IPAddressSpecArgsDict']]] = None,
                  __props__=None):
         """
         IPAddress represents a single IP of a single IP Family. The object is designed to be used by APIs that operate on IP addresses. The object is used by the Service core API for allocation of IP addresses. An IP address can be represented in different formats, to guarantee the uniqueness of the IP, the name of the object is the IP address in canonical format, four decimal digits separated by dots suppressing leading zeros for IPv4 and the representation defined by RFC 5952 for IPv6. Valid: 192.168.1.5 or 2001:db8::1 or 2001:db8:aaaa:bbbb:cccc:dddd:eeee:1 Invalid: 10.01.2.3 or 2001:db8:0:0:0::1
@@ -103,8 +108,8 @@ class IPAddress(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['IPAddressSpecArgs']] spec: spec is the desired state of the IPAddress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['IPAddressSpecArgs', 'IPAddressSpecArgsDict']] spec: spec is the desired state of the IPAddress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -132,8 +137,8 @@ class IPAddress(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['IPAddressSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['IPAddressSpecArgs', 'IPAddressSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/networking/v1alpha1/IPAddressList.py
+++ b/sdk/python/pulumi_kubernetes/networking/v1alpha1/IPAddressList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class IPAddressList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['IPAddressArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['IPAddressArgs', 'IPAddressArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         IPAddressList contains a list of IPAddress.
@@ -101,9 +106,9 @@ class IPAddressList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['IPAddressArgs']]]] items: items is the list of IPAddresses.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['IPAddressArgs', 'IPAddressArgsDict']]]] items: items is the list of IPAddresses.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class IPAddressList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['IPAddressArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['IPAddressArgs', 'IPAddressArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/networking/v1alpha1/IPAddressPatch.py
+++ b/sdk/python/pulumi_kubernetes/networking/v1alpha1/IPAddressPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class IPAddressPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['IPAddressSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['IPAddressSpecPatchArgs', 'IPAddressSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -109,8 +114,8 @@ class IPAddressPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['IPAddressSpecPatchArgs']] spec: spec is the desired state of the IPAddress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['IPAddressSpecPatchArgs', 'IPAddressSpecPatchArgsDict']] spec: spec is the desired state of the IPAddress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -144,8 +149,8 @@ class IPAddressPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['IPAddressSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['IPAddressSpecPatchArgs', 'IPAddressSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/networking/v1alpha1/ServiceCIDR.py
+++ b/sdk/python/pulumi_kubernetes/networking/v1alpha1/ServiceCIDR.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class ServiceCIDR(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ServiceCIDRSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ServiceCIDRSpecArgs', 'ServiceCIDRSpecArgsDict']]] = None,
                  __props__=None):
         """
         ServiceCIDR defines a range of IP addresses using CIDR format (e.g. 192.168.0.0/24 or 2001:db2::/64). This range is used to allocate ClusterIPs to Service objects.
@@ -103,8 +108,8 @@ class ServiceCIDR(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['ServiceCIDRSpecArgs']] spec: spec is the desired state of the ServiceCIDR. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['ServiceCIDRSpecArgs', 'ServiceCIDRSpecArgsDict']] spec: spec is the desired state of the ServiceCIDR. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -132,8 +137,8 @@ class ServiceCIDR(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ServiceCIDRSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ServiceCIDRSpecArgs', 'ServiceCIDRSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/networking/v1alpha1/ServiceCIDRList.py
+++ b/sdk/python/pulumi_kubernetes/networking/v1alpha1/ServiceCIDRList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class ServiceCIDRList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ServiceCIDRArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ServiceCIDRArgs', 'ServiceCIDRArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         ServiceCIDRList contains a list of ServiceCIDR objects.
@@ -101,9 +106,9 @@ class ServiceCIDRList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ServiceCIDRArgs']]]] items: items is the list of ServiceCIDRs.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['ServiceCIDRArgs', 'ServiceCIDRArgsDict']]]] items: items is the list of ServiceCIDRs.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class ServiceCIDRList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ServiceCIDRArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ServiceCIDRArgs', 'ServiceCIDRArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/networking/v1alpha1/ServiceCIDRPatch.py
+++ b/sdk/python/pulumi_kubernetes/networking/v1alpha1/ServiceCIDRPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class ServiceCIDRPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ServiceCIDRSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ServiceCIDRSpecPatchArgs', 'ServiceCIDRSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -109,8 +114,8 @@ class ServiceCIDRPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['ServiceCIDRSpecPatchArgs']] spec: spec is the desired state of the ServiceCIDR. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['ServiceCIDRSpecPatchArgs', 'ServiceCIDRSpecPatchArgsDict']] spec: spec is the desired state of the ServiceCIDR. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -144,8 +149,8 @@ class ServiceCIDRPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ServiceCIDRSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ServiceCIDRSpecPatchArgs', 'ServiceCIDRSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/networking/v1alpha1/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/networking/v1alpha1/_inputs.py
@@ -4,27 +4,70 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import core as _core
 from ... import meta as _meta
 
 __all__ = [
     'ClusterCIDRSpecPatchArgs',
+    'ClusterCIDRSpecPatchArgsDict',
     'ClusterCIDRSpecArgs',
+    'ClusterCIDRSpecArgsDict',
     'ClusterCIDRArgs',
+    'ClusterCIDRArgsDict',
     'IPAddressSpecPatchArgs',
+    'IPAddressSpecPatchArgsDict',
     'IPAddressSpecArgs',
+    'IPAddressSpecArgsDict',
     'IPAddressArgs',
+    'IPAddressArgsDict',
     'ParentReferencePatchArgs',
+    'ParentReferencePatchArgsDict',
     'ParentReferenceArgs',
+    'ParentReferenceArgsDict',
     'ServiceCIDRSpecPatchArgs',
+    'ServiceCIDRSpecPatchArgsDict',
     'ServiceCIDRSpecArgs',
+    'ServiceCIDRSpecArgsDict',
     'ServiceCIDRStatusArgs',
+    'ServiceCIDRStatusArgsDict',
     'ServiceCIDRArgs',
+    'ServiceCIDRArgsDict',
 ]
+
+MYPY = False
+
+if not MYPY:
+    class ClusterCIDRSpecPatchArgsDict(TypedDict):
+        """
+        ClusterCIDRSpec defines the desired state of ClusterCIDR.
+        """
+        ipv4: NotRequired[pulumi.Input[str]]
+        """
+        IPv4 defines an IPv4 IP block in CIDR notation(e.g. "10.0.0.0/8"). At least one of IPv4 and IPv6 must be specified. This field is immutable.
+        """
+        ipv6: NotRequired[pulumi.Input[str]]
+        """
+        IPv6 defines an IPv6 IP block in CIDR notation(e.g. "2001:db8::/64"). At least one of IPv4 and IPv6 must be specified. This field is immutable.
+        """
+        node_selector: NotRequired[pulumi.Input['_core.v1.NodeSelectorPatchArgsDict']]
+        """
+        NodeSelector defines which nodes the config is applicable to. An empty or nil NodeSelector selects all nodes. This field is immutable.
+        """
+        per_node_host_bits: NotRequired[pulumi.Input[int]]
+        """
+        PerNodeHostBits defines the number of host bits to be configured per node. A subnet mask determines how much of the address is used for network bits and host bits. For example an IPv4 address of 192.168.0.0/24, splits the address into 24 bits for the network portion and 8 bits for the host portion. To allocate 256 IPs, set this field to 8 (a /24 mask for IPv4 or a /120 for IPv6). Minimum value is 4 (16 IPs). This field is immutable.
+        """
+elif False:
+    ClusterCIDRSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ClusterCIDRSpecPatchArgs:
@@ -98,6 +141,30 @@ class ClusterCIDRSpecPatchArgs:
         pulumi.set(self, "per_node_host_bits", value)
 
 
+if not MYPY:
+    class ClusterCIDRSpecArgsDict(TypedDict):
+        """
+        ClusterCIDRSpec defines the desired state of ClusterCIDR.
+        """
+        per_node_host_bits: pulumi.Input[int]
+        """
+        PerNodeHostBits defines the number of host bits to be configured per node. A subnet mask determines how much of the address is used for network bits and host bits. For example an IPv4 address of 192.168.0.0/24, splits the address into 24 bits for the network portion and 8 bits for the host portion. To allocate 256 IPs, set this field to 8 (a /24 mask for IPv4 or a /120 for IPv6). Minimum value is 4 (16 IPs). This field is immutable.
+        """
+        ipv4: NotRequired[pulumi.Input[str]]
+        """
+        IPv4 defines an IPv4 IP block in CIDR notation(e.g. "10.0.0.0/8"). At least one of IPv4 and IPv6 must be specified. This field is immutable.
+        """
+        ipv6: NotRequired[pulumi.Input[str]]
+        """
+        IPv6 defines an IPv6 IP block in CIDR notation(e.g. "2001:db8::/64"). At least one of IPv4 and IPv6 must be specified. This field is immutable.
+        """
+        node_selector: NotRequired[pulumi.Input['_core.v1.NodeSelectorArgsDict']]
+        """
+        NodeSelector defines which nodes the config is applicable to. An empty or nil NodeSelector selects all nodes. This field is immutable.
+        """
+elif False:
+    ClusterCIDRSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ClusterCIDRSpecArgs:
     def __init__(__self__, *,
@@ -168,6 +235,30 @@ class ClusterCIDRSpecArgs:
     def node_selector(self, value: Optional[pulumi.Input['_core.v1.NodeSelectorArgs']]):
         pulumi.set(self, "node_selector", value)
 
+
+if not MYPY:
+    class ClusterCIDRArgsDict(TypedDict):
+        """
+        ClusterCIDR represents a single configuration for per-Node Pod CIDR allocations when the MultiCIDRRangeAllocator is enabled (see the config for kube-controller-manager).  A cluster may have any number of ClusterCIDR resources, all of which will be considered when allocating a CIDR for a Node.  A ClusterCIDR is eligible to be used for a given Node when the node selector matches the node in question and has free CIDRs to allocate.  In case of multiple matching ClusterCIDR resources, the allocator will attempt to break ties using internal heuristics, but any ClusterCIDR whose node selector matches the Node may be used.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['ClusterCIDRSpecArgsDict']]
+        """
+        Spec is the desired state of the ClusterCIDR. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+elif False:
+    ClusterCIDRArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ClusterCIDRArgs:
@@ -241,6 +332,18 @@ class ClusterCIDRArgs:
         pulumi.set(self, "spec", value)
 
 
+if not MYPY:
+    class IPAddressSpecPatchArgsDict(TypedDict):
+        """
+        IPAddressSpec describe the attributes in an IP Address.
+        """
+        parent_ref: NotRequired[pulumi.Input['ParentReferencePatchArgsDict']]
+        """
+        ParentRef references the resource that an IPAddress is attached to. An IPAddress must reference a parent object.
+        """
+elif False:
+    IPAddressSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class IPAddressSpecPatchArgs:
     def __init__(__self__, *,
@@ -265,6 +368,18 @@ class IPAddressSpecPatchArgs:
         pulumi.set(self, "parent_ref", value)
 
 
+if not MYPY:
+    class IPAddressSpecArgsDict(TypedDict):
+        """
+        IPAddressSpec describe the attributes in an IP Address.
+        """
+        parent_ref: pulumi.Input['ParentReferenceArgsDict']
+        """
+        ParentRef references the resource that an IPAddress is attached to. An IPAddress must reference a parent object.
+        """
+elif False:
+    IPAddressSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class IPAddressSpecArgs:
     def __init__(__self__, *,
@@ -287,6 +402,30 @@ class IPAddressSpecArgs:
     def parent_ref(self, value: pulumi.Input['ParentReferenceArgs']):
         pulumi.set(self, "parent_ref", value)
 
+
+if not MYPY:
+    class IPAddressArgsDict(TypedDict):
+        """
+        IPAddress represents a single IP of a single IP Family. The object is designed to be used by APIs that operate on IP addresses. The object is used by the Service core API for allocation of IP addresses. An IP address can be represented in different formats, to guarantee the uniqueness of the IP, the name of the object is the IP address in canonical format, four decimal digits separated by dots suppressing leading zeros for IPv4 and the representation defined by RFC 5952 for IPv6. Valid: 192.168.1.5 or 2001:db8::1 or 2001:db8:aaaa:bbbb:cccc:dddd:eeee:1 Invalid: 10.01.2.3 or 2001:db8:0:0:0::1
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['IPAddressSpecArgsDict']]
+        """
+        spec is the desired state of the IPAddress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+elif False:
+    IPAddressArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class IPAddressArgs:
@@ -359,6 +498,34 @@ class IPAddressArgs:
     def spec(self, value: Optional[pulumi.Input['IPAddressSpecArgs']]):
         pulumi.set(self, "spec", value)
 
+
+if not MYPY:
+    class ParentReferencePatchArgsDict(TypedDict):
+        """
+        ParentReference describes a reference to a parent object.
+        """
+        group: NotRequired[pulumi.Input[str]]
+        """
+        Group is the group of the object being referenced.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name is the name of the object being referenced.
+        """
+        namespace: NotRequired[pulumi.Input[str]]
+        """
+        Namespace is the namespace of the object being referenced.
+        """
+        resource: NotRequired[pulumi.Input[str]]
+        """
+        Resource is the resource of the object being referenced.
+        """
+        uid: NotRequired[pulumi.Input[str]]
+        """
+        UID is the uid of the object being referenced.
+        """
+elif False:
+    ParentReferencePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ParentReferencePatchArgs:
@@ -448,6 +615,34 @@ class ParentReferencePatchArgs:
         pulumi.set(self, "uid", value)
 
 
+if not MYPY:
+    class ParentReferenceArgsDict(TypedDict):
+        """
+        ParentReference describes a reference to a parent object.
+        """
+        name: pulumi.Input[str]
+        """
+        Name is the name of the object being referenced.
+        """
+        resource: pulumi.Input[str]
+        """
+        Resource is the resource of the object being referenced.
+        """
+        group: NotRequired[pulumi.Input[str]]
+        """
+        Group is the group of the object being referenced.
+        """
+        namespace: NotRequired[pulumi.Input[str]]
+        """
+        Namespace is the namespace of the object being referenced.
+        """
+        uid: NotRequired[pulumi.Input[str]]
+        """
+        UID is the uid of the object being referenced.
+        """
+elif False:
+    ParentReferenceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ParentReferenceArgs:
     def __init__(__self__, *,
@@ -534,6 +729,18 @@ class ParentReferenceArgs:
         pulumi.set(self, "uid", value)
 
 
+if not MYPY:
+    class ServiceCIDRSpecPatchArgsDict(TypedDict):
+        """
+        ServiceCIDRSpec define the CIDRs the user wants to use for allocating ClusterIPs for Services.
+        """
+        cidrs: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        CIDRs defines the IP blocks in CIDR notation (e.g. "192.168.0.0/24" or "2001:db8::/64") from which to assign service cluster IPs. Max of two CIDRs is allowed, one of each IP family. This field is immutable.
+        """
+elif False:
+    ServiceCIDRSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ServiceCIDRSpecPatchArgs:
     def __init__(__self__, *,
@@ -557,6 +764,18 @@ class ServiceCIDRSpecPatchArgs:
     def cidrs(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]):
         pulumi.set(self, "cidrs", value)
 
+
+if not MYPY:
+    class ServiceCIDRSpecArgsDict(TypedDict):
+        """
+        ServiceCIDRSpec define the CIDRs the user wants to use for allocating ClusterIPs for Services.
+        """
+        cidrs: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        CIDRs defines the IP blocks in CIDR notation (e.g. "192.168.0.0/24" or "2001:db8::/64") from which to assign service cluster IPs. Max of two CIDRs is allowed, one of each IP family. This field is immutable.
+        """
+elif False:
+    ServiceCIDRSpecArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ServiceCIDRSpecArgs:
@@ -582,6 +801,18 @@ class ServiceCIDRSpecArgs:
         pulumi.set(self, "cidrs", value)
 
 
+if not MYPY:
+    class ServiceCIDRStatusArgsDict(TypedDict):
+        """
+        ServiceCIDRStatus describes the current state of the ServiceCIDR.
+        """
+        conditions: NotRequired[pulumi.Input[Sequence[pulumi.Input['_meta.v1.ConditionArgsDict']]]]
+        """
+        conditions holds an array of metav1.Condition that describe the state of the ServiceCIDR. Current service state
+        """
+elif False:
+    ServiceCIDRStatusArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ServiceCIDRStatusArgs:
     def __init__(__self__, *,
@@ -605,6 +836,34 @@ class ServiceCIDRStatusArgs:
     def conditions(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['_meta.v1.ConditionArgs']]]]):
         pulumi.set(self, "conditions", value)
 
+
+if not MYPY:
+    class ServiceCIDRArgsDict(TypedDict):
+        """
+        ServiceCIDR defines a range of IP addresses using CIDR format (e.g. 192.168.0.0/24 or 2001:db2::/64). This range is used to allocate ClusterIPs to Service objects.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['ServiceCIDRSpecArgsDict']]
+        """
+        spec is the desired state of the ServiceCIDR. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+        status: NotRequired[pulumi.Input['ServiceCIDRStatusArgsDict']]
+        """
+        status represents the current state of the ServiceCIDR. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+elif False:
+    ServiceCIDRArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ServiceCIDRArgs:

--- a/sdk/python/pulumi_kubernetes/networking/v1alpha1/outputs.py
+++ b/sdk/python/pulumi_kubernetes/networking/v1alpha1/outputs.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core

--- a/sdk/python/pulumi_kubernetes/networking/v1beta1/Ingress.py
+++ b/sdk/python/pulumi_kubernetes/networking/v1beta1/Ingress.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -94,8 +99,8 @@ class Ingress(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['IngressSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['IngressSpecArgs', 'IngressSpecArgsDict']]] = None,
                  __props__=None):
         """
         Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.
@@ -118,8 +123,8 @@ class Ingress(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['IngressSpecArgs']] spec: Spec is the desired state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['IngressSpecArgs', 'IngressSpecArgsDict']] spec: Spec is the desired state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -161,8 +166,8 @@ class Ingress(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['IngressSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['IngressSpecArgs', 'IngressSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/networking/v1beta1/IngressClass.py
+++ b/sdk/python/pulumi_kubernetes/networking/v1beta1/IngressClass.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -94,8 +99,8 @@ class IngressClass(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['IngressClassSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['IngressClassSpecArgs', 'IngressClassSpecArgsDict']]] = None,
                  __props__=None):
         """
         IngressClass represents the class of the Ingress, referenced by the Ingress Spec. The `ingressclass.kubernetes.io/is-default-class` annotation can be used to indicate that an IngressClass should be considered default. When a single IngressClass resource has this annotation set to true, new Ingress resources without a class specified will be assigned this default class.
@@ -104,8 +109,8 @@ class IngressClass(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['IngressClassSpecArgs']] spec: Spec is the desired state of the IngressClass. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['IngressClassSpecArgs', 'IngressClassSpecArgsDict']] spec: Spec is the desired state of the IngressClass. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -133,8 +138,8 @@ class IngressClass(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['IngressClassSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['IngressClassSpecArgs', 'IngressClassSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/networking/v1beta1/IngressClassList.py
+++ b/sdk/python/pulumi_kubernetes/networking/v1beta1/IngressClassList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -92,9 +97,9 @@ class IngressClassList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['IngressClassArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['IngressClassArgs', 'IngressClassArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         IngressClassList is a collection of IngressClasses.
@@ -102,9 +107,9 @@ class IngressClassList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['IngressClassArgs']]]] items: Items is the list of IngressClasses.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['IngressClassArgs', 'IngressClassArgsDict']]]] items: Items is the list of IngressClasses.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata.
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata.
         """
         ...
     @overload
@@ -131,9 +136,9 @@ class IngressClassList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['IngressClassArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['IngressClassArgs', 'IngressClassArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/networking/v1beta1/IngressClassPatch.py
+++ b/sdk/python/pulumi_kubernetes/networking/v1beta1/IngressClassPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -94,8 +99,8 @@ class IngressClassPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['IngressClassSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['IngressClassSpecPatchArgs', 'IngressClassSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -110,8 +115,8 @@ class IngressClassPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['IngressClassSpecPatchArgs']] spec: Spec is the desired state of the IngressClass. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['IngressClassSpecPatchArgs', 'IngressClassSpecPatchArgsDict']] spec: Spec is the desired state of the IngressClass. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -145,8 +150,8 @@ class IngressClassPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['IngressClassSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['IngressClassSpecPatchArgs', 'IngressClassSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/networking/v1beta1/IngressList.py
+++ b/sdk/python/pulumi_kubernetes/networking/v1beta1/IngressList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -92,9 +97,9 @@ class IngressList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['IngressArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['IngressArgs', 'IngressArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         IngressList is a collection of Ingress.
@@ -102,9 +107,9 @@ class IngressList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['IngressArgs']]]] items: Items is the list of Ingress.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['IngressArgs', 'IngressArgsDict']]]] items: Items is the list of Ingress.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -131,9 +136,9 @@ class IngressList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['IngressArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['IngressArgs', 'IngressArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/networking/v1beta1/IngressPatch.py
+++ b/sdk/python/pulumi_kubernetes/networking/v1beta1/IngressPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -94,8 +99,8 @@ class IngressPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['IngressSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['IngressSpecPatchArgs', 'IngressSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -124,8 +129,8 @@ class IngressPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['IngressSpecPatchArgs']] spec: Spec is the desired state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['IngressSpecPatchArgs', 'IngressSpecPatchArgsDict']] spec: Spec is the desired state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -173,8 +178,8 @@ class IngressPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['IngressSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['IngressSpecPatchArgs', 'IngressSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/networking/v1beta1/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/networking/v1beta1/_inputs.py
@@ -4,32 +4,86 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import core as _core
 from ... import meta as _meta
 
 __all__ = [
     'HTTPIngressPathPatchArgs',
+    'HTTPIngressPathPatchArgsDict',
     'HTTPIngressPathArgs',
+    'HTTPIngressPathArgsDict',
     'HTTPIngressRuleValuePatchArgs',
+    'HTTPIngressRuleValuePatchArgsDict',
     'HTTPIngressRuleValueArgs',
+    'HTTPIngressRuleValueArgsDict',
     'IngressBackendPatchArgs',
+    'IngressBackendPatchArgsDict',
     'IngressBackendArgs',
+    'IngressBackendArgsDict',
     'IngressClassSpecPatchArgs',
+    'IngressClassSpecPatchArgsDict',
     'IngressClassSpecArgs',
+    'IngressClassSpecArgsDict',
     'IngressClassArgs',
+    'IngressClassArgsDict',
     'IngressRulePatchArgs',
+    'IngressRulePatchArgsDict',
     'IngressRuleArgs',
+    'IngressRuleArgsDict',
     'IngressSpecPatchArgs',
+    'IngressSpecPatchArgsDict',
     'IngressSpecArgs',
+    'IngressSpecArgsDict',
     'IngressStatusArgs',
+    'IngressStatusArgsDict',
     'IngressTLSPatchArgs',
+    'IngressTLSPatchArgsDict',
     'IngressTLSArgs',
+    'IngressTLSArgsDict',
     'IngressArgs',
+    'IngressArgsDict',
 ]
+
+MYPY = False
+
+if not MYPY:
+    class HTTPIngressPathPatchArgsDict(TypedDict):
+        """
+        HTTPIngressPath associates a path regex with a backend. Incoming urls matching the path are forwarded to the backend.
+        """
+        backend: NotRequired[pulumi.Input['IngressBackendPatchArgsDict']]
+        """
+        Backend defines the referenced service endpoint to which the traffic will be forwarded to.
+        """
+        path: NotRequired[pulumi.Input[str]]
+        """
+        Path is an extended POSIX regex as defined by IEEE Std 1003.1, (i.e this follows the egrep/unix syntax, not the perl syntax) matched against the path of an incoming request. Currently it can contain characters disallowed from the conventional "path" part of a URL as defined by RFC 3986. Paths must begin with a '/'. If unspecified, the path defaults to a catch all sending traffic to the backend.
+        """
+        path_type: NotRequired[pulumi.Input[str]]
+        """
+        PathType determines the interpretation of the Path matching. PathType can be one of the following values: * Exact: Matches the URL path exactly. * Prefix: Matches based on a URL path prefix split by '/'. Matching is
+          done on a path element by element basis. A path element refers is the
+          list of labels in the path split by the '/' separator. A request is a
+          match for path p if every p is an element-wise prefix of p of the
+          request path. Note that if the last element of the path is a substring
+          of the last element in request path, it is not a match (e.g. /foo/bar
+          matches /foo/bar/baz, but does not match /foo/barbaz).
+        * ImplementationSpecific: Interpretation of the Path matching is up to
+          the IngressClass. Implementations can treat this as a separate PathType
+          or treat it identically to Prefix or Exact path types.
+        Implementations are required to support all path types. Defaults to ImplementationSpecific.
+        """
+elif False:
+    HTTPIngressPathPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class HTTPIngressPathPatchArgs:
@@ -107,6 +161,36 @@ class HTTPIngressPathPatchArgs:
         pulumi.set(self, "path_type", value)
 
 
+if not MYPY:
+    class HTTPIngressPathArgsDict(TypedDict):
+        """
+        HTTPIngressPath associates a path regex with a backend. Incoming urls matching the path are forwarded to the backend.
+        """
+        backend: pulumi.Input['IngressBackendArgsDict']
+        """
+        Backend defines the referenced service endpoint to which the traffic will be forwarded to.
+        """
+        path: NotRequired[pulumi.Input[str]]
+        """
+        Path is an extended POSIX regex as defined by IEEE Std 1003.1, (i.e this follows the egrep/unix syntax, not the perl syntax) matched against the path of an incoming request. Currently it can contain characters disallowed from the conventional "path" part of a URL as defined by RFC 3986. Paths must begin with a '/'. If unspecified, the path defaults to a catch all sending traffic to the backend.
+        """
+        path_type: NotRequired[pulumi.Input[str]]
+        """
+        PathType determines the interpretation of the Path matching. PathType can be one of the following values: * Exact: Matches the URL path exactly. * Prefix: Matches based on a URL path prefix split by '/'. Matching is
+          done on a path element by element basis. A path element refers is the
+          list of labels in the path split by the '/' separator. A request is a
+          match for path p if every p is an element-wise prefix of p of the
+          request path. Note that if the last element of the path is a substring
+          of the last element in request path, it is not a match (e.g. /foo/bar
+          matches /foo/bar/baz, but does not match /foo/barbaz).
+        * ImplementationSpecific: Interpretation of the Path matching is up to
+          the IngressClass. Implementations can treat this as a separate PathType
+          or treat it identically to Prefix or Exact path types.
+        Implementations are required to support all path types. Defaults to ImplementationSpecific.
+        """
+elif False:
+    HTTPIngressPathArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class HTTPIngressPathArgs:
     def __init__(__self__, *,
@@ -182,6 +266,18 @@ class HTTPIngressPathArgs:
         pulumi.set(self, "path_type", value)
 
 
+if not MYPY:
+    class HTTPIngressRuleValuePatchArgsDict(TypedDict):
+        """
+        HTTPIngressRuleValue is a list of http selectors pointing to backends. In the example: http://<host>/<path>?<searchpart> -> backend where where parts of the url correspond to RFC 3986, this resource will be used to match against everything after the last '/' and before the first '?' or '#'.
+        """
+        paths: NotRequired[pulumi.Input[Sequence[pulumi.Input['HTTPIngressPathPatchArgsDict']]]]
+        """
+        A collection of paths that map requests to backends.
+        """
+elif False:
+    HTTPIngressRuleValuePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class HTTPIngressRuleValuePatchArgs:
     def __init__(__self__, *,
@@ -206,6 +302,18 @@ class HTTPIngressRuleValuePatchArgs:
         pulumi.set(self, "paths", value)
 
 
+if not MYPY:
+    class HTTPIngressRuleValueArgsDict(TypedDict):
+        """
+        HTTPIngressRuleValue is a list of http selectors pointing to backends. In the example: http://<host>/<path>?<searchpart> -> backend where where parts of the url correspond to RFC 3986, this resource will be used to match against everything after the last '/' and before the first '?' or '#'.
+        """
+        paths: pulumi.Input[Sequence[pulumi.Input['HTTPIngressPathArgsDict']]]
+        """
+        A collection of paths that map requests to backends.
+        """
+elif False:
+    HTTPIngressRuleValueArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class HTTPIngressRuleValueArgs:
     def __init__(__self__, *,
@@ -228,6 +336,26 @@ class HTTPIngressRuleValueArgs:
     def paths(self, value: pulumi.Input[Sequence[pulumi.Input['HTTPIngressPathArgs']]]):
         pulumi.set(self, "paths", value)
 
+
+if not MYPY:
+    class IngressBackendPatchArgsDict(TypedDict):
+        """
+        IngressBackend describes all endpoints for a given service and port.
+        """
+        resource: NotRequired[pulumi.Input['_core.v1.TypedLocalObjectReferencePatchArgsDict']]
+        """
+        Resource is an ObjectRef to another Kubernetes resource in the namespace of the Ingress object. If resource is specified, serviceName and servicePort must not be specified.
+        """
+        service_name: NotRequired[pulumi.Input[str]]
+        """
+        Specifies the name of the referenced service.
+        """
+        service_port: NotRequired[pulumi.Input[Union[int, str]]]
+        """
+        Specifies the port of the referenced service.
+        """
+elif False:
+    IngressBackendPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class IngressBackendPatchArgs:
@@ -285,6 +413,26 @@ class IngressBackendPatchArgs:
         pulumi.set(self, "service_port", value)
 
 
+if not MYPY:
+    class IngressBackendArgsDict(TypedDict):
+        """
+        IngressBackend describes all endpoints for a given service and port.
+        """
+        service_name: pulumi.Input[str]
+        """
+        Specifies the name of the referenced service.
+        """
+        service_port: pulumi.Input[Union[int, str]]
+        """
+        Specifies the port of the referenced service.
+        """
+        resource: NotRequired[pulumi.Input['_core.v1.TypedLocalObjectReferenceArgsDict']]
+        """
+        Resource is an ObjectRef to another Kubernetes resource in the namespace of the Ingress object. If resource is specified, serviceName and servicePort must not be specified.
+        """
+elif False:
+    IngressBackendArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class IngressBackendArgs:
     def __init__(__self__, *,
@@ -339,6 +487,22 @@ class IngressBackendArgs:
         pulumi.set(self, "resource", value)
 
 
+if not MYPY:
+    class IngressClassSpecPatchArgsDict(TypedDict):
+        """
+        IngressClassSpec provides information about the class of an Ingress.
+        """
+        controller: NotRequired[pulumi.Input[str]]
+        """
+        Controller refers to the name of the controller that should handle this class. This allows for different "flavors" that are controlled by the same controller. For example, you may have different Parameters for the same implementing controller. This should be specified as a domain-prefixed path no more than 250 characters in length, e.g. "acme.io/ingress-controller". This field is immutable.
+        """
+        parameters: NotRequired[pulumi.Input['_core.v1.TypedLocalObjectReferencePatchArgsDict']]
+        """
+        Parameters is a link to a custom resource containing additional configuration for the controller. This is optional if the controller does not require extra parameters.
+        """
+elif False:
+    IngressClassSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class IngressClassSpecPatchArgs:
     def __init__(__self__, *,
@@ -379,6 +543,22 @@ class IngressClassSpecPatchArgs:
         pulumi.set(self, "parameters", value)
 
 
+if not MYPY:
+    class IngressClassSpecArgsDict(TypedDict):
+        """
+        IngressClassSpec provides information about the class of an Ingress.
+        """
+        controller: NotRequired[pulumi.Input[str]]
+        """
+        Controller refers to the name of the controller that should handle this class. This allows for different "flavors" that are controlled by the same controller. For example, you may have different Parameters for the same implementing controller. This should be specified as a domain-prefixed path no more than 250 characters in length, e.g. "acme.io/ingress-controller". This field is immutable.
+        """
+        parameters: NotRequired[pulumi.Input['_core.v1.TypedLocalObjectReferenceArgsDict']]
+        """
+        Parameters is a link to a custom resource containing additional configuration for the controller. This is optional if the controller does not require extra parameters.
+        """
+elif False:
+    IngressClassSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class IngressClassSpecArgs:
     def __init__(__self__, *,
@@ -418,6 +598,30 @@ class IngressClassSpecArgs:
     def parameters(self, value: Optional[pulumi.Input['_core.v1.TypedLocalObjectReferenceArgs']]):
         pulumi.set(self, "parameters", value)
 
+
+if not MYPY:
+    class IngressClassArgsDict(TypedDict):
+        """
+        IngressClass represents the class of the Ingress, referenced by the Ingress Spec. The `ingressclass.kubernetes.io/is-default-class` annotation can be used to indicate that an IngressClass should be considered default. When a single IngressClass resource has this annotation set to true, new Ingress resources without a class specified will be assigned this default class.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['IngressClassSpecArgsDict']]
+        """
+        Spec is the desired state of the IngressClass. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+elif False:
+    IngressClassArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class IngressClassArgs:
@@ -491,6 +695,24 @@ class IngressClassArgs:
         pulumi.set(self, "spec", value)
 
 
+if not MYPY:
+    class IngressRulePatchArgsDict(TypedDict):
+        """
+        IngressRule represents the rules mapping the paths under a specified host to the related backend services. Incoming requests are first evaluated for a host match, then routed to the backend associated with the matching IngressRuleValue.
+        """
+        host: NotRequired[pulumi.Input[str]]
+        """
+        Host is the fully qualified domain name of a network host, as defined by RFC 3986. Note the following deviations from the "host" part of the URI as defined in the RFC: 1. IPs are not allowed. Currently an IngressRuleValue can only apply to the
+        	  IP in the Spec of the parent Ingress.
+        2. The `:` delimiter is not respected because ports are not allowed.
+        	  Currently the port of an Ingress is implicitly :80 for http and
+        	  :443 for https.
+        Both these may change in the future. Incoming requests are matched against the host before the IngressRuleValue. If the host is unspecified, the Ingress routes all traffic based on the specified IngressRuleValue.
+        """
+        http: NotRequired[pulumi.Input['HTTPIngressRuleValuePatchArgsDict']]
+elif False:
+    IngressRulePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class IngressRulePatchArgs:
     def __init__(__self__, *,
@@ -537,6 +759,24 @@ class IngressRulePatchArgs:
         pulumi.set(self, "http", value)
 
 
+if not MYPY:
+    class IngressRuleArgsDict(TypedDict):
+        """
+        IngressRule represents the rules mapping the paths under a specified host to the related backend services. Incoming requests are first evaluated for a host match, then routed to the backend associated with the matching IngressRuleValue.
+        """
+        host: NotRequired[pulumi.Input[str]]
+        """
+        Host is the fully qualified domain name of a network host, as defined by RFC 3986. Note the following deviations from the "host" part of the URI as defined in the RFC: 1. IPs are not allowed. Currently an IngressRuleValue can only apply to the
+        	  IP in the Spec of the parent Ingress.
+        2. The `:` delimiter is not respected because ports are not allowed.
+        	  Currently the port of an Ingress is implicitly :80 for http and
+        	  :443 for https.
+        Both these may change in the future. Incoming requests are matched against the host before the IngressRuleValue. If the host is unspecified, the Ingress routes all traffic based on the specified IngressRuleValue.
+        """
+        http: NotRequired[pulumi.Input['HTTPIngressRuleValueArgsDict']]
+elif False:
+    IngressRuleArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class IngressRuleArgs:
     def __init__(__self__, *,
@@ -582,6 +822,30 @@ class IngressRuleArgs:
     def http(self, value: Optional[pulumi.Input['HTTPIngressRuleValueArgs']]):
         pulumi.set(self, "http", value)
 
+
+if not MYPY:
+    class IngressSpecPatchArgsDict(TypedDict):
+        """
+        IngressSpec describes the Ingress the user wishes to exist.
+        """
+        backend: NotRequired[pulumi.Input['IngressBackendPatchArgsDict']]
+        """
+        A default backend capable of servicing requests that don't match any rule. At least one of 'backend' or 'rules' must be specified. This field is optional to allow the loadbalancer controller or defaulting logic to specify a global default.
+        """
+        ingress_class_name: NotRequired[pulumi.Input[str]]
+        """
+        IngressClassName is the name of the IngressClass cluster resource. The associated IngressClass defines which controller will implement the resource. This replaces the deprecated `kubernetes.io/ingress.class` annotation. For backwards compatibility, when that annotation is set, it must be given precedence over this field. The controller may emit a warning if the field and annotation have different values. Implementations of this API should ignore Ingresses without a class specified. An IngressClass resource may be marked as default, which can be used to set a default value for this field. For more information, refer to the IngressClass documentation.
+        """
+        rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['IngressRulePatchArgsDict']]]]
+        """
+        A list of host rules used to configure the Ingress. If unspecified, or no rule matches, all traffic is sent to the default backend.
+        """
+        tls: NotRequired[pulumi.Input[Sequence[pulumi.Input['IngressTLSPatchArgsDict']]]]
+        """
+        TLS configuration. Currently the Ingress only supports a single TLS port, 443. If multiple members of this list specify different hosts, they will be multiplexed on the same port according to the hostname specified through the SNI TLS extension, if the ingress controller fulfilling the ingress supports SNI.
+        """
+elif False:
+    IngressSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class IngressSpecPatchArgs:
@@ -655,6 +919,30 @@ class IngressSpecPatchArgs:
         pulumi.set(self, "tls", value)
 
 
+if not MYPY:
+    class IngressSpecArgsDict(TypedDict):
+        """
+        IngressSpec describes the Ingress the user wishes to exist.
+        """
+        backend: NotRequired[pulumi.Input['IngressBackendArgsDict']]
+        """
+        A default backend capable of servicing requests that don't match any rule. At least one of 'backend' or 'rules' must be specified. This field is optional to allow the loadbalancer controller or defaulting logic to specify a global default.
+        """
+        ingress_class_name: NotRequired[pulumi.Input[str]]
+        """
+        IngressClassName is the name of the IngressClass cluster resource. The associated IngressClass defines which controller will implement the resource. This replaces the deprecated `kubernetes.io/ingress.class` annotation. For backwards compatibility, when that annotation is set, it must be given precedence over this field. The controller may emit a warning if the field and annotation have different values. Implementations of this API should ignore Ingresses without a class specified. An IngressClass resource may be marked as default, which can be used to set a default value for this field. For more information, refer to the IngressClass documentation.
+        """
+        rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['IngressRuleArgsDict']]]]
+        """
+        A list of host rules used to configure the Ingress. If unspecified, or no rule matches, all traffic is sent to the default backend.
+        """
+        tls: NotRequired[pulumi.Input[Sequence[pulumi.Input['IngressTLSArgsDict']]]]
+        """
+        TLS configuration. Currently the Ingress only supports a single TLS port, 443. If multiple members of this list specify different hosts, they will be multiplexed on the same port according to the hostname specified through the SNI TLS extension, if the ingress controller fulfilling the ingress supports SNI.
+        """
+elif False:
+    IngressSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class IngressSpecArgs:
     def __init__(__self__, *,
@@ -727,6 +1015,18 @@ class IngressSpecArgs:
         pulumi.set(self, "tls", value)
 
 
+if not MYPY:
+    class IngressStatusArgsDict(TypedDict):
+        """
+        IngressStatus describe the current state of the Ingress.
+        """
+        load_balancer: NotRequired[pulumi.Input['_core.v1.LoadBalancerStatusArgsDict']]
+        """
+        LoadBalancer contains the current status of the load-balancer.
+        """
+elif False:
+    IngressStatusArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class IngressStatusArgs:
     def __init__(__self__, *,
@@ -750,6 +1050,22 @@ class IngressStatusArgs:
     def load_balancer(self, value: Optional[pulumi.Input['_core.v1.LoadBalancerStatusArgs']]):
         pulumi.set(self, "load_balancer", value)
 
+
+if not MYPY:
+    class IngressTLSPatchArgsDict(TypedDict):
+        """
+        IngressTLS describes the transport layer security associated with an Ingress.
+        """
+        hosts: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Hosts are a list of hosts included in the TLS certificate. The values in this list must match the name/s used in the tlsSecret. Defaults to the wildcard host setting for the loadbalancer controller fulfilling this Ingress, if left unspecified.
+        """
+        secret_name: NotRequired[pulumi.Input[str]]
+        """
+        SecretName is the name of the secret used to terminate SSL traffic on 443. Field is left optional to allow SSL routing based on SNI hostname alone. If the SNI host in a listener conflicts with the "Host" header field used by an IngressRule, the SNI host is used for termination and value of the Host header is used for routing.
+        """
+elif False:
+    IngressTLSPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class IngressTLSPatchArgs:
@@ -791,6 +1107,22 @@ class IngressTLSPatchArgs:
         pulumi.set(self, "secret_name", value)
 
 
+if not MYPY:
+    class IngressTLSArgsDict(TypedDict):
+        """
+        IngressTLS describes the transport layer security associated with an Ingress.
+        """
+        hosts: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Hosts are a list of hosts included in the TLS certificate. The values in this list must match the name/s used in the tlsSecret. Defaults to the wildcard host setting for the loadbalancer controller fulfilling this Ingress, if left unspecified.
+        """
+        secret_name: NotRequired[pulumi.Input[str]]
+        """
+        SecretName is the name of the secret used to terminate SSL traffic on 443. Field is left optional to allow SSL routing based on SNI hostname alone. If the SNI host in a listener conflicts with the "Host" header field used by an IngressRule, the SNI host is used for termination and value of the Host header is used for routing.
+        """
+elif False:
+    IngressTLSArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class IngressTLSArgs:
     def __init__(__self__, *,
@@ -830,6 +1162,48 @@ class IngressTLSArgs:
     def secret_name(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "secret_name", value)
 
+
+if not MYPY:
+    class IngressArgsDict(TypedDict):
+        """
+        Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.
+
+        This resource waits until its status is ready before registering success
+        for create/update, and populating output properties from the current state of the resource.
+        The following conditions are used to determine whether the resource creation has
+        succeeded or failed:
+
+        1.  Ingress object exists.
+        2.  Endpoint objects exist with matching names for each Ingress path (except when Service
+            type is ExternalName).
+        3.  Ingress entry exists for '.status.loadBalancer.ingress'.
+
+        If the Ingress has not reached a Ready state after 10 minutes, it will
+        time out and mark the resource update as Failed. You can override the default timeout value
+        by setting the 'customTimeouts' option on the resource.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['IngressSpecArgsDict']]
+        """
+        Spec is the desired state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+        status: NotRequired[pulumi.Input['IngressStatusArgsDict']]
+        """
+        Status is the current state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+elif False:
+    IngressArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class IngressArgs:

--- a/sdk/python/pulumi_kubernetes/networking/v1beta1/outputs.py
+++ b/sdk/python/pulumi_kubernetes/networking/v1beta1/outputs.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core

--- a/sdk/python/pulumi_kubernetes/node/v1/RuntimeClass.py
+++ b/sdk/python/pulumi_kubernetes/node/v1/RuntimeClass.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -128,9 +133,9 @@ class RuntimeClass(pulumi.CustomResource):
                  api_version: Optional[pulumi.Input[str]] = None,
                  handler: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 overhead: Optional[pulumi.Input[pulumi.InputType['OverheadArgs']]] = None,
-                 scheduling: Optional[pulumi.Input[pulumi.InputType['SchedulingArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 overhead: Optional[pulumi.Input[Union['OverheadArgs', 'OverheadArgsDict']]] = None,
+                 scheduling: Optional[pulumi.Input[Union['SchedulingArgs', 'SchedulingArgsDict']]] = None,
                  __props__=None):
         """
         RuntimeClass defines a class of container runtime supported in the cluster. The RuntimeClass is used to determine which container runtime is used to run all containers in a pod. RuntimeClasses are manually defined by a user or cluster provisioner, and referenced in the PodSpec. The Kubelet is responsible for resolving the RuntimeClassName reference before running the pod.  For more details, see https://kubernetes.io/docs/concepts/containers/runtime-class/
@@ -140,10 +145,10 @@ class RuntimeClass(pulumi.CustomResource):
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] handler: handler specifies the underlying runtime and configuration that the CRI implementation will use to handle pods of this class. The possible values are specific to the node & CRI configuration.  It is assumed that all handlers are available on every node, and handlers of the same name are equivalent on every node. For example, a handler called "runc" might specify that the runc OCI runtime (using native Linux containers) will be used to run the containers in a pod. The Handler must be lowercase, conform to the DNS Label (RFC 1123) requirements, and is immutable.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['OverheadArgs']] overhead: overhead represents the resource overhead associated with running a pod for a given RuntimeClass. For more details, see
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['OverheadArgs', 'OverheadArgsDict']] overhead: overhead represents the resource overhead associated with running a pod for a given RuntimeClass. For more details, see
                 https://kubernetes.io/docs/concepts/scheduling-eviction/pod-overhead/
-        :param pulumi.Input[pulumi.InputType['SchedulingArgs']] scheduling: scheduling holds the scheduling constraints to ensure that pods running with this RuntimeClass are scheduled to nodes that support it. If scheduling is nil, this RuntimeClass is assumed to be supported by all nodes.
+        :param pulumi.Input[Union['SchedulingArgs', 'SchedulingArgsDict']] scheduling: scheduling holds the scheduling constraints to ensure that pods running with this RuntimeClass are scheduled to nodes that support it. If scheduling is nil, this RuntimeClass is assumed to be supported by all nodes.
         """
         ...
     @overload
@@ -172,9 +177,9 @@ class RuntimeClass(pulumi.CustomResource):
                  api_version: Optional[pulumi.Input[str]] = None,
                  handler: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 overhead: Optional[pulumi.Input[pulumi.InputType['OverheadArgs']]] = None,
-                 scheduling: Optional[pulumi.Input[pulumi.InputType['SchedulingArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 overhead: Optional[pulumi.Input[Union['OverheadArgs', 'OverheadArgsDict']]] = None,
+                 scheduling: Optional[pulumi.Input[Union['SchedulingArgs', 'SchedulingArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/node/v1/RuntimeClassList.py
+++ b/sdk/python/pulumi_kubernetes/node/v1/RuntimeClassList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -92,9 +97,9 @@ class RuntimeClassList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['RuntimeClassArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['RuntimeClassArgs', 'RuntimeClassArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         RuntimeClassList is a list of RuntimeClass objects.
@@ -102,9 +107,9 @@ class RuntimeClassList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['RuntimeClassArgs']]]] items: items is a list of schema objects.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['RuntimeClassArgs', 'RuntimeClassArgsDict']]]] items: items is a list of schema objects.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -131,9 +136,9 @@ class RuntimeClassList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['RuntimeClassArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['RuntimeClassArgs', 'RuntimeClassArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/node/v1/RuntimeClassPatch.py
+++ b/sdk/python/pulumi_kubernetes/node/v1/RuntimeClassPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -129,9 +134,9 @@ class RuntimeClassPatch(pulumi.CustomResource):
                  api_version: Optional[pulumi.Input[str]] = None,
                  handler: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 overhead: Optional[pulumi.Input[pulumi.InputType['OverheadPatchArgs']]] = None,
-                 scheduling: Optional[pulumi.Input[pulumi.InputType['SchedulingPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 overhead: Optional[pulumi.Input[Union['OverheadPatchArgs', 'OverheadPatchArgsDict']]] = None,
+                 scheduling: Optional[pulumi.Input[Union['SchedulingPatchArgs', 'SchedulingPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -147,10 +152,10 @@ class RuntimeClassPatch(pulumi.CustomResource):
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] handler: handler specifies the underlying runtime and configuration that the CRI implementation will use to handle pods of this class. The possible values are specific to the node & CRI configuration.  It is assumed that all handlers are available on every node, and handlers of the same name are equivalent on every node. For example, a handler called "runc" might specify that the runc OCI runtime (using native Linux containers) will be used to run the containers in a pod. The Handler must be lowercase, conform to the DNS Label (RFC 1123) requirements, and is immutable.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['OverheadPatchArgs']] overhead: overhead represents the resource overhead associated with running a pod for a given RuntimeClass. For more details, see
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['OverheadPatchArgs', 'OverheadPatchArgsDict']] overhead: overhead represents the resource overhead associated with running a pod for a given RuntimeClass. For more details, see
                 https://kubernetes.io/docs/concepts/scheduling-eviction/pod-overhead/
-        :param pulumi.Input[pulumi.InputType['SchedulingPatchArgs']] scheduling: scheduling holds the scheduling constraints to ensure that pods running with this RuntimeClass are scheduled to nodes that support it. If scheduling is nil, this RuntimeClass is assumed to be supported by all nodes.
+        :param pulumi.Input[Union['SchedulingPatchArgs', 'SchedulingPatchArgsDict']] scheduling: scheduling holds the scheduling constraints to ensure that pods running with this RuntimeClass are scheduled to nodes that support it. If scheduling is nil, this RuntimeClass is assumed to be supported by all nodes.
         """
         ...
     @overload
@@ -185,9 +190,9 @@ class RuntimeClassPatch(pulumi.CustomResource):
                  api_version: Optional[pulumi.Input[str]] = None,
                  handler: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 overhead: Optional[pulumi.Input[pulumi.InputType['OverheadPatchArgs']]] = None,
-                 scheduling: Optional[pulumi.Input[pulumi.InputType['SchedulingPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 overhead: Optional[pulumi.Input[Union['OverheadPatchArgs', 'OverheadPatchArgsDict']]] = None,
+                 scheduling: Optional[pulumi.Input[Union['SchedulingPatchArgs', 'SchedulingPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/node/v1/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/node/v1/_inputs.py
@@ -4,20 +4,44 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import core as _core
 from ... import meta as _meta
 
 __all__ = [
     'OverheadPatchArgs',
+    'OverheadPatchArgsDict',
     'OverheadArgs',
+    'OverheadArgsDict',
     'RuntimeClassArgs',
+    'RuntimeClassArgsDict',
     'SchedulingPatchArgs',
+    'SchedulingPatchArgsDict',
     'SchedulingArgs',
+    'SchedulingArgsDict',
 ]
+
+MYPY = False
+
+if not MYPY:
+    class OverheadPatchArgsDict(TypedDict):
+        """
+        Overhead structure represents the resource overhead associated with running a pod.
+        """
+        pod_fixed: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        podFixed represents the fixed resource overhead associated with running a pod.
+        """
+elif False:
+    OverheadPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class OverheadPatchArgs:
@@ -43,6 +67,18 @@ class OverheadPatchArgs:
         pulumi.set(self, "pod_fixed", value)
 
 
+if not MYPY:
+    class OverheadArgsDict(TypedDict):
+        """
+        Overhead structure represents the resource overhead associated with running a pod.
+        """
+        pod_fixed: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        podFixed represents the fixed resource overhead associated with running a pod.
+        """
+elif False:
+    OverheadArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class OverheadArgs:
     def __init__(__self__, *,
@@ -66,6 +102,39 @@ class OverheadArgs:
     def pod_fixed(self, value: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]):
         pulumi.set(self, "pod_fixed", value)
 
+
+if not MYPY:
+    class RuntimeClassArgsDict(TypedDict):
+        """
+        RuntimeClass defines a class of container runtime supported in the cluster. The RuntimeClass is used to determine which container runtime is used to run all containers in a pod. RuntimeClasses are manually defined by a user or cluster provisioner, and referenced in the PodSpec. The Kubelet is responsible for resolving the RuntimeClassName reference before running the pod.  For more details, see https://kubernetes.io/docs/concepts/containers/runtime-class/
+        """
+        handler: pulumi.Input[str]
+        """
+        handler specifies the underlying runtime and configuration that the CRI implementation will use to handle pods of this class. The possible values are specific to the node & CRI configuration.  It is assumed that all handlers are available on every node, and handlers of the same name are equivalent on every node. For example, a handler called "runc" might specify that the runc OCI runtime (using native Linux containers) will be used to run the containers in a pod. The Handler must be lowercase, conform to the DNS Label (RFC 1123) requirements, and is immutable.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        overhead: NotRequired[pulumi.Input['OverheadArgsDict']]
+        """
+        overhead represents the resource overhead associated with running a pod for a given RuntimeClass. For more details, see
+         https://kubernetes.io/docs/concepts/scheduling-eviction/pod-overhead/
+        """
+        scheduling: NotRequired[pulumi.Input['SchedulingArgsDict']]
+        """
+        scheduling holds the scheduling constraints to ensure that pods running with this RuntimeClass are scheduled to nodes that support it. If scheduling is nil, this RuntimeClass is assumed to be supported by all nodes.
+        """
+elif False:
+    RuntimeClassArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class RuntimeClassArgs:
@@ -172,6 +241,22 @@ class RuntimeClassArgs:
         pulumi.set(self, "scheduling", value)
 
 
+if not MYPY:
+    class SchedulingPatchArgsDict(TypedDict):
+        """
+        Scheduling specifies the scheduling constraints for nodes supporting a RuntimeClass.
+        """
+        node_selector: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        nodeSelector lists labels that must be present on nodes that support this RuntimeClass. Pods using this RuntimeClass can only be scheduled to a node matched by this selector. The RuntimeClass nodeSelector is merged with a pod's existing nodeSelector. Any conflicts will cause the pod to be rejected in admission.
+        """
+        tolerations: NotRequired[pulumi.Input[Sequence[pulumi.Input['_core.v1.TolerationPatchArgsDict']]]]
+        """
+        tolerations are appended (excluding duplicates) to pods running with this RuntimeClass during admission, effectively unioning the set of nodes tolerated by the pod and the RuntimeClass.
+        """
+elif False:
+    SchedulingPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class SchedulingPatchArgs:
     def __init__(__self__, *,
@@ -211,6 +296,22 @@ class SchedulingPatchArgs:
     def tolerations(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['_core.v1.TolerationPatchArgs']]]]):
         pulumi.set(self, "tolerations", value)
 
+
+if not MYPY:
+    class SchedulingArgsDict(TypedDict):
+        """
+        Scheduling specifies the scheduling constraints for nodes supporting a RuntimeClass.
+        """
+        node_selector: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        nodeSelector lists labels that must be present on nodes that support this RuntimeClass. Pods using this RuntimeClass can only be scheduled to a node matched by this selector. The RuntimeClass nodeSelector is merged with a pod's existing nodeSelector. Any conflicts will cause the pod to be rejected in admission.
+        """
+        tolerations: NotRequired[pulumi.Input[Sequence[pulumi.Input['_core.v1.TolerationArgsDict']]]]
+        """
+        tolerations are appended (excluding duplicates) to pods running with this RuntimeClass during admission, effectively unioning the set of nodes tolerated by the pod and the RuntimeClass.
+        """
+elif False:
+    SchedulingArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class SchedulingArgs:

--- a/sdk/python/pulumi_kubernetes/node/v1/outputs.py
+++ b/sdk/python/pulumi_kubernetes/node/v1/outputs.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core

--- a/sdk/python/pulumi_kubernetes/node/v1alpha1/RuntimeClass.py
+++ b/sdk/python/pulumi_kubernetes/node/v1alpha1/RuntimeClass.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -93,8 +98,8 @@ class RuntimeClass(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['RuntimeClassSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['RuntimeClassSpecArgs', 'RuntimeClassSpecArgsDict']]] = None,
                  __props__=None):
         """
         RuntimeClass defines a class of container runtime supported in the cluster. The RuntimeClass is used to determine which container runtime is used to run all containers in a pod. RuntimeClasses are (currently) manually defined by a user or cluster provisioner, and referenced in the PodSpec. The Kubelet is responsible for resolving the RuntimeClassName reference before running the pod.  For more details, see https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md
@@ -103,8 +108,8 @@ class RuntimeClass(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['RuntimeClassSpecArgs']] spec: Specification of the RuntimeClass More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['RuntimeClassSpecArgs', 'RuntimeClassSpecArgsDict']] spec: Specification of the RuntimeClass More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -132,8 +137,8 @@ class RuntimeClass(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['RuntimeClassSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['RuntimeClassSpecArgs', 'RuntimeClassSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/node/v1alpha1/RuntimeClassList.py
+++ b/sdk/python/pulumi_kubernetes/node/v1alpha1/RuntimeClassList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -92,9 +97,9 @@ class RuntimeClassList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['RuntimeClassArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['RuntimeClassArgs', 'RuntimeClassArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         RuntimeClassList is a list of RuntimeClass objects.
@@ -102,9 +107,9 @@ class RuntimeClassList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['RuntimeClassArgs']]]] items: Items is a list of schema objects.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['RuntimeClassArgs', 'RuntimeClassArgsDict']]]] items: Items is a list of schema objects.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -131,9 +136,9 @@ class RuntimeClassList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['RuntimeClassArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['RuntimeClassArgs', 'RuntimeClassArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/node/v1alpha1/RuntimeClassPatch.py
+++ b/sdk/python/pulumi_kubernetes/node/v1alpha1/RuntimeClassPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -94,8 +99,8 @@ class RuntimeClassPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['RuntimeClassSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['RuntimeClassSpecPatchArgs', 'RuntimeClassSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -110,8 +115,8 @@ class RuntimeClassPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['RuntimeClassSpecPatchArgs']] spec: Specification of the RuntimeClass More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['RuntimeClassSpecPatchArgs', 'RuntimeClassSpecPatchArgsDict']] spec: Specification of the RuntimeClass More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
         """
         ...
     @overload
@@ -145,8 +150,8 @@ class RuntimeClassPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['RuntimeClassSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['RuntimeClassSpecPatchArgs', 'RuntimeClassSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/node/v1alpha1/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/node/v1alpha1/_inputs.py
@@ -4,22 +4,48 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import core as _core
 from ... import meta as _meta
 
 __all__ = [
     'OverheadPatchArgs',
+    'OverheadPatchArgsDict',
     'OverheadArgs',
+    'OverheadArgsDict',
     'RuntimeClassSpecPatchArgs',
+    'RuntimeClassSpecPatchArgsDict',
     'RuntimeClassSpecArgs',
+    'RuntimeClassSpecArgsDict',
     'RuntimeClassArgs',
+    'RuntimeClassArgsDict',
     'SchedulingPatchArgs',
+    'SchedulingPatchArgsDict',
     'SchedulingArgs',
+    'SchedulingArgsDict',
 ]
+
+MYPY = False
+
+if not MYPY:
+    class OverheadPatchArgsDict(TypedDict):
+        """
+        Overhead structure represents the resource overhead associated with running a pod.
+        """
+        pod_fixed: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        PodFixed represents the fixed resource overhead associated with running a pod.
+        """
+elif False:
+    OverheadPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class OverheadPatchArgs:
@@ -45,6 +71,18 @@ class OverheadPatchArgs:
         pulumi.set(self, "pod_fixed", value)
 
 
+if not MYPY:
+    class OverheadArgsDict(TypedDict):
+        """
+        Overhead structure represents the resource overhead associated with running a pod.
+        """
+        pod_fixed: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        PodFixed represents the fixed resource overhead associated with running a pod.
+        """
+elif False:
+    OverheadArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class OverheadArgs:
     def __init__(__self__, *,
@@ -68,6 +106,26 @@ class OverheadArgs:
     def pod_fixed(self, value: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]):
         pulumi.set(self, "pod_fixed", value)
 
+
+if not MYPY:
+    class RuntimeClassSpecPatchArgsDict(TypedDict):
+        """
+        RuntimeClassSpec is a specification of a RuntimeClass. It contains parameters that are required to describe the RuntimeClass to the Container Runtime Interface (CRI) implementation, as well as any other components that need to understand how the pod will be run. The RuntimeClassSpec is immutable.
+        """
+        overhead: NotRequired[pulumi.Input['OverheadPatchArgsDict']]
+        """
+        Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. For more details, see https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md This field is alpha-level as of Kubernetes v1.15, and is only honored by servers that enable the PodOverhead feature.
+        """
+        runtime_handler: NotRequired[pulumi.Input[str]]
+        """
+        RuntimeHandler specifies the underlying runtime and configuration that the CRI implementation will use to handle pods of this class. The possible values are specific to the node & CRI configuration.  It is assumed that all handlers are available on every node, and handlers of the same name are equivalent on every node. For example, a handler called "runc" might specify that the runc OCI runtime (using native Linux containers) will be used to run the containers in a pod. The RuntimeHandler must conform to the DNS Label (RFC 1123) requirements and is immutable.
+        """
+        scheduling: NotRequired[pulumi.Input['SchedulingPatchArgsDict']]
+        """
+        Scheduling holds the scheduling constraints to ensure that pods running with this RuntimeClass are scheduled to nodes that support it. If scheduling is nil, this RuntimeClass is assumed to be supported by all nodes.
+        """
+elif False:
+    RuntimeClassSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class RuntimeClassSpecPatchArgs:
@@ -125,6 +183,26 @@ class RuntimeClassSpecPatchArgs:
         pulumi.set(self, "scheduling", value)
 
 
+if not MYPY:
+    class RuntimeClassSpecArgsDict(TypedDict):
+        """
+        RuntimeClassSpec is a specification of a RuntimeClass. It contains parameters that are required to describe the RuntimeClass to the Container Runtime Interface (CRI) implementation, as well as any other components that need to understand how the pod will be run. The RuntimeClassSpec is immutable.
+        """
+        runtime_handler: pulumi.Input[str]
+        """
+        RuntimeHandler specifies the underlying runtime and configuration that the CRI implementation will use to handle pods of this class. The possible values are specific to the node & CRI configuration.  It is assumed that all handlers are available on every node, and handlers of the same name are equivalent on every node. For example, a handler called "runc" might specify that the runc OCI runtime (using native Linux containers) will be used to run the containers in a pod. The RuntimeHandler must conform to the DNS Label (RFC 1123) requirements and is immutable.
+        """
+        overhead: NotRequired[pulumi.Input['OverheadArgsDict']]
+        """
+        Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. For more details, see https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md This field is alpha-level as of Kubernetes v1.15, and is only honored by servers that enable the PodOverhead feature.
+        """
+        scheduling: NotRequired[pulumi.Input['SchedulingArgsDict']]
+        """
+        Scheduling holds the scheduling constraints to ensure that pods running with this RuntimeClass are scheduled to nodes that support it. If scheduling is nil, this RuntimeClass is assumed to be supported by all nodes.
+        """
+elif False:
+    RuntimeClassSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class RuntimeClassSpecArgs:
     def __init__(__self__, *,
@@ -179,6 +257,30 @@ class RuntimeClassSpecArgs:
     def scheduling(self, value: Optional[pulumi.Input['SchedulingArgs']]):
         pulumi.set(self, "scheduling", value)
 
+
+if not MYPY:
+    class RuntimeClassArgsDict(TypedDict):
+        """
+        RuntimeClass defines a class of container runtime supported in the cluster. The RuntimeClass is used to determine which container runtime is used to run all containers in a pod. RuntimeClasses are (currently) manually defined by a user or cluster provisioner, and referenced in the PodSpec. The Kubelet is responsible for resolving the RuntimeClassName reference before running the pod.  For more details, see https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md
+        """
+        spec: pulumi.Input['RuntimeClassSpecArgsDict']
+        """
+        Specification of the RuntimeClass More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+elif False:
+    RuntimeClassArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class RuntimeClassArgs:
@@ -251,6 +353,22 @@ class RuntimeClassArgs:
         pulumi.set(self, "metadata", value)
 
 
+if not MYPY:
+    class SchedulingPatchArgsDict(TypedDict):
+        """
+        Scheduling specifies the scheduling constraints for nodes supporting a RuntimeClass.
+        """
+        node_selector: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        nodeSelector lists labels that must be present on nodes that support this RuntimeClass. Pods using this RuntimeClass can only be scheduled to a node matched by this selector. The RuntimeClass nodeSelector is merged with a pod's existing nodeSelector. Any conflicts will cause the pod to be rejected in admission.
+        """
+        tolerations: NotRequired[pulumi.Input[Sequence[pulumi.Input['_core.v1.TolerationPatchArgsDict']]]]
+        """
+        tolerations are appended (excluding duplicates) to pods running with this RuntimeClass during admission, effectively unioning the set of nodes tolerated by the pod and the RuntimeClass.
+        """
+elif False:
+    SchedulingPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class SchedulingPatchArgs:
     def __init__(__self__, *,
@@ -290,6 +408,22 @@ class SchedulingPatchArgs:
     def tolerations(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['_core.v1.TolerationPatchArgs']]]]):
         pulumi.set(self, "tolerations", value)
 
+
+if not MYPY:
+    class SchedulingArgsDict(TypedDict):
+        """
+        Scheduling specifies the scheduling constraints for nodes supporting a RuntimeClass.
+        """
+        node_selector: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        nodeSelector lists labels that must be present on nodes that support this RuntimeClass. Pods using this RuntimeClass can only be scheduled to a node matched by this selector. The RuntimeClass nodeSelector is merged with a pod's existing nodeSelector. Any conflicts will cause the pod to be rejected in admission.
+        """
+        tolerations: NotRequired[pulumi.Input[Sequence[pulumi.Input['_core.v1.TolerationArgsDict']]]]
+        """
+        tolerations are appended (excluding duplicates) to pods running with this RuntimeClass during admission, effectively unioning the set of nodes tolerated by the pod and the RuntimeClass.
+        """
+elif False:
+    SchedulingArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class SchedulingArgs:

--- a/sdk/python/pulumi_kubernetes/node/v1alpha1/outputs.py
+++ b/sdk/python/pulumi_kubernetes/node/v1alpha1/outputs.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core

--- a/sdk/python/pulumi_kubernetes/node/v1beta1/RuntimeClass.py
+++ b/sdk/python/pulumi_kubernetes/node/v1beta1/RuntimeClass.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -126,9 +131,9 @@ class RuntimeClass(pulumi.CustomResource):
                  api_version: Optional[pulumi.Input[str]] = None,
                  handler: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 overhead: Optional[pulumi.Input[pulumi.InputType['OverheadArgs']]] = None,
-                 scheduling: Optional[pulumi.Input[pulumi.InputType['SchedulingArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 overhead: Optional[pulumi.Input[Union['OverheadArgs', 'OverheadArgsDict']]] = None,
+                 scheduling: Optional[pulumi.Input[Union['SchedulingArgs', 'SchedulingArgsDict']]] = None,
                  __props__=None):
         """
         RuntimeClass defines a class of container runtime supported in the cluster. The RuntimeClass is used to determine which container runtime is used to run all containers in a pod. RuntimeClasses are (currently) manually defined by a user or cluster provisioner, and referenced in the PodSpec. The Kubelet is responsible for resolving the RuntimeClassName reference before running the pod.  For more details, see https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md
@@ -138,9 +143,9 @@ class RuntimeClass(pulumi.CustomResource):
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] handler: Handler specifies the underlying runtime and configuration that the CRI implementation will use to handle pods of this class. The possible values are specific to the node & CRI configuration.  It is assumed that all handlers are available on every node, and handlers of the same name are equivalent on every node. For example, a handler called "runc" might specify that the runc OCI runtime (using native Linux containers) will be used to run the containers in a pod. The Handler must conform to the DNS Label (RFC 1123) requirements, and is immutable.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['OverheadArgs']] overhead: Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. For more details, see https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md This field is alpha-level as of Kubernetes v1.15, and is only honored by servers that enable the PodOverhead feature.
-        :param pulumi.Input[pulumi.InputType['SchedulingArgs']] scheduling: Scheduling holds the scheduling constraints to ensure that pods running with this RuntimeClass are scheduled to nodes that support it. If scheduling is nil, this RuntimeClass is assumed to be supported by all nodes.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['OverheadArgs', 'OverheadArgsDict']] overhead: Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. For more details, see https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md This field is alpha-level as of Kubernetes v1.15, and is only honored by servers that enable the PodOverhead feature.
+        :param pulumi.Input[Union['SchedulingArgs', 'SchedulingArgsDict']] scheduling: Scheduling holds the scheduling constraints to ensure that pods running with this RuntimeClass are scheduled to nodes that support it. If scheduling is nil, this RuntimeClass is assumed to be supported by all nodes.
         """
         ...
     @overload
@@ -169,9 +174,9 @@ class RuntimeClass(pulumi.CustomResource):
                  api_version: Optional[pulumi.Input[str]] = None,
                  handler: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 overhead: Optional[pulumi.Input[pulumi.InputType['OverheadArgs']]] = None,
-                 scheduling: Optional[pulumi.Input[pulumi.InputType['SchedulingArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 overhead: Optional[pulumi.Input[Union['OverheadArgs', 'OverheadArgsDict']]] = None,
+                 scheduling: Optional[pulumi.Input[Union['SchedulingArgs', 'SchedulingArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/node/v1beta1/RuntimeClassList.py
+++ b/sdk/python/pulumi_kubernetes/node/v1beta1/RuntimeClassList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -92,9 +97,9 @@ class RuntimeClassList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['RuntimeClassArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['RuntimeClassArgs', 'RuntimeClassArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         RuntimeClassList is a list of RuntimeClass objects.
@@ -102,9 +107,9 @@ class RuntimeClassList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['RuntimeClassArgs']]]] items: Items is a list of schema objects.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['RuntimeClassArgs', 'RuntimeClassArgsDict']]]] items: Items is a list of schema objects.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -131,9 +136,9 @@ class RuntimeClassList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['RuntimeClassArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['RuntimeClassArgs', 'RuntimeClassArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/node/v1beta1/RuntimeClassPatch.py
+++ b/sdk/python/pulumi_kubernetes/node/v1beta1/RuntimeClassPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -127,9 +132,9 @@ class RuntimeClassPatch(pulumi.CustomResource):
                  api_version: Optional[pulumi.Input[str]] = None,
                  handler: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 overhead: Optional[pulumi.Input[pulumi.InputType['OverheadPatchArgs']]] = None,
-                 scheduling: Optional[pulumi.Input[pulumi.InputType['SchedulingPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 overhead: Optional[pulumi.Input[Union['OverheadPatchArgs', 'OverheadPatchArgsDict']]] = None,
+                 scheduling: Optional[pulumi.Input[Union['SchedulingPatchArgs', 'SchedulingPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -145,9 +150,9 @@ class RuntimeClassPatch(pulumi.CustomResource):
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] handler: Handler specifies the underlying runtime and configuration that the CRI implementation will use to handle pods of this class. The possible values are specific to the node & CRI configuration.  It is assumed that all handlers are available on every node, and handlers of the same name are equivalent on every node. For example, a handler called "runc" might specify that the runc OCI runtime (using native Linux containers) will be used to run the containers in a pod. The Handler must conform to the DNS Label (RFC 1123) requirements, and is immutable.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['OverheadPatchArgs']] overhead: Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. For more details, see https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md This field is alpha-level as of Kubernetes v1.15, and is only honored by servers that enable the PodOverhead feature.
-        :param pulumi.Input[pulumi.InputType['SchedulingPatchArgs']] scheduling: Scheduling holds the scheduling constraints to ensure that pods running with this RuntimeClass are scheduled to nodes that support it. If scheduling is nil, this RuntimeClass is assumed to be supported by all nodes.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['OverheadPatchArgs', 'OverheadPatchArgsDict']] overhead: Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. For more details, see https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md This field is alpha-level as of Kubernetes v1.15, and is only honored by servers that enable the PodOverhead feature.
+        :param pulumi.Input[Union['SchedulingPatchArgs', 'SchedulingPatchArgsDict']] scheduling: Scheduling holds the scheduling constraints to ensure that pods running with this RuntimeClass are scheduled to nodes that support it. If scheduling is nil, this RuntimeClass is assumed to be supported by all nodes.
         """
         ...
     @overload
@@ -182,9 +187,9 @@ class RuntimeClassPatch(pulumi.CustomResource):
                  api_version: Optional[pulumi.Input[str]] = None,
                  handler: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 overhead: Optional[pulumi.Input[pulumi.InputType['OverheadPatchArgs']]] = None,
-                 scheduling: Optional[pulumi.Input[pulumi.InputType['SchedulingPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 overhead: Optional[pulumi.Input[Union['OverheadPatchArgs', 'OverheadPatchArgsDict']]] = None,
+                 scheduling: Optional[pulumi.Input[Union['SchedulingPatchArgs', 'SchedulingPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/node/v1beta1/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/node/v1beta1/_inputs.py
@@ -4,20 +4,44 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import core as _core
 from ... import meta as _meta
 
 __all__ = [
     'OverheadPatchArgs',
+    'OverheadPatchArgsDict',
     'OverheadArgs',
+    'OverheadArgsDict',
     'RuntimeClassArgs',
+    'RuntimeClassArgsDict',
     'SchedulingPatchArgs',
+    'SchedulingPatchArgsDict',
     'SchedulingArgs',
+    'SchedulingArgsDict',
 ]
+
+MYPY = False
+
+if not MYPY:
+    class OverheadPatchArgsDict(TypedDict):
+        """
+        Overhead structure represents the resource overhead associated with running a pod.
+        """
+        pod_fixed: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        PodFixed represents the fixed resource overhead associated with running a pod.
+        """
+elif False:
+    OverheadPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class OverheadPatchArgs:
@@ -43,6 +67,18 @@ class OverheadPatchArgs:
         pulumi.set(self, "pod_fixed", value)
 
 
+if not MYPY:
+    class OverheadArgsDict(TypedDict):
+        """
+        Overhead structure represents the resource overhead associated with running a pod.
+        """
+        pod_fixed: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        PodFixed represents the fixed resource overhead associated with running a pod.
+        """
+elif False:
+    OverheadArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class OverheadArgs:
     def __init__(__self__, *,
@@ -66,6 +102,38 @@ class OverheadArgs:
     def pod_fixed(self, value: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]):
         pulumi.set(self, "pod_fixed", value)
 
+
+if not MYPY:
+    class RuntimeClassArgsDict(TypedDict):
+        """
+        RuntimeClass defines a class of container runtime supported in the cluster. The RuntimeClass is used to determine which container runtime is used to run all containers in a pod. RuntimeClasses are (currently) manually defined by a user or cluster provisioner, and referenced in the PodSpec. The Kubelet is responsible for resolving the RuntimeClassName reference before running the pod.  For more details, see https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md
+        """
+        handler: pulumi.Input[str]
+        """
+        Handler specifies the underlying runtime and configuration that the CRI implementation will use to handle pods of this class. The possible values are specific to the node & CRI configuration.  It is assumed that all handlers are available on every node, and handlers of the same name are equivalent on every node. For example, a handler called "runc" might specify that the runc OCI runtime (using native Linux containers) will be used to run the containers in a pod. The Handler must conform to the DNS Label (RFC 1123) requirements, and is immutable.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        overhead: NotRequired[pulumi.Input['OverheadArgsDict']]
+        """
+        Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. For more details, see https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md This field is alpha-level as of Kubernetes v1.15, and is only honored by servers that enable the PodOverhead feature.
+        """
+        scheduling: NotRequired[pulumi.Input['SchedulingArgsDict']]
+        """
+        Scheduling holds the scheduling constraints to ensure that pods running with this RuntimeClass are scheduled to nodes that support it. If scheduling is nil, this RuntimeClass is assumed to be supported by all nodes.
+        """
+elif False:
+    RuntimeClassArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class RuntimeClassArgs:
@@ -170,6 +238,22 @@ class RuntimeClassArgs:
         pulumi.set(self, "scheduling", value)
 
 
+if not MYPY:
+    class SchedulingPatchArgsDict(TypedDict):
+        """
+        Scheduling specifies the scheduling constraints for nodes supporting a RuntimeClass.
+        """
+        node_selector: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        nodeSelector lists labels that must be present on nodes that support this RuntimeClass. Pods using this RuntimeClass can only be scheduled to a node matched by this selector. The RuntimeClass nodeSelector is merged with a pod's existing nodeSelector. Any conflicts will cause the pod to be rejected in admission.
+        """
+        tolerations: NotRequired[pulumi.Input[Sequence[pulumi.Input['_core.v1.TolerationPatchArgsDict']]]]
+        """
+        tolerations are appended (excluding duplicates) to pods running with this RuntimeClass during admission, effectively unioning the set of nodes tolerated by the pod and the RuntimeClass.
+        """
+elif False:
+    SchedulingPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class SchedulingPatchArgs:
     def __init__(__self__, *,
@@ -209,6 +293,22 @@ class SchedulingPatchArgs:
     def tolerations(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['_core.v1.TolerationPatchArgs']]]]):
         pulumi.set(self, "tolerations", value)
 
+
+if not MYPY:
+    class SchedulingArgsDict(TypedDict):
+        """
+        Scheduling specifies the scheduling constraints for nodes supporting a RuntimeClass.
+        """
+        node_selector: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        nodeSelector lists labels that must be present on nodes that support this RuntimeClass. Pods using this RuntimeClass can only be scheduled to a node matched by this selector. The RuntimeClass nodeSelector is merged with a pod's existing nodeSelector. Any conflicts will cause the pod to be rejected in admission.
+        """
+        tolerations: NotRequired[pulumi.Input[Sequence[pulumi.Input['_core.v1.TolerationArgsDict']]]]
+        """
+        tolerations are appended (excluding duplicates) to pods running with this RuntimeClass during admission, effectively unioning the set of nodes tolerated by the pod and the RuntimeClass.
+        """
+elif False:
+    SchedulingArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class SchedulingArgs:

--- a/sdk/python/pulumi_kubernetes/node/v1beta1/outputs.py
+++ b/sdk/python/pulumi_kubernetes/node/v1beta1/outputs.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core

--- a/sdk/python/pulumi_kubernetes/policy/v1/PodDisruptionBudget.py
+++ b/sdk/python/pulumi_kubernetes/policy/v1/PodDisruptionBudget.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class PodDisruptionBudget(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PodDisruptionBudgetSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PodDisruptionBudgetSpecArgs', 'PodDisruptionBudgetSpecArgsDict']]] = None,
                  __props__=None):
         """
         PodDisruptionBudget is an object to define the max disruption that can be caused to a collection of pods
@@ -103,8 +108,8 @@ class PodDisruptionBudget(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['PodDisruptionBudgetSpecArgs']] spec: Specification of the desired behavior of the PodDisruptionBudget.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['PodDisruptionBudgetSpecArgs', 'PodDisruptionBudgetSpecArgsDict']] spec: Specification of the desired behavior of the PodDisruptionBudget.
         """
         ...
     @overload
@@ -132,8 +137,8 @@ class PodDisruptionBudget(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PodDisruptionBudgetSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PodDisruptionBudgetSpecArgs', 'PodDisruptionBudgetSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/policy/v1/PodDisruptionBudgetList.py
+++ b/sdk/python/pulumi_kubernetes/policy/v1/PodDisruptionBudgetList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class PodDisruptionBudgetList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PodDisruptionBudgetArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PodDisruptionBudgetArgs', 'PodDisruptionBudgetArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         PodDisruptionBudgetList is a collection of PodDisruptionBudgets.
@@ -101,9 +106,9 @@ class PodDisruptionBudgetList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PodDisruptionBudgetArgs']]]] items: Items is a list of PodDisruptionBudgets
+        :param pulumi.Input[Sequence[pulumi.Input[Union['PodDisruptionBudgetArgs', 'PodDisruptionBudgetArgsDict']]]] items: Items is a list of PodDisruptionBudgets
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class PodDisruptionBudgetList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PodDisruptionBudgetArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PodDisruptionBudgetArgs', 'PodDisruptionBudgetArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/policy/v1/PodDisruptionBudgetPatch.py
+++ b/sdk/python/pulumi_kubernetes/policy/v1/PodDisruptionBudgetPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class PodDisruptionBudgetPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PodDisruptionBudgetSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PodDisruptionBudgetSpecPatchArgs', 'PodDisruptionBudgetSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -109,8 +114,8 @@ class PodDisruptionBudgetPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['PodDisruptionBudgetSpecPatchArgs']] spec: Specification of the desired behavior of the PodDisruptionBudget.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['PodDisruptionBudgetSpecPatchArgs', 'PodDisruptionBudgetSpecPatchArgsDict']] spec: Specification of the desired behavior of the PodDisruptionBudget.
         """
         ...
     @overload
@@ -144,8 +149,8 @@ class PodDisruptionBudgetPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PodDisruptionBudgetSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PodDisruptionBudgetSpecPatchArgs', 'PodDisruptionBudgetSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/policy/v1/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/policy/v1/_inputs.py
@@ -4,18 +4,63 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import meta as _meta
 
 __all__ = [
     'PodDisruptionBudgetSpecPatchArgs',
+    'PodDisruptionBudgetSpecPatchArgsDict',
     'PodDisruptionBudgetSpecArgs',
+    'PodDisruptionBudgetSpecArgsDict',
     'PodDisruptionBudgetStatusArgs',
+    'PodDisruptionBudgetStatusArgsDict',
     'PodDisruptionBudgetArgs',
+    'PodDisruptionBudgetArgsDict',
 ]
+
+MYPY = False
+
+if not MYPY:
+    class PodDisruptionBudgetSpecPatchArgsDict(TypedDict):
+        """
+        PodDisruptionBudgetSpec is a description of a PodDisruptionBudget.
+        """
+        max_unavailable: NotRequired[pulumi.Input[Union[int, str]]]
+        """
+        An eviction is allowed if at most "maxUnavailable" pods selected by "selector" are unavailable after the eviction, i.e. even in absence of the evicted pod. For example, one can prevent all voluntary evictions by specifying 0. This is a mutually exclusive setting with "minAvailable".
+        """
+        min_available: NotRequired[pulumi.Input[Union[int, str]]]
+        """
+        An eviction is allowed if at least "minAvailable" pods selected by "selector" will still be available after the eviction, i.e. even in the absence of the evicted pod.  So for example you can prevent all voluntary evictions by specifying "100%".
+        """
+        selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorPatchArgsDict']]
+        """
+        Label query over pods whose evictions are managed by the disruption budget. A null selector will match no pods, while an empty ({}) selector will select all pods within the namespace.
+        """
+        unhealthy_pod_eviction_policy: NotRequired[pulumi.Input[str]]
+        """
+        UnhealthyPodEvictionPolicy defines the criteria for when unhealthy pods should be considered for eviction. Current implementation considers healthy pods, as pods that have status.conditions item with type="Ready",status="True".
+
+        Valid policies are IfHealthyBudget and AlwaysAllow. If no policy is specified, the default behavior will be used, which corresponds to the IfHealthyBudget policy.
+
+        IfHealthyBudget policy means that running pods (status.phase="Running"), but not yet healthy can be evicted only if the guarded application is not disrupted (status.currentHealthy is at least equal to status.desiredHealthy). Healthy pods will be subject to the PDB for eviction.
+
+        AlwaysAllow policy means that all running pods (status.phase="Running"), but not yet healthy are considered disrupted and can be evicted regardless of whether the criteria in a PDB is met. This means perspective running pods of a disrupted application might not get a chance to become healthy. Healthy pods will be subject to the PDB for eviction.
+
+        Additional policies may be added in the future. Clients making eviction decisions should disallow eviction of unhealthy pods if they encounter an unrecognized policy in this field.
+
+        This field is beta-level. The eviction API uses this field when the feature gate PDBUnhealthyPodEvictionPolicy is enabled (enabled by default).
+        """
+elif False:
+    PodDisruptionBudgetSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class PodDisruptionBudgetSpecPatchArgs:
@@ -109,6 +154,40 @@ class PodDisruptionBudgetSpecPatchArgs:
         pulumi.set(self, "unhealthy_pod_eviction_policy", value)
 
 
+if not MYPY:
+    class PodDisruptionBudgetSpecArgsDict(TypedDict):
+        """
+        PodDisruptionBudgetSpec is a description of a PodDisruptionBudget.
+        """
+        max_unavailable: NotRequired[pulumi.Input[Union[int, str]]]
+        """
+        An eviction is allowed if at most "maxUnavailable" pods selected by "selector" are unavailable after the eviction, i.e. even in absence of the evicted pod. For example, one can prevent all voluntary evictions by specifying 0. This is a mutually exclusive setting with "minAvailable".
+        """
+        min_available: NotRequired[pulumi.Input[Union[int, str]]]
+        """
+        An eviction is allowed if at least "minAvailable" pods selected by "selector" will still be available after the eviction, i.e. even in the absence of the evicted pod.  So for example you can prevent all voluntary evictions by specifying "100%".
+        """
+        selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorArgsDict']]
+        """
+        Label query over pods whose evictions are managed by the disruption budget. A null selector will match no pods, while an empty ({}) selector will select all pods within the namespace.
+        """
+        unhealthy_pod_eviction_policy: NotRequired[pulumi.Input[str]]
+        """
+        UnhealthyPodEvictionPolicy defines the criteria for when unhealthy pods should be considered for eviction. Current implementation considers healthy pods, as pods that have status.conditions item with type="Ready",status="True".
+
+        Valid policies are IfHealthyBudget and AlwaysAllow. If no policy is specified, the default behavior will be used, which corresponds to the IfHealthyBudget policy.
+
+        IfHealthyBudget policy means that running pods (status.phase="Running"), but not yet healthy can be evicted only if the guarded application is not disrupted (status.currentHealthy is at least equal to status.desiredHealthy). Healthy pods will be subject to the PDB for eviction.
+
+        AlwaysAllow policy means that all running pods (status.phase="Running"), but not yet healthy are considered disrupted and can be evicted regardless of whether the criteria in a PDB is met. This means perspective running pods of a disrupted application might not get a chance to become healthy. Healthy pods will be subject to the PDB for eviction.
+
+        Additional policies may be added in the future. Clients making eviction decisions should disallow eviction of unhealthy pods if they encounter an unrecognized policy in this field.
+
+        This field is beta-level. The eviction API uses this field when the feature gate PDBUnhealthyPodEvictionPolicy is enabled (enabled by default).
+        """
+elif False:
+    PodDisruptionBudgetSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PodDisruptionBudgetSpecArgs:
     def __init__(__self__, *,
@@ -200,6 +279,50 @@ class PodDisruptionBudgetSpecArgs:
     def unhealthy_pod_eviction_policy(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "unhealthy_pod_eviction_policy", value)
 
+
+if not MYPY:
+    class PodDisruptionBudgetStatusArgsDict(TypedDict):
+        """
+        PodDisruptionBudgetStatus represents information about the status of a PodDisruptionBudget. Status may trail the actual state of a system.
+        """
+        current_healthy: pulumi.Input[int]
+        """
+        current number of healthy pods
+        """
+        desired_healthy: pulumi.Input[int]
+        """
+        minimum desired number of healthy pods
+        """
+        disruptions_allowed: pulumi.Input[int]
+        """
+        Number of pod disruptions that are currently allowed.
+        """
+        expected_pods: pulumi.Input[int]
+        """
+        total number of pods counted by this disruption budget
+        """
+        conditions: NotRequired[pulumi.Input[Sequence[pulumi.Input['_meta.v1.ConditionArgsDict']]]]
+        """
+        Conditions contain conditions for PDB. The disruption controller sets the DisruptionAllowed condition. The following are known values for the reason field (additional reasons could be added in the future): - SyncFailed: The controller encountered an error and wasn't able to compute
+                      the number of allowed disruptions. Therefore no disruptions are
+                      allowed and the status of the condition will be False.
+        - InsufficientPods: The number of pods are either at or below the number
+                            required by the PodDisruptionBudget. No disruptions are
+                            allowed and the status of the condition will be False.
+        - SufficientPods: There are more pods than required by the PodDisruptionBudget.
+                          The condition will be True, and the number of allowed
+                          disruptions are provided by the disruptionsAllowed property.
+        """
+        disrupted_pods: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        DisruptedPods contains information about pods whose eviction was processed by the API server eviction subresource handler but has not yet been observed by the PodDisruptionBudget controller. A pod will be in this map from the time when the API server processed the eviction request to the time when the pod is seen by PDB controller as having been marked for deletion (or after a timeout). The key in the map is the name of the pod and the value is the time when the API server processed the eviction request. If the deletion didn't occur and a pod is still there it will be removed from the list automatically by PodDisruptionBudget controller after some time. If everything goes smooth this map should be empty for the most of the time. Large number of entries in the map may indicate problems with pod deletions.
+        """
+        observed_generation: NotRequired[pulumi.Input[int]]
+        """
+        Most recent generation observed when updating this PDB status. DisruptionsAllowed and other status information is valid only if observedGeneration equals to PDB's object generation.
+        """
+elif False:
+    PodDisruptionBudgetStatusArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class PodDisruptionBudgetStatusArgs:
@@ -332,6 +455,34 @@ class PodDisruptionBudgetStatusArgs:
     def observed_generation(self, value: Optional[pulumi.Input[int]]):
         pulumi.set(self, "observed_generation", value)
 
+
+if not MYPY:
+    class PodDisruptionBudgetArgsDict(TypedDict):
+        """
+        PodDisruptionBudget is an object to define the max disruption that can be caused to a collection of pods
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['PodDisruptionBudgetSpecArgsDict']]
+        """
+        Specification of the desired behavior of the PodDisruptionBudget.
+        """
+        status: NotRequired[pulumi.Input['PodDisruptionBudgetStatusArgsDict']]
+        """
+        Most recently observed status of the PodDisruptionBudget.
+        """
+elif False:
+    PodDisruptionBudgetArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class PodDisruptionBudgetArgs:

--- a/sdk/python/pulumi_kubernetes/policy/v1/outputs.py
+++ b/sdk/python/pulumi_kubernetes/policy/v1/outputs.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta

--- a/sdk/python/pulumi_kubernetes/policy/v1beta1/PodDisruptionBudget.py
+++ b/sdk/python/pulumi_kubernetes/policy/v1beta1/PodDisruptionBudget.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -89,8 +94,8 @@ class PodDisruptionBudget(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PodDisruptionBudgetSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PodDisruptionBudgetSpecArgs', 'PodDisruptionBudgetSpecArgsDict']]] = None,
                  __props__=None):
         """
         PodDisruptionBudget is an object to define the max disruption that can be caused to a collection of pods
@@ -99,7 +104,7 @@ class PodDisruptionBudget(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['PodDisruptionBudgetSpecArgs']] spec: Specification of the desired behavior of the PodDisruptionBudget.
+        :param pulumi.Input[Union['PodDisruptionBudgetSpecArgs', 'PodDisruptionBudgetSpecArgsDict']] spec: Specification of the desired behavior of the PodDisruptionBudget.
         """
         ...
     @overload
@@ -127,8 +132,8 @@ class PodDisruptionBudget(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PodDisruptionBudgetSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PodDisruptionBudgetSpecArgs', 'PodDisruptionBudgetSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/policy/v1beta1/PodDisruptionBudgetList.py
+++ b/sdk/python/pulumi_kubernetes/policy/v1beta1/PodDisruptionBudgetList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -83,9 +88,9 @@ class PodDisruptionBudgetList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PodDisruptionBudgetArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PodDisruptionBudgetArgs', 'PodDisruptionBudgetArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         PodDisruptionBudgetList is a collection of PodDisruptionBudgets.
@@ -120,9 +125,9 @@ class PodDisruptionBudgetList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PodDisruptionBudgetArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PodDisruptionBudgetArgs', 'PodDisruptionBudgetArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/policy/v1beta1/PodDisruptionBudgetPatch.py
+++ b/sdk/python/pulumi_kubernetes/policy/v1beta1/PodDisruptionBudgetPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -89,8 +94,8 @@ class PodDisruptionBudgetPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PodDisruptionBudgetSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PodDisruptionBudgetSpecPatchArgs', 'PodDisruptionBudgetSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -105,7 +110,7 @@ class PodDisruptionBudgetPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['PodDisruptionBudgetSpecPatchArgs']] spec: Specification of the desired behavior of the PodDisruptionBudget.
+        :param pulumi.Input[Union['PodDisruptionBudgetSpecPatchArgs', 'PodDisruptionBudgetSpecPatchArgsDict']] spec: Specification of the desired behavior of the PodDisruptionBudget.
         """
         ...
     @overload
@@ -139,8 +144,8 @@ class PodDisruptionBudgetPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PodDisruptionBudgetSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PodDisruptionBudgetSpecPatchArgs', 'PodDisruptionBudgetSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/policy/v1beta1/PodSecurityPolicy.py
+++ b/sdk/python/pulumi_kubernetes/policy/v1beta1/PodSecurityPolicy.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -94,8 +99,8 @@ class PodSecurityPolicy(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PodSecurityPolicySpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PodSecurityPolicySpecArgs', 'PodSecurityPolicySpecArgsDict']]] = None,
                  __props__=None):
         """
         PodSecurityPolicy governs the ability to make requests that affect the Security Context that will be applied to a pod and container.
@@ -104,8 +109,8 @@ class PodSecurityPolicy(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['PodSecurityPolicySpecArgs']] spec: spec defines the policy enforced.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['PodSecurityPolicySpecArgs', 'PodSecurityPolicySpecArgsDict']] spec: spec defines the policy enforced.
         """
         ...
     @overload
@@ -133,8 +138,8 @@ class PodSecurityPolicy(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PodSecurityPolicySpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PodSecurityPolicySpecArgs', 'PodSecurityPolicySpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/policy/v1beta1/PodSecurityPolicyList.py
+++ b/sdk/python/pulumi_kubernetes/policy/v1beta1/PodSecurityPolicyList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -92,9 +97,9 @@ class PodSecurityPolicyList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PodSecurityPolicyArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PodSecurityPolicyArgs', 'PodSecurityPolicyArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         PodSecurityPolicyList is a list of PodSecurityPolicy objects.
@@ -102,9 +107,9 @@ class PodSecurityPolicyList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PodSecurityPolicyArgs']]]] items: items is a list of schema objects.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['PodSecurityPolicyArgs', 'PodSecurityPolicyArgsDict']]]] items: items is a list of schema objects.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -131,9 +136,9 @@ class PodSecurityPolicyList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PodSecurityPolicyArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PodSecurityPolicyArgs', 'PodSecurityPolicyArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/policy/v1beta1/PodSecurityPolicyPatch.py
+++ b/sdk/python/pulumi_kubernetes/policy/v1beta1/PodSecurityPolicyPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -94,8 +99,8 @@ class PodSecurityPolicyPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PodSecurityPolicySpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PodSecurityPolicySpecPatchArgs', 'PodSecurityPolicySpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -110,8 +115,8 @@ class PodSecurityPolicyPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['PodSecurityPolicySpecPatchArgs']] spec: spec defines the policy enforced.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['PodSecurityPolicySpecPatchArgs', 'PodSecurityPolicySpecPatchArgsDict']] spec: spec defines the policy enforced.
         """
         ...
     @overload
@@ -145,8 +150,8 @@ class PodSecurityPolicyPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PodSecurityPolicySpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PodSecurityPolicySpecPatchArgs', 'PodSecurityPolicySpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/policy/v1beta1/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/policy/v1beta1/_inputs.py
@@ -4,44 +4,92 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import core as _core
 from ... import meta as _meta
 
 __all__ = [
     'AllowedCSIDriverPatchArgs',
+    'AllowedCSIDriverPatchArgsDict',
     'AllowedCSIDriverArgs',
+    'AllowedCSIDriverArgsDict',
     'AllowedFlexVolumePatchArgs',
+    'AllowedFlexVolumePatchArgsDict',
     'AllowedFlexVolumeArgs',
+    'AllowedFlexVolumeArgsDict',
     'AllowedHostPathPatchArgs',
+    'AllowedHostPathPatchArgsDict',
     'AllowedHostPathArgs',
+    'AllowedHostPathArgsDict',
     'FSGroupStrategyOptionsPatchArgs',
+    'FSGroupStrategyOptionsPatchArgsDict',
     'FSGroupStrategyOptionsArgs',
+    'FSGroupStrategyOptionsArgsDict',
     'HostPortRangePatchArgs',
+    'HostPortRangePatchArgsDict',
     'HostPortRangeArgs',
+    'HostPortRangeArgsDict',
     'IDRangePatchArgs',
+    'IDRangePatchArgsDict',
     'IDRangeArgs',
+    'IDRangeArgsDict',
     'PodDisruptionBudgetSpecPatchArgs',
+    'PodDisruptionBudgetSpecPatchArgsDict',
     'PodDisruptionBudgetSpecArgs',
+    'PodDisruptionBudgetSpecArgsDict',
     'PodDisruptionBudgetStatusArgs',
+    'PodDisruptionBudgetStatusArgsDict',
     'PodDisruptionBudgetArgs',
+    'PodDisruptionBudgetArgsDict',
     'PodSecurityPolicySpecPatchArgs',
+    'PodSecurityPolicySpecPatchArgsDict',
     'PodSecurityPolicySpecArgs',
+    'PodSecurityPolicySpecArgsDict',
     'PodSecurityPolicyArgs',
+    'PodSecurityPolicyArgsDict',
     'RunAsGroupStrategyOptionsPatchArgs',
+    'RunAsGroupStrategyOptionsPatchArgsDict',
     'RunAsGroupStrategyOptionsArgs',
+    'RunAsGroupStrategyOptionsArgsDict',
     'RunAsUserStrategyOptionsPatchArgs',
+    'RunAsUserStrategyOptionsPatchArgsDict',
     'RunAsUserStrategyOptionsArgs',
+    'RunAsUserStrategyOptionsArgsDict',
     'RuntimeClassStrategyOptionsPatchArgs',
+    'RuntimeClassStrategyOptionsPatchArgsDict',
     'RuntimeClassStrategyOptionsArgs',
+    'RuntimeClassStrategyOptionsArgsDict',
     'SELinuxStrategyOptionsPatchArgs',
+    'SELinuxStrategyOptionsPatchArgsDict',
     'SELinuxStrategyOptionsArgs',
+    'SELinuxStrategyOptionsArgsDict',
     'SupplementalGroupsStrategyOptionsPatchArgs',
+    'SupplementalGroupsStrategyOptionsPatchArgsDict',
     'SupplementalGroupsStrategyOptionsArgs',
+    'SupplementalGroupsStrategyOptionsArgsDict',
 ]
+
+MYPY = False
+
+if not MYPY:
+    class AllowedCSIDriverPatchArgsDict(TypedDict):
+        """
+        AllowedCSIDriver represents a single inline CSI Driver that is allowed to be used.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name is the registered name of the CSI driver
+        """
+elif False:
+    AllowedCSIDriverPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class AllowedCSIDriverPatchArgs:
@@ -67,6 +115,18 @@ class AllowedCSIDriverPatchArgs:
         pulumi.set(self, "name", value)
 
 
+if not MYPY:
+    class AllowedCSIDriverArgsDict(TypedDict):
+        """
+        AllowedCSIDriver represents a single inline CSI Driver that is allowed to be used.
+        """
+        name: pulumi.Input[str]
+        """
+        Name is the registered name of the CSI driver
+        """
+elif False:
+    AllowedCSIDriverArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class AllowedCSIDriverArgs:
     def __init__(__self__, *,
@@ -89,6 +149,18 @@ class AllowedCSIDriverArgs:
     def name(self, value: pulumi.Input[str]):
         pulumi.set(self, "name", value)
 
+
+if not MYPY:
+    class AllowedFlexVolumePatchArgsDict(TypedDict):
+        """
+        AllowedFlexVolume represents a single Flexvolume that is allowed to be used.
+        """
+        driver: NotRequired[pulumi.Input[str]]
+        """
+        driver is the name of the Flexvolume driver.
+        """
+elif False:
+    AllowedFlexVolumePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class AllowedFlexVolumePatchArgs:
@@ -114,6 +186,18 @@ class AllowedFlexVolumePatchArgs:
         pulumi.set(self, "driver", value)
 
 
+if not MYPY:
+    class AllowedFlexVolumeArgsDict(TypedDict):
+        """
+        AllowedFlexVolume represents a single Flexvolume that is allowed to be used.
+        """
+        driver: pulumi.Input[str]
+        """
+        driver is the name of the Flexvolume driver.
+        """
+elif False:
+    AllowedFlexVolumeArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class AllowedFlexVolumeArgs:
     def __init__(__self__, *,
@@ -136,6 +220,24 @@ class AllowedFlexVolumeArgs:
     def driver(self, value: pulumi.Input[str]):
         pulumi.set(self, "driver", value)
 
+
+if not MYPY:
+    class AllowedHostPathPatchArgsDict(TypedDict):
+        """
+        AllowedHostPath defines the host volume conditions that will be enabled by a policy for pods to use. It requires the path prefix to be defined.
+        """
+        path_prefix: NotRequired[pulumi.Input[str]]
+        """
+        pathPrefix is the path prefix that the host volume must match. It does not support `*`. Trailing slashes are trimmed when validating the path prefix with a host path.
+
+        Examples: `/foo` would allow `/foo`, `/foo/` and `/foo/bar` `/foo` would not allow `/food` or `/etc/foo`
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        when set to true, will allow host volumes matching the pathPrefix only if all volume mounts are readOnly.
+        """
+elif False:
+    AllowedHostPathPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class AllowedHostPathPatchArgs:
@@ -181,6 +283,24 @@ class AllowedHostPathPatchArgs:
         pulumi.set(self, "read_only", value)
 
 
+if not MYPY:
+    class AllowedHostPathArgsDict(TypedDict):
+        """
+        AllowedHostPath defines the host volume conditions that will be enabled by a policy for pods to use. It requires the path prefix to be defined.
+        """
+        path_prefix: NotRequired[pulumi.Input[str]]
+        """
+        pathPrefix is the path prefix that the host volume must match. It does not support `*`. Trailing slashes are trimmed when validating the path prefix with a host path.
+
+        Examples: `/foo` would allow `/foo`, `/foo/` and `/foo/bar` `/foo` would not allow `/food` or `/etc/foo`
+        """
+        read_only: NotRequired[pulumi.Input[bool]]
+        """
+        when set to true, will allow host volumes matching the pathPrefix only if all volume mounts are readOnly.
+        """
+elif False:
+    AllowedHostPathArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class AllowedHostPathArgs:
     def __init__(__self__, *,
@@ -225,6 +345,22 @@ class AllowedHostPathArgs:
         pulumi.set(self, "read_only", value)
 
 
+if not MYPY:
+    class FSGroupStrategyOptionsPatchArgsDict(TypedDict):
+        """
+        FSGroupStrategyOptions defines the strategy type and options used to create the strategy.
+        """
+        ranges: NotRequired[pulumi.Input[Sequence[pulumi.Input['IDRangePatchArgsDict']]]]
+        """
+        ranges are the allowed ranges of fs groups.  If you would like to force a single fs group then supply a single range with the same start and end. Required for MustRunAs.
+        """
+        rule: NotRequired[pulumi.Input[str]]
+        """
+        rule is the strategy that will dictate what FSGroup is used in the SecurityContext.
+        """
+elif False:
+    FSGroupStrategyOptionsPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class FSGroupStrategyOptionsPatchArgs:
     def __init__(__self__, *,
@@ -264,6 +400,22 @@ class FSGroupStrategyOptionsPatchArgs:
     def rule(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "rule", value)
 
+
+if not MYPY:
+    class FSGroupStrategyOptionsArgsDict(TypedDict):
+        """
+        FSGroupStrategyOptions defines the strategy type and options used to create the strategy.
+        """
+        ranges: NotRequired[pulumi.Input[Sequence[pulumi.Input['IDRangeArgsDict']]]]
+        """
+        ranges are the allowed ranges of fs groups.  If you would like to force a single fs group then supply a single range with the same start and end. Required for MustRunAs.
+        """
+        rule: NotRequired[pulumi.Input[str]]
+        """
+        rule is the strategy that will dictate what FSGroup is used in the SecurityContext.
+        """
+elif False:
+    FSGroupStrategyOptionsArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class FSGroupStrategyOptionsArgs:
@@ -305,6 +457,22 @@ class FSGroupStrategyOptionsArgs:
         pulumi.set(self, "rule", value)
 
 
+if not MYPY:
+    class HostPortRangePatchArgsDict(TypedDict):
+        """
+        HostPortRange defines a range of host ports that will be enabled by a policy for pods to use.  It requires both the start and end to be defined.
+        """
+        max: NotRequired[pulumi.Input[int]]
+        """
+        max is the end of the range, inclusive.
+        """
+        min: NotRequired[pulumi.Input[int]]
+        """
+        min is the start of the range, inclusive.
+        """
+elif False:
+    HostPortRangePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class HostPortRangePatchArgs:
     def __init__(__self__, *,
@@ -345,6 +513,22 @@ class HostPortRangePatchArgs:
         pulumi.set(self, "min", value)
 
 
+if not MYPY:
+    class HostPortRangeArgsDict(TypedDict):
+        """
+        HostPortRange defines a range of host ports that will be enabled by a policy for pods to use.  It requires both the start and end to be defined.
+        """
+        max: pulumi.Input[int]
+        """
+        max is the end of the range, inclusive.
+        """
+        min: pulumi.Input[int]
+        """
+        min is the start of the range, inclusive.
+        """
+elif False:
+    HostPortRangeArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class HostPortRangeArgs:
     def __init__(__self__, *,
@@ -382,6 +566,22 @@ class HostPortRangeArgs:
     def min(self, value: pulumi.Input[int]):
         pulumi.set(self, "min", value)
 
+
+if not MYPY:
+    class IDRangePatchArgsDict(TypedDict):
+        """
+        IDRange provides a min/max of an allowed range of IDs.
+        """
+        max: NotRequired[pulumi.Input[int]]
+        """
+        max is the end of the range, inclusive.
+        """
+        min: NotRequired[pulumi.Input[int]]
+        """
+        min is the start of the range, inclusive.
+        """
+elif False:
+    IDRangePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class IDRangePatchArgs:
@@ -423,6 +623,22 @@ class IDRangePatchArgs:
         pulumi.set(self, "min", value)
 
 
+if not MYPY:
+    class IDRangeArgsDict(TypedDict):
+        """
+        IDRange provides a min/max of an allowed range of IDs.
+        """
+        max: pulumi.Input[int]
+        """
+        max is the end of the range, inclusive.
+        """
+        min: pulumi.Input[int]
+        """
+        min is the start of the range, inclusive.
+        """
+elif False:
+    IDRangeArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class IDRangeArgs:
     def __init__(__self__, *,
@@ -460,6 +676,26 @@ class IDRangeArgs:
     def min(self, value: pulumi.Input[int]):
         pulumi.set(self, "min", value)
 
+
+if not MYPY:
+    class PodDisruptionBudgetSpecPatchArgsDict(TypedDict):
+        """
+        PodDisruptionBudgetSpec is a description of a PodDisruptionBudget.
+        """
+        max_unavailable: NotRequired[pulumi.Input[Union[int, str]]]
+        """
+        An eviction is allowed if at most "maxUnavailable" pods selected by "selector" are unavailable after the eviction, i.e. even in absence of the evicted pod. For example, one can prevent all voluntary evictions by specifying 0. This is a mutually exclusive setting with "minAvailable".
+        """
+        min_available: NotRequired[pulumi.Input[Union[int, str]]]
+        """
+        An eviction is allowed if at least "minAvailable" pods selected by "selector" will still be available after the eviction, i.e. even in the absence of the evicted pod.  So for example you can prevent all voluntary evictions by specifying "100%".
+        """
+        selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorPatchArgsDict']]
+        """
+        Label query over pods whose evictions are managed by the disruption budget.
+        """
+elif False:
+    PodDisruptionBudgetSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class PodDisruptionBudgetSpecPatchArgs:
@@ -517,6 +753,26 @@ class PodDisruptionBudgetSpecPatchArgs:
         pulumi.set(self, "selector", value)
 
 
+if not MYPY:
+    class PodDisruptionBudgetSpecArgsDict(TypedDict):
+        """
+        PodDisruptionBudgetSpec is a description of a PodDisruptionBudget.
+        """
+        max_unavailable: NotRequired[pulumi.Input[Union[int, str]]]
+        """
+        An eviction is allowed if at most "maxUnavailable" pods selected by "selector" are unavailable after the eviction, i.e. even in absence of the evicted pod. For example, one can prevent all voluntary evictions by specifying 0. This is a mutually exclusive setting with "minAvailable".
+        """
+        min_available: NotRequired[pulumi.Input[Union[int, str]]]
+        """
+        An eviction is allowed if at least "minAvailable" pods selected by "selector" will still be available after the eviction, i.e. even in the absence of the evicted pod.  So for example you can prevent all voluntary evictions by specifying "100%".
+        """
+        selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorArgsDict']]
+        """
+        Label query over pods whose evictions are managed by the disruption budget.
+        """
+elif False:
+    PodDisruptionBudgetSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PodDisruptionBudgetSpecArgs:
     def __init__(__self__, *,
@@ -572,6 +828,38 @@ class PodDisruptionBudgetSpecArgs:
     def selector(self, value: Optional[pulumi.Input['_meta.v1.LabelSelectorArgs']]):
         pulumi.set(self, "selector", value)
 
+
+if not MYPY:
+    class PodDisruptionBudgetStatusArgsDict(TypedDict):
+        """
+        PodDisruptionBudgetStatus represents information about the status of a PodDisruptionBudget. Status may trail the actual state of a system.
+        """
+        current_healthy: pulumi.Input[int]
+        """
+        current number of healthy pods
+        """
+        desired_healthy: pulumi.Input[int]
+        """
+        minimum desired number of healthy pods
+        """
+        disruptions_allowed: pulumi.Input[int]
+        """
+        Number of pod disruptions that are currently allowed.
+        """
+        expected_pods: pulumi.Input[int]
+        """
+        total number of pods counted by this disruption budget
+        """
+        disrupted_pods: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        DisruptedPods contains information about pods whose eviction was processed by the API server eviction subresource handler but has not yet been observed by the PodDisruptionBudget controller. A pod will be in this map from the time when the API server processed the eviction request to the time when the pod is seen by PDB controller as having been marked for deletion (or after a timeout). The key in the map is the name of the pod and the value is the time when the API server processed the eviction request. If the deletion didn't occur and a pod is still there it will be removed from the list automatically by PodDisruptionBudget controller after some time. If everything goes smooth this map should be empty for the most of the time. Large number of entries in the map may indicate problems with pod deletions.
+        """
+        observed_generation: NotRequired[pulumi.Input[int]]
+        """
+        Most recent generation observed when updating this PDB status. PodDisruptionsAllowed and other status information is valid only if observedGeneration equals to PDB's object generation.
+        """
+elif False:
+    PodDisruptionBudgetStatusArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class PodDisruptionBudgetStatusArgs:
@@ -673,6 +961,31 @@ class PodDisruptionBudgetStatusArgs:
         pulumi.set(self, "observed_generation", value)
 
 
+if not MYPY:
+    class PodDisruptionBudgetArgsDict(TypedDict):
+        """
+        PodDisruptionBudget is an object to define the max disruption that can be caused to a collection of pods
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        spec: NotRequired[pulumi.Input['PodDisruptionBudgetSpecArgsDict']]
+        """
+        Specification of the desired behavior of the PodDisruptionBudget.
+        """
+        status: NotRequired[pulumi.Input['PodDisruptionBudgetStatusArgsDict']]
+        """
+        Most recently observed status of the PodDisruptionBudget.
+        """
+elif False:
+    PodDisruptionBudgetArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PodDisruptionBudgetArgs:
     def __init__(__self__, *,
@@ -756,6 +1069,114 @@ class PodDisruptionBudgetArgs:
     def status(self, value: Optional[pulumi.Input['PodDisruptionBudgetStatusArgs']]):
         pulumi.set(self, "status", value)
 
+
+if not MYPY:
+    class PodSecurityPolicySpecPatchArgsDict(TypedDict):
+        """
+        PodSecurityPolicySpec defines the policy enforced.
+        """
+        allow_privilege_escalation: NotRequired[pulumi.Input[bool]]
+        """
+        allowPrivilegeEscalation determines if a pod can request to allow privilege escalation. If unspecified, defaults to true.
+        """
+        allowed_csi_drivers: NotRequired[pulumi.Input[Sequence[pulumi.Input['AllowedCSIDriverPatchArgsDict']]]]
+        """
+        AllowedCSIDrivers is a whitelist of inline CSI drivers that must be explicitly set to be embedded within a pod spec. An empty value indicates that any CSI driver can be used for inline ephemeral volumes. This is an alpha field, and is only honored if the API server enables the CSIInlineVolume feature gate.
+        """
+        allowed_capabilities: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        allowedCapabilities is a list of capabilities that can be requested to add to the container. Capabilities in this field may be added at the pod author's discretion. You must not list a capability in both allowedCapabilities and requiredDropCapabilities.
+        """
+        allowed_flex_volumes: NotRequired[pulumi.Input[Sequence[pulumi.Input['AllowedFlexVolumePatchArgsDict']]]]
+        """
+        allowedFlexVolumes is a whitelist of allowed Flexvolumes.  Empty or nil indicates that all Flexvolumes may be used.  This parameter is effective only when the usage of the Flexvolumes is allowed in the "volumes" field.
+        """
+        allowed_host_paths: NotRequired[pulumi.Input[Sequence[pulumi.Input['AllowedHostPathPatchArgsDict']]]]
+        """
+        allowedHostPaths is a white list of allowed host paths. Empty indicates that all host paths may be used.
+        """
+        allowed_proc_mount_types: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        AllowedProcMountTypes is a whitelist of allowed ProcMountTypes. Empty or nil indicates that only the DefaultProcMountType may be used. This requires the ProcMountType feature flag to be enabled.
+        """
+        allowed_unsafe_sysctls: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        allowedUnsafeSysctls is a list of explicitly allowed unsafe sysctls, defaults to none. Each entry is either a plain sysctl name or ends in "*" in which case it is considered as a prefix of allowed sysctls. Single * means all unsafe sysctls are allowed. Kubelet has to whitelist all allowed unsafe sysctls explicitly to avoid rejection.
+
+        Examples: e.g. "foo/*" allows "foo/bar", "foo/baz", etc. e.g. "foo.*" allows "foo.bar", "foo.baz", etc.
+        """
+        default_add_capabilities: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        defaultAddCapabilities is the default set of capabilities that will be added to the container unless the pod spec specifically drops the capability.  You may not list a capability in both defaultAddCapabilities and requiredDropCapabilities. Capabilities added here are implicitly allowed, and need not be included in the allowedCapabilities list.
+        """
+        default_allow_privilege_escalation: NotRequired[pulumi.Input[bool]]
+        """
+        defaultAllowPrivilegeEscalation controls the default setting for whether a process can gain more privileges than its parent process.
+        """
+        forbidden_sysctls: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        forbiddenSysctls is a list of explicitly forbidden sysctls, defaults to none. Each entry is either a plain sysctl name or ends in "*" in which case it is considered as a prefix of forbidden sysctls. Single * means all sysctls are forbidden.
+
+        Examples: e.g. "foo/*" forbids "foo/bar", "foo/baz", etc. e.g. "foo.*" forbids "foo.bar", "foo.baz", etc.
+        """
+        fs_group: NotRequired[pulumi.Input['FSGroupStrategyOptionsPatchArgsDict']]
+        """
+        fsGroup is the strategy that will dictate what fs group is used by the SecurityContext.
+        """
+        host_ipc: NotRequired[pulumi.Input[bool]]
+        """
+        hostIPC determines if the policy allows the use of HostIPC in the pod spec.
+        """
+        host_network: NotRequired[pulumi.Input[bool]]
+        """
+        hostNetwork determines if the policy allows the use of HostNetwork in the pod spec.
+        """
+        host_pid: NotRequired[pulumi.Input[bool]]
+        """
+        hostPID determines if the policy allows the use of HostPID in the pod spec.
+        """
+        host_ports: NotRequired[pulumi.Input[Sequence[pulumi.Input['HostPortRangePatchArgsDict']]]]
+        """
+        hostPorts determines which host port ranges are allowed to be exposed.
+        """
+        privileged: NotRequired[pulumi.Input[bool]]
+        """
+        privileged determines if a pod can request to be run as privileged.
+        """
+        read_only_root_filesystem: NotRequired[pulumi.Input[bool]]
+        """
+        readOnlyRootFilesystem when set to true will force containers to run with a read only root file system.  If the container specifically requests to run with a non-read only root file system the PSP should deny the pod. If set to false the container may run with a read only root file system if it wishes but it will not be forced to.
+        """
+        required_drop_capabilities: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        requiredDropCapabilities are the capabilities that will be dropped from the container.  These are required to be dropped and cannot be added.
+        """
+        run_as_group: NotRequired[pulumi.Input['RunAsGroupStrategyOptionsPatchArgsDict']]
+        """
+        RunAsGroup is the strategy that will dictate the allowable RunAsGroup values that may be set. If this field is omitted, the pod's RunAsGroup can take any value. This field requires the RunAsGroup feature gate to be enabled.
+        """
+        run_as_user: NotRequired[pulumi.Input['RunAsUserStrategyOptionsPatchArgsDict']]
+        """
+        runAsUser is the strategy that will dictate the allowable RunAsUser values that may be set.
+        """
+        runtime_class: NotRequired[pulumi.Input['RuntimeClassStrategyOptionsPatchArgsDict']]
+        """
+        runtimeClass is the strategy that will dictate the allowable RuntimeClasses for a pod. If this field is omitted, the pod's runtimeClassName field is unrestricted. Enforcement of this field depends on the RuntimeClass feature gate being enabled.
+        """
+        se_linux: NotRequired[pulumi.Input['SELinuxStrategyOptionsPatchArgsDict']]
+        """
+        seLinux is the strategy that will dictate the allowable labels that may be set.
+        """
+        supplemental_groups: NotRequired[pulumi.Input['SupplementalGroupsStrategyOptionsPatchArgsDict']]
+        """
+        supplementalGroups is the strategy that will dictate what supplemental groups are used by the SecurityContext.
+        """
+        volumes: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        volumes is a white list of allowed volume plugins. Empty indicates that no volumes may be used. To allow all volumes you may use '*'.
+        """
+elif False:
+    PodSecurityPolicySpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class PodSecurityPolicySpecPatchArgs:
@@ -1157,6 +1578,114 @@ class PodSecurityPolicySpecPatchArgs:
         pulumi.set(self, "volumes", value)
 
 
+if not MYPY:
+    class PodSecurityPolicySpecArgsDict(TypedDict):
+        """
+        PodSecurityPolicySpec defines the policy enforced.
+        """
+        fs_group: pulumi.Input['FSGroupStrategyOptionsArgsDict']
+        """
+        fsGroup is the strategy that will dictate what fs group is used by the SecurityContext.
+        """
+        run_as_user: pulumi.Input['RunAsUserStrategyOptionsArgsDict']
+        """
+        runAsUser is the strategy that will dictate the allowable RunAsUser values that may be set.
+        """
+        se_linux: pulumi.Input['SELinuxStrategyOptionsArgsDict']
+        """
+        seLinux is the strategy that will dictate the allowable labels that may be set.
+        """
+        supplemental_groups: pulumi.Input['SupplementalGroupsStrategyOptionsArgsDict']
+        """
+        supplementalGroups is the strategy that will dictate what supplemental groups are used by the SecurityContext.
+        """
+        allow_privilege_escalation: NotRequired[pulumi.Input[bool]]
+        """
+        allowPrivilegeEscalation determines if a pod can request to allow privilege escalation. If unspecified, defaults to true.
+        """
+        allowed_csi_drivers: NotRequired[pulumi.Input[Sequence[pulumi.Input['AllowedCSIDriverArgsDict']]]]
+        """
+        AllowedCSIDrivers is a whitelist of inline CSI drivers that must be explicitly set to be embedded within a pod spec. An empty value indicates that any CSI driver can be used for inline ephemeral volumes. This is an alpha field, and is only honored if the API server enables the CSIInlineVolume feature gate.
+        """
+        allowed_capabilities: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        allowedCapabilities is a list of capabilities that can be requested to add to the container. Capabilities in this field may be added at the pod author's discretion. You must not list a capability in both allowedCapabilities and requiredDropCapabilities.
+        """
+        allowed_flex_volumes: NotRequired[pulumi.Input[Sequence[pulumi.Input['AllowedFlexVolumeArgsDict']]]]
+        """
+        allowedFlexVolumes is a whitelist of allowed Flexvolumes.  Empty or nil indicates that all Flexvolumes may be used.  This parameter is effective only when the usage of the Flexvolumes is allowed in the "volumes" field.
+        """
+        allowed_host_paths: NotRequired[pulumi.Input[Sequence[pulumi.Input['AllowedHostPathArgsDict']]]]
+        """
+        allowedHostPaths is a white list of allowed host paths. Empty indicates that all host paths may be used.
+        """
+        allowed_proc_mount_types: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        AllowedProcMountTypes is a whitelist of allowed ProcMountTypes. Empty or nil indicates that only the DefaultProcMountType may be used. This requires the ProcMountType feature flag to be enabled.
+        """
+        allowed_unsafe_sysctls: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        allowedUnsafeSysctls is a list of explicitly allowed unsafe sysctls, defaults to none. Each entry is either a plain sysctl name or ends in "*" in which case it is considered as a prefix of allowed sysctls. Single * means all unsafe sysctls are allowed. Kubelet has to whitelist all allowed unsafe sysctls explicitly to avoid rejection.
+
+        Examples: e.g. "foo/*" allows "foo/bar", "foo/baz", etc. e.g. "foo.*" allows "foo.bar", "foo.baz", etc.
+        """
+        default_add_capabilities: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        defaultAddCapabilities is the default set of capabilities that will be added to the container unless the pod spec specifically drops the capability.  You may not list a capability in both defaultAddCapabilities and requiredDropCapabilities. Capabilities added here are implicitly allowed, and need not be included in the allowedCapabilities list.
+        """
+        default_allow_privilege_escalation: NotRequired[pulumi.Input[bool]]
+        """
+        defaultAllowPrivilegeEscalation controls the default setting for whether a process can gain more privileges than its parent process.
+        """
+        forbidden_sysctls: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        forbiddenSysctls is a list of explicitly forbidden sysctls, defaults to none. Each entry is either a plain sysctl name or ends in "*" in which case it is considered as a prefix of forbidden sysctls. Single * means all sysctls are forbidden.
+
+        Examples: e.g. "foo/*" forbids "foo/bar", "foo/baz", etc. e.g. "foo.*" forbids "foo.bar", "foo.baz", etc.
+        """
+        host_ipc: NotRequired[pulumi.Input[bool]]
+        """
+        hostIPC determines if the policy allows the use of HostIPC in the pod spec.
+        """
+        host_network: NotRequired[pulumi.Input[bool]]
+        """
+        hostNetwork determines if the policy allows the use of HostNetwork in the pod spec.
+        """
+        host_pid: NotRequired[pulumi.Input[bool]]
+        """
+        hostPID determines if the policy allows the use of HostPID in the pod spec.
+        """
+        host_ports: NotRequired[pulumi.Input[Sequence[pulumi.Input['HostPortRangeArgsDict']]]]
+        """
+        hostPorts determines which host port ranges are allowed to be exposed.
+        """
+        privileged: NotRequired[pulumi.Input[bool]]
+        """
+        privileged determines if a pod can request to be run as privileged.
+        """
+        read_only_root_filesystem: NotRequired[pulumi.Input[bool]]
+        """
+        readOnlyRootFilesystem when set to true will force containers to run with a read only root file system.  If the container specifically requests to run with a non-read only root file system the PSP should deny the pod. If set to false the container may run with a read only root file system if it wishes but it will not be forced to.
+        """
+        required_drop_capabilities: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        requiredDropCapabilities are the capabilities that will be dropped from the container.  These are required to be dropped and cannot be added.
+        """
+        run_as_group: NotRequired[pulumi.Input['RunAsGroupStrategyOptionsArgsDict']]
+        """
+        RunAsGroup is the strategy that will dictate the allowable RunAsGroup values that may be set. If this field is omitted, the pod's RunAsGroup can take any value. This field requires the RunAsGroup feature gate to be enabled.
+        """
+        runtime_class: NotRequired[pulumi.Input['RuntimeClassStrategyOptionsArgsDict']]
+        """
+        runtimeClass is the strategy that will dictate the allowable RuntimeClasses for a pod. If this field is omitted, the pod's runtimeClassName field is unrestricted. Enforcement of this field depends on the RuntimeClass feature gate being enabled.
+        """
+        volumes: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        volumes is a white list of allowed volume plugins. Empty indicates that no volumes may be used. To allow all volumes you may use '*'.
+        """
+elif False:
+    PodSecurityPolicySpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PodSecurityPolicySpecArgs:
     def __init__(__self__, *,
@@ -1553,6 +2082,30 @@ class PodSecurityPolicySpecArgs:
         pulumi.set(self, "volumes", value)
 
 
+if not MYPY:
+    class PodSecurityPolicyArgsDict(TypedDict):
+        """
+        PodSecurityPolicy governs the ability to make requests that affect the Security Context that will be applied to a pod and container.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['PodSecurityPolicySpecArgsDict']]
+        """
+        spec defines the policy enforced.
+        """
+elif False:
+    PodSecurityPolicyArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PodSecurityPolicyArgs:
     def __init__(__self__, *,
@@ -1625,6 +2178,22 @@ class PodSecurityPolicyArgs:
         pulumi.set(self, "spec", value)
 
 
+if not MYPY:
+    class RunAsGroupStrategyOptionsPatchArgsDict(TypedDict):
+        """
+        RunAsGroupStrategyOptions defines the strategy type and any options used to create the strategy.
+        """
+        ranges: NotRequired[pulumi.Input[Sequence[pulumi.Input['IDRangePatchArgsDict']]]]
+        """
+        ranges are the allowed ranges of gids that may be used. If you would like to force a single gid then supply a single range with the same start and end. Required for MustRunAs.
+        """
+        rule: NotRequired[pulumi.Input[str]]
+        """
+        rule is the strategy that will dictate the allowable RunAsGroup values that may be set.
+        """
+elif False:
+    RunAsGroupStrategyOptionsPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class RunAsGroupStrategyOptionsPatchArgs:
     def __init__(__self__, *,
@@ -1665,6 +2234,22 @@ class RunAsGroupStrategyOptionsPatchArgs:
         pulumi.set(self, "rule", value)
 
 
+if not MYPY:
+    class RunAsGroupStrategyOptionsArgsDict(TypedDict):
+        """
+        RunAsGroupStrategyOptions defines the strategy type and any options used to create the strategy.
+        """
+        rule: pulumi.Input[str]
+        """
+        rule is the strategy that will dictate the allowable RunAsGroup values that may be set.
+        """
+        ranges: NotRequired[pulumi.Input[Sequence[pulumi.Input['IDRangeArgsDict']]]]
+        """
+        ranges are the allowed ranges of gids that may be used. If you would like to force a single gid then supply a single range with the same start and end. Required for MustRunAs.
+        """
+elif False:
+    RunAsGroupStrategyOptionsArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class RunAsGroupStrategyOptionsArgs:
     def __init__(__self__, *,
@@ -1703,6 +2288,22 @@ class RunAsGroupStrategyOptionsArgs:
     def ranges(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['IDRangeArgs']]]]):
         pulumi.set(self, "ranges", value)
 
+
+if not MYPY:
+    class RunAsUserStrategyOptionsPatchArgsDict(TypedDict):
+        """
+        RunAsUserStrategyOptions defines the strategy type and any options used to create the strategy.
+        """
+        ranges: NotRequired[pulumi.Input[Sequence[pulumi.Input['IDRangePatchArgsDict']]]]
+        """
+        ranges are the allowed ranges of uids that may be used. If you would like to force a single uid then supply a single range with the same start and end. Required for MustRunAs.
+        """
+        rule: NotRequired[pulumi.Input[str]]
+        """
+        rule is the strategy that will dictate the allowable RunAsUser values that may be set.
+        """
+elif False:
+    RunAsUserStrategyOptionsPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class RunAsUserStrategyOptionsPatchArgs:
@@ -1744,6 +2345,22 @@ class RunAsUserStrategyOptionsPatchArgs:
         pulumi.set(self, "rule", value)
 
 
+if not MYPY:
+    class RunAsUserStrategyOptionsArgsDict(TypedDict):
+        """
+        RunAsUserStrategyOptions defines the strategy type and any options used to create the strategy.
+        """
+        rule: pulumi.Input[str]
+        """
+        rule is the strategy that will dictate the allowable RunAsUser values that may be set.
+        """
+        ranges: NotRequired[pulumi.Input[Sequence[pulumi.Input['IDRangeArgsDict']]]]
+        """
+        ranges are the allowed ranges of uids that may be used. If you would like to force a single uid then supply a single range with the same start and end. Required for MustRunAs.
+        """
+elif False:
+    RunAsUserStrategyOptionsArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class RunAsUserStrategyOptionsArgs:
     def __init__(__self__, *,
@@ -1782,6 +2399,22 @@ class RunAsUserStrategyOptionsArgs:
     def ranges(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['IDRangeArgs']]]]):
         pulumi.set(self, "ranges", value)
 
+
+if not MYPY:
+    class RuntimeClassStrategyOptionsPatchArgsDict(TypedDict):
+        """
+        RuntimeClassStrategyOptions define the strategy that will dictate the allowable RuntimeClasses for a pod.
+        """
+        allowed_runtime_class_names: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        allowedRuntimeClassNames is a whitelist of RuntimeClass names that may be specified on a pod. A value of "*" means that any RuntimeClass name is allowed, and must be the only item in the list. An empty list requires the RuntimeClassName field to be unset.
+        """
+        default_runtime_class_name: NotRequired[pulumi.Input[str]]
+        """
+        defaultRuntimeClassName is the default RuntimeClassName to set on the pod. The default MUST be allowed by the allowedRuntimeClassNames list. A value of nil does not mutate the Pod.
+        """
+elif False:
+    RuntimeClassStrategyOptionsPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class RuntimeClassStrategyOptionsPatchArgs:
@@ -1823,6 +2456,22 @@ class RuntimeClassStrategyOptionsPatchArgs:
         pulumi.set(self, "default_runtime_class_name", value)
 
 
+if not MYPY:
+    class RuntimeClassStrategyOptionsArgsDict(TypedDict):
+        """
+        RuntimeClassStrategyOptions define the strategy that will dictate the allowable RuntimeClasses for a pod.
+        """
+        allowed_runtime_class_names: pulumi.Input[Sequence[pulumi.Input[str]]]
+        """
+        allowedRuntimeClassNames is a whitelist of RuntimeClass names that may be specified on a pod. A value of "*" means that any RuntimeClass name is allowed, and must be the only item in the list. An empty list requires the RuntimeClassName field to be unset.
+        """
+        default_runtime_class_name: NotRequired[pulumi.Input[str]]
+        """
+        defaultRuntimeClassName is the default RuntimeClassName to set on the pod. The default MUST be allowed by the allowedRuntimeClassNames list. A value of nil does not mutate the Pod.
+        """
+elif False:
+    RuntimeClassStrategyOptionsArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class RuntimeClassStrategyOptionsArgs:
     def __init__(__self__, *,
@@ -1861,6 +2510,22 @@ class RuntimeClassStrategyOptionsArgs:
     def default_runtime_class_name(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "default_runtime_class_name", value)
 
+
+if not MYPY:
+    class SELinuxStrategyOptionsPatchArgsDict(TypedDict):
+        """
+        SELinuxStrategyOptions defines the strategy type and any options used to create the strategy.
+        """
+        rule: NotRequired[pulumi.Input[str]]
+        """
+        rule is the strategy that will dictate the allowable labels that may be set.
+        """
+        se_linux_options: NotRequired[pulumi.Input['_core.v1.SELinuxOptionsPatchArgsDict']]
+        """
+        seLinuxOptions required to run as; required for MustRunAs More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+        """
+elif False:
+    SELinuxStrategyOptionsPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class SELinuxStrategyOptionsPatchArgs:
@@ -1902,6 +2567,22 @@ class SELinuxStrategyOptionsPatchArgs:
         pulumi.set(self, "se_linux_options", value)
 
 
+if not MYPY:
+    class SELinuxStrategyOptionsArgsDict(TypedDict):
+        """
+        SELinuxStrategyOptions defines the strategy type and any options used to create the strategy.
+        """
+        rule: pulumi.Input[str]
+        """
+        rule is the strategy that will dictate the allowable labels that may be set.
+        """
+        se_linux_options: NotRequired[pulumi.Input['_core.v1.SELinuxOptionsArgsDict']]
+        """
+        seLinuxOptions required to run as; required for MustRunAs More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+        """
+elif False:
+    SELinuxStrategyOptionsArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class SELinuxStrategyOptionsArgs:
     def __init__(__self__, *,
@@ -1940,6 +2621,22 @@ class SELinuxStrategyOptionsArgs:
     def se_linux_options(self, value: Optional[pulumi.Input['_core.v1.SELinuxOptionsArgs']]):
         pulumi.set(self, "se_linux_options", value)
 
+
+if not MYPY:
+    class SupplementalGroupsStrategyOptionsPatchArgsDict(TypedDict):
+        """
+        SupplementalGroupsStrategyOptions defines the strategy type and options used to create the strategy.
+        """
+        ranges: NotRequired[pulumi.Input[Sequence[pulumi.Input['IDRangePatchArgsDict']]]]
+        """
+        ranges are the allowed ranges of supplemental groups.  If you would like to force a single supplemental group then supply a single range with the same start and end. Required for MustRunAs.
+        """
+        rule: NotRequired[pulumi.Input[str]]
+        """
+        rule is the strategy that will dictate what supplemental groups is used in the SecurityContext.
+        """
+elif False:
+    SupplementalGroupsStrategyOptionsPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class SupplementalGroupsStrategyOptionsPatchArgs:
@@ -1980,6 +2677,22 @@ class SupplementalGroupsStrategyOptionsPatchArgs:
     def rule(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "rule", value)
 
+
+if not MYPY:
+    class SupplementalGroupsStrategyOptionsArgsDict(TypedDict):
+        """
+        SupplementalGroupsStrategyOptions defines the strategy type and options used to create the strategy.
+        """
+        ranges: NotRequired[pulumi.Input[Sequence[pulumi.Input['IDRangeArgsDict']]]]
+        """
+        ranges are the allowed ranges of supplemental groups.  If you would like to force a single supplemental group then supply a single range with the same start and end. Required for MustRunAs.
+        """
+        rule: NotRequired[pulumi.Input[str]]
+        """
+        rule is the strategy that will dictate what supplemental groups is used in the SecurityContext.
+        """
+elif False:
+    SupplementalGroupsStrategyOptionsArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class SupplementalGroupsStrategyOptionsArgs:

--- a/sdk/python/pulumi_kubernetes/policy/v1beta1/outputs.py
+++ b/sdk/python/pulumi_kubernetes/policy/v1beta1/outputs.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core

--- a/sdk/python/pulumi_kubernetes/provider.py
+++ b/sdk/python/pulumi_kubernetes/provider.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from . import _utilities
 from ._inputs import *
 
@@ -288,8 +293,8 @@ class Provider(pulumi.ProviderResource):
                  delete_unreachable: Optional[pulumi.Input[bool]] = None,
                  enable_config_map_mutable: Optional[pulumi.Input[bool]] = None,
                  enable_server_side_apply: Optional[pulumi.Input[bool]] = None,
-                 helm_release_settings: Optional[pulumi.Input[pulumi.InputType['HelmReleaseSettingsArgs']]] = None,
-                 kube_client_settings: Optional[pulumi.Input[pulumi.InputType['KubeClientSettingsArgs']]] = None,
+                 helm_release_settings: Optional[pulumi.Input[Union['HelmReleaseSettingsArgs', 'HelmReleaseSettingsArgsDict']]] = None,
+                 kube_client_settings: Optional[pulumi.Input[Union['KubeClientSettingsArgs', 'KubeClientSettingsArgsDict']]] = None,
                  kubeconfig: Optional[pulumi.Input[str]] = None,
                  namespace: Optional[pulumi.Input[str]] = None,
                  render_yaml_to_directory: Optional[pulumi.Input[str]] = None,
@@ -313,8 +318,8 @@ class Provider(pulumi.ProviderResource):
                2. The `PULUMI_K8S_ENABLE_CONFIGMAP_MUTABLE` environment variable.
         :param pulumi.Input[bool] enable_server_side_apply: If present and set to false, disable Server-Side Apply mode.
                See https://github.com/pulumi/pulumi-kubernetes/issues/2011 for additional details.
-        :param pulumi.Input[pulumi.InputType['HelmReleaseSettingsArgs']] helm_release_settings: Options to configure the Helm Release resource.
-        :param pulumi.Input[pulumi.InputType['KubeClientSettingsArgs']] kube_client_settings: Options for tuning the Kubernetes client used by a Provider.
+        :param pulumi.Input[Union['HelmReleaseSettingsArgs', 'HelmReleaseSettingsArgsDict']] helm_release_settings: Options to configure the Helm Release resource.
+        :param pulumi.Input[Union['KubeClientSettingsArgs', 'KubeClientSettingsArgsDict']] kube_client_settings: Options for tuning the Kubernetes client used by a Provider.
         :param pulumi.Input[str] kubeconfig: The contents of a kubeconfig file or the path to a kubeconfig file.
         :param pulumi.Input[str] namespace: If present, the default namespace to use. This flag is ignored for cluster-scoped resources.
                
@@ -363,8 +368,8 @@ class Provider(pulumi.ProviderResource):
                  delete_unreachable: Optional[pulumi.Input[bool]] = None,
                  enable_config_map_mutable: Optional[pulumi.Input[bool]] = None,
                  enable_server_side_apply: Optional[pulumi.Input[bool]] = None,
-                 helm_release_settings: Optional[pulumi.Input[pulumi.InputType['HelmReleaseSettingsArgs']]] = None,
-                 kube_client_settings: Optional[pulumi.Input[pulumi.InputType['KubeClientSettingsArgs']]] = None,
+                 helm_release_settings: Optional[pulumi.Input[Union['HelmReleaseSettingsArgs', 'HelmReleaseSettingsArgsDict']]] = None,
+                 kube_client_settings: Optional[pulumi.Input[Union['KubeClientSettingsArgs', 'KubeClientSettingsArgsDict']]] = None,
                  kubeconfig: Optional[pulumi.Input[str]] = None,
                  namespace: Optional[pulumi.Input[str]] = None,
                  render_yaml_to_directory: Optional[pulumi.Input[str]] = None,

--- a/sdk/python/pulumi_kubernetes/pulumi-plugin.json
+++ b/sdk/python/pulumi_kubernetes/pulumi-plugin.json
@@ -1,5 +1,5 @@
 {
   "resource": true,
   "name": "kubernetes",
-  "version": "4.14.0-alpha.1718665781"
+  "version": "4.0.0-alpha.0+dev"
 }

--- a/sdk/python/pulumi_kubernetes/rbac/v1/ClusterRole.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1/ClusterRole.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -107,22 +112,22 @@ class ClusterRole(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 aggregation_rule: Optional[pulumi.Input[pulumi.InputType['AggregationRuleArgs']]] = None,
+                 aggregation_rule: Optional[pulumi.Input[Union['AggregationRuleArgs', 'AggregationRuleArgsDict']]] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 rules: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PolicyRuleArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 rules: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PolicyRuleArgs', 'PolicyRuleArgsDict']]]]] = None,
                  __props__=None):
         """
         ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding.
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[pulumi.InputType['AggregationRuleArgs']] aggregation_rule: AggregationRule is an optional field that describes how to build the Rules for this ClusterRole. If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be stomped by the controller.
+        :param pulumi.Input[Union['AggregationRuleArgs', 'AggregationRuleArgsDict']] aggregation_rule: AggregationRule is an optional field that describes how to build the Rules for this ClusterRole. If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be stomped by the controller.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata.
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PolicyRuleArgs']]]] rules: Rules holds all the PolicyRules for this ClusterRole
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['PolicyRuleArgs', 'PolicyRuleArgsDict']]]] rules: Rules holds all the PolicyRules for this ClusterRole
         """
         ...
     @overload
@@ -148,11 +153,11 @@ class ClusterRole(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 aggregation_rule: Optional[pulumi.Input[pulumi.InputType['AggregationRuleArgs']]] = None,
+                 aggregation_rule: Optional[pulumi.Input[Union['AggregationRuleArgs', 'AggregationRuleArgsDict']]] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 rules: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PolicyRuleArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 rules: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PolicyRuleArgs', 'PolicyRuleArgsDict']]]]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/rbac/v1/ClusterRoleBinding.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1/ClusterRoleBinding.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -108,9 +113,9 @@ class ClusterRoleBinding(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 role_ref: Optional[pulumi.Input[pulumi.InputType['RoleRefArgs']]] = None,
-                 subjects: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SubjectArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 role_ref: Optional[pulumi.Input[Union['RoleRefArgs', 'RoleRefArgsDict']]] = None,
+                 subjects: Optional[pulumi.Input[Sequence[pulumi.Input[Union['SubjectArgs', 'SubjectArgsDict']]]]] = None,
                  __props__=None):
         """
         ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace, and adds who information via Subject.
@@ -119,9 +124,9 @@ class ClusterRoleBinding(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata.
-        :param pulumi.Input[pulumi.InputType['RoleRefArgs']] role_ref: RoleRef can only reference a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error. This field is immutable.
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SubjectArgs']]]] subjects: Subjects holds references to the objects the role applies to.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata.
+        :param pulumi.Input[Union['RoleRefArgs', 'RoleRefArgsDict']] role_ref: RoleRef can only reference a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error. This field is immutable.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['SubjectArgs', 'SubjectArgsDict']]]] subjects: Subjects holds references to the objects the role applies to.
         """
         ...
     @overload
@@ -149,9 +154,9 @@ class ClusterRoleBinding(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 role_ref: Optional[pulumi.Input[pulumi.InputType['RoleRefArgs']]] = None,
-                 subjects: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SubjectArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 role_ref: Optional[pulumi.Input[Union['RoleRefArgs', 'RoleRefArgsDict']]] = None,
+                 subjects: Optional[pulumi.Input[Sequence[pulumi.Input[Union['SubjectArgs', 'SubjectArgsDict']]]]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/rbac/v1/ClusterRoleBindingList.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1/ClusterRoleBindingList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class ClusterRoleBindingList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ClusterRoleBindingArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ClusterRoleBindingArgs', 'ClusterRoleBindingArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         ClusterRoleBindingList is a collection of ClusterRoleBindings
@@ -101,9 +106,9 @@ class ClusterRoleBindingList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ClusterRoleBindingArgs']]]] items: Items is a list of ClusterRoleBindings
+        :param pulumi.Input[Sequence[pulumi.Input[Union['ClusterRoleBindingArgs', 'ClusterRoleBindingArgsDict']]]] items: Items is a list of ClusterRoleBindings
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard object's metadata.
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard object's metadata.
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class ClusterRoleBindingList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ClusterRoleBindingArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ClusterRoleBindingArgs', 'ClusterRoleBindingArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/rbac/v1/ClusterRoleBindingPatch.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1/ClusterRoleBindingPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -109,9 +114,9 @@ class ClusterRoleBindingPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 role_ref: Optional[pulumi.Input[pulumi.InputType['RoleRefPatchArgs']]] = None,
-                 subjects: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SubjectPatchArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 role_ref: Optional[pulumi.Input[Union['RoleRefPatchArgs', 'RoleRefPatchArgsDict']]] = None,
+                 subjects: Optional[pulumi.Input[Sequence[pulumi.Input[Union['SubjectPatchArgs', 'SubjectPatchArgsDict']]]]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -126,9 +131,9 @@ class ClusterRoleBindingPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata.
-        :param pulumi.Input[pulumi.InputType['RoleRefPatchArgs']] role_ref: RoleRef can only reference a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error. This field is immutable.
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SubjectPatchArgs']]]] subjects: Subjects holds references to the objects the role applies to.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata.
+        :param pulumi.Input[Union['RoleRefPatchArgs', 'RoleRefPatchArgsDict']] role_ref: RoleRef can only reference a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error. This field is immutable.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['SubjectPatchArgs', 'SubjectPatchArgsDict']]]] subjects: Subjects holds references to the objects the role applies to.
         """
         ...
     @overload
@@ -162,9 +167,9 @@ class ClusterRoleBindingPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 role_ref: Optional[pulumi.Input[pulumi.InputType['RoleRefPatchArgs']]] = None,
-                 subjects: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SubjectPatchArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 role_ref: Optional[pulumi.Input[Union['RoleRefPatchArgs', 'RoleRefPatchArgsDict']]] = None,
+                 subjects: Optional[pulumi.Input[Sequence[pulumi.Input[Union['SubjectPatchArgs', 'SubjectPatchArgsDict']]]]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/rbac/v1/ClusterRoleList.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1/ClusterRoleList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class ClusterRoleList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ClusterRoleArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ClusterRoleArgs', 'ClusterRoleArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         ClusterRoleList is a collection of ClusterRoles
@@ -101,9 +106,9 @@ class ClusterRoleList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ClusterRoleArgs']]]] items: Items is a list of ClusterRoles
+        :param pulumi.Input[Sequence[pulumi.Input[Union['ClusterRoleArgs', 'ClusterRoleArgsDict']]]] items: Items is a list of ClusterRoles
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard object's metadata.
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard object's metadata.
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class ClusterRoleList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ClusterRoleArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ClusterRoleArgs', 'ClusterRoleArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/rbac/v1/ClusterRolePatch.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1/ClusterRolePatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -107,11 +112,11 @@ class ClusterRolePatch(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 aggregation_rule: Optional[pulumi.Input[pulumi.InputType['AggregationRulePatchArgs']]] = None,
+                 aggregation_rule: Optional[pulumi.Input[Union['AggregationRulePatchArgs', 'AggregationRulePatchArgsDict']]] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 rules: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PolicyRulePatchArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 rules: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PolicyRulePatchArgs', 'PolicyRulePatchArgsDict']]]]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -124,11 +129,11 @@ class ClusterRolePatch(pulumi.CustomResource):
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[pulumi.InputType['AggregationRulePatchArgs']] aggregation_rule: AggregationRule is an optional field that describes how to build the Rules for this ClusterRole. If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be stomped by the controller.
+        :param pulumi.Input[Union['AggregationRulePatchArgs', 'AggregationRulePatchArgsDict']] aggregation_rule: AggregationRule is an optional field that describes how to build the Rules for this ClusterRole. If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be stomped by the controller.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata.
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PolicyRulePatchArgs']]]] rules: Rules holds all the PolicyRules for this ClusterRole
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['PolicyRulePatchArgs', 'PolicyRulePatchArgsDict']]]] rules: Rules holds all the PolicyRules for this ClusterRole
         """
         ...
     @overload
@@ -160,11 +165,11 @@ class ClusterRolePatch(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 aggregation_rule: Optional[pulumi.Input[pulumi.InputType['AggregationRulePatchArgs']]] = None,
+                 aggregation_rule: Optional[pulumi.Input[Union['AggregationRulePatchArgs', 'AggregationRulePatchArgsDict']]] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 rules: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PolicyRulePatchArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 rules: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PolicyRulePatchArgs', 'PolicyRulePatchArgsDict']]]]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/rbac/v1/Role.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1/Role.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class Role(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 rules: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PolicyRuleArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 rules: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PolicyRuleArgs', 'PolicyRuleArgsDict']]]]] = None,
                  __props__=None):
         """
         Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding.
@@ -103,8 +108,8 @@ class Role(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata.
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PolicyRuleArgs']]]] rules: Rules holds all the PolicyRules for this Role
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['PolicyRuleArgs', 'PolicyRuleArgsDict']]]] rules: Rules holds all the PolicyRules for this Role
         """
         ...
     @overload
@@ -132,8 +137,8 @@ class Role(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 rules: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PolicyRuleArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 rules: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PolicyRuleArgs', 'PolicyRuleArgsDict']]]]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/rbac/v1/RoleBinding.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1/RoleBinding.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -108,9 +113,9 @@ class RoleBinding(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 role_ref: Optional[pulumi.Input[pulumi.InputType['RoleRefArgs']]] = None,
-                 subjects: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SubjectArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 role_ref: Optional[pulumi.Input[Union['RoleRefArgs', 'RoleRefArgsDict']]] = None,
+                 subjects: Optional[pulumi.Input[Sequence[pulumi.Input[Union['SubjectArgs', 'SubjectArgsDict']]]]] = None,
                  __props__=None):
         """
         RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace. It adds who information via Subjects and namespace information by which namespace it exists in.  RoleBindings in a given namespace only have effect in that namespace.
@@ -119,9 +124,9 @@ class RoleBinding(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata.
-        :param pulumi.Input[pulumi.InputType['RoleRefArgs']] role_ref: RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error. This field is immutable.
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SubjectArgs']]]] subjects: Subjects holds references to the objects the role applies to.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata.
+        :param pulumi.Input[Union['RoleRefArgs', 'RoleRefArgsDict']] role_ref: RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error. This field is immutable.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['SubjectArgs', 'SubjectArgsDict']]]] subjects: Subjects holds references to the objects the role applies to.
         """
         ...
     @overload
@@ -149,9 +154,9 @@ class RoleBinding(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 role_ref: Optional[pulumi.Input[pulumi.InputType['RoleRefArgs']]] = None,
-                 subjects: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SubjectArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 role_ref: Optional[pulumi.Input[Union['RoleRefArgs', 'RoleRefArgsDict']]] = None,
+                 subjects: Optional[pulumi.Input[Sequence[pulumi.Input[Union['SubjectArgs', 'SubjectArgsDict']]]]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/rbac/v1/RoleBindingList.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1/RoleBindingList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class RoleBindingList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['RoleBindingArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['RoleBindingArgs', 'RoleBindingArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         RoleBindingList is a collection of RoleBindings
@@ -101,9 +106,9 @@ class RoleBindingList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['RoleBindingArgs']]]] items: Items is a list of RoleBindings
+        :param pulumi.Input[Sequence[pulumi.Input[Union['RoleBindingArgs', 'RoleBindingArgsDict']]]] items: Items is a list of RoleBindings
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard object's metadata.
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard object's metadata.
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class RoleBindingList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['RoleBindingArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['RoleBindingArgs', 'RoleBindingArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/rbac/v1/RoleBindingPatch.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1/RoleBindingPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -109,9 +114,9 @@ class RoleBindingPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 role_ref: Optional[pulumi.Input[pulumi.InputType['RoleRefPatchArgs']]] = None,
-                 subjects: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SubjectPatchArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 role_ref: Optional[pulumi.Input[Union['RoleRefPatchArgs', 'RoleRefPatchArgsDict']]] = None,
+                 subjects: Optional[pulumi.Input[Sequence[pulumi.Input[Union['SubjectPatchArgs', 'SubjectPatchArgsDict']]]]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -126,9 +131,9 @@ class RoleBindingPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata.
-        :param pulumi.Input[pulumi.InputType['RoleRefPatchArgs']] role_ref: RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error. This field is immutable.
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SubjectPatchArgs']]]] subjects: Subjects holds references to the objects the role applies to.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata.
+        :param pulumi.Input[Union['RoleRefPatchArgs', 'RoleRefPatchArgsDict']] role_ref: RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error. This field is immutable.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['SubjectPatchArgs', 'SubjectPatchArgsDict']]]] subjects: Subjects holds references to the objects the role applies to.
         """
         ...
     @overload
@@ -162,9 +167,9 @@ class RoleBindingPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 role_ref: Optional[pulumi.Input[pulumi.InputType['RoleRefPatchArgs']]] = None,
-                 subjects: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SubjectPatchArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 role_ref: Optional[pulumi.Input[Union['RoleRefPatchArgs', 'RoleRefPatchArgsDict']]] = None,
+                 subjects: Optional[pulumi.Input[Sequence[pulumi.Input[Union['SubjectPatchArgs', 'SubjectPatchArgsDict']]]]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/rbac/v1/RoleList.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1/RoleList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class RoleList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['RoleArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['RoleArgs', 'RoleArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         RoleList is a collection of Roles
@@ -101,9 +106,9 @@ class RoleList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['RoleArgs']]]] items: Items is a list of Roles
+        :param pulumi.Input[Sequence[pulumi.Input[Union['RoleArgs', 'RoleArgsDict']]]] items: Items is a list of Roles
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard object's metadata.
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard object's metadata.
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class RoleList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['RoleArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['RoleArgs', 'RoleArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/rbac/v1/RolePatch.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1/RolePatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class RolePatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 rules: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PolicyRulePatchArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 rules: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PolicyRulePatchArgs', 'PolicyRulePatchArgsDict']]]]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -109,8 +114,8 @@ class RolePatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata.
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PolicyRulePatchArgs']]]] rules: Rules holds all the PolicyRules for this Role
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['PolicyRulePatchArgs', 'PolicyRulePatchArgsDict']]]] rules: Rules holds all the PolicyRules for this Role
         """
         ...
     @overload
@@ -144,8 +149,8 @@ class RolePatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 rules: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PolicyRulePatchArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 rules: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PolicyRulePatchArgs', 'PolicyRulePatchArgsDict']]]]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/rbac/v1/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1/_inputs.py
@@ -4,26 +4,57 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import meta as _meta
 
 __all__ = [
     'AggregationRulePatchArgs',
+    'AggregationRulePatchArgsDict',
     'AggregationRuleArgs',
+    'AggregationRuleArgsDict',
     'ClusterRoleBindingArgs',
+    'ClusterRoleBindingArgsDict',
     'ClusterRoleArgs',
+    'ClusterRoleArgsDict',
     'PolicyRulePatchArgs',
+    'PolicyRulePatchArgsDict',
     'PolicyRuleArgs',
+    'PolicyRuleArgsDict',
     'RoleBindingArgs',
+    'RoleBindingArgsDict',
     'RoleRefPatchArgs',
+    'RoleRefPatchArgsDict',
     'RoleRefArgs',
+    'RoleRefArgsDict',
     'RoleArgs',
+    'RoleArgsDict',
     'SubjectPatchArgs',
+    'SubjectPatchArgsDict',
     'SubjectArgs',
+    'SubjectArgsDict',
 ]
+
+MYPY = False
+
+if not MYPY:
+    class AggregationRulePatchArgsDict(TypedDict):
+        """
+        AggregationRule describes how to locate ClusterRoles to aggregate into the ClusterRole
+        """
+        cluster_role_selectors: NotRequired[pulumi.Input[Sequence[pulumi.Input['_meta.v1.LabelSelectorPatchArgsDict']]]]
+        """
+        ClusterRoleSelectors holds a list of selectors which will be used to find ClusterRoles and create the rules. If any of the selectors match, then the ClusterRole's permissions will be added
+        """
+elif False:
+    AggregationRulePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class AggregationRulePatchArgs:
@@ -49,6 +80,18 @@ class AggregationRulePatchArgs:
         pulumi.set(self, "cluster_role_selectors", value)
 
 
+if not MYPY:
+    class AggregationRuleArgsDict(TypedDict):
+        """
+        AggregationRule describes how to locate ClusterRoles to aggregate into the ClusterRole
+        """
+        cluster_role_selectors: NotRequired[pulumi.Input[Sequence[pulumi.Input['_meta.v1.LabelSelectorArgsDict']]]]
+        """
+        ClusterRoleSelectors holds a list of selectors which will be used to find ClusterRoles and create the rules. If any of the selectors match, then the ClusterRole's permissions will be added
+        """
+elif False:
+    AggregationRuleArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class AggregationRuleArgs:
     def __init__(__self__, *,
@@ -72,6 +115,34 @@ class AggregationRuleArgs:
     def cluster_role_selectors(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['_meta.v1.LabelSelectorArgs']]]]):
         pulumi.set(self, "cluster_role_selectors", value)
 
+
+if not MYPY:
+    class ClusterRoleBindingArgsDict(TypedDict):
+        """
+        ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace, and adds who information via Subject.
+        """
+        role_ref: pulumi.Input['RoleRefArgsDict']
+        """
+        RoleRef can only reference a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error. This field is immutable.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata.
+        """
+        subjects: NotRequired[pulumi.Input[Sequence[pulumi.Input['SubjectArgsDict']]]]
+        """
+        Subjects holds references to the objects the role applies to.
+        """
+elif False:
+    ClusterRoleBindingArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ClusterRoleBindingArgs:
@@ -159,6 +230,34 @@ class ClusterRoleBindingArgs:
     def subjects(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['SubjectArgs']]]]):
         pulumi.set(self, "subjects", value)
 
+
+if not MYPY:
+    class ClusterRoleArgsDict(TypedDict):
+        """
+        ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding.
+        """
+        aggregation_rule: NotRequired[pulumi.Input['AggregationRuleArgsDict']]
+        """
+        AggregationRule is an optional field that describes how to build the Rules for this ClusterRole. If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be stomped by the controller.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata.
+        """
+        rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['PolicyRuleArgsDict']]]]
+        """
+        Rules holds all the PolicyRules for this ClusterRole
+        """
+elif False:
+    ClusterRoleArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ClusterRoleArgs:
@@ -248,6 +347,34 @@ class ClusterRoleArgs:
         pulumi.set(self, "rules", value)
 
 
+if not MYPY:
+    class PolicyRulePatchArgsDict(TypedDict):
+        """
+        PolicyRule holds information that describes a policy rule, but does not contain information about who the rule applies to or which namespace the rule applies to.
+        """
+        api_groups: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed. "" represents the core API group and "*" represents all API groups.
+        """
+        non_resource_urls: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding. Rules can either apply to API resources (such as "pods" or "secrets") or non-resource URL paths (such as "/api"),  but not both.
+        """
+        resource_names: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
+        """
+        resources: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Resources is a list of resources this rule applies to. '*' represents all resources.
+        """
+        verbs: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
+        """
+elif False:
+    PolicyRulePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PolicyRulePatchArgs:
     def __init__(__self__, *,
@@ -336,6 +463,34 @@ class PolicyRulePatchArgs:
         pulumi.set(self, "verbs", value)
 
 
+if not MYPY:
+    class PolicyRuleArgsDict(TypedDict):
+        """
+        PolicyRule holds information that describes a policy rule, but does not contain information about who the rule applies to or which namespace the rule applies to.
+        """
+        verbs: pulumi.Input[Sequence[pulumi.Input[str]]]
+        """
+        Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
+        """
+        api_groups: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed. "" represents the core API group and "*" represents all API groups.
+        """
+        non_resource_urls: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding. Rules can either apply to API resources (such as "pods" or "secrets") or non-resource URL paths (such as "/api"),  but not both.
+        """
+        resource_names: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
+        """
+        resources: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Resources is a list of resources this rule applies to. '*' represents all resources.
+        """
+elif False:
+    PolicyRuleArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PolicyRuleArgs:
     def __init__(__self__, *,
@@ -422,6 +577,34 @@ class PolicyRuleArgs:
     def resources(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]):
         pulumi.set(self, "resources", value)
 
+
+if not MYPY:
+    class RoleBindingArgsDict(TypedDict):
+        """
+        RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace. It adds who information via Subjects and namespace information by which namespace it exists in.  RoleBindings in a given namespace only have effect in that namespace.
+        """
+        role_ref: pulumi.Input['RoleRefArgsDict']
+        """
+        RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error. This field is immutable.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata.
+        """
+        subjects: NotRequired[pulumi.Input[Sequence[pulumi.Input['SubjectArgsDict']]]]
+        """
+        Subjects holds references to the objects the role applies to.
+        """
+elif False:
+    RoleBindingArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class RoleBindingArgs:
@@ -510,6 +693,26 @@ class RoleBindingArgs:
         pulumi.set(self, "subjects", value)
 
 
+if not MYPY:
+    class RoleRefPatchArgsDict(TypedDict):
+        """
+        RoleRef contains information that points to the role being used
+        """
+        api_group: NotRequired[pulumi.Input[str]]
+        """
+        APIGroup is the group for the resource being referenced
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is the type of resource being referenced
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name is the name of resource being referenced
+        """
+elif False:
+    RoleRefPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class RoleRefPatchArgs:
     def __init__(__self__, *,
@@ -566,6 +769,26 @@ class RoleRefPatchArgs:
         pulumi.set(self, "name", value)
 
 
+if not MYPY:
+    class RoleRefArgsDict(TypedDict):
+        """
+        RoleRef contains information that points to the role being used
+        """
+        api_group: pulumi.Input[str]
+        """
+        APIGroup is the group for the resource being referenced
+        """
+        kind: pulumi.Input[str]
+        """
+        Kind is the type of resource being referenced
+        """
+        name: pulumi.Input[str]
+        """
+        Name is the name of resource being referenced
+        """
+elif False:
+    RoleRefArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class RoleRefArgs:
     def __init__(__self__, *,
@@ -618,6 +841,30 @@ class RoleRefArgs:
     def name(self, value: pulumi.Input[str]):
         pulumi.set(self, "name", value)
 
+
+if not MYPY:
+    class RoleArgsDict(TypedDict):
+        """
+        Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata.
+        """
+        rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['PolicyRuleArgsDict']]]]
+        """
+        Rules holds all the PolicyRules for this Role
+        """
+elif False:
+    RoleArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class RoleArgs:
@@ -691,6 +938,30 @@ class RoleArgs:
         pulumi.set(self, "rules", value)
 
 
+if not MYPY:
+    class SubjectPatchArgsDict(TypedDict):
+        """
+        Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.
+        """
+        api_group: NotRequired[pulumi.Input[str]]
+        """
+        APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name of the object being referenced.
+        """
+        namespace: NotRequired[pulumi.Input[str]]
+        """
+        Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
+        """
+elif False:
+    SubjectPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class SubjectPatchArgs:
     def __init__(__self__, *,
@@ -762,6 +1033,30 @@ class SubjectPatchArgs:
     def namespace(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "namespace", value)
 
+
+if not MYPY:
+    class SubjectArgsDict(TypedDict):
+        """
+        Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.
+        """
+        kind: pulumi.Input[str]
+        """
+        Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+        """
+        name: pulumi.Input[str]
+        """
+        Name of the object being referenced.
+        """
+        api_group: NotRequired[pulumi.Input[str]]
+        """
+        APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+        """
+        namespace: NotRequired[pulumi.Input[str]]
+        """
+        Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
+        """
+elif False:
+    SubjectArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class SubjectArgs:

--- a/sdk/python/pulumi_kubernetes/rbac/v1/outputs.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1/outputs.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta

--- a/sdk/python/pulumi_kubernetes/rbac/v1alpha1/ClusterRole.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1alpha1/ClusterRole.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -107,22 +112,22 @@ class ClusterRole(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 aggregation_rule: Optional[pulumi.Input[pulumi.InputType['AggregationRuleArgs']]] = None,
+                 aggregation_rule: Optional[pulumi.Input[Union['AggregationRuleArgs', 'AggregationRuleArgsDict']]] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 rules: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PolicyRuleArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 rules: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PolicyRuleArgs', 'PolicyRuleArgsDict']]]]] = None,
                  __props__=None):
         """
         ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRole, and will no longer be served in v1.20.
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[pulumi.InputType['AggregationRuleArgs']] aggregation_rule: AggregationRule is an optional field that describes how to build the Rules for this ClusterRole. If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be stomped by the controller.
+        :param pulumi.Input[Union['AggregationRuleArgs', 'AggregationRuleArgsDict']] aggregation_rule: AggregationRule is an optional field that describes how to build the Rules for this ClusterRole. If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be stomped by the controller.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata.
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PolicyRuleArgs']]]] rules: Rules holds all the PolicyRules for this ClusterRole
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['PolicyRuleArgs', 'PolicyRuleArgsDict']]]] rules: Rules holds all the PolicyRules for this ClusterRole
         """
         ...
     @overload
@@ -148,11 +153,11 @@ class ClusterRole(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 aggregation_rule: Optional[pulumi.Input[pulumi.InputType['AggregationRuleArgs']]] = None,
+                 aggregation_rule: Optional[pulumi.Input[Union['AggregationRuleArgs', 'AggregationRuleArgsDict']]] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 rules: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PolicyRuleArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 rules: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PolicyRuleArgs', 'PolicyRuleArgsDict']]]]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/rbac/v1alpha1/ClusterRoleBinding.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1alpha1/ClusterRoleBinding.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -108,9 +113,9 @@ class ClusterRoleBinding(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 role_ref: Optional[pulumi.Input[pulumi.InputType['RoleRefArgs']]] = None,
-                 subjects: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SubjectArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 role_ref: Optional[pulumi.Input[Union['RoleRefArgs', 'RoleRefArgsDict']]] = None,
+                 subjects: Optional[pulumi.Input[Sequence[pulumi.Input[Union['SubjectArgs', 'SubjectArgsDict']]]]] = None,
                  __props__=None):
         """
         ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace, and adds who information via Subject. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRoleBinding, and will no longer be served in v1.20.
@@ -119,9 +124,9 @@ class ClusterRoleBinding(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata.
-        :param pulumi.Input[pulumi.InputType['RoleRefArgs']] role_ref: RoleRef can only reference a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SubjectArgs']]]] subjects: Subjects holds references to the objects the role applies to.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata.
+        :param pulumi.Input[Union['RoleRefArgs', 'RoleRefArgsDict']] role_ref: RoleRef can only reference a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['SubjectArgs', 'SubjectArgsDict']]]] subjects: Subjects holds references to the objects the role applies to.
         """
         ...
     @overload
@@ -149,9 +154,9 @@ class ClusterRoleBinding(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 role_ref: Optional[pulumi.Input[pulumi.InputType['RoleRefArgs']]] = None,
-                 subjects: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SubjectArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 role_ref: Optional[pulumi.Input[Union['RoleRefArgs', 'RoleRefArgsDict']]] = None,
+                 subjects: Optional[pulumi.Input[Sequence[pulumi.Input[Union['SubjectArgs', 'SubjectArgsDict']]]]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/rbac/v1alpha1/ClusterRoleBindingList.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1alpha1/ClusterRoleBindingList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class ClusterRoleBindingList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ClusterRoleBindingArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ClusterRoleBindingArgs', 'ClusterRoleBindingArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         ClusterRoleBindingList is a collection of ClusterRoleBindings. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRoleBindings, and will no longer be served in v1.20.
@@ -101,9 +106,9 @@ class ClusterRoleBindingList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ClusterRoleBindingArgs']]]] items: Items is a list of ClusterRoleBindings
+        :param pulumi.Input[Sequence[pulumi.Input[Union['ClusterRoleBindingArgs', 'ClusterRoleBindingArgsDict']]]] items: Items is a list of ClusterRoleBindings
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard object's metadata.
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard object's metadata.
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class ClusterRoleBindingList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ClusterRoleBindingArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ClusterRoleBindingArgs', 'ClusterRoleBindingArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/rbac/v1alpha1/ClusterRoleBindingPatch.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1alpha1/ClusterRoleBindingPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -109,9 +114,9 @@ class ClusterRoleBindingPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 role_ref: Optional[pulumi.Input[pulumi.InputType['RoleRefPatchArgs']]] = None,
-                 subjects: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SubjectPatchArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 role_ref: Optional[pulumi.Input[Union['RoleRefPatchArgs', 'RoleRefPatchArgsDict']]] = None,
+                 subjects: Optional[pulumi.Input[Sequence[pulumi.Input[Union['SubjectPatchArgs', 'SubjectPatchArgsDict']]]]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -126,9 +131,9 @@ class ClusterRoleBindingPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata.
-        :param pulumi.Input[pulumi.InputType['RoleRefPatchArgs']] role_ref: RoleRef can only reference a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SubjectPatchArgs']]]] subjects: Subjects holds references to the objects the role applies to.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata.
+        :param pulumi.Input[Union['RoleRefPatchArgs', 'RoleRefPatchArgsDict']] role_ref: RoleRef can only reference a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['SubjectPatchArgs', 'SubjectPatchArgsDict']]]] subjects: Subjects holds references to the objects the role applies to.
         """
         ...
     @overload
@@ -162,9 +167,9 @@ class ClusterRoleBindingPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 role_ref: Optional[pulumi.Input[pulumi.InputType['RoleRefPatchArgs']]] = None,
-                 subjects: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SubjectPatchArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 role_ref: Optional[pulumi.Input[Union['RoleRefPatchArgs', 'RoleRefPatchArgsDict']]] = None,
+                 subjects: Optional[pulumi.Input[Sequence[pulumi.Input[Union['SubjectPatchArgs', 'SubjectPatchArgsDict']]]]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/rbac/v1alpha1/ClusterRoleList.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1alpha1/ClusterRoleList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class ClusterRoleList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ClusterRoleArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ClusterRoleArgs', 'ClusterRoleArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         ClusterRoleList is a collection of ClusterRoles. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRoles, and will no longer be served in v1.20.
@@ -101,9 +106,9 @@ class ClusterRoleList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ClusterRoleArgs']]]] items: Items is a list of ClusterRoles
+        :param pulumi.Input[Sequence[pulumi.Input[Union['ClusterRoleArgs', 'ClusterRoleArgsDict']]]] items: Items is a list of ClusterRoles
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard object's metadata.
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard object's metadata.
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class ClusterRoleList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ClusterRoleArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ClusterRoleArgs', 'ClusterRoleArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/rbac/v1alpha1/ClusterRolePatch.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1alpha1/ClusterRolePatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -107,11 +112,11 @@ class ClusterRolePatch(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 aggregation_rule: Optional[pulumi.Input[pulumi.InputType['AggregationRulePatchArgs']]] = None,
+                 aggregation_rule: Optional[pulumi.Input[Union['AggregationRulePatchArgs', 'AggregationRulePatchArgsDict']]] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 rules: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PolicyRulePatchArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 rules: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PolicyRulePatchArgs', 'PolicyRulePatchArgsDict']]]]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -124,11 +129,11 @@ class ClusterRolePatch(pulumi.CustomResource):
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[pulumi.InputType['AggregationRulePatchArgs']] aggregation_rule: AggregationRule is an optional field that describes how to build the Rules for this ClusterRole. If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be stomped by the controller.
+        :param pulumi.Input[Union['AggregationRulePatchArgs', 'AggregationRulePatchArgsDict']] aggregation_rule: AggregationRule is an optional field that describes how to build the Rules for this ClusterRole. If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be stomped by the controller.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata.
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PolicyRulePatchArgs']]]] rules: Rules holds all the PolicyRules for this ClusterRole
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['PolicyRulePatchArgs', 'PolicyRulePatchArgsDict']]]] rules: Rules holds all the PolicyRules for this ClusterRole
         """
         ...
     @overload
@@ -160,11 +165,11 @@ class ClusterRolePatch(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 aggregation_rule: Optional[pulumi.Input[pulumi.InputType['AggregationRulePatchArgs']]] = None,
+                 aggregation_rule: Optional[pulumi.Input[Union['AggregationRulePatchArgs', 'AggregationRulePatchArgsDict']]] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 rules: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PolicyRulePatchArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 rules: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PolicyRulePatchArgs', 'PolicyRulePatchArgsDict']]]]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/rbac/v1alpha1/Role.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1alpha1/Role.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class Role(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 rules: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PolicyRuleArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 rules: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PolicyRuleArgs', 'PolicyRuleArgsDict']]]]] = None,
                  __props__=None):
         """
         Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 Role, and will no longer be served in v1.20.
@@ -103,8 +108,8 @@ class Role(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata.
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PolicyRuleArgs']]]] rules: Rules holds all the PolicyRules for this Role
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['PolicyRuleArgs', 'PolicyRuleArgsDict']]]] rules: Rules holds all the PolicyRules for this Role
         """
         ...
     @overload
@@ -132,8 +137,8 @@ class Role(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 rules: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PolicyRuleArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 rules: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PolicyRuleArgs', 'PolicyRuleArgsDict']]]]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/rbac/v1alpha1/RoleBinding.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1alpha1/RoleBinding.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -108,9 +113,9 @@ class RoleBinding(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 role_ref: Optional[pulumi.Input[pulumi.InputType['RoleRefArgs']]] = None,
-                 subjects: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SubjectArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 role_ref: Optional[pulumi.Input[Union['RoleRefArgs', 'RoleRefArgsDict']]] = None,
+                 subjects: Optional[pulumi.Input[Sequence[pulumi.Input[Union['SubjectArgs', 'SubjectArgsDict']]]]] = None,
                  __props__=None):
         """
         RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace. It adds who information via Subjects and namespace information by which namespace it exists in.  RoleBindings in a given namespace only have effect in that namespace. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 RoleBinding, and will no longer be served in v1.20.
@@ -119,9 +124,9 @@ class RoleBinding(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata.
-        :param pulumi.Input[pulumi.InputType['RoleRefArgs']] role_ref: RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SubjectArgs']]]] subjects: Subjects holds references to the objects the role applies to.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata.
+        :param pulumi.Input[Union['RoleRefArgs', 'RoleRefArgsDict']] role_ref: RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['SubjectArgs', 'SubjectArgsDict']]]] subjects: Subjects holds references to the objects the role applies to.
         """
         ...
     @overload
@@ -149,9 +154,9 @@ class RoleBinding(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 role_ref: Optional[pulumi.Input[pulumi.InputType['RoleRefArgs']]] = None,
-                 subjects: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SubjectArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 role_ref: Optional[pulumi.Input[Union['RoleRefArgs', 'RoleRefArgsDict']]] = None,
+                 subjects: Optional[pulumi.Input[Sequence[pulumi.Input[Union['SubjectArgs', 'SubjectArgsDict']]]]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/rbac/v1alpha1/RoleBindingList.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1alpha1/RoleBindingList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class RoleBindingList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['RoleBindingArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['RoleBindingArgs', 'RoleBindingArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         RoleBindingList is a collection of RoleBindings Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 RoleBindingList, and will no longer be served in v1.20.
@@ -101,9 +106,9 @@ class RoleBindingList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['RoleBindingArgs']]]] items: Items is a list of RoleBindings
+        :param pulumi.Input[Sequence[pulumi.Input[Union['RoleBindingArgs', 'RoleBindingArgsDict']]]] items: Items is a list of RoleBindings
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard object's metadata.
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard object's metadata.
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class RoleBindingList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['RoleBindingArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['RoleBindingArgs', 'RoleBindingArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/rbac/v1alpha1/RoleBindingPatch.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1alpha1/RoleBindingPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -109,9 +114,9 @@ class RoleBindingPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 role_ref: Optional[pulumi.Input[pulumi.InputType['RoleRefPatchArgs']]] = None,
-                 subjects: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SubjectPatchArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 role_ref: Optional[pulumi.Input[Union['RoleRefPatchArgs', 'RoleRefPatchArgsDict']]] = None,
+                 subjects: Optional[pulumi.Input[Sequence[pulumi.Input[Union['SubjectPatchArgs', 'SubjectPatchArgsDict']]]]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -126,9 +131,9 @@ class RoleBindingPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata.
-        :param pulumi.Input[pulumi.InputType['RoleRefPatchArgs']] role_ref: RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SubjectPatchArgs']]]] subjects: Subjects holds references to the objects the role applies to.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata.
+        :param pulumi.Input[Union['RoleRefPatchArgs', 'RoleRefPatchArgsDict']] role_ref: RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['SubjectPatchArgs', 'SubjectPatchArgsDict']]]] subjects: Subjects holds references to the objects the role applies to.
         """
         ...
     @overload
@@ -162,9 +167,9 @@ class RoleBindingPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 role_ref: Optional[pulumi.Input[pulumi.InputType['RoleRefPatchArgs']]] = None,
-                 subjects: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SubjectPatchArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 role_ref: Optional[pulumi.Input[Union['RoleRefPatchArgs', 'RoleRefPatchArgsDict']]] = None,
+                 subjects: Optional[pulumi.Input[Sequence[pulumi.Input[Union['SubjectPatchArgs', 'SubjectPatchArgsDict']]]]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/rbac/v1alpha1/RoleList.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1alpha1/RoleList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class RoleList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['RoleArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['RoleArgs', 'RoleArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         RoleList is a collection of Roles. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 RoleList, and will no longer be served in v1.20.
@@ -101,9 +106,9 @@ class RoleList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['RoleArgs']]]] items: Items is a list of Roles
+        :param pulumi.Input[Sequence[pulumi.Input[Union['RoleArgs', 'RoleArgsDict']]]] items: Items is a list of Roles
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard object's metadata.
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard object's metadata.
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class RoleList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['RoleArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['RoleArgs', 'RoleArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/rbac/v1alpha1/RolePatch.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1alpha1/RolePatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class RolePatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 rules: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PolicyRulePatchArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 rules: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PolicyRulePatchArgs', 'PolicyRulePatchArgsDict']]]]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -109,8 +114,8 @@ class RolePatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata.
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PolicyRulePatchArgs']]]] rules: Rules holds all the PolicyRules for this Role
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['PolicyRulePatchArgs', 'PolicyRulePatchArgsDict']]]] rules: Rules holds all the PolicyRules for this Role
         """
         ...
     @overload
@@ -144,8 +149,8 @@ class RolePatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 rules: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PolicyRulePatchArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 rules: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PolicyRulePatchArgs', 'PolicyRulePatchArgsDict']]]]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/rbac/v1alpha1/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1alpha1/_inputs.py
@@ -4,26 +4,57 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import meta as _meta
 
 __all__ = [
     'AggregationRulePatchArgs',
+    'AggregationRulePatchArgsDict',
     'AggregationRuleArgs',
+    'AggregationRuleArgsDict',
     'ClusterRoleBindingArgs',
+    'ClusterRoleBindingArgsDict',
     'ClusterRoleArgs',
+    'ClusterRoleArgsDict',
     'PolicyRulePatchArgs',
+    'PolicyRulePatchArgsDict',
     'PolicyRuleArgs',
+    'PolicyRuleArgsDict',
     'RoleBindingArgs',
+    'RoleBindingArgsDict',
     'RoleRefPatchArgs',
+    'RoleRefPatchArgsDict',
     'RoleRefArgs',
+    'RoleRefArgsDict',
     'RoleArgs',
+    'RoleArgsDict',
     'SubjectPatchArgs',
+    'SubjectPatchArgsDict',
     'SubjectArgs',
+    'SubjectArgsDict',
 ]
+
+MYPY = False
+
+if not MYPY:
+    class AggregationRulePatchArgsDict(TypedDict):
+        """
+        AggregationRule describes how to locate ClusterRoles to aggregate into the ClusterRole
+        """
+        cluster_role_selectors: NotRequired[pulumi.Input[Sequence[pulumi.Input['_meta.v1.LabelSelectorPatchArgsDict']]]]
+        """
+        ClusterRoleSelectors holds a list of selectors which will be used to find ClusterRoles and create the rules. If any of the selectors match, then the ClusterRole's permissions will be added
+        """
+elif False:
+    AggregationRulePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class AggregationRulePatchArgs:
@@ -49,6 +80,18 @@ class AggregationRulePatchArgs:
         pulumi.set(self, "cluster_role_selectors", value)
 
 
+if not MYPY:
+    class AggregationRuleArgsDict(TypedDict):
+        """
+        AggregationRule describes how to locate ClusterRoles to aggregate into the ClusterRole
+        """
+        cluster_role_selectors: NotRequired[pulumi.Input[Sequence[pulumi.Input['_meta.v1.LabelSelectorArgsDict']]]]
+        """
+        ClusterRoleSelectors holds a list of selectors which will be used to find ClusterRoles and create the rules. If any of the selectors match, then the ClusterRole's permissions will be added
+        """
+elif False:
+    AggregationRuleArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class AggregationRuleArgs:
     def __init__(__self__, *,
@@ -72,6 +115,34 @@ class AggregationRuleArgs:
     def cluster_role_selectors(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['_meta.v1.LabelSelectorArgs']]]]):
         pulumi.set(self, "cluster_role_selectors", value)
 
+
+if not MYPY:
+    class ClusterRoleBindingArgsDict(TypedDict):
+        """
+        ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace, and adds who information via Subject. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRoleBinding, and will no longer be served in v1.20.
+        """
+        role_ref: pulumi.Input['RoleRefArgsDict']
+        """
+        RoleRef can only reference a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata.
+        """
+        subjects: NotRequired[pulumi.Input[Sequence[pulumi.Input['SubjectArgsDict']]]]
+        """
+        Subjects holds references to the objects the role applies to.
+        """
+elif False:
+    ClusterRoleBindingArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ClusterRoleBindingArgs:
@@ -159,6 +230,34 @@ class ClusterRoleBindingArgs:
     def subjects(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['SubjectArgs']]]]):
         pulumi.set(self, "subjects", value)
 
+
+if not MYPY:
+    class ClusterRoleArgsDict(TypedDict):
+        """
+        ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRole, and will no longer be served in v1.20.
+        """
+        aggregation_rule: NotRequired[pulumi.Input['AggregationRuleArgsDict']]
+        """
+        AggregationRule is an optional field that describes how to build the Rules for this ClusterRole. If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be stomped by the controller.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata.
+        """
+        rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['PolicyRuleArgsDict']]]]
+        """
+        Rules holds all the PolicyRules for this ClusterRole
+        """
+elif False:
+    ClusterRoleArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ClusterRoleArgs:
@@ -248,6 +347,34 @@ class ClusterRoleArgs:
         pulumi.set(self, "rules", value)
 
 
+if not MYPY:
+    class PolicyRulePatchArgsDict(TypedDict):
+        """
+        PolicyRule holds information that describes a policy rule, but does not contain information about who the rule applies to or which namespace the rule applies to.
+        """
+        api_groups: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed.
+        """
+        non_resource_urls: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path This name is intentionally different than the internal type so that the DefaultConvert works nicely and because the ordering may be different. Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding. Rules can either apply to API resources (such as "pods" or "secrets") or non-resource URL paths (such as "/api"),  but not both.
+        """
+        resource_names: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
+        """
+        resources: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Resources is a list of resources this rule applies to.  ResourceAll represents all resources.
+        """
+        verbs: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule.  VerbAll represents all kinds.
+        """
+elif False:
+    PolicyRulePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PolicyRulePatchArgs:
     def __init__(__self__, *,
@@ -336,6 +463,34 @@ class PolicyRulePatchArgs:
         pulumi.set(self, "verbs", value)
 
 
+if not MYPY:
+    class PolicyRuleArgsDict(TypedDict):
+        """
+        PolicyRule holds information that describes a policy rule, but does not contain information about who the rule applies to or which namespace the rule applies to.
+        """
+        verbs: pulumi.Input[Sequence[pulumi.Input[str]]]
+        """
+        Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule.  VerbAll represents all kinds.
+        """
+        api_groups: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed.
+        """
+        non_resource_urls: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path This name is intentionally different than the internal type so that the DefaultConvert works nicely and because the ordering may be different. Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding. Rules can either apply to API resources (such as "pods" or "secrets") or non-resource URL paths (such as "/api"),  but not both.
+        """
+        resource_names: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
+        """
+        resources: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Resources is a list of resources this rule applies to.  ResourceAll represents all resources.
+        """
+elif False:
+    PolicyRuleArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PolicyRuleArgs:
     def __init__(__self__, *,
@@ -422,6 +577,34 @@ class PolicyRuleArgs:
     def resources(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]):
         pulumi.set(self, "resources", value)
 
+
+if not MYPY:
+    class RoleBindingArgsDict(TypedDict):
+        """
+        RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace. It adds who information via Subjects and namespace information by which namespace it exists in.  RoleBindings in a given namespace only have effect in that namespace. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 RoleBinding, and will no longer be served in v1.20.
+        """
+        role_ref: pulumi.Input['RoleRefArgsDict']
+        """
+        RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata.
+        """
+        subjects: NotRequired[pulumi.Input[Sequence[pulumi.Input['SubjectArgsDict']]]]
+        """
+        Subjects holds references to the objects the role applies to.
+        """
+elif False:
+    RoleBindingArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class RoleBindingArgs:
@@ -510,6 +693,26 @@ class RoleBindingArgs:
         pulumi.set(self, "subjects", value)
 
 
+if not MYPY:
+    class RoleRefPatchArgsDict(TypedDict):
+        """
+        RoleRef contains information that points to the role being used
+        """
+        api_group: NotRequired[pulumi.Input[str]]
+        """
+        APIGroup is the group for the resource being referenced
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is the type of resource being referenced
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name is the name of resource being referenced
+        """
+elif False:
+    RoleRefPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class RoleRefPatchArgs:
     def __init__(__self__, *,
@@ -566,6 +769,26 @@ class RoleRefPatchArgs:
         pulumi.set(self, "name", value)
 
 
+if not MYPY:
+    class RoleRefArgsDict(TypedDict):
+        """
+        RoleRef contains information that points to the role being used
+        """
+        api_group: pulumi.Input[str]
+        """
+        APIGroup is the group for the resource being referenced
+        """
+        kind: pulumi.Input[str]
+        """
+        Kind is the type of resource being referenced
+        """
+        name: pulumi.Input[str]
+        """
+        Name is the name of resource being referenced
+        """
+elif False:
+    RoleRefArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class RoleRefArgs:
     def __init__(__self__, *,
@@ -618,6 +841,30 @@ class RoleRefArgs:
     def name(self, value: pulumi.Input[str]):
         pulumi.set(self, "name", value)
 
+
+if not MYPY:
+    class RoleArgsDict(TypedDict):
+        """
+        Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 Role, and will no longer be served in v1.20.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata.
+        """
+        rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['PolicyRuleArgsDict']]]]
+        """
+        Rules holds all the PolicyRules for this Role
+        """
+elif False:
+    RoleArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class RoleArgs:
@@ -691,6 +938,30 @@ class RoleArgs:
         pulumi.set(self, "rules", value)
 
 
+if not MYPY:
+    class SubjectPatchArgsDict(TypedDict):
+        """
+        Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion holds the API group and version of the referenced subject. Defaults to "v1" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io/v1alpha1" for User and Group subjects.
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name of the object being referenced.
+        """
+        namespace: NotRequired[pulumi.Input[str]]
+        """
+        Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
+        """
+elif False:
+    SubjectPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class SubjectPatchArgs:
     def __init__(__self__, *,
@@ -762,6 +1033,30 @@ class SubjectPatchArgs:
     def namespace(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "namespace", value)
 
+
+if not MYPY:
+    class SubjectArgsDict(TypedDict):
+        """
+        Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.
+        """
+        kind: pulumi.Input[str]
+        """
+        Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+        """
+        name: pulumi.Input[str]
+        """
+        Name of the object being referenced.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion holds the API group and version of the referenced subject. Defaults to "v1" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io/v1alpha1" for User and Group subjects.
+        """
+        namespace: NotRequired[pulumi.Input[str]]
+        """
+        Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
+        """
+elif False:
+    SubjectArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class SubjectArgs:

--- a/sdk/python/pulumi_kubernetes/rbac/v1alpha1/outputs.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1alpha1/outputs.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta

--- a/sdk/python/pulumi_kubernetes/rbac/v1beta1/ClusterRole.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1beta1/ClusterRole.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -107,22 +112,22 @@ class ClusterRole(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 aggregation_rule: Optional[pulumi.Input[pulumi.InputType['AggregationRuleArgs']]] = None,
+                 aggregation_rule: Optional[pulumi.Input[Union['AggregationRuleArgs', 'AggregationRuleArgsDict']]] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 rules: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PolicyRuleArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 rules: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PolicyRuleArgs', 'PolicyRuleArgsDict']]]]] = None,
                  __props__=None):
         """
         ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRole, and will no longer be served in v1.20.
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[pulumi.InputType['AggregationRuleArgs']] aggregation_rule: AggregationRule is an optional field that describes how to build the Rules for this ClusterRole. If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be stomped by the controller.
+        :param pulumi.Input[Union['AggregationRuleArgs', 'AggregationRuleArgsDict']] aggregation_rule: AggregationRule is an optional field that describes how to build the Rules for this ClusterRole. If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be stomped by the controller.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata.
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PolicyRuleArgs']]]] rules: Rules holds all the PolicyRules for this ClusterRole
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['PolicyRuleArgs', 'PolicyRuleArgsDict']]]] rules: Rules holds all the PolicyRules for this ClusterRole
         """
         ...
     @overload
@@ -148,11 +153,11 @@ class ClusterRole(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 aggregation_rule: Optional[pulumi.Input[pulumi.InputType['AggregationRuleArgs']]] = None,
+                 aggregation_rule: Optional[pulumi.Input[Union['AggregationRuleArgs', 'AggregationRuleArgsDict']]] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 rules: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PolicyRuleArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 rules: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PolicyRuleArgs', 'PolicyRuleArgsDict']]]]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/rbac/v1beta1/ClusterRoleBinding.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1beta1/ClusterRoleBinding.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -108,9 +113,9 @@ class ClusterRoleBinding(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 role_ref: Optional[pulumi.Input[pulumi.InputType['RoleRefArgs']]] = None,
-                 subjects: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SubjectArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 role_ref: Optional[pulumi.Input[Union['RoleRefArgs', 'RoleRefArgsDict']]] = None,
+                 subjects: Optional[pulumi.Input[Sequence[pulumi.Input[Union['SubjectArgs', 'SubjectArgsDict']]]]] = None,
                  __props__=None):
         """
         ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace, and adds who information via Subject. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRoleBinding, and will no longer be served in v1.20.
@@ -119,9 +124,9 @@ class ClusterRoleBinding(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata.
-        :param pulumi.Input[pulumi.InputType['RoleRefArgs']] role_ref: RoleRef can only reference a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SubjectArgs']]]] subjects: Subjects holds references to the objects the role applies to.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata.
+        :param pulumi.Input[Union['RoleRefArgs', 'RoleRefArgsDict']] role_ref: RoleRef can only reference a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['SubjectArgs', 'SubjectArgsDict']]]] subjects: Subjects holds references to the objects the role applies to.
         """
         ...
     @overload
@@ -149,9 +154,9 @@ class ClusterRoleBinding(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 role_ref: Optional[pulumi.Input[pulumi.InputType['RoleRefArgs']]] = None,
-                 subjects: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SubjectArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 role_ref: Optional[pulumi.Input[Union['RoleRefArgs', 'RoleRefArgsDict']]] = None,
+                 subjects: Optional[pulumi.Input[Sequence[pulumi.Input[Union['SubjectArgs', 'SubjectArgsDict']]]]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/rbac/v1beta1/ClusterRoleBindingList.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1beta1/ClusterRoleBindingList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class ClusterRoleBindingList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ClusterRoleBindingArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ClusterRoleBindingArgs', 'ClusterRoleBindingArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         ClusterRoleBindingList is a collection of ClusterRoleBindings. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRoleBindingList, and will no longer be served in v1.20.
@@ -101,9 +106,9 @@ class ClusterRoleBindingList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ClusterRoleBindingArgs']]]] items: Items is a list of ClusterRoleBindings
+        :param pulumi.Input[Sequence[pulumi.Input[Union['ClusterRoleBindingArgs', 'ClusterRoleBindingArgsDict']]]] items: Items is a list of ClusterRoleBindings
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard object's metadata.
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard object's metadata.
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class ClusterRoleBindingList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ClusterRoleBindingArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ClusterRoleBindingArgs', 'ClusterRoleBindingArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/rbac/v1beta1/ClusterRoleBindingPatch.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1beta1/ClusterRoleBindingPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -109,9 +114,9 @@ class ClusterRoleBindingPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 role_ref: Optional[pulumi.Input[pulumi.InputType['RoleRefPatchArgs']]] = None,
-                 subjects: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SubjectPatchArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 role_ref: Optional[pulumi.Input[Union['RoleRefPatchArgs', 'RoleRefPatchArgsDict']]] = None,
+                 subjects: Optional[pulumi.Input[Sequence[pulumi.Input[Union['SubjectPatchArgs', 'SubjectPatchArgsDict']]]]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -126,9 +131,9 @@ class ClusterRoleBindingPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata.
-        :param pulumi.Input[pulumi.InputType['RoleRefPatchArgs']] role_ref: RoleRef can only reference a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SubjectPatchArgs']]]] subjects: Subjects holds references to the objects the role applies to.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata.
+        :param pulumi.Input[Union['RoleRefPatchArgs', 'RoleRefPatchArgsDict']] role_ref: RoleRef can only reference a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['SubjectPatchArgs', 'SubjectPatchArgsDict']]]] subjects: Subjects holds references to the objects the role applies to.
         """
         ...
     @overload
@@ -162,9 +167,9 @@ class ClusterRoleBindingPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 role_ref: Optional[pulumi.Input[pulumi.InputType['RoleRefPatchArgs']]] = None,
-                 subjects: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SubjectPatchArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 role_ref: Optional[pulumi.Input[Union['RoleRefPatchArgs', 'RoleRefPatchArgsDict']]] = None,
+                 subjects: Optional[pulumi.Input[Sequence[pulumi.Input[Union['SubjectPatchArgs', 'SubjectPatchArgsDict']]]]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/rbac/v1beta1/ClusterRoleList.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1beta1/ClusterRoleList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class ClusterRoleList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ClusterRoleArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ClusterRoleArgs', 'ClusterRoleArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         ClusterRoleList is a collection of ClusterRoles. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRoles, and will no longer be served in v1.20.
@@ -101,9 +106,9 @@ class ClusterRoleList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ClusterRoleArgs']]]] items: Items is a list of ClusterRoles
+        :param pulumi.Input[Sequence[pulumi.Input[Union['ClusterRoleArgs', 'ClusterRoleArgsDict']]]] items: Items is a list of ClusterRoles
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard object's metadata.
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard object's metadata.
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class ClusterRoleList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ClusterRoleArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ClusterRoleArgs', 'ClusterRoleArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/rbac/v1beta1/ClusterRolePatch.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1beta1/ClusterRolePatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -107,11 +112,11 @@ class ClusterRolePatch(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 aggregation_rule: Optional[pulumi.Input[pulumi.InputType['AggregationRulePatchArgs']]] = None,
+                 aggregation_rule: Optional[pulumi.Input[Union['AggregationRulePatchArgs', 'AggregationRulePatchArgsDict']]] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 rules: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PolicyRulePatchArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 rules: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PolicyRulePatchArgs', 'PolicyRulePatchArgsDict']]]]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -124,11 +129,11 @@ class ClusterRolePatch(pulumi.CustomResource):
 
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
-        :param pulumi.Input[pulumi.InputType['AggregationRulePatchArgs']] aggregation_rule: AggregationRule is an optional field that describes how to build the Rules for this ClusterRole. If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be stomped by the controller.
+        :param pulumi.Input[Union['AggregationRulePatchArgs', 'AggregationRulePatchArgsDict']] aggregation_rule: AggregationRule is an optional field that describes how to build the Rules for this ClusterRole. If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be stomped by the controller.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata.
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PolicyRulePatchArgs']]]] rules: Rules holds all the PolicyRules for this ClusterRole
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['PolicyRulePatchArgs', 'PolicyRulePatchArgsDict']]]] rules: Rules holds all the PolicyRules for this ClusterRole
         """
         ...
     @overload
@@ -160,11 +165,11 @@ class ClusterRolePatch(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 aggregation_rule: Optional[pulumi.Input[pulumi.InputType['AggregationRulePatchArgs']]] = None,
+                 aggregation_rule: Optional[pulumi.Input[Union['AggregationRulePatchArgs', 'AggregationRulePatchArgsDict']]] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 rules: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PolicyRulePatchArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 rules: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PolicyRulePatchArgs', 'PolicyRulePatchArgsDict']]]]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/rbac/v1beta1/Role.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1beta1/Role.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class Role(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 rules: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PolicyRuleArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 rules: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PolicyRuleArgs', 'PolicyRuleArgsDict']]]]] = None,
                  __props__=None):
         """
         Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 Role, and will no longer be served in v1.20.
@@ -103,8 +108,8 @@ class Role(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata.
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PolicyRuleArgs']]]] rules: Rules holds all the PolicyRules for this Role
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['PolicyRuleArgs', 'PolicyRuleArgsDict']]]] rules: Rules holds all the PolicyRules for this Role
         """
         ...
     @overload
@@ -132,8 +137,8 @@ class Role(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 rules: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PolicyRuleArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 rules: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PolicyRuleArgs', 'PolicyRuleArgsDict']]]]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/rbac/v1beta1/RoleBinding.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1beta1/RoleBinding.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -108,9 +113,9 @@ class RoleBinding(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 role_ref: Optional[pulumi.Input[pulumi.InputType['RoleRefArgs']]] = None,
-                 subjects: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SubjectArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 role_ref: Optional[pulumi.Input[Union['RoleRefArgs', 'RoleRefArgsDict']]] = None,
+                 subjects: Optional[pulumi.Input[Sequence[pulumi.Input[Union['SubjectArgs', 'SubjectArgsDict']]]]] = None,
                  __props__=None):
         """
         RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace. It adds who information via Subjects and namespace information by which namespace it exists in.  RoleBindings in a given namespace only have effect in that namespace. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 RoleBinding, and will no longer be served in v1.20.
@@ -119,9 +124,9 @@ class RoleBinding(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata.
-        :param pulumi.Input[pulumi.InputType['RoleRefArgs']] role_ref: RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SubjectArgs']]]] subjects: Subjects holds references to the objects the role applies to.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata.
+        :param pulumi.Input[Union['RoleRefArgs', 'RoleRefArgsDict']] role_ref: RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['SubjectArgs', 'SubjectArgsDict']]]] subjects: Subjects holds references to the objects the role applies to.
         """
         ...
     @overload
@@ -149,9 +154,9 @@ class RoleBinding(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 role_ref: Optional[pulumi.Input[pulumi.InputType['RoleRefArgs']]] = None,
-                 subjects: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SubjectArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 role_ref: Optional[pulumi.Input[Union['RoleRefArgs', 'RoleRefArgsDict']]] = None,
+                 subjects: Optional[pulumi.Input[Sequence[pulumi.Input[Union['SubjectArgs', 'SubjectArgsDict']]]]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/rbac/v1beta1/RoleBindingList.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1beta1/RoleBindingList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class RoleBindingList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['RoleBindingArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['RoleBindingArgs', 'RoleBindingArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         RoleBindingList is a collection of RoleBindings Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 RoleBindingList, and will no longer be served in v1.20.
@@ -101,9 +106,9 @@ class RoleBindingList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['RoleBindingArgs']]]] items: Items is a list of RoleBindings
+        :param pulumi.Input[Sequence[pulumi.Input[Union['RoleBindingArgs', 'RoleBindingArgsDict']]]] items: Items is a list of RoleBindings
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard object's metadata.
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard object's metadata.
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class RoleBindingList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['RoleBindingArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['RoleBindingArgs', 'RoleBindingArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/rbac/v1beta1/RoleBindingPatch.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1beta1/RoleBindingPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -109,9 +114,9 @@ class RoleBindingPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 role_ref: Optional[pulumi.Input[pulumi.InputType['RoleRefPatchArgs']]] = None,
-                 subjects: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SubjectPatchArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 role_ref: Optional[pulumi.Input[Union['RoleRefPatchArgs', 'RoleRefPatchArgsDict']]] = None,
+                 subjects: Optional[pulumi.Input[Sequence[pulumi.Input[Union['SubjectPatchArgs', 'SubjectPatchArgsDict']]]]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -126,9 +131,9 @@ class RoleBindingPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata.
-        :param pulumi.Input[pulumi.InputType['RoleRefPatchArgs']] role_ref: RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SubjectPatchArgs']]]] subjects: Subjects holds references to the objects the role applies to.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata.
+        :param pulumi.Input[Union['RoleRefPatchArgs', 'RoleRefPatchArgsDict']] role_ref: RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['SubjectPatchArgs', 'SubjectPatchArgsDict']]]] subjects: Subjects holds references to the objects the role applies to.
         """
         ...
     @overload
@@ -162,9 +167,9 @@ class RoleBindingPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 role_ref: Optional[pulumi.Input[pulumi.InputType['RoleRefPatchArgs']]] = None,
-                 subjects: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['SubjectPatchArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 role_ref: Optional[pulumi.Input[Union['RoleRefPatchArgs', 'RoleRefPatchArgsDict']]] = None,
+                 subjects: Optional[pulumi.Input[Sequence[pulumi.Input[Union['SubjectPatchArgs', 'SubjectPatchArgsDict']]]]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/rbac/v1beta1/RoleList.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1beta1/RoleList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class RoleList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['RoleArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['RoleArgs', 'RoleArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         RoleList is a collection of Roles Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 RoleList, and will no longer be served in v1.20.
@@ -101,9 +106,9 @@ class RoleList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['RoleArgs']]]] items: Items is a list of Roles
+        :param pulumi.Input[Sequence[pulumi.Input[Union['RoleArgs', 'RoleArgsDict']]]] items: Items is a list of Roles
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard object's metadata.
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard object's metadata.
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class RoleList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['RoleArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['RoleArgs', 'RoleArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/rbac/v1beta1/RolePatch.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1beta1/RolePatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class RolePatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 rules: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PolicyRulePatchArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 rules: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PolicyRulePatchArgs', 'PolicyRulePatchArgsDict']]]]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -109,8 +114,8 @@ class RolePatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata.
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PolicyRulePatchArgs']]]] rules: Rules holds all the PolicyRules for this Role
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['PolicyRulePatchArgs', 'PolicyRulePatchArgsDict']]]] rules: Rules holds all the PolicyRules for this Role
         """
         ...
     @overload
@@ -144,8 +149,8 @@ class RolePatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 rules: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PolicyRulePatchArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 rules: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PolicyRulePatchArgs', 'PolicyRulePatchArgsDict']]]]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/rbac/v1beta1/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1beta1/_inputs.py
@@ -4,26 +4,57 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import meta as _meta
 
 __all__ = [
     'AggregationRulePatchArgs',
+    'AggregationRulePatchArgsDict',
     'AggregationRuleArgs',
+    'AggregationRuleArgsDict',
     'ClusterRoleBindingArgs',
+    'ClusterRoleBindingArgsDict',
     'ClusterRoleArgs',
+    'ClusterRoleArgsDict',
     'PolicyRulePatchArgs',
+    'PolicyRulePatchArgsDict',
     'PolicyRuleArgs',
+    'PolicyRuleArgsDict',
     'RoleBindingArgs',
+    'RoleBindingArgsDict',
     'RoleRefPatchArgs',
+    'RoleRefPatchArgsDict',
     'RoleRefArgs',
+    'RoleRefArgsDict',
     'RoleArgs',
+    'RoleArgsDict',
     'SubjectPatchArgs',
+    'SubjectPatchArgsDict',
     'SubjectArgs',
+    'SubjectArgsDict',
 ]
+
+MYPY = False
+
+if not MYPY:
+    class AggregationRulePatchArgsDict(TypedDict):
+        """
+        AggregationRule describes how to locate ClusterRoles to aggregate into the ClusterRole
+        """
+        cluster_role_selectors: NotRequired[pulumi.Input[Sequence[pulumi.Input['_meta.v1.LabelSelectorPatchArgsDict']]]]
+        """
+        ClusterRoleSelectors holds a list of selectors which will be used to find ClusterRoles and create the rules. If any of the selectors match, then the ClusterRole's permissions will be added
+        """
+elif False:
+    AggregationRulePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class AggregationRulePatchArgs:
@@ -49,6 +80,18 @@ class AggregationRulePatchArgs:
         pulumi.set(self, "cluster_role_selectors", value)
 
 
+if not MYPY:
+    class AggregationRuleArgsDict(TypedDict):
+        """
+        AggregationRule describes how to locate ClusterRoles to aggregate into the ClusterRole
+        """
+        cluster_role_selectors: NotRequired[pulumi.Input[Sequence[pulumi.Input['_meta.v1.LabelSelectorArgsDict']]]]
+        """
+        ClusterRoleSelectors holds a list of selectors which will be used to find ClusterRoles and create the rules. If any of the selectors match, then the ClusterRole's permissions will be added
+        """
+elif False:
+    AggregationRuleArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class AggregationRuleArgs:
     def __init__(__self__, *,
@@ -72,6 +115,34 @@ class AggregationRuleArgs:
     def cluster_role_selectors(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['_meta.v1.LabelSelectorArgs']]]]):
         pulumi.set(self, "cluster_role_selectors", value)
 
+
+if not MYPY:
+    class ClusterRoleBindingArgsDict(TypedDict):
+        """
+        ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace, and adds who information via Subject. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRoleBinding, and will no longer be served in v1.20.
+        """
+        role_ref: pulumi.Input['RoleRefArgsDict']
+        """
+        RoleRef can only reference a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata.
+        """
+        subjects: NotRequired[pulumi.Input[Sequence[pulumi.Input['SubjectArgsDict']]]]
+        """
+        Subjects holds references to the objects the role applies to.
+        """
+elif False:
+    ClusterRoleBindingArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ClusterRoleBindingArgs:
@@ -159,6 +230,34 @@ class ClusterRoleBindingArgs:
     def subjects(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['SubjectArgs']]]]):
         pulumi.set(self, "subjects", value)
 
+
+if not MYPY:
+    class ClusterRoleArgsDict(TypedDict):
+        """
+        ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 ClusterRole, and will no longer be served in v1.20.
+        """
+        aggregation_rule: NotRequired[pulumi.Input['AggregationRuleArgsDict']]
+        """
+        AggregationRule is an optional field that describes how to build the Rules for this ClusterRole. If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be stomped by the controller.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata.
+        """
+        rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['PolicyRuleArgsDict']]]]
+        """
+        Rules holds all the PolicyRules for this ClusterRole
+        """
+elif False:
+    ClusterRoleArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ClusterRoleArgs:
@@ -248,6 +347,34 @@ class ClusterRoleArgs:
         pulumi.set(self, "rules", value)
 
 
+if not MYPY:
+    class PolicyRulePatchArgsDict(TypedDict):
+        """
+        PolicyRule holds information that describes a policy rule, but does not contain information about who the rule applies to or which namespace the rule applies to.
+        """
+        api_groups: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed.
+        """
+        non_resource_urls: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding. Rules can either apply to API resources (such as "pods" or "secrets") or non-resource URL paths (such as "/api"),  but not both.
+        """
+        resource_names: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
+        """
+        resources: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Resources is a list of resources this rule applies to.  '*' represents all resources in the specified apiGroups. '*/foo' represents the subresource 'foo' for all resources in the specified apiGroups.
+        """
+        verbs: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule.  VerbAll represents all kinds.
+        """
+elif False:
+    PolicyRulePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PolicyRulePatchArgs:
     def __init__(__self__, *,
@@ -336,6 +463,34 @@ class PolicyRulePatchArgs:
         pulumi.set(self, "verbs", value)
 
 
+if not MYPY:
+    class PolicyRuleArgsDict(TypedDict):
+        """
+        PolicyRule holds information that describes a policy rule, but does not contain information about who the rule applies to or which namespace the rule applies to.
+        """
+        verbs: pulumi.Input[Sequence[pulumi.Input[str]]]
+        """
+        Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule.  VerbAll represents all kinds.
+        """
+        api_groups: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed.
+        """
+        non_resource_urls: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding. Rules can either apply to API resources (such as "pods" or "secrets") or non-resource URL paths (such as "/api"),  but not both.
+        """
+        resource_names: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
+        """
+        resources: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Resources is a list of resources this rule applies to.  '*' represents all resources in the specified apiGroups. '*/foo' represents the subresource 'foo' for all resources in the specified apiGroups.
+        """
+elif False:
+    PolicyRuleArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PolicyRuleArgs:
     def __init__(__self__, *,
@@ -422,6 +577,34 @@ class PolicyRuleArgs:
     def resources(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]):
         pulumi.set(self, "resources", value)
 
+
+if not MYPY:
+    class RoleBindingArgsDict(TypedDict):
+        """
+        RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace. It adds who information via Subjects and namespace information by which namespace it exists in.  RoleBindings in a given namespace only have effect in that namespace. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 RoleBinding, and will no longer be served in v1.20.
+        """
+        role_ref: pulumi.Input['RoleRefArgsDict']
+        """
+        RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata.
+        """
+        subjects: NotRequired[pulumi.Input[Sequence[pulumi.Input['SubjectArgsDict']]]]
+        """
+        Subjects holds references to the objects the role applies to.
+        """
+elif False:
+    RoleBindingArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class RoleBindingArgs:
@@ -510,6 +693,26 @@ class RoleBindingArgs:
         pulumi.set(self, "subjects", value)
 
 
+if not MYPY:
+    class RoleRefPatchArgsDict(TypedDict):
+        """
+        RoleRef contains information that points to the role being used
+        """
+        api_group: NotRequired[pulumi.Input[str]]
+        """
+        APIGroup is the group for the resource being referenced
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is the type of resource being referenced
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name is the name of resource being referenced
+        """
+elif False:
+    RoleRefPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class RoleRefPatchArgs:
     def __init__(__self__, *,
@@ -566,6 +769,26 @@ class RoleRefPatchArgs:
         pulumi.set(self, "name", value)
 
 
+if not MYPY:
+    class RoleRefArgsDict(TypedDict):
+        """
+        RoleRef contains information that points to the role being used
+        """
+        api_group: pulumi.Input[str]
+        """
+        APIGroup is the group for the resource being referenced
+        """
+        kind: pulumi.Input[str]
+        """
+        Kind is the type of resource being referenced
+        """
+        name: pulumi.Input[str]
+        """
+        Name is the name of resource being referenced
+        """
+elif False:
+    RoleRefArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class RoleRefArgs:
     def __init__(__self__, *,
@@ -618,6 +841,30 @@ class RoleRefArgs:
     def name(self, value: pulumi.Input[str]):
         pulumi.set(self, "name", value)
 
+
+if not MYPY:
+    class RoleArgsDict(TypedDict):
+        """
+        Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding. Deprecated in v1.17 in favor of rbac.authorization.k8s.io/v1 Role, and will no longer be served in v1.20.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata.
+        """
+        rules: NotRequired[pulumi.Input[Sequence[pulumi.Input['PolicyRuleArgsDict']]]]
+        """
+        Rules holds all the PolicyRules for this Role
+        """
+elif False:
+    RoleArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class RoleArgs:
@@ -691,6 +938,30 @@ class RoleArgs:
         pulumi.set(self, "rules", value)
 
 
+if not MYPY:
+    class SubjectPatchArgsDict(TypedDict):
+        """
+        Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.
+        """
+        api_group: NotRequired[pulumi.Input[str]]
+        """
+        APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name of the object being referenced.
+        """
+        namespace: NotRequired[pulumi.Input[str]]
+        """
+        Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
+        """
+elif False:
+    SubjectPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class SubjectPatchArgs:
     def __init__(__self__, *,
@@ -762,6 +1033,30 @@ class SubjectPatchArgs:
     def namespace(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "namespace", value)
 
+
+if not MYPY:
+    class SubjectArgsDict(TypedDict):
+        """
+        Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.
+        """
+        kind: pulumi.Input[str]
+        """
+        Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount". If the Authorizer does not recognized the kind value, the Authorizer should report an error.
+        """
+        name: pulumi.Input[str]
+        """
+        Name of the object being referenced.
+        """
+        api_group: NotRequired[pulumi.Input[str]]
+        """
+        APIGroup holds the API group of the referenced subject. Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io" for User and Group subjects.
+        """
+        namespace: NotRequired[pulumi.Input[str]]
+        """
+        Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty the Authorizer should report an error.
+        """
+elif False:
+    SubjectArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class SubjectArgs:

--- a/sdk/python/pulumi_kubernetes/rbac/v1beta1/outputs.py
+++ b/sdk/python/pulumi_kubernetes/rbac/v1beta1/outputs.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta

--- a/sdk/python/pulumi_kubernetes/resource/v1alpha1/PodScheduling.py
+++ b/sdk/python/pulumi_kubernetes/resource/v1alpha1/PodScheduling.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -92,8 +97,8 @@ class PodScheduling(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PodSchedulingSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PodSchedulingSpecArgs', 'PodSchedulingSpecArgsDict']]] = None,
                  __props__=None):
         """
         PodScheduling objects hold information that is needed to schedule a Pod with ResourceClaims that use "WaitForFirstConsumer" allocation mode.
@@ -104,8 +109,8 @@ class PodScheduling(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object metadata
-        :param pulumi.Input[pulumi.InputType['PodSchedulingSpecArgs']] spec: Spec describes where resources for the Pod are needed.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object metadata
+        :param pulumi.Input[Union['PodSchedulingSpecArgs', 'PodSchedulingSpecArgsDict']] spec: Spec describes where resources for the Pod are needed.
         """
         ...
     @overload
@@ -135,8 +140,8 @@ class PodScheduling(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PodSchedulingSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PodSchedulingSpecArgs', 'PodSchedulingSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/resource/v1alpha1/PodSchedulingList.py
+++ b/sdk/python/pulumi_kubernetes/resource/v1alpha1/PodSchedulingList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class PodSchedulingList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PodSchedulingArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PodSchedulingArgs', 'PodSchedulingArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         PodSchedulingList is a collection of Pod scheduling objects.
@@ -101,9 +106,9 @@ class PodSchedulingList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PodSchedulingArgs']]]] items: Items is the list of PodScheduling objects.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['PodSchedulingArgs', 'PodSchedulingArgsDict']]]] items: Items is the list of PodScheduling objects.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class PodSchedulingList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PodSchedulingArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PodSchedulingArgs', 'PodSchedulingArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/resource/v1alpha1/PodSchedulingPatch.py
+++ b/sdk/python/pulumi_kubernetes/resource/v1alpha1/PodSchedulingPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class PodSchedulingPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PodSchedulingSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PodSchedulingSpecPatchArgs', 'PodSchedulingSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -111,8 +116,8 @@ class PodSchedulingPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object metadata
-        :param pulumi.Input[pulumi.InputType['PodSchedulingSpecPatchArgs']] spec: Spec describes where resources for the Pod are needed.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object metadata
+        :param pulumi.Input[Union['PodSchedulingSpecPatchArgs', 'PodSchedulingSpecPatchArgsDict']] spec: Spec describes where resources for the Pod are needed.
         """
         ...
     @overload
@@ -148,8 +153,8 @@ class PodSchedulingPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PodSchedulingSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PodSchedulingSpecPatchArgs', 'PodSchedulingSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/resource/v1alpha1/ResourceClaim.py
+++ b/sdk/python/pulumi_kubernetes/resource/v1alpha1/ResourceClaim.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -93,8 +98,8 @@ class ResourceClaim(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ResourceClaimSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ResourceClaimSpecArgs', 'ResourceClaimSpecArgsDict']]] = None,
                  __props__=None):
         """
         ResourceClaim describes which resources are needed by a resource consumer. Its status tracks whether the resource has been allocated and what the resulting attributes are.
@@ -105,8 +110,8 @@ class ResourceClaim(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object metadata
-        :param pulumi.Input[pulumi.InputType['ResourceClaimSpecArgs']] spec: Spec describes the desired attributes of a resource that then needs to be allocated. It can only be set once when creating the ResourceClaim.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object metadata
+        :param pulumi.Input[Union['ResourceClaimSpecArgs', 'ResourceClaimSpecArgsDict']] spec: Spec describes the desired attributes of a resource that then needs to be allocated. It can only be set once when creating the ResourceClaim.
         """
         ...
     @overload
@@ -136,8 +141,8 @@ class ResourceClaim(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ResourceClaimSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ResourceClaimSpecArgs', 'ResourceClaimSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/resource/v1alpha1/ResourceClaimList.py
+++ b/sdk/python/pulumi_kubernetes/resource/v1alpha1/ResourceClaimList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -92,9 +97,9 @@ class ResourceClaimList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ResourceClaimArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ResourceClaimArgs', 'ResourceClaimArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         ResourceClaimList is a collection of claims.
@@ -102,9 +107,9 @@ class ResourceClaimList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ResourceClaimArgs']]]] items: Items is the list of resource claims.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['ResourceClaimArgs', 'ResourceClaimArgsDict']]]] items: Items is the list of resource claims.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata
         """
         ...
     @overload
@@ -131,9 +136,9 @@ class ResourceClaimList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ResourceClaimArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ResourceClaimArgs', 'ResourceClaimArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/resource/v1alpha1/ResourceClaimPatch.py
+++ b/sdk/python/pulumi_kubernetes/resource/v1alpha1/ResourceClaimPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -94,8 +99,8 @@ class ResourceClaimPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ResourceClaimSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ResourceClaimSpecPatchArgs', 'ResourceClaimSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -112,8 +117,8 @@ class ResourceClaimPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object metadata
-        :param pulumi.Input[pulumi.InputType['ResourceClaimSpecPatchArgs']] spec: Spec describes the desired attributes of a resource that then needs to be allocated. It can only be set once when creating the ResourceClaim.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object metadata
+        :param pulumi.Input[Union['ResourceClaimSpecPatchArgs', 'ResourceClaimSpecPatchArgsDict']] spec: Spec describes the desired attributes of a resource that then needs to be allocated. It can only be set once when creating the ResourceClaim.
         """
         ...
     @overload
@@ -149,8 +154,8 @@ class ResourceClaimPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ResourceClaimSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ResourceClaimSpecPatchArgs', 'ResourceClaimSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/resource/v1alpha1/ResourceClaimTemplate.py
+++ b/sdk/python/pulumi_kubernetes/resource/v1alpha1/ResourceClaimTemplate.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -96,8 +101,8 @@ class ResourceClaimTemplate(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ResourceClaimTemplateSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ResourceClaimTemplateSpecArgs', 'ResourceClaimTemplateSpecArgsDict']]] = None,
                  __props__=None):
         """
         ResourceClaimTemplate is used to produce ResourceClaim objects.
@@ -106,8 +111,8 @@ class ResourceClaimTemplate(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object metadata
-        :param pulumi.Input[pulumi.InputType['ResourceClaimTemplateSpecArgs']] spec: Describes the ResourceClaim that is to be generated.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object metadata
+        :param pulumi.Input[Union['ResourceClaimTemplateSpecArgs', 'ResourceClaimTemplateSpecArgsDict']] spec: Describes the ResourceClaim that is to be generated.
                
                This field is immutable. A ResourceClaim will get created by the control plane for a Pod when needed and then not get updated anymore.
         """
@@ -137,8 +142,8 @@ class ResourceClaimTemplate(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ResourceClaimTemplateSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ResourceClaimTemplateSpecArgs', 'ResourceClaimTemplateSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/resource/v1alpha1/ResourceClaimTemplateList.py
+++ b/sdk/python/pulumi_kubernetes/resource/v1alpha1/ResourceClaimTemplateList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class ResourceClaimTemplateList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ResourceClaimTemplateArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ResourceClaimTemplateArgs', 'ResourceClaimTemplateArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         ResourceClaimTemplateList is a collection of claim templates.
@@ -101,9 +106,9 @@ class ResourceClaimTemplateList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ResourceClaimTemplateArgs']]]] items: Items is the list of resource claim templates.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['ResourceClaimTemplateArgs', 'ResourceClaimTemplateArgsDict']]]] items: Items is the list of resource claim templates.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class ResourceClaimTemplateList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ResourceClaimTemplateArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ResourceClaimTemplateArgs', 'ResourceClaimTemplateArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/resource/v1alpha1/ResourceClaimTemplatePatch.py
+++ b/sdk/python/pulumi_kubernetes/resource/v1alpha1/ResourceClaimTemplatePatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -97,8 +102,8 @@ class ResourceClaimTemplatePatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ResourceClaimTemplateSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ResourceClaimTemplateSpecPatchArgs', 'ResourceClaimTemplateSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -113,8 +118,8 @@ class ResourceClaimTemplatePatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object metadata
-        :param pulumi.Input[pulumi.InputType['ResourceClaimTemplateSpecPatchArgs']] spec: Describes the ResourceClaim that is to be generated.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object metadata
+        :param pulumi.Input[Union['ResourceClaimTemplateSpecPatchArgs', 'ResourceClaimTemplateSpecPatchArgsDict']] spec: Describes the ResourceClaim that is to be generated.
                
                This field is immutable. A ResourceClaim will get created by the control plane for a Pod when needed and then not get updated anymore.
         """
@@ -150,8 +155,8 @@ class ResourceClaimTemplatePatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ResourceClaimTemplateSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ResourceClaimTemplateSpecPatchArgs', 'ResourceClaimTemplateSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/resource/v1alpha1/ResourceClass.py
+++ b/sdk/python/pulumi_kubernetes/resource/v1alpha1/ResourceClass.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -134,9 +139,9 @@ class ResourceClass(pulumi.CustomResource):
                  api_version: Optional[pulumi.Input[str]] = None,
                  driver_name: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 parameters_ref: Optional[pulumi.Input[pulumi.InputType['ResourceClassParametersReferenceArgs']]] = None,
-                 suitable_nodes: Optional[pulumi.Input[pulumi.InputType['_core.v1.NodeSelectorArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 parameters_ref: Optional[pulumi.Input[Union['ResourceClassParametersReferenceArgs', 'ResourceClassParametersReferenceArgsDict']]] = None,
+                 suitable_nodes: Optional[pulumi.Input[Union['_core.v1.NodeSelectorArgs', '_core.v1.NodeSelectorArgsDict']]] = None,
                  __props__=None):
         """
         ResourceClass is used by administrators to influence how resources are allocated.
@@ -150,9 +155,9 @@ class ResourceClass(pulumi.CustomResource):
                
                Resource drivers have a unique name in forward domain order (acme.example.com).
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object metadata
-        :param pulumi.Input[pulumi.InputType['ResourceClassParametersReferenceArgs']] parameters_ref: ParametersRef references an arbitrary separate object that may hold parameters that will be used by the driver when allocating a resource that uses this class. A dynamic resource driver can distinguish between parameters stored here and and those stored in ResourceClaimSpec.
-        :param pulumi.Input[pulumi.InputType['_core.v1.NodeSelectorArgs']] suitable_nodes: Only nodes matching the selector will be considered by the scheduler when trying to find a Node that fits a Pod when that Pod uses a ResourceClaim that has not been allocated yet.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object metadata
+        :param pulumi.Input[Union['ResourceClassParametersReferenceArgs', 'ResourceClassParametersReferenceArgsDict']] parameters_ref: ParametersRef references an arbitrary separate object that may hold parameters that will be used by the driver when allocating a resource that uses this class. A dynamic resource driver can distinguish between parameters stored here and and those stored in ResourceClaimSpec.
+        :param pulumi.Input[Union['_core.v1.NodeSelectorArgs', '_core.v1.NodeSelectorArgsDict']] suitable_nodes: Only nodes matching the selector will be considered by the scheduler when trying to find a Node that fits a Pod when that Pod uses a ResourceClaim that has not been allocated yet.
                
                Setting this field is optional. If null, all nodes are candidates.
         """
@@ -185,9 +190,9 @@ class ResourceClass(pulumi.CustomResource):
                  api_version: Optional[pulumi.Input[str]] = None,
                  driver_name: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 parameters_ref: Optional[pulumi.Input[pulumi.InputType['ResourceClassParametersReferenceArgs']]] = None,
-                 suitable_nodes: Optional[pulumi.Input[pulumi.InputType['_core.v1.NodeSelectorArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 parameters_ref: Optional[pulumi.Input[Union['ResourceClassParametersReferenceArgs', 'ResourceClassParametersReferenceArgsDict']]] = None,
+                 suitable_nodes: Optional[pulumi.Input[Union['_core.v1.NodeSelectorArgs', '_core.v1.NodeSelectorArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/resource/v1alpha1/ResourceClassList.py
+++ b/sdk/python/pulumi_kubernetes/resource/v1alpha1/ResourceClassList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -92,9 +97,9 @@ class ResourceClassList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ResourceClassArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ResourceClassArgs', 'ResourceClassArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         ResourceClassList is a collection of classes.
@@ -102,9 +107,9 @@ class ResourceClassList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ResourceClassArgs']]]] items: Items is the list of resource classes.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['ResourceClassArgs', 'ResourceClassArgsDict']]]] items: Items is the list of resource classes.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata
         """
         ...
     @overload
@@ -131,9 +136,9 @@ class ResourceClassList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ResourceClassArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ResourceClassArgs', 'ResourceClassArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/resource/v1alpha1/ResourceClassPatch.py
+++ b/sdk/python/pulumi_kubernetes/resource/v1alpha1/ResourceClassPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -135,9 +140,9 @@ class ResourceClassPatch(pulumi.CustomResource):
                  api_version: Optional[pulumi.Input[str]] = None,
                  driver_name: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 parameters_ref: Optional[pulumi.Input[pulumi.InputType['ResourceClassParametersReferencePatchArgs']]] = None,
-                 suitable_nodes: Optional[pulumi.Input[pulumi.InputType['_core.v1.NodeSelectorPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 parameters_ref: Optional[pulumi.Input[Union['ResourceClassParametersReferencePatchArgs', 'ResourceClassParametersReferencePatchArgsDict']]] = None,
+                 suitable_nodes: Optional[pulumi.Input[Union['_core.v1.NodeSelectorPatchArgs', '_core.v1.NodeSelectorPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -157,9 +162,9 @@ class ResourceClassPatch(pulumi.CustomResource):
                
                Resource drivers have a unique name in forward domain order (acme.example.com).
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object metadata
-        :param pulumi.Input[pulumi.InputType['ResourceClassParametersReferencePatchArgs']] parameters_ref: ParametersRef references an arbitrary separate object that may hold parameters that will be used by the driver when allocating a resource that uses this class. A dynamic resource driver can distinguish between parameters stored here and and those stored in ResourceClaimSpec.
-        :param pulumi.Input[pulumi.InputType['_core.v1.NodeSelectorPatchArgs']] suitable_nodes: Only nodes matching the selector will be considered by the scheduler when trying to find a Node that fits a Pod when that Pod uses a ResourceClaim that has not been allocated yet.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object metadata
+        :param pulumi.Input[Union['ResourceClassParametersReferencePatchArgs', 'ResourceClassParametersReferencePatchArgsDict']] parameters_ref: ParametersRef references an arbitrary separate object that may hold parameters that will be used by the driver when allocating a resource that uses this class. A dynamic resource driver can distinguish between parameters stored here and and those stored in ResourceClaimSpec.
+        :param pulumi.Input[Union['_core.v1.NodeSelectorPatchArgs', '_core.v1.NodeSelectorPatchArgsDict']] suitable_nodes: Only nodes matching the selector will be considered by the scheduler when trying to find a Node that fits a Pod when that Pod uses a ResourceClaim that has not been allocated yet.
                
                Setting this field is optional. If null, all nodes are candidates.
         """
@@ -198,9 +203,9 @@ class ResourceClassPatch(pulumi.CustomResource):
                  api_version: Optional[pulumi.Input[str]] = None,
                  driver_name: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 parameters_ref: Optional[pulumi.Input[pulumi.InputType['ResourceClassParametersReferencePatchArgs']]] = None,
-                 suitable_nodes: Optional[pulumi.Input[pulumi.InputType['_core.v1.NodeSelectorPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 parameters_ref: Optional[pulumi.Input[Union['ResourceClassParametersReferencePatchArgs', 'ResourceClassParametersReferencePatchArgsDict']]] = None,
+                 suitable_nodes: Optional[pulumi.Input[Union['_core.v1.NodeSelectorPatchArgs', '_core.v1.NodeSelectorPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/resource/v1alpha1/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/resource/v1alpha1/_inputs.py
@@ -4,34 +4,84 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import core as _core
 from ... import meta as _meta
 
 __all__ = [
     'AllocationResultArgs',
+    'AllocationResultArgsDict',
     'PodSchedulingSpecPatchArgs',
+    'PodSchedulingSpecPatchArgsDict',
     'PodSchedulingSpecArgs',
+    'PodSchedulingSpecArgsDict',
     'PodSchedulingStatusArgs',
+    'PodSchedulingStatusArgsDict',
     'PodSchedulingArgs',
+    'PodSchedulingArgsDict',
     'ResourceClaimConsumerReferenceArgs',
+    'ResourceClaimConsumerReferenceArgsDict',
     'ResourceClaimParametersReferencePatchArgs',
+    'ResourceClaimParametersReferencePatchArgsDict',
     'ResourceClaimParametersReferenceArgs',
+    'ResourceClaimParametersReferenceArgsDict',
     'ResourceClaimSchedulingStatusArgs',
+    'ResourceClaimSchedulingStatusArgsDict',
     'ResourceClaimSpecPatchArgs',
+    'ResourceClaimSpecPatchArgsDict',
     'ResourceClaimSpecArgs',
+    'ResourceClaimSpecArgsDict',
     'ResourceClaimStatusArgs',
+    'ResourceClaimStatusArgsDict',
     'ResourceClaimTemplateSpecPatchArgs',
+    'ResourceClaimTemplateSpecPatchArgsDict',
     'ResourceClaimTemplateSpecArgs',
+    'ResourceClaimTemplateSpecArgsDict',
     'ResourceClaimTemplateArgs',
+    'ResourceClaimTemplateArgsDict',
     'ResourceClaimArgs',
+    'ResourceClaimArgsDict',
     'ResourceClassParametersReferencePatchArgs',
+    'ResourceClassParametersReferencePatchArgsDict',
     'ResourceClassParametersReferenceArgs',
+    'ResourceClassParametersReferenceArgsDict',
     'ResourceClassArgs',
+    'ResourceClassArgsDict',
 ]
+
+MYPY = False
+
+if not MYPY:
+    class AllocationResultArgsDict(TypedDict):
+        """
+        AllocationResult contains attributed of an allocated resource.
+        """
+        available_on_nodes: NotRequired[pulumi.Input['_core.v1.NodeSelectorArgsDict']]
+        """
+        This field will get set by the resource driver after it has allocated the resource driver to inform the scheduler where it can schedule Pods using the ResourceClaim.
+
+        Setting this field is optional. If null, the resource is available everywhere.
+        """
+        resource_handle: NotRequired[pulumi.Input[str]]
+        """
+        ResourceHandle contains arbitrary data returned by the driver after a successful allocation. This is opaque for Kubernetes. Driver documentation may explain to users how to interpret this data if needed.
+
+        The maximum size of this field is 16KiB. This may get increased in the future, but not reduced.
+        """
+        shareable: NotRequired[pulumi.Input[bool]]
+        """
+        Shareable determines whether the resource supports more than one consumer at a time.
+        """
+elif False:
+    AllocationResultArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class AllocationResultArgs:
@@ -97,6 +147,24 @@ class AllocationResultArgs:
         pulumi.set(self, "shareable", value)
 
 
+if not MYPY:
+    class PodSchedulingSpecPatchArgsDict(TypedDict):
+        """
+        PodSchedulingSpec describes where resources for the Pod are needed.
+        """
+        potential_nodes: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        PotentialNodes lists nodes where the Pod might be able to run.
+
+        The size of this field is limited to 128. This is large enough for many clusters. Larger clusters may need more attempts to find a node that suits all pending resources. This may get increased in the future, but not reduced.
+        """
+        selected_node: NotRequired[pulumi.Input[str]]
+        """
+        SelectedNode is the node for which allocation of ResourceClaims that are referenced by the Pod and that use "WaitForFirstConsumer" allocation is to be attempted.
+        """
+elif False:
+    PodSchedulingSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PodSchedulingSpecPatchArgs:
     def __init__(__self__, *,
@@ -140,6 +208,24 @@ class PodSchedulingSpecPatchArgs:
     def selected_node(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "selected_node", value)
 
+
+if not MYPY:
+    class PodSchedulingSpecArgsDict(TypedDict):
+        """
+        PodSchedulingSpec describes where resources for the Pod are needed.
+        """
+        potential_nodes: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        PotentialNodes lists nodes where the Pod might be able to run.
+
+        The size of this field is limited to 128. This is large enough for many clusters. Larger clusters may need more attempts to find a node that suits all pending resources. This may get increased in the future, but not reduced.
+        """
+        selected_node: NotRequired[pulumi.Input[str]]
+        """
+        SelectedNode is the node for which allocation of ResourceClaims that are referenced by the Pod and that use "WaitForFirstConsumer" allocation is to be attempted.
+        """
+elif False:
+    PodSchedulingSpecArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class PodSchedulingSpecArgs:
@@ -185,6 +271,18 @@ class PodSchedulingSpecArgs:
         pulumi.set(self, "selected_node", value)
 
 
+if not MYPY:
+    class PodSchedulingStatusArgsDict(TypedDict):
+        """
+        PodSchedulingStatus describes where resources for the Pod can be allocated.
+        """
+        resource_claims: NotRequired[pulumi.Input[Sequence[pulumi.Input['ResourceClaimSchedulingStatusArgsDict']]]]
+        """
+        ResourceClaims describes resource availability for each pod.spec.resourceClaim entry where the corresponding ResourceClaim uses "WaitForFirstConsumer" allocation mode.
+        """
+elif False:
+    PodSchedulingStatusArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PodSchedulingStatusArgs:
     def __init__(__self__, *,
@@ -208,6 +306,36 @@ class PodSchedulingStatusArgs:
     def resource_claims(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['ResourceClaimSchedulingStatusArgs']]]]):
         pulumi.set(self, "resource_claims", value)
 
+
+if not MYPY:
+    class PodSchedulingArgsDict(TypedDict):
+        """
+        PodScheduling objects hold information that is needed to schedule a Pod with ResourceClaims that use "WaitForFirstConsumer" allocation mode.
+
+        This is an alpha type and requires enabling the DynamicResourceAllocation feature gate.
+        """
+        spec: pulumi.Input['PodSchedulingSpecArgsDict']
+        """
+        Spec describes where resources for the Pod are needed.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object metadata
+        """
+        status: NotRequired[pulumi.Input['PodSchedulingStatusArgsDict']]
+        """
+        Status describes where resources for the Pod can be allocated.
+        """
+elif False:
+    PodSchedulingArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class PodSchedulingArgs:
@@ -298,6 +426,30 @@ class PodSchedulingArgs:
         pulumi.set(self, "status", value)
 
 
+if not MYPY:
+    class ResourceClaimConsumerReferenceArgsDict(TypedDict):
+        """
+        ResourceClaimConsumerReference contains enough information to let you locate the consumer of a ResourceClaim. The user must be a resource in the same namespace as the ResourceClaim.
+        """
+        name: pulumi.Input[str]
+        """
+        Name is the name of resource being referenced.
+        """
+        resource: pulumi.Input[str]
+        """
+        Resource is the type of resource being referenced, for example "pods".
+        """
+        uid: pulumi.Input[str]
+        """
+        UID identifies exactly one incarnation of the resource.
+        """
+        api_group: NotRequired[pulumi.Input[str]]
+        """
+        APIGroup is the group for the resource being referenced. It is empty for the core API. This matches the group in the APIVersion that is used when creating the resources.
+        """
+elif False:
+    ResourceClaimConsumerReferenceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ResourceClaimConsumerReferenceArgs:
     def __init__(__self__, *,
@@ -367,6 +519,26 @@ class ResourceClaimConsumerReferenceArgs:
         pulumi.set(self, "api_group", value)
 
 
+if not MYPY:
+    class ResourceClaimParametersReferencePatchArgsDict(TypedDict):
+        """
+        ResourceClaimParametersReference contains enough information to let you locate the parameters for a ResourceClaim. The object must be in the same namespace as the ResourceClaim.
+        """
+        api_group: NotRequired[pulumi.Input[str]]
+        """
+        APIGroup is the group for the resource being referenced. It is empty for the core API. This matches the group in the APIVersion that is used when creating the resources.
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is the type of resource being referenced. This is the same value as in the parameter object's metadata, for example "ConfigMap".
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name is the name of resource being referenced.
+        """
+elif False:
+    ResourceClaimParametersReferencePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ResourceClaimParametersReferencePatchArgs:
     def __init__(__self__, *,
@@ -423,6 +595,26 @@ class ResourceClaimParametersReferencePatchArgs:
         pulumi.set(self, "name", value)
 
 
+if not MYPY:
+    class ResourceClaimParametersReferenceArgsDict(TypedDict):
+        """
+        ResourceClaimParametersReference contains enough information to let you locate the parameters for a ResourceClaim. The object must be in the same namespace as the ResourceClaim.
+        """
+        kind: pulumi.Input[str]
+        """
+        Kind is the type of resource being referenced. This is the same value as in the parameter object's metadata, for example "ConfigMap".
+        """
+        name: pulumi.Input[str]
+        """
+        Name is the name of resource being referenced.
+        """
+        api_group: NotRequired[pulumi.Input[str]]
+        """
+        APIGroup is the group for the resource being referenced. It is empty for the core API. This matches the group in the APIVersion that is used when creating the resources.
+        """
+elif False:
+    ResourceClaimParametersReferenceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ResourceClaimParametersReferenceArgs:
     def __init__(__self__, *,
@@ -477,6 +669,24 @@ class ResourceClaimParametersReferenceArgs:
         pulumi.set(self, "api_group", value)
 
 
+if not MYPY:
+    class ResourceClaimSchedulingStatusArgsDict(TypedDict):
+        """
+        ResourceClaimSchedulingStatus contains information about one particular ResourceClaim with "WaitForFirstConsumer" allocation mode.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name matches the pod.spec.resourceClaims[*].Name field.
+        """
+        unsuitable_nodes: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        UnsuitableNodes lists nodes that the ResourceClaim cannot be allocated for.
+
+        The size of this field is limited to 128, the same as for PodSchedulingSpec.PotentialNodes. This may get increased in the future, but not reduced.
+        """
+elif False:
+    ResourceClaimSchedulingStatusArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ResourceClaimSchedulingStatusArgs:
     def __init__(__self__, *,
@@ -520,6 +730,28 @@ class ResourceClaimSchedulingStatusArgs:
     def unsuitable_nodes(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]):
         pulumi.set(self, "unsuitable_nodes", value)
 
+
+if not MYPY:
+    class ResourceClaimSpecPatchArgsDict(TypedDict):
+        """
+        ResourceClaimSpec defines how a resource is to be allocated.
+        """
+        allocation_mode: NotRequired[pulumi.Input[str]]
+        """
+        Allocation can start immediately or when a Pod wants to use the resource. "WaitForFirstConsumer" is the default.
+        """
+        parameters_ref: NotRequired[pulumi.Input['ResourceClaimParametersReferencePatchArgsDict']]
+        """
+        ParametersRef references a separate object with arbitrary parameters that will be used by the driver when allocating a resource for the claim.
+
+        The object must be in the same namespace as the ResourceClaim.
+        """
+        resource_class_name: NotRequired[pulumi.Input[str]]
+        """
+        ResourceClassName references the driver and additional parameters via the name of a ResourceClass that was created as part of the driver deployment.
+        """
+elif False:
+    ResourceClaimSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ResourceClaimSpecPatchArgs:
@@ -581,6 +813,28 @@ class ResourceClaimSpecPatchArgs:
         pulumi.set(self, "resource_class_name", value)
 
 
+if not MYPY:
+    class ResourceClaimSpecArgsDict(TypedDict):
+        """
+        ResourceClaimSpec defines how a resource is to be allocated.
+        """
+        resource_class_name: pulumi.Input[str]
+        """
+        ResourceClassName references the driver and additional parameters via the name of a ResourceClass that was created as part of the driver deployment.
+        """
+        allocation_mode: NotRequired[pulumi.Input[str]]
+        """
+        Allocation can start immediately or when a Pod wants to use the resource. "WaitForFirstConsumer" is the default.
+        """
+        parameters_ref: NotRequired[pulumi.Input['ResourceClaimParametersReferenceArgsDict']]
+        """
+        ParametersRef references a separate object with arbitrary parameters that will be used by the driver when allocating a resource for the claim.
+
+        The object must be in the same namespace as the ResourceClaim.
+        """
+elif False:
+    ResourceClaimSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ResourceClaimSpecArgs:
     def __init__(__self__, *,
@@ -639,6 +893,36 @@ class ResourceClaimSpecArgs:
     def parameters_ref(self, value: Optional[pulumi.Input['ResourceClaimParametersReferenceArgs']]):
         pulumi.set(self, "parameters_ref", value)
 
+
+if not MYPY:
+    class ResourceClaimStatusArgsDict(TypedDict):
+        """
+        ResourceClaimStatus tracks whether the resource has been allocated and what the resulting attributes are.
+        """
+        allocation: NotRequired[pulumi.Input['AllocationResultArgsDict']]
+        """
+        Allocation is set by the resource driver once a resource has been allocated successfully. If this is not specified, the resource is not yet allocated.
+        """
+        deallocation_requested: NotRequired[pulumi.Input[bool]]
+        """
+        DeallocationRequested indicates that a ResourceClaim is to be deallocated.
+
+        The driver then must deallocate this claim and reset the field together with clearing the Allocation field.
+
+        While DeallocationRequested is set, no new consumers may be added to ReservedFor.
+        """
+        driver_name: NotRequired[pulumi.Input[str]]
+        """
+        DriverName is a copy of the driver name from the ResourceClass at the time when allocation started.
+        """
+        reserved_for: NotRequired[pulumi.Input[Sequence[pulumi.Input['ResourceClaimConsumerReferenceArgsDict']]]]
+        """
+        ReservedFor indicates which entities are currently allowed to use the claim. A Pod which references a ResourceClaim which is not reserved for that Pod will not be started.
+
+        There can be at most 32 such reservations. This may get increased in the future, but not reduced.
+        """
+elif False:
+    ResourceClaimStatusArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ResourceClaimStatusArgs:
@@ -724,6 +1008,22 @@ class ResourceClaimStatusArgs:
         pulumi.set(self, "reserved_for", value)
 
 
+if not MYPY:
+    class ResourceClaimTemplateSpecPatchArgsDict(TypedDict):
+        """
+        ResourceClaimTemplateSpec contains the metadata and fields for a ResourceClaim.
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaPatchArgsDict']]
+        """
+        ObjectMeta may contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.
+        """
+        spec: NotRequired[pulumi.Input['ResourceClaimSpecPatchArgsDict']]
+        """
+        Spec for the ResourceClaim. The entire content is copied unchanged into the ResourceClaim that gets created from this template. The same fields as in a ResourceClaim are also valid here.
+        """
+elif False:
+    ResourceClaimTemplateSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ResourceClaimTemplateSpecPatchArgs:
     def __init__(__self__, *,
@@ -764,6 +1064,22 @@ class ResourceClaimTemplateSpecPatchArgs:
         pulumi.set(self, "spec", value)
 
 
+if not MYPY:
+    class ResourceClaimTemplateSpecArgsDict(TypedDict):
+        """
+        ResourceClaimTemplateSpec contains the metadata and fields for a ResourceClaim.
+        """
+        spec: pulumi.Input['ResourceClaimSpecArgsDict']
+        """
+        Spec for the ResourceClaim. The entire content is copied unchanged into the ResourceClaim that gets created from this template. The same fields as in a ResourceClaim are also valid here.
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        ObjectMeta may contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.
+        """
+elif False:
+    ResourceClaimTemplateSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ResourceClaimTemplateSpecArgs:
     def __init__(__self__, *,
@@ -802,6 +1118,32 @@ class ResourceClaimTemplateSpecArgs:
     def metadata(self, value: Optional[pulumi.Input['_meta.v1.ObjectMetaArgs']]):
         pulumi.set(self, "metadata", value)
 
+
+if not MYPY:
+    class ResourceClaimTemplateArgsDict(TypedDict):
+        """
+        ResourceClaimTemplate is used to produce ResourceClaim objects.
+        """
+        spec: pulumi.Input['ResourceClaimTemplateSpecArgsDict']
+        """
+        Describes the ResourceClaim that is to be generated.
+
+        This field is immutable. A ResourceClaim will get created by the control plane for a Pod when needed and then not get updated anymore.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object metadata
+        """
+elif False:
+    ResourceClaimTemplateArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ResourceClaimTemplateArgs:
@@ -877,6 +1219,36 @@ class ResourceClaimTemplateArgs:
     def metadata(self, value: Optional[pulumi.Input['_meta.v1.ObjectMetaArgs']]):
         pulumi.set(self, "metadata", value)
 
+
+if not MYPY:
+    class ResourceClaimArgsDict(TypedDict):
+        """
+        ResourceClaim describes which resources are needed by a resource consumer. Its status tracks whether the resource has been allocated and what the resulting attributes are.
+
+        This is an alpha type and requires enabling the DynamicResourceAllocation feature gate.
+        """
+        spec: pulumi.Input['ResourceClaimSpecArgsDict']
+        """
+        Spec describes the desired attributes of a resource that then needs to be allocated. It can only be set once when creating the ResourceClaim.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object metadata
+        """
+        status: NotRequired[pulumi.Input['ResourceClaimStatusArgsDict']]
+        """
+        Status describes whether the resource is available and with which attributes.
+        """
+elif False:
+    ResourceClaimArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ResourceClaimArgs:
@@ -967,6 +1339,30 @@ class ResourceClaimArgs:
         pulumi.set(self, "status", value)
 
 
+if not MYPY:
+    class ResourceClassParametersReferencePatchArgsDict(TypedDict):
+        """
+        ResourceClassParametersReference contains enough information to let you locate the parameters for a ResourceClass.
+        """
+        api_group: NotRequired[pulumi.Input[str]]
+        """
+        APIGroup is the group for the resource being referenced. It is empty for the core API. This matches the group in the APIVersion that is used when creating the resources.
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is the type of resource being referenced. This is the same value as in the parameter object's metadata.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name is the name of resource being referenced.
+        """
+        namespace: NotRequired[pulumi.Input[str]]
+        """
+        Namespace that contains the referenced resource. Must be empty for cluster-scoped resources and non-empty for namespaced resources.
+        """
+elif False:
+    ResourceClassParametersReferencePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ResourceClassParametersReferencePatchArgs:
     def __init__(__self__, *,
@@ -1039,6 +1435,30 @@ class ResourceClassParametersReferencePatchArgs:
         pulumi.set(self, "namespace", value)
 
 
+if not MYPY:
+    class ResourceClassParametersReferenceArgsDict(TypedDict):
+        """
+        ResourceClassParametersReference contains enough information to let you locate the parameters for a ResourceClass.
+        """
+        kind: pulumi.Input[str]
+        """
+        Kind is the type of resource being referenced. This is the same value as in the parameter object's metadata.
+        """
+        name: pulumi.Input[str]
+        """
+        Name is the name of resource being referenced.
+        """
+        api_group: NotRequired[pulumi.Input[str]]
+        """
+        APIGroup is the group for the resource being referenced. It is empty for the core API. This matches the group in the APIVersion that is used when creating the resources.
+        """
+        namespace: NotRequired[pulumi.Input[str]]
+        """
+        Namespace that contains the referenced resource. Must be empty for cluster-scoped resources and non-empty for namespaced resources.
+        """
+elif False:
+    ResourceClassParametersReferenceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ResourceClassParametersReferenceArgs:
     def __init__(__self__, *,
@@ -1108,6 +1528,44 @@ class ResourceClassParametersReferenceArgs:
     def namespace(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "namespace", value)
 
+
+if not MYPY:
+    class ResourceClassArgsDict(TypedDict):
+        """
+        ResourceClass is used by administrators to influence how resources are allocated.
+
+        This is an alpha type and requires enabling the DynamicResourceAllocation feature gate.
+        """
+        driver_name: pulumi.Input[str]
+        """
+        DriverName defines the name of the dynamic resource driver that is used for allocation of a ResourceClaim that uses this class.
+
+        Resource drivers have a unique name in forward domain order (acme.example.com).
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object metadata
+        """
+        parameters_ref: NotRequired[pulumi.Input['ResourceClassParametersReferenceArgsDict']]
+        """
+        ParametersRef references an arbitrary separate object that may hold parameters that will be used by the driver when allocating a resource that uses this class. A dynamic resource driver can distinguish between parameters stored here and and those stored in ResourceClaimSpec.
+        """
+        suitable_nodes: NotRequired[pulumi.Input['_core.v1.NodeSelectorArgsDict']]
+        """
+        Only nodes matching the selector will be considered by the scheduler when trying to find a Node that fits a Pod when that Pod uses a ResourceClaim that has not been allocated yet.
+
+        Setting this field is optional. If null, all nodes are candidates.
+        """
+elif False:
+    ResourceClassArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ResourceClassArgs:

--- a/sdk/python/pulumi_kubernetes/resource/v1alpha1/outputs.py
+++ b/sdk/python/pulumi_kubernetes/resource/v1alpha1/outputs.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core

--- a/sdk/python/pulumi_kubernetes/resource/v1alpha2/PodSchedulingContext.py
+++ b/sdk/python/pulumi_kubernetes/resource/v1alpha2/PodSchedulingContext.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -92,8 +97,8 @@ class PodSchedulingContext(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PodSchedulingContextSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PodSchedulingContextSpecArgs', 'PodSchedulingContextSpecArgsDict']]] = None,
                  __props__=None):
         """
         PodSchedulingContext objects hold information that is needed to schedule a Pod with ResourceClaims that use "WaitForFirstConsumer" allocation mode.
@@ -104,8 +109,8 @@ class PodSchedulingContext(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object metadata
-        :param pulumi.Input[pulumi.InputType['PodSchedulingContextSpecArgs']] spec: Spec describes where resources for the Pod are needed.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object metadata
+        :param pulumi.Input[Union['PodSchedulingContextSpecArgs', 'PodSchedulingContextSpecArgsDict']] spec: Spec describes where resources for the Pod are needed.
         """
         ...
     @overload
@@ -135,8 +140,8 @@ class PodSchedulingContext(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PodSchedulingContextSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PodSchedulingContextSpecArgs', 'PodSchedulingContextSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/resource/v1alpha2/PodSchedulingContextList.py
+++ b/sdk/python/pulumi_kubernetes/resource/v1alpha2/PodSchedulingContextList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class PodSchedulingContextList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PodSchedulingContextArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PodSchedulingContextArgs', 'PodSchedulingContextArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         PodSchedulingContextList is a collection of Pod scheduling objects.
@@ -101,9 +106,9 @@ class PodSchedulingContextList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PodSchedulingContextArgs']]]] items: Items is the list of PodSchedulingContext objects.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['PodSchedulingContextArgs', 'PodSchedulingContextArgsDict']]]] items: Items is the list of PodSchedulingContext objects.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class PodSchedulingContextList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PodSchedulingContextArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PodSchedulingContextArgs', 'PodSchedulingContextArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/resource/v1alpha2/PodSchedulingContextPatch.py
+++ b/sdk/python/pulumi_kubernetes/resource/v1alpha2/PodSchedulingContextPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class PodSchedulingContextPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PodSchedulingContextSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PodSchedulingContextSpecPatchArgs', 'PodSchedulingContextSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -111,8 +116,8 @@ class PodSchedulingContextPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object metadata
-        :param pulumi.Input[pulumi.InputType['PodSchedulingContextSpecPatchArgs']] spec: Spec describes where resources for the Pod are needed.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object metadata
+        :param pulumi.Input[Union['PodSchedulingContextSpecPatchArgs', 'PodSchedulingContextSpecPatchArgsDict']] spec: Spec describes where resources for the Pod are needed.
         """
         ...
     @overload
@@ -148,8 +153,8 @@ class PodSchedulingContextPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PodSchedulingContextSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PodSchedulingContextSpecPatchArgs', 'PodSchedulingContextSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/resource/v1alpha2/ResourceClaim.py
+++ b/sdk/python/pulumi_kubernetes/resource/v1alpha2/ResourceClaim.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -93,8 +98,8 @@ class ResourceClaim(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ResourceClaimSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ResourceClaimSpecArgs', 'ResourceClaimSpecArgsDict']]] = None,
                  __props__=None):
         """
         ResourceClaim describes which resources are needed by a resource consumer. Its status tracks whether the resource has been allocated and what the resulting attributes are.
@@ -105,8 +110,8 @@ class ResourceClaim(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object metadata
-        :param pulumi.Input[pulumi.InputType['ResourceClaimSpecArgs']] spec: Spec describes the desired attributes of a resource that then needs to be allocated. It can only be set once when creating the ResourceClaim.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object metadata
+        :param pulumi.Input[Union['ResourceClaimSpecArgs', 'ResourceClaimSpecArgsDict']] spec: Spec describes the desired attributes of a resource that then needs to be allocated. It can only be set once when creating the ResourceClaim.
         """
         ...
     @overload
@@ -136,8 +141,8 @@ class ResourceClaim(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ResourceClaimSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ResourceClaimSpecArgs', 'ResourceClaimSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/resource/v1alpha2/ResourceClaimList.py
+++ b/sdk/python/pulumi_kubernetes/resource/v1alpha2/ResourceClaimList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -92,9 +97,9 @@ class ResourceClaimList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ResourceClaimArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ResourceClaimArgs', 'ResourceClaimArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         ResourceClaimList is a collection of claims.
@@ -102,9 +107,9 @@ class ResourceClaimList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ResourceClaimArgs']]]] items: Items is the list of resource claims.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['ResourceClaimArgs', 'ResourceClaimArgsDict']]]] items: Items is the list of resource claims.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata
         """
         ...
     @overload
@@ -131,9 +136,9 @@ class ResourceClaimList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ResourceClaimArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ResourceClaimArgs', 'ResourceClaimArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/resource/v1alpha2/ResourceClaimParameters.py
+++ b/sdk/python/pulumi_kubernetes/resource/v1alpha2/ResourceClaimParameters.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -128,10 +133,10 @@ class ResourceClaimParameters(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 driver_requests: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['DriverRequestsArgs']]]]] = None,
-                 generated_from: Optional[pulumi.Input[pulumi.InputType['ResourceClaimParametersReferenceArgs']]] = None,
+                 driver_requests: Optional[pulumi.Input[Sequence[pulumi.Input[Union['DriverRequestsArgs', 'DriverRequestsArgsDict']]]]] = None,
+                 generated_from: Optional[pulumi.Input[Union['ResourceClaimParametersReferenceArgs', 'ResourceClaimParametersReferenceArgsDict']]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
                  shareable: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         """
@@ -140,12 +145,12 @@ class ResourceClaimParameters(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['DriverRequestsArgs']]]] driver_requests: DriverRequests describes all resources that are needed for the allocated claim. A single claim may use resources coming from different drivers. For each driver, this array has at most one entry which then may have one or more per-driver requests.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['DriverRequestsArgs', 'DriverRequestsArgsDict']]]] driver_requests: DriverRequests describes all resources that are needed for the allocated claim. A single claim may use resources coming from different drivers. For each driver, this array has at most one entry which then may have one or more per-driver requests.
                
                May be empty, in which case the claim can always be allocated.
-        :param pulumi.Input[pulumi.InputType['ResourceClaimParametersReferenceArgs']] generated_from: If this object was created from some other resource, then this links back to that resource. This field is used to find the in-tree representation of the claim parameters when the parameter reference of the claim refers to some unknown type.
+        :param pulumi.Input[Union['ResourceClaimParametersReferenceArgs', 'ResourceClaimParametersReferenceArgsDict']] generated_from: If this object was created from some other resource, then this links back to that resource. This field is used to find the in-tree representation of the claim parameters when the parameter reference of the claim refers to some unknown type.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object metadata
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object metadata
         :param pulumi.Input[bool] shareable: Shareable indicates whether the allocated claim is meant to be shareable by multiple consumers at the same time.
         """
         ...
@@ -173,10 +178,10 @@ class ResourceClaimParameters(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 driver_requests: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['DriverRequestsArgs']]]]] = None,
-                 generated_from: Optional[pulumi.Input[pulumi.InputType['ResourceClaimParametersReferenceArgs']]] = None,
+                 driver_requests: Optional[pulumi.Input[Sequence[pulumi.Input[Union['DriverRequestsArgs', 'DriverRequestsArgsDict']]]]] = None,
+                 generated_from: Optional[pulumi.Input[Union['ResourceClaimParametersReferenceArgs', 'ResourceClaimParametersReferenceArgsDict']]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
                  shareable: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)

--- a/sdk/python/pulumi_kubernetes/resource/v1alpha2/ResourceClaimParametersList.py
+++ b/sdk/python/pulumi_kubernetes/resource/v1alpha2/ResourceClaimParametersList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class ResourceClaimParametersList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ResourceClaimParametersArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ResourceClaimParametersArgs', 'ResourceClaimParametersArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         ResourceClaimParametersList is a collection of ResourceClaimParameters.
@@ -101,9 +106,9 @@ class ResourceClaimParametersList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ResourceClaimParametersArgs']]]] items: Items is the list of node resource capacity objects.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['ResourceClaimParametersArgs', 'ResourceClaimParametersArgsDict']]]] items: Items is the list of node resource capacity objects.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class ResourceClaimParametersList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ResourceClaimParametersArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ResourceClaimParametersArgs', 'ResourceClaimParametersArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/resource/v1alpha2/ResourceClaimParametersPatch.py
+++ b/sdk/python/pulumi_kubernetes/resource/v1alpha2/ResourceClaimParametersPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -128,10 +133,10 @@ class ResourceClaimParametersPatch(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 driver_requests: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['DriverRequestsPatchArgs']]]]] = None,
-                 generated_from: Optional[pulumi.Input[pulumi.InputType['ResourceClaimParametersReferencePatchArgs']]] = None,
+                 driver_requests: Optional[pulumi.Input[Sequence[pulumi.Input[Union['DriverRequestsPatchArgs', 'DriverRequestsPatchArgsDict']]]]] = None,
+                 generated_from: Optional[pulumi.Input[Union['ResourceClaimParametersReferencePatchArgs', 'ResourceClaimParametersReferencePatchArgsDict']]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
                  shareable: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         """
@@ -146,12 +151,12 @@ class ResourceClaimParametersPatch(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['DriverRequestsPatchArgs']]]] driver_requests: DriverRequests describes all resources that are needed for the allocated claim. A single claim may use resources coming from different drivers. For each driver, this array has at most one entry which then may have one or more per-driver requests.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['DriverRequestsPatchArgs', 'DriverRequestsPatchArgsDict']]]] driver_requests: DriverRequests describes all resources that are needed for the allocated claim. A single claim may use resources coming from different drivers. For each driver, this array has at most one entry which then may have one or more per-driver requests.
                
                May be empty, in which case the claim can always be allocated.
-        :param pulumi.Input[pulumi.InputType['ResourceClaimParametersReferencePatchArgs']] generated_from: If this object was created from some other resource, then this links back to that resource. This field is used to find the in-tree representation of the claim parameters when the parameter reference of the claim refers to some unknown type.
+        :param pulumi.Input[Union['ResourceClaimParametersReferencePatchArgs', 'ResourceClaimParametersReferencePatchArgsDict']] generated_from: If this object was created from some other resource, then this links back to that resource. This field is used to find the in-tree representation of the claim parameters when the parameter reference of the claim refers to some unknown type.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object metadata
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object metadata
         :param pulumi.Input[bool] shareable: Shareable indicates whether the allocated claim is meant to be shareable by multiple consumers at the same time.
         """
         ...
@@ -185,10 +190,10 @@ class ResourceClaimParametersPatch(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 driver_requests: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['DriverRequestsPatchArgs']]]]] = None,
-                 generated_from: Optional[pulumi.Input[pulumi.InputType['ResourceClaimParametersReferencePatchArgs']]] = None,
+                 driver_requests: Optional[pulumi.Input[Sequence[pulumi.Input[Union['DriverRequestsPatchArgs', 'DriverRequestsPatchArgsDict']]]]] = None,
+                 generated_from: Optional[pulumi.Input[Union['ResourceClaimParametersReferencePatchArgs', 'ResourceClaimParametersReferencePatchArgsDict']]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
                  shareable: Optional[pulumi.Input[bool]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)

--- a/sdk/python/pulumi_kubernetes/resource/v1alpha2/ResourceClaimPatch.py
+++ b/sdk/python/pulumi_kubernetes/resource/v1alpha2/ResourceClaimPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -94,8 +99,8 @@ class ResourceClaimPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ResourceClaimSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ResourceClaimSpecPatchArgs', 'ResourceClaimSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -112,8 +117,8 @@ class ResourceClaimPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object metadata
-        :param pulumi.Input[pulumi.InputType['ResourceClaimSpecPatchArgs']] spec: Spec describes the desired attributes of a resource that then needs to be allocated. It can only be set once when creating the ResourceClaim.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object metadata
+        :param pulumi.Input[Union['ResourceClaimSpecPatchArgs', 'ResourceClaimSpecPatchArgsDict']] spec: Spec describes the desired attributes of a resource that then needs to be allocated. It can only be set once when creating the ResourceClaim.
         """
         ...
     @overload
@@ -149,8 +154,8 @@ class ResourceClaimPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ResourceClaimSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ResourceClaimSpecPatchArgs', 'ResourceClaimSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/resource/v1alpha2/ResourceClaimTemplate.py
+++ b/sdk/python/pulumi_kubernetes/resource/v1alpha2/ResourceClaimTemplate.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -96,8 +101,8 @@ class ResourceClaimTemplate(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ResourceClaimTemplateSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ResourceClaimTemplateSpecArgs', 'ResourceClaimTemplateSpecArgsDict']]] = None,
                  __props__=None):
         """
         ResourceClaimTemplate is used to produce ResourceClaim objects.
@@ -106,8 +111,8 @@ class ResourceClaimTemplate(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object metadata
-        :param pulumi.Input[pulumi.InputType['ResourceClaimTemplateSpecArgs']] spec: Describes the ResourceClaim that is to be generated.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object metadata
+        :param pulumi.Input[Union['ResourceClaimTemplateSpecArgs', 'ResourceClaimTemplateSpecArgsDict']] spec: Describes the ResourceClaim that is to be generated.
                
                This field is immutable. A ResourceClaim will get created by the control plane for a Pod when needed and then not get updated anymore.
         """
@@ -137,8 +142,8 @@ class ResourceClaimTemplate(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ResourceClaimTemplateSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ResourceClaimTemplateSpecArgs', 'ResourceClaimTemplateSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/resource/v1alpha2/ResourceClaimTemplateList.py
+++ b/sdk/python/pulumi_kubernetes/resource/v1alpha2/ResourceClaimTemplateList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class ResourceClaimTemplateList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ResourceClaimTemplateArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ResourceClaimTemplateArgs', 'ResourceClaimTemplateArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         ResourceClaimTemplateList is a collection of claim templates.
@@ -101,9 +106,9 @@ class ResourceClaimTemplateList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ResourceClaimTemplateArgs']]]] items: Items is the list of resource claim templates.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['ResourceClaimTemplateArgs', 'ResourceClaimTemplateArgsDict']]]] items: Items is the list of resource claim templates.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class ResourceClaimTemplateList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ResourceClaimTemplateArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ResourceClaimTemplateArgs', 'ResourceClaimTemplateArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/resource/v1alpha2/ResourceClaimTemplatePatch.py
+++ b/sdk/python/pulumi_kubernetes/resource/v1alpha2/ResourceClaimTemplatePatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -97,8 +102,8 @@ class ResourceClaimTemplatePatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ResourceClaimTemplateSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ResourceClaimTemplateSpecPatchArgs', 'ResourceClaimTemplateSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -113,8 +118,8 @@ class ResourceClaimTemplatePatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object metadata
-        :param pulumi.Input[pulumi.InputType['ResourceClaimTemplateSpecPatchArgs']] spec: Describes the ResourceClaim that is to be generated.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object metadata
+        :param pulumi.Input[Union['ResourceClaimTemplateSpecPatchArgs', 'ResourceClaimTemplateSpecPatchArgsDict']] spec: Describes the ResourceClaim that is to be generated.
                
                This field is immutable. A ResourceClaim will get created by the control plane for a Pod when needed and then not get updated anymore.
         """
@@ -150,8 +155,8 @@ class ResourceClaimTemplatePatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['ResourceClaimTemplateSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['ResourceClaimTemplateSpecPatchArgs', 'ResourceClaimTemplateSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/resource/v1alpha2/ResourceClass.py
+++ b/sdk/python/pulumi_kubernetes/resource/v1alpha2/ResourceClass.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -150,10 +155,10 @@ class ResourceClass(pulumi.CustomResource):
                  api_version: Optional[pulumi.Input[str]] = None,
                  driver_name: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 parameters_ref: Optional[pulumi.Input[pulumi.InputType['ResourceClassParametersReferenceArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 parameters_ref: Optional[pulumi.Input[Union['ResourceClassParametersReferenceArgs', 'ResourceClassParametersReferenceArgsDict']]] = None,
                  structured_parameters: Optional[pulumi.Input[bool]] = None,
-                 suitable_nodes: Optional[pulumi.Input[pulumi.InputType['_core.v1.NodeSelectorArgs']]] = None,
+                 suitable_nodes: Optional[pulumi.Input[Union['_core.v1.NodeSelectorArgs', '_core.v1.NodeSelectorArgsDict']]] = None,
                  __props__=None):
         """
         ResourceClass is used by administrators to influence how resources are allocated.
@@ -167,10 +172,10 @@ class ResourceClass(pulumi.CustomResource):
                
                Resource drivers have a unique name in forward domain order (acme.example.com).
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object metadata
-        :param pulumi.Input[pulumi.InputType['ResourceClassParametersReferenceArgs']] parameters_ref: ParametersRef references an arbitrary separate object that may hold parameters that will be used by the driver when allocating a resource that uses this class. A dynamic resource driver can distinguish between parameters stored here and and those stored in ResourceClaimSpec.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object metadata
+        :param pulumi.Input[Union['ResourceClassParametersReferenceArgs', 'ResourceClassParametersReferenceArgsDict']] parameters_ref: ParametersRef references an arbitrary separate object that may hold parameters that will be used by the driver when allocating a resource that uses this class. A dynamic resource driver can distinguish between parameters stored here and and those stored in ResourceClaimSpec.
         :param pulumi.Input[bool] structured_parameters: If and only if allocation of claims using this class is handled via structured parameters, then StructuredParameters must be set to true.
-        :param pulumi.Input[pulumi.InputType['_core.v1.NodeSelectorArgs']] suitable_nodes: Only nodes matching the selector will be considered by the scheduler when trying to find a Node that fits a Pod when that Pod uses a ResourceClaim that has not been allocated yet.
+        :param pulumi.Input[Union['_core.v1.NodeSelectorArgs', '_core.v1.NodeSelectorArgsDict']] suitable_nodes: Only nodes matching the selector will be considered by the scheduler when trying to find a Node that fits a Pod when that Pod uses a ResourceClaim that has not been allocated yet.
                
                Setting this field is optional. If null, all nodes are candidates.
         """
@@ -203,10 +208,10 @@ class ResourceClass(pulumi.CustomResource):
                  api_version: Optional[pulumi.Input[str]] = None,
                  driver_name: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 parameters_ref: Optional[pulumi.Input[pulumi.InputType['ResourceClassParametersReferenceArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 parameters_ref: Optional[pulumi.Input[Union['ResourceClassParametersReferenceArgs', 'ResourceClassParametersReferenceArgsDict']]] = None,
                  structured_parameters: Optional[pulumi.Input[bool]] = None,
-                 suitable_nodes: Optional[pulumi.Input[pulumi.InputType['_core.v1.NodeSelectorArgs']]] = None,
+                 suitable_nodes: Optional[pulumi.Input[Union['_core.v1.NodeSelectorArgs', '_core.v1.NodeSelectorArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/resource/v1alpha2/ResourceClassList.py
+++ b/sdk/python/pulumi_kubernetes/resource/v1alpha2/ResourceClassList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -92,9 +97,9 @@ class ResourceClassList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ResourceClassArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ResourceClassArgs', 'ResourceClassArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         ResourceClassList is a collection of classes.
@@ -102,9 +107,9 @@ class ResourceClassList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ResourceClassArgs']]]] items: Items is the list of resource classes.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['ResourceClassArgs', 'ResourceClassArgsDict']]]] items: Items is the list of resource classes.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata
         """
         ...
     @overload
@@ -131,9 +136,9 @@ class ResourceClassList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ResourceClassArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ResourceClassArgs', 'ResourceClassArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/resource/v1alpha2/ResourceClassParameters.py
+++ b/sdk/python/pulumi_kubernetes/resource/v1alpha2/ResourceClassParameters.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -124,11 +129,11 @@ class ResourceClassParameters(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 filters: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ResourceFilterArgs']]]]] = None,
-                 generated_from: Optional[pulumi.Input[pulumi.InputType['ResourceClassParametersReferenceArgs']]] = None,
+                 filters: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ResourceFilterArgs', 'ResourceFilterArgsDict']]]]] = None,
+                 generated_from: Optional[pulumi.Input[Union['ResourceClassParametersReferenceArgs', 'ResourceClassParametersReferenceArgsDict']]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 vendor_parameters: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['VendorParametersArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 vendor_parameters: Optional[pulumi.Input[Sequence[pulumi.Input[Union['VendorParametersArgs', 'VendorParametersArgsDict']]]]] = None,
                  __props__=None):
         """
         ResourceClassParameters defines resource requests for a ResourceClass in an in-tree format understood by Kubernetes.
@@ -136,11 +141,11 @@ class ResourceClassParameters(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ResourceFilterArgs']]]] filters: Filters describes additional contraints that must be met when using the class.
-        :param pulumi.Input[pulumi.InputType['ResourceClassParametersReferenceArgs']] generated_from: If this object was created from some other resource, then this links back to that resource. This field is used to find the in-tree representation of the class parameters when the parameter reference of the class refers to some unknown type.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['ResourceFilterArgs', 'ResourceFilterArgsDict']]]] filters: Filters describes additional contraints that must be met when using the class.
+        :param pulumi.Input[Union['ResourceClassParametersReferenceArgs', 'ResourceClassParametersReferenceArgsDict']] generated_from: If this object was created from some other resource, then this links back to that resource. This field is used to find the in-tree representation of the class parameters when the parameter reference of the class refers to some unknown type.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object metadata
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['VendorParametersArgs']]]] vendor_parameters: VendorParameters are arbitrary setup parameters for all claims using this class. They are ignored while allocating the claim. There must not be more than one entry per driver.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object metadata
+        :param pulumi.Input[Sequence[pulumi.Input[Union['VendorParametersArgs', 'VendorParametersArgsDict']]]] vendor_parameters: VendorParameters are arbitrary setup parameters for all claims using this class. They are ignored while allocating the claim. There must not be more than one entry per driver.
         """
         ...
     @overload
@@ -167,11 +172,11 @@ class ResourceClassParameters(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 filters: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ResourceFilterArgs']]]]] = None,
-                 generated_from: Optional[pulumi.Input[pulumi.InputType['ResourceClassParametersReferenceArgs']]] = None,
+                 filters: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ResourceFilterArgs', 'ResourceFilterArgsDict']]]]] = None,
+                 generated_from: Optional[pulumi.Input[Union['ResourceClassParametersReferenceArgs', 'ResourceClassParametersReferenceArgsDict']]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 vendor_parameters: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['VendorParametersArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 vendor_parameters: Optional[pulumi.Input[Sequence[pulumi.Input[Union['VendorParametersArgs', 'VendorParametersArgsDict']]]]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/resource/v1alpha2/ResourceClassParametersList.py
+++ b/sdk/python/pulumi_kubernetes/resource/v1alpha2/ResourceClassParametersList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class ResourceClassParametersList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ResourceClassParametersArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ResourceClassParametersArgs', 'ResourceClassParametersArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         ResourceClassParametersList is a collection of ResourceClassParameters.
@@ -101,9 +106,9 @@ class ResourceClassParametersList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ResourceClassParametersArgs']]]] items: Items is the list of node resource capacity objects.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['ResourceClassParametersArgs', 'ResourceClassParametersArgsDict']]]] items: Items is the list of node resource capacity objects.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class ResourceClassParametersList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ResourceClassParametersArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ResourceClassParametersArgs', 'ResourceClassParametersArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/resource/v1alpha2/ResourceClassParametersPatch.py
+++ b/sdk/python/pulumi_kubernetes/resource/v1alpha2/ResourceClassParametersPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -124,11 +129,11 @@ class ResourceClassParametersPatch(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 filters: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ResourceFilterPatchArgs']]]]] = None,
-                 generated_from: Optional[pulumi.Input[pulumi.InputType['ResourceClassParametersReferencePatchArgs']]] = None,
+                 filters: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ResourceFilterPatchArgs', 'ResourceFilterPatchArgsDict']]]]] = None,
+                 generated_from: Optional[pulumi.Input[Union['ResourceClassParametersReferencePatchArgs', 'ResourceClassParametersReferencePatchArgsDict']]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 vendor_parameters: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['VendorParametersPatchArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 vendor_parameters: Optional[pulumi.Input[Sequence[pulumi.Input[Union['VendorParametersPatchArgs', 'VendorParametersPatchArgsDict']]]]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -142,11 +147,11 @@ class ResourceClassParametersPatch(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ResourceFilterPatchArgs']]]] filters: Filters describes additional contraints that must be met when using the class.
-        :param pulumi.Input[pulumi.InputType['ResourceClassParametersReferencePatchArgs']] generated_from: If this object was created from some other resource, then this links back to that resource. This field is used to find the in-tree representation of the class parameters when the parameter reference of the class refers to some unknown type.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['ResourceFilterPatchArgs', 'ResourceFilterPatchArgsDict']]]] filters: Filters describes additional contraints that must be met when using the class.
+        :param pulumi.Input[Union['ResourceClassParametersReferencePatchArgs', 'ResourceClassParametersReferencePatchArgsDict']] generated_from: If this object was created from some other resource, then this links back to that resource. This field is used to find the in-tree representation of the class parameters when the parameter reference of the class refers to some unknown type.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object metadata
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['VendorParametersPatchArgs']]]] vendor_parameters: VendorParameters are arbitrary setup parameters for all claims using this class. They are ignored while allocating the claim. There must not be more than one entry per driver.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object metadata
+        :param pulumi.Input[Sequence[pulumi.Input[Union['VendorParametersPatchArgs', 'VendorParametersPatchArgsDict']]]] vendor_parameters: VendorParameters are arbitrary setup parameters for all claims using this class. They are ignored while allocating the claim. There must not be more than one entry per driver.
         """
         ...
     @overload
@@ -179,11 +184,11 @@ class ResourceClassParametersPatch(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 filters: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ResourceFilterPatchArgs']]]]] = None,
-                 generated_from: Optional[pulumi.Input[pulumi.InputType['ResourceClassParametersReferencePatchArgs']]] = None,
+                 filters: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ResourceFilterPatchArgs', 'ResourceFilterPatchArgsDict']]]]] = None,
+                 generated_from: Optional[pulumi.Input[Union['ResourceClassParametersReferencePatchArgs', 'ResourceClassParametersReferencePatchArgsDict']]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 vendor_parameters: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['VendorParametersPatchArgs']]]]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 vendor_parameters: Optional[pulumi.Input[Sequence[pulumi.Input[Union['VendorParametersPatchArgs', 'VendorParametersPatchArgsDict']]]]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/resource/v1alpha2/ResourceClassPatch.py
+++ b/sdk/python/pulumi_kubernetes/resource/v1alpha2/ResourceClassPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -151,10 +156,10 @@ class ResourceClassPatch(pulumi.CustomResource):
                  api_version: Optional[pulumi.Input[str]] = None,
                  driver_name: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 parameters_ref: Optional[pulumi.Input[pulumi.InputType['ResourceClassParametersReferencePatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 parameters_ref: Optional[pulumi.Input[Union['ResourceClassParametersReferencePatchArgs', 'ResourceClassParametersReferencePatchArgsDict']]] = None,
                  structured_parameters: Optional[pulumi.Input[bool]] = None,
-                 suitable_nodes: Optional[pulumi.Input[pulumi.InputType['_core.v1.NodeSelectorPatchArgs']]] = None,
+                 suitable_nodes: Optional[pulumi.Input[Union['_core.v1.NodeSelectorPatchArgs', '_core.v1.NodeSelectorPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -174,10 +179,10 @@ class ResourceClassPatch(pulumi.CustomResource):
                
                Resource drivers have a unique name in forward domain order (acme.example.com).
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object metadata
-        :param pulumi.Input[pulumi.InputType['ResourceClassParametersReferencePatchArgs']] parameters_ref: ParametersRef references an arbitrary separate object that may hold parameters that will be used by the driver when allocating a resource that uses this class. A dynamic resource driver can distinguish between parameters stored here and and those stored in ResourceClaimSpec.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object metadata
+        :param pulumi.Input[Union['ResourceClassParametersReferencePatchArgs', 'ResourceClassParametersReferencePatchArgsDict']] parameters_ref: ParametersRef references an arbitrary separate object that may hold parameters that will be used by the driver when allocating a resource that uses this class. A dynamic resource driver can distinguish between parameters stored here and and those stored in ResourceClaimSpec.
         :param pulumi.Input[bool] structured_parameters: If and only if allocation of claims using this class is handled via structured parameters, then StructuredParameters must be set to true.
-        :param pulumi.Input[pulumi.InputType['_core.v1.NodeSelectorPatchArgs']] suitable_nodes: Only nodes matching the selector will be considered by the scheduler when trying to find a Node that fits a Pod when that Pod uses a ResourceClaim that has not been allocated yet.
+        :param pulumi.Input[Union['_core.v1.NodeSelectorPatchArgs', '_core.v1.NodeSelectorPatchArgsDict']] suitable_nodes: Only nodes matching the selector will be considered by the scheduler when trying to find a Node that fits a Pod when that Pod uses a ResourceClaim that has not been allocated yet.
                
                Setting this field is optional. If null, all nodes are candidates.
         """
@@ -216,10 +221,10 @@ class ResourceClassPatch(pulumi.CustomResource):
                  api_version: Optional[pulumi.Input[str]] = None,
                  driver_name: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 parameters_ref: Optional[pulumi.Input[pulumi.InputType['ResourceClassParametersReferencePatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 parameters_ref: Optional[pulumi.Input[Union['ResourceClassParametersReferencePatchArgs', 'ResourceClassParametersReferencePatchArgsDict']]] = None,
                  structured_parameters: Optional[pulumi.Input[bool]] = None,
-                 suitable_nodes: Optional[pulumi.Input[pulumi.InputType['_core.v1.NodeSelectorPatchArgs']]] = None,
+                 suitable_nodes: Optional[pulumi.Input[Union['_core.v1.NodeSelectorPatchArgs', '_core.v1.NodeSelectorPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/resource/v1alpha2/ResourceSlice.py
+++ b/sdk/python/pulumi_kubernetes/resource/v1alpha2/ResourceSlice.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -129,8 +134,8 @@ class ResourceSlice(pulumi.CustomResource):
                  api_version: Optional[pulumi.Input[str]] = None,
                  driver_name: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 named_resources: Optional[pulumi.Input[pulumi.InputType['NamedResourcesResourcesArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 named_resources: Optional[pulumi.Input[Union['NamedResourcesResourcesArgs', 'NamedResourcesResourcesArgsDict']]] = None,
                  node_name: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         """
@@ -141,8 +146,8 @@ class ResourceSlice(pulumi.CustomResource):
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] driver_name: DriverName identifies the DRA driver providing the capacity information. A field selector can be used to list only ResourceSlice objects with a certain driver name.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object metadata
-        :param pulumi.Input[pulumi.InputType['NamedResourcesResourcesArgs']] named_resources: NamedResources describes available resources using the named resources model.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object metadata
+        :param pulumi.Input[Union['NamedResourcesResourcesArgs', 'NamedResourcesResourcesArgsDict']] named_resources: NamedResources describes available resources using the named resources model.
         :param pulumi.Input[str] node_name: NodeName identifies the node which provides the resources if they are local to a node.
                
                A field selector can be used to list only ResourceSlice objects with a certain node name.
@@ -174,8 +179,8 @@ class ResourceSlice(pulumi.CustomResource):
                  api_version: Optional[pulumi.Input[str]] = None,
                  driver_name: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 named_resources: Optional[pulumi.Input[pulumi.InputType['NamedResourcesResourcesArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 named_resources: Optional[pulumi.Input[Union['NamedResourcesResourcesArgs', 'NamedResourcesResourcesArgsDict']]] = None,
                  node_name: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)

--- a/sdk/python/pulumi_kubernetes/resource/v1alpha2/ResourceSliceList.py
+++ b/sdk/python/pulumi_kubernetes/resource/v1alpha2/ResourceSliceList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class ResourceSliceList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ResourceSliceArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ResourceSliceArgs', 'ResourceSliceArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         ResourceSliceList is a collection of ResourceSlices.
@@ -101,9 +106,9 @@ class ResourceSliceList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ResourceSliceArgs']]]] items: Items is the list of node resource capacity objects.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['ResourceSliceArgs', 'ResourceSliceArgsDict']]]] items: Items is the list of node resource capacity objects.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class ResourceSliceList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['ResourceSliceArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['ResourceSliceArgs', 'ResourceSliceArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/resource/v1alpha2/ResourceSlicePatch.py
+++ b/sdk/python/pulumi_kubernetes/resource/v1alpha2/ResourceSlicePatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -130,8 +135,8 @@ class ResourceSlicePatch(pulumi.CustomResource):
                  api_version: Optional[pulumi.Input[str]] = None,
                  driver_name: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 named_resources: Optional[pulumi.Input[pulumi.InputType['NamedResourcesResourcesPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 named_resources: Optional[pulumi.Input[Union['NamedResourcesResourcesPatchArgs', 'NamedResourcesResourcesPatchArgsDict']]] = None,
                  node_name: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         """
@@ -148,8 +153,8 @@ class ResourceSlicePatch(pulumi.CustomResource):
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] driver_name: DriverName identifies the DRA driver providing the capacity information. A field selector can be used to list only ResourceSlice objects with a certain driver name.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object metadata
-        :param pulumi.Input[pulumi.InputType['NamedResourcesResourcesPatchArgs']] named_resources: NamedResources describes available resources using the named resources model.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object metadata
+        :param pulumi.Input[Union['NamedResourcesResourcesPatchArgs', 'NamedResourcesResourcesPatchArgsDict']] named_resources: NamedResources describes available resources using the named resources model.
         :param pulumi.Input[str] node_name: NodeName identifies the node which provides the resources if they are local to a node.
                
                A field selector can be used to list only ResourceSlice objects with a certain node name.
@@ -187,8 +192,8 @@ class ResourceSlicePatch(pulumi.CustomResource):
                  api_version: Optional[pulumi.Input[str]] = None,
                  driver_name: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 named_resources: Optional[pulumi.Input[pulumi.InputType['NamedResourcesResourcesPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 named_resources: Optional[pulumi.Input[Union['NamedResourcesResourcesPatchArgs', 'NamedResourcesResourcesPatchArgsDict']]] = None,
                  node_name: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)

--- a/sdk/python/pulumi_kubernetes/resource/v1alpha2/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/resource/v1alpha2/_inputs.py
@@ -4,63 +4,142 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import core as _core
 from ... import meta as _meta
 
 __all__ = [
     'AllocationResultArgs',
+    'AllocationResultArgsDict',
     'DriverAllocationResultArgs',
+    'DriverAllocationResultArgsDict',
     'DriverRequestsPatchArgs',
+    'DriverRequestsPatchArgsDict',
     'DriverRequestsArgs',
+    'DriverRequestsArgsDict',
     'NamedResourcesAllocationResultArgs',
+    'NamedResourcesAllocationResultArgsDict',
     'NamedResourcesAttributePatchArgs',
+    'NamedResourcesAttributePatchArgsDict',
     'NamedResourcesAttributeArgs',
+    'NamedResourcesAttributeArgsDict',
     'NamedResourcesFilterPatchArgs',
+    'NamedResourcesFilterPatchArgsDict',
     'NamedResourcesFilterArgs',
+    'NamedResourcesFilterArgsDict',
     'NamedResourcesInstancePatchArgs',
+    'NamedResourcesInstancePatchArgsDict',
     'NamedResourcesInstanceArgs',
+    'NamedResourcesInstanceArgsDict',
     'NamedResourcesIntSlicePatchArgs',
+    'NamedResourcesIntSlicePatchArgsDict',
     'NamedResourcesIntSliceArgs',
+    'NamedResourcesIntSliceArgsDict',
     'NamedResourcesRequestPatchArgs',
+    'NamedResourcesRequestPatchArgsDict',
     'NamedResourcesRequestArgs',
+    'NamedResourcesRequestArgsDict',
     'NamedResourcesResourcesPatchArgs',
+    'NamedResourcesResourcesPatchArgsDict',
     'NamedResourcesResourcesArgs',
+    'NamedResourcesResourcesArgsDict',
     'NamedResourcesStringSlicePatchArgs',
+    'NamedResourcesStringSlicePatchArgsDict',
     'NamedResourcesStringSliceArgs',
+    'NamedResourcesStringSliceArgsDict',
     'PodSchedulingContextSpecPatchArgs',
+    'PodSchedulingContextSpecPatchArgsDict',
     'PodSchedulingContextSpecArgs',
+    'PodSchedulingContextSpecArgsDict',
     'PodSchedulingContextStatusArgs',
+    'PodSchedulingContextStatusArgsDict',
     'PodSchedulingContextArgs',
+    'PodSchedulingContextArgsDict',
     'ResourceClaimConsumerReferenceArgs',
+    'ResourceClaimConsumerReferenceArgsDict',
     'ResourceClaimParametersReferencePatchArgs',
+    'ResourceClaimParametersReferencePatchArgsDict',
     'ResourceClaimParametersReferenceArgs',
+    'ResourceClaimParametersReferenceArgsDict',
     'ResourceClaimParametersArgs',
+    'ResourceClaimParametersArgsDict',
     'ResourceClaimSchedulingStatusArgs',
+    'ResourceClaimSchedulingStatusArgsDict',
     'ResourceClaimSpecPatchArgs',
+    'ResourceClaimSpecPatchArgsDict',
     'ResourceClaimSpecArgs',
+    'ResourceClaimSpecArgsDict',
     'ResourceClaimStatusArgs',
+    'ResourceClaimStatusArgsDict',
     'ResourceClaimTemplateSpecPatchArgs',
+    'ResourceClaimTemplateSpecPatchArgsDict',
     'ResourceClaimTemplateSpecArgs',
+    'ResourceClaimTemplateSpecArgsDict',
     'ResourceClaimTemplateArgs',
+    'ResourceClaimTemplateArgsDict',
     'ResourceClaimArgs',
+    'ResourceClaimArgsDict',
     'ResourceClassParametersReferencePatchArgs',
+    'ResourceClassParametersReferencePatchArgsDict',
     'ResourceClassParametersReferenceArgs',
+    'ResourceClassParametersReferenceArgsDict',
     'ResourceClassParametersArgs',
+    'ResourceClassParametersArgsDict',
     'ResourceClassArgs',
+    'ResourceClassArgsDict',
     'ResourceFilterPatchArgs',
+    'ResourceFilterPatchArgsDict',
     'ResourceFilterArgs',
+    'ResourceFilterArgsDict',
     'ResourceHandleArgs',
+    'ResourceHandleArgsDict',
     'ResourceRequestPatchArgs',
+    'ResourceRequestPatchArgsDict',
     'ResourceRequestArgs',
+    'ResourceRequestArgsDict',
     'ResourceSliceArgs',
+    'ResourceSliceArgsDict',
     'StructuredResourceHandleArgs',
+    'StructuredResourceHandleArgsDict',
     'VendorParametersPatchArgs',
+    'VendorParametersPatchArgsDict',
     'VendorParametersArgs',
+    'VendorParametersArgsDict',
 ]
+
+MYPY = False
+
+if not MYPY:
+    class AllocationResultArgsDict(TypedDict):
+        """
+        AllocationResult contains attributes of an allocated resource.
+        """
+        available_on_nodes: NotRequired[pulumi.Input['_core.v1.NodeSelectorArgsDict']]
+        """
+        This field will get set by the resource driver after it has allocated the resource to inform the scheduler where it can schedule Pods using the ResourceClaim.
+
+        Setting this field is optional. If null, the resource is available everywhere.
+        """
+        resource_handles: NotRequired[pulumi.Input[Sequence[pulumi.Input['ResourceHandleArgsDict']]]]
+        """
+        ResourceHandles contain the state associated with an allocation that should be maintained throughout the lifetime of a claim. Each ResourceHandle contains data that should be passed to a specific kubelet plugin once it lands on a node. This data is returned by the driver after a successful allocation and is opaque to Kubernetes. Driver documentation may explain to users how to interpret this data if needed.
+
+        Setting this field is optional. It has a maximum size of 32 entries. If null (or empty), it is assumed this allocation will be processed by a single kubelet plugin with no ResourceHandle data attached. The name of the kubelet plugin invoked will match the DriverName set in the ResourceClaimStatus this AllocationResult is embedded in.
+        """
+        shareable: NotRequired[pulumi.Input[bool]]
+        """
+        Shareable determines whether the resource supports more than one consumer at a time.
+        """
+elif False:
+    AllocationResultArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class AllocationResultArgs:
@@ -126,6 +205,22 @@ class AllocationResultArgs:
         pulumi.set(self, "shareable", value)
 
 
+if not MYPY:
+    class DriverAllocationResultArgsDict(TypedDict):
+        """
+        DriverAllocationResult contains vendor parameters and the allocation result for one request.
+        """
+        named_resources: NotRequired[pulumi.Input['NamedResourcesAllocationResultArgsDict']]
+        """
+        NamedResources describes the allocation result when using the named resources model.
+        """
+        vendor_request_parameters: NotRequired[Any]
+        """
+        VendorRequestParameters are the per-request configuration parameters from the time that the claim was allocated.
+        """
+elif False:
+    DriverAllocationResultArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class DriverAllocationResultArgs:
     def __init__(__self__, *,
@@ -165,6 +260,26 @@ class DriverAllocationResultArgs:
     def vendor_request_parameters(self, value: Optional[Any]):
         pulumi.set(self, "vendor_request_parameters", value)
 
+
+if not MYPY:
+    class DriverRequestsPatchArgsDict(TypedDict):
+        """
+        DriverRequests describes all resources that are needed from one particular driver.
+        """
+        driver_name: NotRequired[pulumi.Input[str]]
+        """
+        DriverName is the name used by the DRA driver kubelet plugin.
+        """
+        requests: NotRequired[pulumi.Input[Sequence[pulumi.Input['ResourceRequestPatchArgsDict']]]]
+        """
+        Requests describes all resources that are needed from the driver.
+        """
+        vendor_parameters: NotRequired[Any]
+        """
+        VendorParameters are arbitrary setup parameters for all requests of the claim. They are ignored while allocating the claim.
+        """
+elif False:
+    DriverRequestsPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class DriverRequestsPatchArgs:
@@ -222,6 +337,26 @@ class DriverRequestsPatchArgs:
         pulumi.set(self, "vendor_parameters", value)
 
 
+if not MYPY:
+    class DriverRequestsArgsDict(TypedDict):
+        """
+        DriverRequests describes all resources that are needed from one particular driver.
+        """
+        driver_name: NotRequired[pulumi.Input[str]]
+        """
+        DriverName is the name used by the DRA driver kubelet plugin.
+        """
+        requests: NotRequired[pulumi.Input[Sequence[pulumi.Input['ResourceRequestArgsDict']]]]
+        """
+        Requests describes all resources that are needed from the driver.
+        """
+        vendor_parameters: NotRequired[Any]
+        """
+        VendorParameters are arbitrary setup parameters for all requests of the claim. They are ignored while allocating the claim.
+        """
+elif False:
+    DriverRequestsArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class DriverRequestsArgs:
     def __init__(__self__, *,
@@ -278,6 +413,18 @@ class DriverRequestsArgs:
         pulumi.set(self, "vendor_parameters", value)
 
 
+if not MYPY:
+    class NamedResourcesAllocationResultArgsDict(TypedDict):
+        """
+        NamedResourcesAllocationResult is used in AllocationResultModel.
+        """
+        name: pulumi.Input[str]
+        """
+        Name is the name of the selected resource instance.
+        """
+elif False:
+    NamedResourcesAllocationResultArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class NamedResourcesAllocationResultArgs:
     def __init__(__self__, *,
@@ -300,6 +447,46 @@ class NamedResourcesAllocationResultArgs:
     def name(self, value: pulumi.Input[str]):
         pulumi.set(self, "name", value)
 
+
+if not MYPY:
+    class NamedResourcesAttributePatchArgsDict(TypedDict):
+        """
+        NamedResourcesAttribute is a combination of an attribute name and its value.
+        """
+        bool: NotRequired[pulumi.Input[bool]]
+        """
+        BoolValue is a true/false value.
+        """
+        int: NotRequired[pulumi.Input[int]]
+        """
+        IntValue is a 64-bit integer.
+        """
+        int_slice: NotRequired[pulumi.Input['NamedResourcesIntSlicePatchArgsDict']]
+        """
+        IntSliceValue is an array of 64-bit integers.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name is unique identifier among all resource instances managed by the driver on the node. It must be a DNS subdomain.
+        """
+        quantity: NotRequired[pulumi.Input[str]]
+        """
+        QuantityValue is a quantity.
+        """
+        string: NotRequired[pulumi.Input[str]]
+        """
+        StringValue is a string.
+        """
+        string_slice: NotRequired[pulumi.Input['NamedResourcesStringSlicePatchArgsDict']]
+        """
+        StringSliceValue is an array of strings.
+        """
+        version: NotRequired[pulumi.Input[str]]
+        """
+        VersionValue is a semantic version according to semver.org spec 2.0.0.
+        """
+elif False:
+    NamedResourcesAttributePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class NamedResourcesAttributePatchArgs:
@@ -437,6 +624,46 @@ class NamedResourcesAttributePatchArgs:
         pulumi.set(self, "version", value)
 
 
+if not MYPY:
+    class NamedResourcesAttributeArgsDict(TypedDict):
+        """
+        NamedResourcesAttribute is a combination of an attribute name and its value.
+        """
+        name: pulumi.Input[str]
+        """
+        Name is unique identifier among all resource instances managed by the driver on the node. It must be a DNS subdomain.
+        """
+        bool: NotRequired[pulumi.Input[bool]]
+        """
+        BoolValue is a true/false value.
+        """
+        int: NotRequired[pulumi.Input[int]]
+        """
+        IntValue is a 64-bit integer.
+        """
+        int_slice: NotRequired[pulumi.Input['NamedResourcesIntSliceArgsDict']]
+        """
+        IntSliceValue is an array of 64-bit integers.
+        """
+        quantity: NotRequired[pulumi.Input[str]]
+        """
+        QuantityValue is a quantity.
+        """
+        string: NotRequired[pulumi.Input[str]]
+        """
+        StringValue is a string.
+        """
+        string_slice: NotRequired[pulumi.Input['NamedResourcesStringSliceArgsDict']]
+        """
+        StringSliceValue is an array of strings.
+        """
+        version: NotRequired[pulumi.Input[str]]
+        """
+        VersionValue is a semantic version according to semver.org spec 2.0.0.
+        """
+elif False:
+    NamedResourcesAttributeArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class NamedResourcesAttributeArgs:
     def __init__(__self__, *,
@@ -572,6 +799,23 @@ class NamedResourcesAttributeArgs:
         pulumi.set(self, "version", value)
 
 
+if not MYPY:
+    class NamedResourcesFilterPatchArgsDict(TypedDict):
+        """
+        NamedResourcesFilter is used in ResourceFilterModel.
+        """
+        selector: NotRequired[pulumi.Input[str]]
+        """
+        Selector is a CEL expression which must evaluate to true if a resource instance is suitable. The language is as defined in https://kubernetes.io/docs/reference/using-api/cel/
+
+        In addition, for each type NamedResourcesin AttributeValue there is a map that resolves to the corresponding value of the instance under evaluation. For example:
+
+           attributes.quantity["a"].isGreaterThan(quantity("0")) &&
+           attributes.stringslice["b"].isSorted()
+        """
+elif False:
+    NamedResourcesFilterPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class NamedResourcesFilterPatchArgs:
     def __init__(__self__, *,
@@ -606,6 +850,23 @@ class NamedResourcesFilterPatchArgs:
         pulumi.set(self, "selector", value)
 
 
+if not MYPY:
+    class NamedResourcesFilterArgsDict(TypedDict):
+        """
+        NamedResourcesFilter is used in ResourceFilterModel.
+        """
+        selector: pulumi.Input[str]
+        """
+        Selector is a CEL expression which must evaluate to true if a resource instance is suitable. The language is as defined in https://kubernetes.io/docs/reference/using-api/cel/
+
+        In addition, for each type NamedResourcesin AttributeValue there is a map that resolves to the corresponding value of the instance under evaluation. For example:
+
+           attributes.quantity["a"].isGreaterThan(quantity("0")) &&
+           attributes.stringslice["b"].isSorted()
+        """
+elif False:
+    NamedResourcesFilterArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class NamedResourcesFilterArgs:
     def __init__(__self__, *,
@@ -638,6 +899,22 @@ class NamedResourcesFilterArgs:
     def selector(self, value: pulumi.Input[str]):
         pulumi.set(self, "selector", value)
 
+
+if not MYPY:
+    class NamedResourcesInstancePatchArgsDict(TypedDict):
+        """
+        NamedResourcesInstance represents one individual hardware instance that can be selected based on its attributes.
+        """
+        attributes: NotRequired[pulumi.Input[Sequence[pulumi.Input['NamedResourcesAttributePatchArgsDict']]]]
+        """
+        Attributes defines the attributes of this resource instance. The name of each attribute must be unique.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name is unique identifier among all resource instances managed by the driver on the node. It must be a DNS subdomain.
+        """
+elif False:
+    NamedResourcesInstancePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class NamedResourcesInstancePatchArgs:
@@ -679,6 +956,22 @@ class NamedResourcesInstancePatchArgs:
         pulumi.set(self, "name", value)
 
 
+if not MYPY:
+    class NamedResourcesInstanceArgsDict(TypedDict):
+        """
+        NamedResourcesInstance represents one individual hardware instance that can be selected based on its attributes.
+        """
+        name: pulumi.Input[str]
+        """
+        Name is unique identifier among all resource instances managed by the driver on the node. It must be a DNS subdomain.
+        """
+        attributes: NotRequired[pulumi.Input[Sequence[pulumi.Input['NamedResourcesAttributeArgsDict']]]]
+        """
+        Attributes defines the attributes of this resource instance. The name of each attribute must be unique.
+        """
+elif False:
+    NamedResourcesInstanceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class NamedResourcesInstanceArgs:
     def __init__(__self__, *,
@@ -718,6 +1011,18 @@ class NamedResourcesInstanceArgs:
         pulumi.set(self, "attributes", value)
 
 
+if not MYPY:
+    class NamedResourcesIntSlicePatchArgsDict(TypedDict):
+        """
+        NamedResourcesIntSlice contains a slice of 64-bit integers.
+        """
+        ints: NotRequired[pulumi.Input[Sequence[pulumi.Input[int]]]]
+        """
+        Ints is the slice of 64-bit integers.
+        """
+elif False:
+    NamedResourcesIntSlicePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class NamedResourcesIntSlicePatchArgs:
     def __init__(__self__, *,
@@ -742,6 +1047,18 @@ class NamedResourcesIntSlicePatchArgs:
         pulumi.set(self, "ints", value)
 
 
+if not MYPY:
+    class NamedResourcesIntSliceArgsDict(TypedDict):
+        """
+        NamedResourcesIntSlice contains a slice of 64-bit integers.
+        """
+        ints: pulumi.Input[Sequence[pulumi.Input[int]]]
+        """
+        Ints is the slice of 64-bit integers.
+        """
+elif False:
+    NamedResourcesIntSliceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class NamedResourcesIntSliceArgs:
     def __init__(__self__, *,
@@ -764,6 +1081,23 @@ class NamedResourcesIntSliceArgs:
     def ints(self, value: pulumi.Input[Sequence[pulumi.Input[int]]]):
         pulumi.set(self, "ints", value)
 
+
+if not MYPY:
+    class NamedResourcesRequestPatchArgsDict(TypedDict):
+        """
+        NamedResourcesRequest is used in ResourceRequestModel.
+        """
+        selector: NotRequired[pulumi.Input[str]]
+        """
+        Selector is a CEL expression which must evaluate to true if a resource instance is suitable. The language is as defined in https://kubernetes.io/docs/reference/using-api/cel/
+
+        In addition, for each type NamedResourcesin AttributeValue there is a map that resolves to the corresponding value of the instance under evaluation. For example:
+
+           attributes.quantity["a"].isGreaterThan(quantity("0")) &&
+           attributes.stringslice["b"].isSorted()
+        """
+elif False:
+    NamedResourcesRequestPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class NamedResourcesRequestPatchArgs:
@@ -799,6 +1133,23 @@ class NamedResourcesRequestPatchArgs:
         pulumi.set(self, "selector", value)
 
 
+if not MYPY:
+    class NamedResourcesRequestArgsDict(TypedDict):
+        """
+        NamedResourcesRequest is used in ResourceRequestModel.
+        """
+        selector: pulumi.Input[str]
+        """
+        Selector is a CEL expression which must evaluate to true if a resource instance is suitable. The language is as defined in https://kubernetes.io/docs/reference/using-api/cel/
+
+        In addition, for each type NamedResourcesin AttributeValue there is a map that resolves to the corresponding value of the instance under evaluation. For example:
+
+           attributes.quantity["a"].isGreaterThan(quantity("0")) &&
+           attributes.stringslice["b"].isSorted()
+        """
+elif False:
+    NamedResourcesRequestArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class NamedResourcesRequestArgs:
     def __init__(__self__, *,
@@ -832,6 +1183,18 @@ class NamedResourcesRequestArgs:
         pulumi.set(self, "selector", value)
 
 
+if not MYPY:
+    class NamedResourcesResourcesPatchArgsDict(TypedDict):
+        """
+        NamedResourcesResources is used in ResourceModel.
+        """
+        instances: NotRequired[pulumi.Input[Sequence[pulumi.Input['NamedResourcesInstancePatchArgsDict']]]]
+        """
+        The list of all individual resources instances currently available.
+        """
+elif False:
+    NamedResourcesResourcesPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class NamedResourcesResourcesPatchArgs:
     def __init__(__self__, *,
@@ -856,6 +1219,18 @@ class NamedResourcesResourcesPatchArgs:
         pulumi.set(self, "instances", value)
 
 
+if not MYPY:
+    class NamedResourcesResourcesArgsDict(TypedDict):
+        """
+        NamedResourcesResources is used in ResourceModel.
+        """
+        instances: pulumi.Input[Sequence[pulumi.Input['NamedResourcesInstanceArgsDict']]]
+        """
+        The list of all individual resources instances currently available.
+        """
+elif False:
+    NamedResourcesResourcesArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class NamedResourcesResourcesArgs:
     def __init__(__self__, *,
@@ -878,6 +1253,18 @@ class NamedResourcesResourcesArgs:
     def instances(self, value: pulumi.Input[Sequence[pulumi.Input['NamedResourcesInstanceArgs']]]):
         pulumi.set(self, "instances", value)
 
+
+if not MYPY:
+    class NamedResourcesStringSlicePatchArgsDict(TypedDict):
+        """
+        NamedResourcesStringSlice contains a slice of strings.
+        """
+        strings: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Strings is the slice of strings.
+        """
+elif False:
+    NamedResourcesStringSlicePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class NamedResourcesStringSlicePatchArgs:
@@ -903,6 +1290,18 @@ class NamedResourcesStringSlicePatchArgs:
         pulumi.set(self, "strings", value)
 
 
+if not MYPY:
+    class NamedResourcesStringSliceArgsDict(TypedDict):
+        """
+        NamedResourcesStringSlice contains a slice of strings.
+        """
+        strings: pulumi.Input[Sequence[pulumi.Input[str]]]
+        """
+        Strings is the slice of strings.
+        """
+elif False:
+    NamedResourcesStringSliceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class NamedResourcesStringSliceArgs:
     def __init__(__self__, *,
@@ -925,6 +1324,24 @@ class NamedResourcesStringSliceArgs:
     def strings(self, value: pulumi.Input[Sequence[pulumi.Input[str]]]):
         pulumi.set(self, "strings", value)
 
+
+if not MYPY:
+    class PodSchedulingContextSpecPatchArgsDict(TypedDict):
+        """
+        PodSchedulingContextSpec describes where resources for the Pod are needed.
+        """
+        potential_nodes: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        PotentialNodes lists nodes where the Pod might be able to run.
+
+        The size of this field is limited to 128. This is large enough for many clusters. Larger clusters may need more attempts to find a node that suits all pending resources. This may get increased in the future, but not reduced.
+        """
+        selected_node: NotRequired[pulumi.Input[str]]
+        """
+        SelectedNode is the node for which allocation of ResourceClaims that are referenced by the Pod and that use "WaitForFirstConsumer" allocation is to be attempted.
+        """
+elif False:
+    PodSchedulingContextSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class PodSchedulingContextSpecPatchArgs:
@@ -970,6 +1387,24 @@ class PodSchedulingContextSpecPatchArgs:
         pulumi.set(self, "selected_node", value)
 
 
+if not MYPY:
+    class PodSchedulingContextSpecArgsDict(TypedDict):
+        """
+        PodSchedulingContextSpec describes where resources for the Pod are needed.
+        """
+        potential_nodes: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        PotentialNodes lists nodes where the Pod might be able to run.
+
+        The size of this field is limited to 128. This is large enough for many clusters. Larger clusters may need more attempts to find a node that suits all pending resources. This may get increased in the future, but not reduced.
+        """
+        selected_node: NotRequired[pulumi.Input[str]]
+        """
+        SelectedNode is the node for which allocation of ResourceClaims that are referenced by the Pod and that use "WaitForFirstConsumer" allocation is to be attempted.
+        """
+elif False:
+    PodSchedulingContextSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PodSchedulingContextSpecArgs:
     def __init__(__self__, *,
@@ -1014,6 +1449,18 @@ class PodSchedulingContextSpecArgs:
         pulumi.set(self, "selected_node", value)
 
 
+if not MYPY:
+    class PodSchedulingContextStatusArgsDict(TypedDict):
+        """
+        PodSchedulingContextStatus describes where resources for the Pod can be allocated.
+        """
+        resource_claims: NotRequired[pulumi.Input[Sequence[pulumi.Input['ResourceClaimSchedulingStatusArgsDict']]]]
+        """
+        ResourceClaims describes resource availability for each pod.spec.resourceClaim entry where the corresponding ResourceClaim uses "WaitForFirstConsumer" allocation mode.
+        """
+elif False:
+    PodSchedulingContextStatusArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PodSchedulingContextStatusArgs:
     def __init__(__self__, *,
@@ -1037,6 +1484,36 @@ class PodSchedulingContextStatusArgs:
     def resource_claims(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['ResourceClaimSchedulingStatusArgs']]]]):
         pulumi.set(self, "resource_claims", value)
 
+
+if not MYPY:
+    class PodSchedulingContextArgsDict(TypedDict):
+        """
+        PodSchedulingContext objects hold information that is needed to schedule a Pod with ResourceClaims that use "WaitForFirstConsumer" allocation mode.
+
+        This is an alpha type and requires enabling the DynamicResourceAllocation feature gate.
+        """
+        spec: pulumi.Input['PodSchedulingContextSpecArgsDict']
+        """
+        Spec describes where resources for the Pod are needed.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object metadata
+        """
+        status: NotRequired[pulumi.Input['PodSchedulingContextStatusArgsDict']]
+        """
+        Status describes where resources for the Pod can be allocated.
+        """
+elif False:
+    PodSchedulingContextArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class PodSchedulingContextArgs:
@@ -1127,6 +1604,30 @@ class PodSchedulingContextArgs:
         pulumi.set(self, "status", value)
 
 
+if not MYPY:
+    class ResourceClaimConsumerReferenceArgsDict(TypedDict):
+        """
+        ResourceClaimConsumerReference contains enough information to let you locate the consumer of a ResourceClaim. The user must be a resource in the same namespace as the ResourceClaim.
+        """
+        name: pulumi.Input[str]
+        """
+        Name is the name of resource being referenced.
+        """
+        resource: pulumi.Input[str]
+        """
+        Resource is the type of resource being referenced, for example "pods".
+        """
+        uid: pulumi.Input[str]
+        """
+        UID identifies exactly one incarnation of the resource.
+        """
+        api_group: NotRequired[pulumi.Input[str]]
+        """
+        APIGroup is the group for the resource being referenced. It is empty for the core API. This matches the group in the APIVersion that is used when creating the resources.
+        """
+elif False:
+    ResourceClaimConsumerReferenceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ResourceClaimConsumerReferenceArgs:
     def __init__(__self__, *,
@@ -1196,6 +1697,26 @@ class ResourceClaimConsumerReferenceArgs:
         pulumi.set(self, "api_group", value)
 
 
+if not MYPY:
+    class ResourceClaimParametersReferencePatchArgsDict(TypedDict):
+        """
+        ResourceClaimParametersReference contains enough information to let you locate the parameters for a ResourceClaim. The object must be in the same namespace as the ResourceClaim.
+        """
+        api_group: NotRequired[pulumi.Input[str]]
+        """
+        APIGroup is the group for the resource being referenced. It is empty for the core API. This matches the group in the APIVersion that is used when creating the resources.
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is the type of resource being referenced. This is the same value as in the parameter object's metadata, for example "ConfigMap".
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name is the name of resource being referenced.
+        """
+elif False:
+    ResourceClaimParametersReferencePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ResourceClaimParametersReferencePatchArgs:
     def __init__(__self__, *,
@@ -1252,6 +1773,26 @@ class ResourceClaimParametersReferencePatchArgs:
         pulumi.set(self, "name", value)
 
 
+if not MYPY:
+    class ResourceClaimParametersReferenceArgsDict(TypedDict):
+        """
+        ResourceClaimParametersReference contains enough information to let you locate the parameters for a ResourceClaim. The object must be in the same namespace as the ResourceClaim.
+        """
+        kind: pulumi.Input[str]
+        """
+        Kind is the type of resource being referenced. This is the same value as in the parameter object's metadata, for example "ConfigMap".
+        """
+        name: pulumi.Input[str]
+        """
+        Name is the name of resource being referenced.
+        """
+        api_group: NotRequired[pulumi.Input[str]]
+        """
+        APIGroup is the group for the resource being referenced. It is empty for the core API. This matches the group in the APIVersion that is used when creating the resources.
+        """
+elif False:
+    ResourceClaimParametersReferenceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ResourceClaimParametersReferenceArgs:
     def __init__(__self__, *,
@@ -1305,6 +1846,40 @@ class ResourceClaimParametersReferenceArgs:
     def api_group(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "api_group", value)
 
+
+if not MYPY:
+    class ResourceClaimParametersArgsDict(TypedDict):
+        """
+        ResourceClaimParameters defines resource requests for a ResourceClaim in an in-tree format understood by Kubernetes.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        driver_requests: NotRequired[pulumi.Input[Sequence[pulumi.Input['DriverRequestsArgsDict']]]]
+        """
+        DriverRequests describes all resources that are needed for the allocated claim. A single claim may use resources coming from different drivers. For each driver, this array has at most one entry which then may have one or more per-driver requests.
+
+        May be empty, in which case the claim can always be allocated.
+        """
+        generated_from: NotRequired[pulumi.Input['ResourceClaimParametersReferenceArgsDict']]
+        """
+        If this object was created from some other resource, then this links back to that resource. This field is used to find the in-tree representation of the claim parameters when the parameter reference of the claim refers to some unknown type.
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object metadata
+        """
+        shareable: NotRequired[pulumi.Input[bool]]
+        """
+        Shareable indicates whether the allocated claim is meant to be shareable by multiple consumers at the same time.
+        """
+elif False:
+    ResourceClaimParametersArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ResourceClaimParametersArgs:
@@ -1414,6 +1989,24 @@ class ResourceClaimParametersArgs:
         pulumi.set(self, "shareable", value)
 
 
+if not MYPY:
+    class ResourceClaimSchedulingStatusArgsDict(TypedDict):
+        """
+        ResourceClaimSchedulingStatus contains information about one particular ResourceClaim with "WaitForFirstConsumer" allocation mode.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name matches the pod.spec.resourceClaims[*].Name field.
+        """
+        unsuitable_nodes: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        UnsuitableNodes lists nodes that the ResourceClaim cannot be allocated for.
+
+        The size of this field is limited to 128, the same as for PodSchedulingSpec.PotentialNodes. This may get increased in the future, but not reduced.
+        """
+elif False:
+    ResourceClaimSchedulingStatusArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ResourceClaimSchedulingStatusArgs:
     def __init__(__self__, *,
@@ -1457,6 +2050,28 @@ class ResourceClaimSchedulingStatusArgs:
     def unsuitable_nodes(self, value: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]):
         pulumi.set(self, "unsuitable_nodes", value)
 
+
+if not MYPY:
+    class ResourceClaimSpecPatchArgsDict(TypedDict):
+        """
+        ResourceClaimSpec defines how a resource is to be allocated.
+        """
+        allocation_mode: NotRequired[pulumi.Input[str]]
+        """
+        Allocation can start immediately or when a Pod wants to use the resource. "WaitForFirstConsumer" is the default.
+        """
+        parameters_ref: NotRequired[pulumi.Input['ResourceClaimParametersReferencePatchArgsDict']]
+        """
+        ParametersRef references a separate object with arbitrary parameters that will be used by the driver when allocating a resource for the claim.
+
+        The object must be in the same namespace as the ResourceClaim.
+        """
+        resource_class_name: NotRequired[pulumi.Input[str]]
+        """
+        ResourceClassName references the driver and additional parameters via the name of a ResourceClass that was created as part of the driver deployment.
+        """
+elif False:
+    ResourceClaimSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ResourceClaimSpecPatchArgs:
@@ -1518,6 +2133,28 @@ class ResourceClaimSpecPatchArgs:
         pulumi.set(self, "resource_class_name", value)
 
 
+if not MYPY:
+    class ResourceClaimSpecArgsDict(TypedDict):
+        """
+        ResourceClaimSpec defines how a resource is to be allocated.
+        """
+        resource_class_name: pulumi.Input[str]
+        """
+        ResourceClassName references the driver and additional parameters via the name of a ResourceClass that was created as part of the driver deployment.
+        """
+        allocation_mode: NotRequired[pulumi.Input[str]]
+        """
+        Allocation can start immediately or when a Pod wants to use the resource. "WaitForFirstConsumer" is the default.
+        """
+        parameters_ref: NotRequired[pulumi.Input['ResourceClaimParametersReferenceArgsDict']]
+        """
+        ParametersRef references a separate object with arbitrary parameters that will be used by the driver when allocating a resource for the claim.
+
+        The object must be in the same namespace as the ResourceClaim.
+        """
+elif False:
+    ResourceClaimSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ResourceClaimSpecArgs:
     def __init__(__self__, *,
@@ -1576,6 +2213,36 @@ class ResourceClaimSpecArgs:
     def parameters_ref(self, value: Optional[pulumi.Input['ResourceClaimParametersReferenceArgs']]):
         pulumi.set(self, "parameters_ref", value)
 
+
+if not MYPY:
+    class ResourceClaimStatusArgsDict(TypedDict):
+        """
+        ResourceClaimStatus tracks whether the resource has been allocated and what the resulting attributes are.
+        """
+        allocation: NotRequired[pulumi.Input['AllocationResultArgsDict']]
+        """
+        Allocation is set by the resource driver once a resource or set of resources has been allocated successfully. If this is not specified, the resources have not been allocated yet.
+        """
+        deallocation_requested: NotRequired[pulumi.Input[bool]]
+        """
+        DeallocationRequested indicates that a ResourceClaim is to be deallocated.
+
+        The driver then must deallocate this claim and reset the field together with clearing the Allocation field.
+
+        While DeallocationRequested is set, no new consumers may be added to ReservedFor.
+        """
+        driver_name: NotRequired[pulumi.Input[str]]
+        """
+        DriverName is a copy of the driver name from the ResourceClass at the time when allocation started.
+        """
+        reserved_for: NotRequired[pulumi.Input[Sequence[pulumi.Input['ResourceClaimConsumerReferenceArgsDict']]]]
+        """
+        ReservedFor indicates which entities are currently allowed to use the claim. A Pod which references a ResourceClaim which is not reserved for that Pod will not be started.
+
+        There can be at most 32 such reservations. This may get increased in the future, but not reduced.
+        """
+elif False:
+    ResourceClaimStatusArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ResourceClaimStatusArgs:
@@ -1661,6 +2328,22 @@ class ResourceClaimStatusArgs:
         pulumi.set(self, "reserved_for", value)
 
 
+if not MYPY:
+    class ResourceClaimTemplateSpecPatchArgsDict(TypedDict):
+        """
+        ResourceClaimTemplateSpec contains the metadata and fields for a ResourceClaim.
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaPatchArgsDict']]
+        """
+        ObjectMeta may contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.
+        """
+        spec: NotRequired[pulumi.Input['ResourceClaimSpecPatchArgsDict']]
+        """
+        Spec for the ResourceClaim. The entire content is copied unchanged into the ResourceClaim that gets created from this template. The same fields as in a ResourceClaim are also valid here.
+        """
+elif False:
+    ResourceClaimTemplateSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ResourceClaimTemplateSpecPatchArgs:
     def __init__(__self__, *,
@@ -1701,6 +2384,22 @@ class ResourceClaimTemplateSpecPatchArgs:
         pulumi.set(self, "spec", value)
 
 
+if not MYPY:
+    class ResourceClaimTemplateSpecArgsDict(TypedDict):
+        """
+        ResourceClaimTemplateSpec contains the metadata and fields for a ResourceClaim.
+        """
+        spec: pulumi.Input['ResourceClaimSpecArgsDict']
+        """
+        Spec for the ResourceClaim. The entire content is copied unchanged into the ResourceClaim that gets created from this template. The same fields as in a ResourceClaim are also valid here.
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        ObjectMeta may contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.
+        """
+elif False:
+    ResourceClaimTemplateSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ResourceClaimTemplateSpecArgs:
     def __init__(__self__, *,
@@ -1739,6 +2438,32 @@ class ResourceClaimTemplateSpecArgs:
     def metadata(self, value: Optional[pulumi.Input['_meta.v1.ObjectMetaArgs']]):
         pulumi.set(self, "metadata", value)
 
+
+if not MYPY:
+    class ResourceClaimTemplateArgsDict(TypedDict):
+        """
+        ResourceClaimTemplate is used to produce ResourceClaim objects.
+        """
+        spec: pulumi.Input['ResourceClaimTemplateSpecArgsDict']
+        """
+        Describes the ResourceClaim that is to be generated.
+
+        This field is immutable. A ResourceClaim will get created by the control plane for a Pod when needed and then not get updated anymore.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object metadata
+        """
+elif False:
+    ResourceClaimTemplateArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ResourceClaimTemplateArgs:
@@ -1814,6 +2539,36 @@ class ResourceClaimTemplateArgs:
     def metadata(self, value: Optional[pulumi.Input['_meta.v1.ObjectMetaArgs']]):
         pulumi.set(self, "metadata", value)
 
+
+if not MYPY:
+    class ResourceClaimArgsDict(TypedDict):
+        """
+        ResourceClaim describes which resources are needed by a resource consumer. Its status tracks whether the resource has been allocated and what the resulting attributes are.
+
+        This is an alpha type and requires enabling the DynamicResourceAllocation feature gate.
+        """
+        spec: pulumi.Input['ResourceClaimSpecArgsDict']
+        """
+        Spec describes the desired attributes of a resource that then needs to be allocated. It can only be set once when creating the ResourceClaim.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object metadata
+        """
+        status: NotRequired[pulumi.Input['ResourceClaimStatusArgsDict']]
+        """
+        Status describes whether the resource is available and with which attributes.
+        """
+elif False:
+    ResourceClaimArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ResourceClaimArgs:
@@ -1904,6 +2659,30 @@ class ResourceClaimArgs:
         pulumi.set(self, "status", value)
 
 
+if not MYPY:
+    class ResourceClassParametersReferencePatchArgsDict(TypedDict):
+        """
+        ResourceClassParametersReference contains enough information to let you locate the parameters for a ResourceClass.
+        """
+        api_group: NotRequired[pulumi.Input[str]]
+        """
+        APIGroup is the group for the resource being referenced. It is empty for the core API. This matches the group in the APIVersion that is used when creating the resources.
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is the type of resource being referenced. This is the same value as in the parameter object's metadata.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        Name is the name of resource being referenced.
+        """
+        namespace: NotRequired[pulumi.Input[str]]
+        """
+        Namespace that contains the referenced resource. Must be empty for cluster-scoped resources and non-empty for namespaced resources.
+        """
+elif False:
+    ResourceClassParametersReferencePatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ResourceClassParametersReferencePatchArgs:
     def __init__(__self__, *,
@@ -1976,6 +2755,30 @@ class ResourceClassParametersReferencePatchArgs:
         pulumi.set(self, "namespace", value)
 
 
+if not MYPY:
+    class ResourceClassParametersReferenceArgsDict(TypedDict):
+        """
+        ResourceClassParametersReference contains enough information to let you locate the parameters for a ResourceClass.
+        """
+        kind: pulumi.Input[str]
+        """
+        Kind is the type of resource being referenced. This is the same value as in the parameter object's metadata.
+        """
+        name: pulumi.Input[str]
+        """
+        Name is the name of resource being referenced.
+        """
+        api_group: NotRequired[pulumi.Input[str]]
+        """
+        APIGroup is the group for the resource being referenced. It is empty for the core API. This matches the group in the APIVersion that is used when creating the resources.
+        """
+        namespace: NotRequired[pulumi.Input[str]]
+        """
+        Namespace that contains the referenced resource. Must be empty for cluster-scoped resources and non-empty for namespaced resources.
+        """
+elif False:
+    ResourceClassParametersReferenceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ResourceClassParametersReferenceArgs:
     def __init__(__self__, *,
@@ -2045,6 +2848,38 @@ class ResourceClassParametersReferenceArgs:
     def namespace(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "namespace", value)
 
+
+if not MYPY:
+    class ResourceClassParametersArgsDict(TypedDict):
+        """
+        ResourceClassParameters defines resource requests for a ResourceClass in an in-tree format understood by Kubernetes.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        filters: NotRequired[pulumi.Input[Sequence[pulumi.Input['ResourceFilterArgsDict']]]]
+        """
+        Filters describes additional contraints that must be met when using the class.
+        """
+        generated_from: NotRequired[pulumi.Input['ResourceClassParametersReferenceArgsDict']]
+        """
+        If this object was created from some other resource, then this links back to that resource. This field is used to find the in-tree representation of the class parameters when the parameter reference of the class refers to some unknown type.
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object metadata
+        """
+        vendor_parameters: NotRequired[pulumi.Input[Sequence[pulumi.Input['VendorParametersArgsDict']]]]
+        """
+        VendorParameters are arbitrary setup parameters for all claims using this class. They are ignored while allocating the claim. There must not be more than one entry per driver.
+        """
+elif False:
+    ResourceClassParametersArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ResourceClassParametersArgs:
@@ -2149,6 +2984,48 @@ class ResourceClassParametersArgs:
     def vendor_parameters(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['VendorParametersArgs']]]]):
         pulumi.set(self, "vendor_parameters", value)
 
+
+if not MYPY:
+    class ResourceClassArgsDict(TypedDict):
+        """
+        ResourceClass is used by administrators to influence how resources are allocated.
+
+        This is an alpha type and requires enabling the DynamicResourceAllocation feature gate.
+        """
+        driver_name: pulumi.Input[str]
+        """
+        DriverName defines the name of the dynamic resource driver that is used for allocation of a ResourceClaim that uses this class.
+
+        Resource drivers have a unique name in forward domain order (acme.example.com).
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object metadata
+        """
+        parameters_ref: NotRequired[pulumi.Input['ResourceClassParametersReferenceArgsDict']]
+        """
+        ParametersRef references an arbitrary separate object that may hold parameters that will be used by the driver when allocating a resource that uses this class. A dynamic resource driver can distinguish between parameters stored here and and those stored in ResourceClaimSpec.
+        """
+        structured_parameters: NotRequired[pulumi.Input[bool]]
+        """
+        If and only if allocation of claims using this class is handled via structured parameters, then StructuredParameters must be set to true.
+        """
+        suitable_nodes: NotRequired[pulumi.Input['_core.v1.NodeSelectorArgsDict']]
+        """
+        Only nodes matching the selector will be considered by the scheduler when trying to find a Node that fits a Pod when that Pod uses a ResourceClaim that has not been allocated yet.
+
+        Setting this field is optional. If null, all nodes are candidates.
+        """
+elif False:
+    ResourceClassArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ResourceClassArgs:
@@ -2279,6 +3156,22 @@ class ResourceClassArgs:
         pulumi.set(self, "suitable_nodes", value)
 
 
+if not MYPY:
+    class ResourceFilterPatchArgsDict(TypedDict):
+        """
+        ResourceFilter is a filter for resources from one particular driver.
+        """
+        driver_name: NotRequired[pulumi.Input[str]]
+        """
+        DriverName is the name used by the DRA driver kubelet plugin.
+        """
+        named_resources: NotRequired[pulumi.Input['NamedResourcesFilterPatchArgsDict']]
+        """
+        NamedResources describes a resource filter using the named resources model.
+        """
+elif False:
+    ResourceFilterPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ResourceFilterPatchArgs:
     def __init__(__self__, *,
@@ -2319,6 +3212,22 @@ class ResourceFilterPatchArgs:
         pulumi.set(self, "named_resources", value)
 
 
+if not MYPY:
+    class ResourceFilterArgsDict(TypedDict):
+        """
+        ResourceFilter is a filter for resources from one particular driver.
+        """
+        driver_name: NotRequired[pulumi.Input[str]]
+        """
+        DriverName is the name used by the DRA driver kubelet plugin.
+        """
+        named_resources: NotRequired[pulumi.Input['NamedResourcesFilterArgsDict']]
+        """
+        NamedResources describes a resource filter using the named resources model.
+        """
+elif False:
+    ResourceFilterArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ResourceFilterArgs:
     def __init__(__self__, *,
@@ -2358,6 +3267,28 @@ class ResourceFilterArgs:
     def named_resources(self, value: Optional[pulumi.Input['NamedResourcesFilterArgs']]):
         pulumi.set(self, "named_resources", value)
 
+
+if not MYPY:
+    class ResourceHandleArgsDict(TypedDict):
+        """
+        ResourceHandle holds opaque resource data for processing by a specific kubelet plugin.
+        """
+        data: NotRequired[pulumi.Input[str]]
+        """
+        Data contains the opaque data associated with this ResourceHandle. It is set by the controller component of the resource driver whose name matches the DriverName set in the ResourceClaimStatus this ResourceHandle is embedded in. It is set at allocation time and is intended for processing by the kubelet plugin whose name matches the DriverName set in this ResourceHandle.
+
+        The maximum size of this field is 16KiB. This may get increased in the future, but not reduced.
+        """
+        driver_name: NotRequired[pulumi.Input[str]]
+        """
+        DriverName specifies the name of the resource driver whose kubelet plugin should be invoked to process this ResourceHandle's data once it lands on a node. This may differ from the DriverName set in ResourceClaimStatus this ResourceHandle is embedded in.
+        """
+        structured_data: NotRequired[pulumi.Input['StructuredResourceHandleArgsDict']]
+        """
+        If StructuredData is set, then it needs to be used instead of Data.
+        """
+elif False:
+    ResourceHandleArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ResourceHandleArgs:
@@ -2419,6 +3350,22 @@ class ResourceHandleArgs:
         pulumi.set(self, "structured_data", value)
 
 
+if not MYPY:
+    class ResourceRequestPatchArgsDict(TypedDict):
+        """
+        ResourceRequest is a request for resources from one particular driver.
+        """
+        named_resources: NotRequired[pulumi.Input['NamedResourcesRequestPatchArgsDict']]
+        """
+        NamedResources describes a request for resources with the named resources model.
+        """
+        vendor_parameters: NotRequired[Any]
+        """
+        VendorParameters are arbitrary setup parameters for the requested resource. They are ignored while allocating a claim.
+        """
+elif False:
+    ResourceRequestPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ResourceRequestPatchArgs:
     def __init__(__self__, *,
@@ -2459,6 +3406,22 @@ class ResourceRequestPatchArgs:
         pulumi.set(self, "vendor_parameters", value)
 
 
+if not MYPY:
+    class ResourceRequestArgsDict(TypedDict):
+        """
+        ResourceRequest is a request for resources from one particular driver.
+        """
+        named_resources: NotRequired[pulumi.Input['NamedResourcesRequestArgsDict']]
+        """
+        NamedResources describes a request for resources with the named resources model.
+        """
+        vendor_parameters: NotRequired[Any]
+        """
+        VendorParameters are arbitrary setup parameters for the requested resource. They are ignored while allocating a claim.
+        """
+elif False:
+    ResourceRequestArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class ResourceRequestArgs:
     def __init__(__self__, *,
@@ -2498,6 +3461,40 @@ class ResourceRequestArgs:
     def vendor_parameters(self, value: Optional[Any]):
         pulumi.set(self, "vendor_parameters", value)
 
+
+if not MYPY:
+    class ResourceSliceArgsDict(TypedDict):
+        """
+        ResourceSlice provides information about available resources on individual nodes.
+        """
+        driver_name: pulumi.Input[str]
+        """
+        DriverName identifies the DRA driver providing the capacity information. A field selector can be used to list only ResourceSlice objects with a certain driver name.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object metadata
+        """
+        named_resources: NotRequired[pulumi.Input['NamedResourcesResourcesArgsDict']]
+        """
+        NamedResources describes available resources using the named resources model.
+        """
+        node_name: NotRequired[pulumi.Input[str]]
+        """
+        NodeName identifies the node which provides the resources if they are local to a node.
+
+        A field selector can be used to list only ResourceSlice objects with a certain node name.
+        """
+elif False:
+    ResourceSliceArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class ResourceSliceArgs:
@@ -2606,6 +3603,30 @@ class ResourceSliceArgs:
         pulumi.set(self, "node_name", value)
 
 
+if not MYPY:
+    class StructuredResourceHandleArgsDict(TypedDict):
+        """
+        StructuredResourceHandle is the in-tree representation of the allocation result.
+        """
+        results: pulumi.Input[Sequence[pulumi.Input['DriverAllocationResultArgsDict']]]
+        """
+        Results lists all allocated driver resources.
+        """
+        node_name: NotRequired[pulumi.Input[str]]
+        """
+        NodeName is the name of the node providing the necessary resources if the resources are local to a node.
+        """
+        vendor_claim_parameters: NotRequired[Any]
+        """
+        VendorClaimParameters are the per-claim configuration parameters from the resource claim parameters at the time that the claim was allocated.
+        """
+        vendor_class_parameters: NotRequired[Any]
+        """
+        VendorClassParameters are the per-claim configuration parameters from the resource class at the time that the claim was allocated.
+        """
+elif False:
+    StructuredResourceHandleArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class StructuredResourceHandleArgs:
     def __init__(__self__, *,
@@ -2677,6 +3698,22 @@ class StructuredResourceHandleArgs:
         pulumi.set(self, "vendor_class_parameters", value)
 
 
+if not MYPY:
+    class VendorParametersPatchArgsDict(TypedDict):
+        """
+        VendorParameters are opaque parameters for one particular driver.
+        """
+        driver_name: NotRequired[pulumi.Input[str]]
+        """
+        DriverName is the name used by the DRA driver kubelet plugin.
+        """
+        parameters: NotRequired[Any]
+        """
+        Parameters can be arbitrary setup parameters. They are ignored while allocating a claim.
+        """
+elif False:
+    VendorParametersPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class VendorParametersPatchArgs:
     def __init__(__self__, *,
@@ -2716,6 +3753,22 @@ class VendorParametersPatchArgs:
     def parameters(self, value: Optional[Any]):
         pulumi.set(self, "parameters", value)
 
+
+if not MYPY:
+    class VendorParametersArgsDict(TypedDict):
+        """
+        VendorParameters are opaque parameters for one particular driver.
+        """
+        driver_name: NotRequired[pulumi.Input[str]]
+        """
+        DriverName is the name used by the DRA driver kubelet plugin.
+        """
+        parameters: NotRequired[Any]
+        """
+        Parameters can be arbitrary setup parameters. They are ignored while allocating a claim.
+        """
+elif False:
+    VendorParametersArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class VendorParametersArgs:

--- a/sdk/python/pulumi_kubernetes/resource/v1alpha2/outputs.py
+++ b/sdk/python/pulumi_kubernetes/resource/v1alpha2/outputs.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core

--- a/sdk/python/pulumi_kubernetes/scheduling/v1/PriorityClass.py
+++ b/sdk/python/pulumi_kubernetes/scheduling/v1/PriorityClass.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import meta as _meta
 
@@ -140,7 +145,7 @@ class PriorityClass(pulumi.CustomResource):
                  description: Optional[pulumi.Input[str]] = None,
                  global_default: Optional[pulumi.Input[bool]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
                  preemption_policy: Optional[pulumi.Input[str]] = None,
                  value: Optional[pulumi.Input[int]] = None,
                  __props__=None):
@@ -153,7 +158,7 @@ class PriorityClass(pulumi.CustomResource):
         :param pulumi.Input[str] description: description is an arbitrary string that usually provides guidelines on when this priority class should be used.
         :param pulumi.Input[bool] global_default: globalDefault specifies whether this PriorityClass should be considered as the default priority for pods that do not have any priority class. Only one PriorityClass can be marked as `globalDefault`. However, if more than one PriorityClasses exists with their `globalDefault` field set to true, the smallest value of such global default PriorityClasses will be used as the default priority.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         :param pulumi.Input[str] preemption_policy: preemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset.
         :param pulumi.Input[int] value: value represents the integer value of this priority class. This is the actual priority that pods receive when they have the name of this class in their pod spec.
         """
@@ -185,7 +190,7 @@ class PriorityClass(pulumi.CustomResource):
                  description: Optional[pulumi.Input[str]] = None,
                  global_default: Optional[pulumi.Input[bool]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
                  preemption_policy: Optional[pulumi.Input[str]] = None,
                  value: Optional[pulumi.Input[int]] = None,
                  __props__=None):

--- a/sdk/python/pulumi_kubernetes/scheduling/v1/PriorityClassList.py
+++ b/sdk/python/pulumi_kubernetes/scheduling/v1/PriorityClassList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class PriorityClassList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PriorityClassArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PriorityClassArgs', 'PriorityClassArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         PriorityClassList is a collection of priority classes.
@@ -101,9 +106,9 @@ class PriorityClassList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PriorityClassArgs']]]] items: items is the list of PriorityClasses
+        :param pulumi.Input[Sequence[pulumi.Input[Union['PriorityClassArgs', 'PriorityClassArgsDict']]]] items: items is the list of PriorityClasses
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class PriorityClassList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PriorityClassArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PriorityClassArgs', 'PriorityClassArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/scheduling/v1/PriorityClassPatch.py
+++ b/sdk/python/pulumi_kubernetes/scheduling/v1/PriorityClassPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import meta as _meta
 
@@ -141,7 +146,7 @@ class PriorityClassPatch(pulumi.CustomResource):
                  description: Optional[pulumi.Input[str]] = None,
                  global_default: Optional[pulumi.Input[bool]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
                  preemption_policy: Optional[pulumi.Input[str]] = None,
                  value: Optional[pulumi.Input[int]] = None,
                  __props__=None):
@@ -160,7 +165,7 @@ class PriorityClassPatch(pulumi.CustomResource):
         :param pulumi.Input[str] description: description is an arbitrary string that usually provides guidelines on when this priority class should be used.
         :param pulumi.Input[bool] global_default: globalDefault specifies whether this PriorityClass should be considered as the default priority for pods that do not have any priority class. Only one PriorityClass can be marked as `globalDefault`. However, if more than one PriorityClasses exists with their `globalDefault` field set to true, the smallest value of such global default PriorityClasses will be used as the default priority.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         :param pulumi.Input[str] preemption_policy: preemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset.
         :param pulumi.Input[int] value: value represents the integer value of this priority class. This is the actual priority that pods receive when they have the name of this class in their pod spec.
         """
@@ -198,7 +203,7 @@ class PriorityClassPatch(pulumi.CustomResource):
                  description: Optional[pulumi.Input[str]] = None,
                  global_default: Optional[pulumi.Input[bool]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
                  preemption_policy: Optional[pulumi.Input[str]] = None,
                  value: Optional[pulumi.Input[int]] = None,
                  __props__=None):

--- a/sdk/python/pulumi_kubernetes/scheduling/v1/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/scheduling/v1/_inputs.py
@@ -4,15 +4,59 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import meta as _meta
 
 __all__ = [
     'PriorityClassArgs',
+    'PriorityClassArgsDict',
 ]
+
+MYPY = False
+
+if not MYPY:
+    class PriorityClassArgsDict(TypedDict):
+        """
+        PriorityClass defines mapping from a priority class name to the priority integer value. The value can be any valid integer.
+        """
+        value: pulumi.Input[int]
+        """
+        value represents the integer value of this priority class. This is the actual priority that pods receive when they have the name of this class in their pod spec.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        description: NotRequired[pulumi.Input[str]]
+        """
+        description is an arbitrary string that usually provides guidelines on when this priority class should be used.
+        """
+        global_default: NotRequired[pulumi.Input[bool]]
+        """
+        globalDefault specifies whether this PriorityClass should be considered as the default priority for pods that do not have any priority class. Only one PriorityClass can be marked as `globalDefault`. However, if more than one PriorityClasses exists with their `globalDefault` field set to true, the smallest value of such global default PriorityClasses will be used as the default priority.
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        preemption_policy: NotRequired[pulumi.Input[str]]
+        """
+        preemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset.
+        """
+elif False:
+    PriorityClassArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class PriorityClassArgs:

--- a/sdk/python/pulumi_kubernetes/scheduling/v1/outputs.py
+++ b/sdk/python/pulumi_kubernetes/scheduling/v1/outputs.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import meta as _meta
 

--- a/sdk/python/pulumi_kubernetes/scheduling/v1alpha1/PriorityClass.py
+++ b/sdk/python/pulumi_kubernetes/scheduling/v1alpha1/PriorityClass.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import meta as _meta
 
@@ -140,7 +145,7 @@ class PriorityClass(pulumi.CustomResource):
                  description: Optional[pulumi.Input[str]] = None,
                  global_default: Optional[pulumi.Input[bool]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
                  preemption_policy: Optional[pulumi.Input[str]] = None,
                  value: Optional[pulumi.Input[int]] = None,
                  __props__=None):
@@ -153,7 +158,7 @@ class PriorityClass(pulumi.CustomResource):
         :param pulumi.Input[str] description: description is an arbitrary string that usually provides guidelines on when this priority class should be used.
         :param pulumi.Input[bool] global_default: globalDefault specifies whether this PriorityClass should be considered as the default priority for pods that do not have any priority class. Only one PriorityClass can be marked as `globalDefault`. However, if more than one PriorityClasses exists with their `globalDefault` field set to true, the smallest value of such global default PriorityClasses will be used as the default priority.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         :param pulumi.Input[str] preemption_policy: PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset. This field is alpha-level and is only honored by servers that enable the NonPreemptingPriority feature.
         :param pulumi.Input[int] value: The value of this priority class. This is the actual priority that pods receive when they have the name of this class in their pod spec.
         """
@@ -185,7 +190,7 @@ class PriorityClass(pulumi.CustomResource):
                  description: Optional[pulumi.Input[str]] = None,
                  global_default: Optional[pulumi.Input[bool]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
                  preemption_policy: Optional[pulumi.Input[str]] = None,
                  value: Optional[pulumi.Input[int]] = None,
                  __props__=None):

--- a/sdk/python/pulumi_kubernetes/scheduling/v1alpha1/PriorityClassList.py
+++ b/sdk/python/pulumi_kubernetes/scheduling/v1alpha1/PriorityClassList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class PriorityClassList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PriorityClassArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PriorityClassArgs', 'PriorityClassArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         PriorityClassList is a collection of priority classes.
@@ -101,9 +106,9 @@ class PriorityClassList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PriorityClassArgs']]]] items: items is the list of PriorityClasses
+        :param pulumi.Input[Sequence[pulumi.Input[Union['PriorityClassArgs', 'PriorityClassArgsDict']]]] items: items is the list of PriorityClasses
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class PriorityClassList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PriorityClassArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PriorityClassArgs', 'PriorityClassArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/scheduling/v1alpha1/PriorityClassPatch.py
+++ b/sdk/python/pulumi_kubernetes/scheduling/v1alpha1/PriorityClassPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import meta as _meta
 
@@ -141,7 +146,7 @@ class PriorityClassPatch(pulumi.CustomResource):
                  description: Optional[pulumi.Input[str]] = None,
                  global_default: Optional[pulumi.Input[bool]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
                  preemption_policy: Optional[pulumi.Input[str]] = None,
                  value: Optional[pulumi.Input[int]] = None,
                  __props__=None):
@@ -160,7 +165,7 @@ class PriorityClassPatch(pulumi.CustomResource):
         :param pulumi.Input[str] description: description is an arbitrary string that usually provides guidelines on when this priority class should be used.
         :param pulumi.Input[bool] global_default: globalDefault specifies whether this PriorityClass should be considered as the default priority for pods that do not have any priority class. Only one PriorityClass can be marked as `globalDefault`. However, if more than one PriorityClasses exists with their `globalDefault` field set to true, the smallest value of such global default PriorityClasses will be used as the default priority.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         :param pulumi.Input[str] preemption_policy: PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset. This field is alpha-level and is only honored by servers that enable the NonPreemptingPriority feature.
         :param pulumi.Input[int] value: The value of this priority class. This is the actual priority that pods receive when they have the name of this class in their pod spec.
         """
@@ -198,7 +203,7 @@ class PriorityClassPatch(pulumi.CustomResource):
                  description: Optional[pulumi.Input[str]] = None,
                  global_default: Optional[pulumi.Input[bool]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
                  preemption_policy: Optional[pulumi.Input[str]] = None,
                  value: Optional[pulumi.Input[int]] = None,
                  __props__=None):

--- a/sdk/python/pulumi_kubernetes/scheduling/v1alpha1/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/scheduling/v1alpha1/_inputs.py
@@ -4,15 +4,59 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import meta as _meta
 
 __all__ = [
     'PriorityClassArgs',
+    'PriorityClassArgsDict',
 ]
+
+MYPY = False
+
+if not MYPY:
+    class PriorityClassArgsDict(TypedDict):
+        """
+        DEPRECATED - This group version of PriorityClass is deprecated by scheduling.k8s.io/v1/PriorityClass. PriorityClass defines mapping from a priority class name to the priority integer value. The value can be any valid integer.
+        """
+        value: pulumi.Input[int]
+        """
+        The value of this priority class. This is the actual priority that pods receive when they have the name of this class in their pod spec.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        description: NotRequired[pulumi.Input[str]]
+        """
+        description is an arbitrary string that usually provides guidelines on when this priority class should be used.
+        """
+        global_default: NotRequired[pulumi.Input[bool]]
+        """
+        globalDefault specifies whether this PriorityClass should be considered as the default priority for pods that do not have any priority class. Only one PriorityClass can be marked as `globalDefault`. However, if more than one PriorityClasses exists with their `globalDefault` field set to true, the smallest value of such global default PriorityClasses will be used as the default priority.
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        preemption_policy: NotRequired[pulumi.Input[str]]
+        """
+        PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset. This field is alpha-level and is only honored by servers that enable the NonPreemptingPriority feature.
+        """
+elif False:
+    PriorityClassArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class PriorityClassArgs:

--- a/sdk/python/pulumi_kubernetes/scheduling/v1alpha1/outputs.py
+++ b/sdk/python/pulumi_kubernetes/scheduling/v1alpha1/outputs.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import meta as _meta
 

--- a/sdk/python/pulumi_kubernetes/scheduling/v1beta1/PriorityClass.py
+++ b/sdk/python/pulumi_kubernetes/scheduling/v1beta1/PriorityClass.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import meta as _meta
 
@@ -140,7 +145,7 @@ class PriorityClass(pulumi.CustomResource):
                  description: Optional[pulumi.Input[str]] = None,
                  global_default: Optional[pulumi.Input[bool]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
                  preemption_policy: Optional[pulumi.Input[str]] = None,
                  value: Optional[pulumi.Input[int]] = None,
                  __props__=None):
@@ -153,7 +158,7 @@ class PriorityClass(pulumi.CustomResource):
         :param pulumi.Input[str] description: description is an arbitrary string that usually provides guidelines on when this priority class should be used.
         :param pulumi.Input[bool] global_default: globalDefault specifies whether this PriorityClass should be considered as the default priority for pods that do not have any priority class. Only one PriorityClass can be marked as `globalDefault`. However, if more than one PriorityClasses exists with their `globalDefault` field set to true, the smallest value of such global default PriorityClasses will be used as the default priority.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         :param pulumi.Input[str] preemption_policy: PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset. This field is alpha-level and is only honored by servers that enable the NonPreemptingPriority feature.
         :param pulumi.Input[int] value: The value of this priority class. This is the actual priority that pods receive when they have the name of this class in their pod spec.
         """
@@ -185,7 +190,7 @@ class PriorityClass(pulumi.CustomResource):
                  description: Optional[pulumi.Input[str]] = None,
                  global_default: Optional[pulumi.Input[bool]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
                  preemption_policy: Optional[pulumi.Input[str]] = None,
                  value: Optional[pulumi.Input[int]] = None,
                  __props__=None):

--- a/sdk/python/pulumi_kubernetes/scheduling/v1beta1/PriorityClassList.py
+++ b/sdk/python/pulumi_kubernetes/scheduling/v1beta1/PriorityClassList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class PriorityClassList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PriorityClassArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PriorityClassArgs', 'PriorityClassArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         PriorityClassList is a collection of priority classes.
@@ -101,9 +106,9 @@ class PriorityClassList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PriorityClassArgs']]]] items: items is the list of PriorityClasses
+        :param pulumi.Input[Sequence[pulumi.Input[Union['PriorityClassArgs', 'PriorityClassArgsDict']]]] items: items is the list of PriorityClasses
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class PriorityClassList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PriorityClassArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PriorityClassArgs', 'PriorityClassArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/scheduling/v1beta1/PriorityClassPatch.py
+++ b/sdk/python/pulumi_kubernetes/scheduling/v1beta1/PriorityClassPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import meta as _meta
 
@@ -141,7 +146,7 @@ class PriorityClassPatch(pulumi.CustomResource):
                  description: Optional[pulumi.Input[str]] = None,
                  global_default: Optional[pulumi.Input[bool]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
                  preemption_policy: Optional[pulumi.Input[str]] = None,
                  value: Optional[pulumi.Input[int]] = None,
                  __props__=None):
@@ -160,7 +165,7 @@ class PriorityClassPatch(pulumi.CustomResource):
         :param pulumi.Input[str] description: description is an arbitrary string that usually provides guidelines on when this priority class should be used.
         :param pulumi.Input[bool] global_default: globalDefault specifies whether this PriorityClass should be considered as the default priority for pods that do not have any priority class. Only one PriorityClass can be marked as `globalDefault`. However, if more than one PriorityClasses exists with their `globalDefault` field set to true, the smallest value of such global default PriorityClasses will be used as the default priority.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         :param pulumi.Input[str] preemption_policy: PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset. This field is alpha-level and is only honored by servers that enable the NonPreemptingPriority feature.
         :param pulumi.Input[int] value: The value of this priority class. This is the actual priority that pods receive when they have the name of this class in their pod spec.
         """
@@ -198,7 +203,7 @@ class PriorityClassPatch(pulumi.CustomResource):
                  description: Optional[pulumi.Input[str]] = None,
                  global_default: Optional[pulumi.Input[bool]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
                  preemption_policy: Optional[pulumi.Input[str]] = None,
                  value: Optional[pulumi.Input[int]] = None,
                  __props__=None):

--- a/sdk/python/pulumi_kubernetes/scheduling/v1beta1/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/scheduling/v1beta1/_inputs.py
@@ -4,15 +4,59 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import meta as _meta
 
 __all__ = [
     'PriorityClassArgs',
+    'PriorityClassArgsDict',
 ]
+
+MYPY = False
+
+if not MYPY:
+    class PriorityClassArgsDict(TypedDict):
+        """
+        DEPRECATED - This group version of PriorityClass is deprecated by scheduling.k8s.io/v1/PriorityClass. PriorityClass defines mapping from a priority class name to the priority integer value. The value can be any valid integer.
+        """
+        value: pulumi.Input[int]
+        """
+        The value of this priority class. This is the actual priority that pods receive when they have the name of this class in their pod spec.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        description: NotRequired[pulumi.Input[str]]
+        """
+        description is an arbitrary string that usually provides guidelines on when this priority class should be used.
+        """
+        global_default: NotRequired[pulumi.Input[bool]]
+        """
+        globalDefault specifies whether this PriorityClass should be considered as the default priority for pods that do not have any priority class. Only one PriorityClass can be marked as `globalDefault`. However, if more than one PriorityClasses exists with their `globalDefault` field set to true, the smallest value of such global default PriorityClasses will be used as the default priority.
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        preemption_policy: NotRequired[pulumi.Input[str]]
+        """
+        PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset. This field is alpha-level and is only honored by servers that enable the NonPreemptingPriority feature.
+        """
+elif False:
+    PriorityClassArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class PriorityClassArgs:

--- a/sdk/python/pulumi_kubernetes/scheduling/v1beta1/outputs.py
+++ b/sdk/python/pulumi_kubernetes/scheduling/v1beta1/outputs.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import meta as _meta
 

--- a/sdk/python/pulumi_kubernetes/settings/v1alpha1/PodPreset.py
+++ b/sdk/python/pulumi_kubernetes/settings/v1alpha1/PodPreset.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -86,8 +91,8 @@ class PodPreset(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PodPresetSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PodPresetSpecArgs', 'PodPresetSpecArgsDict']]] = None,
                  __props__=None):
         """
         PodPreset is a policy resource that defines additional runtime requirements for a Pod.
@@ -123,8 +128,8 @@ class PodPreset(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PodPresetSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PodPresetSpecArgs', 'PodPresetSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/settings/v1alpha1/PodPresetList.py
+++ b/sdk/python/pulumi_kubernetes/settings/v1alpha1/PodPresetList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -92,9 +97,9 @@ class PodPresetList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PodPresetArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PodPresetArgs', 'PodPresetArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         PodPresetList is a list of PodPreset objects.
@@ -102,9 +107,9 @@ class PodPresetList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PodPresetArgs']]]] items: Items is a list of schema objects.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['PodPresetArgs', 'PodPresetArgsDict']]]] items: Items is a list of schema objects.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -131,9 +136,9 @@ class PodPresetList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['PodPresetArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['PodPresetArgs', 'PodPresetArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/settings/v1alpha1/PodPresetPatch.py
+++ b/sdk/python/pulumi_kubernetes/settings/v1alpha1/PodPresetPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -86,8 +91,8 @@ class PodPresetPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PodPresetSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PodPresetSpecPatchArgs', 'PodPresetSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -135,8 +140,8 @@ class PodPresetPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['PodPresetSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['PodPresetSpecPatchArgs', 'PodPresetSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/settings/v1alpha1/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/settings/v1alpha1/_inputs.py
@@ -4,18 +4,56 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import core as _core
 from ... import meta as _meta
 
 __all__ = [
     'PodPresetSpecPatchArgs',
+    'PodPresetSpecPatchArgsDict',
     'PodPresetSpecArgs',
+    'PodPresetSpecArgsDict',
     'PodPresetArgs',
+    'PodPresetArgsDict',
 ]
+
+MYPY = False
+
+if not MYPY:
+    class PodPresetSpecPatchArgsDict(TypedDict):
+        """
+        PodPresetSpec is a description of a pod preset.
+        """
+        env: NotRequired[pulumi.Input[Sequence[pulumi.Input['_core.v1.EnvVarPatchArgsDict']]]]
+        """
+        Env defines the collection of EnvVar to inject into containers.
+        """
+        env_from: NotRequired[pulumi.Input[Sequence[pulumi.Input['_core.v1.EnvFromSourcePatchArgsDict']]]]
+        """
+        EnvFrom defines the collection of EnvFromSource to inject into containers.
+        """
+        selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorPatchArgsDict']]
+        """
+        Selector is a label query over a set of resources, in this case pods. Required.
+        """
+        volume_mounts: NotRequired[pulumi.Input[Sequence[pulumi.Input['_core.v1.VolumeMountPatchArgsDict']]]]
+        """
+        VolumeMounts defines the collection of VolumeMount to inject into containers.
+        """
+        volumes: NotRequired[pulumi.Input[Sequence[pulumi.Input['_core.v1.VolumePatchArgsDict']]]]
+        """
+        Volumes defines the collection of Volume to inject into the pod.
+        """
+elif False:
+    PodPresetSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class PodPresetSpecPatchArgs:
@@ -105,6 +143,34 @@ class PodPresetSpecPatchArgs:
         pulumi.set(self, "volumes", value)
 
 
+if not MYPY:
+    class PodPresetSpecArgsDict(TypedDict):
+        """
+        PodPresetSpec is a description of a pod preset.
+        """
+        env: NotRequired[pulumi.Input[Sequence[pulumi.Input['_core.v1.EnvVarArgsDict']]]]
+        """
+        Env defines the collection of EnvVar to inject into containers.
+        """
+        env_from: NotRequired[pulumi.Input[Sequence[pulumi.Input['_core.v1.EnvFromSourceArgsDict']]]]
+        """
+        EnvFrom defines the collection of EnvFromSource to inject into containers.
+        """
+        selector: NotRequired[pulumi.Input['_meta.v1.LabelSelectorArgsDict']]
+        """
+        Selector is a label query over a set of resources, in this case pods. Required.
+        """
+        volume_mounts: NotRequired[pulumi.Input[Sequence[pulumi.Input['_core.v1.VolumeMountArgsDict']]]]
+        """
+        VolumeMounts defines the collection of VolumeMount to inject into containers.
+        """
+        volumes: NotRequired[pulumi.Input[Sequence[pulumi.Input['_core.v1.VolumeArgsDict']]]]
+        """
+        Volumes defines the collection of Volume to inject into the pod.
+        """
+elif False:
+    PodPresetSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class PodPresetSpecArgs:
     def __init__(__self__, *,
@@ -192,6 +258,24 @@ class PodPresetSpecArgs:
     def volumes(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['_core.v1.VolumeArgs']]]]):
         pulumi.set(self, "volumes", value)
 
+
+if not MYPY:
+    class PodPresetArgsDict(TypedDict):
+        """
+        PodPreset is a policy resource that defines additional runtime requirements for a Pod.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        spec: NotRequired[pulumi.Input['PodPresetSpecArgsDict']]
+elif False:
+    PodPresetArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class PodPresetArgs:

--- a/sdk/python/pulumi_kubernetes/settings/v1alpha1/outputs.py
+++ b/sdk/python/pulumi_kubernetes/settings/v1alpha1/outputs.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core

--- a/sdk/python/pulumi_kubernetes/storage/v1/CSIDriver.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1/CSIDriver.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -92,8 +97,8 @@ class CSIDriver(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['CSIDriverSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['CSIDriverSpecArgs', 'CSIDriverSpecArgsDict']]] = None,
                  __props__=None):
         """
         CSIDriver captures information about a Container Storage Interface (CSI) volume driver deployed on the cluster. Kubernetes attach detach controller uses this object to determine whether attach is required. Kubelet uses this object to determine whether pod information needs to be passed on mount. CSIDriver objects are non-namespaced.
@@ -102,8 +107,8 @@ class CSIDriver(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object metadata. metadata.Name indicates the name of the CSI driver that this object refers to; it MUST be the same name returned by the CSI GetPluginName() call for that driver. The driver name must be 63 characters or less, beginning and ending with an alphanumeric character ([a-z0-9A-Z]) with dashes (-), dots (.), and alphanumerics between. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['CSIDriverSpecArgs']] spec: spec represents the specification of the CSI Driver.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object metadata. metadata.Name indicates the name of the CSI driver that this object refers to; it MUST be the same name returned by the CSI GetPluginName() call for that driver. The driver name must be 63 characters or less, beginning and ending with an alphanumeric character ([a-z0-9A-Z]) with dashes (-), dots (.), and alphanumerics between. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['CSIDriverSpecArgs', 'CSIDriverSpecArgsDict']] spec: spec represents the specification of the CSI Driver.
         """
         ...
     @overload
@@ -131,8 +136,8 @@ class CSIDriver(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['CSIDriverSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['CSIDriverSpecArgs', 'CSIDriverSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/storage/v1/CSIDriverList.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1/CSIDriverList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class CSIDriverList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['CSIDriverArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['CSIDriverArgs', 'CSIDriverArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         CSIDriverList is a collection of CSIDriver objects.
@@ -101,9 +106,9 @@ class CSIDriverList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['CSIDriverArgs']]]] items: items is the list of CSIDriver
+        :param pulumi.Input[Sequence[pulumi.Input[Union['CSIDriverArgs', 'CSIDriverArgsDict']]]] items: items is the list of CSIDriver
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class CSIDriverList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['CSIDriverArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['CSIDriverArgs', 'CSIDriverArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/storage/v1/CSIDriverPatch.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1/CSIDriverPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class CSIDriverPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['CSIDriverSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['CSIDriverSpecPatchArgs', 'CSIDriverSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -109,8 +114,8 @@ class CSIDriverPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object metadata. metadata.Name indicates the name of the CSI driver that this object refers to; it MUST be the same name returned by the CSI GetPluginName() call for that driver. The driver name must be 63 characters or less, beginning and ending with an alphanumeric character ([a-z0-9A-Z]) with dashes (-), dots (.), and alphanumerics between. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['CSIDriverSpecPatchArgs']] spec: spec represents the specification of the CSI Driver.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object metadata. metadata.Name indicates the name of the CSI driver that this object refers to; it MUST be the same name returned by the CSI GetPluginName() call for that driver. The driver name must be 63 characters or less, beginning and ending with an alphanumeric character ([a-z0-9A-Z]) with dashes (-), dots (.), and alphanumerics between. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['CSIDriverSpecPatchArgs', 'CSIDriverSpecPatchArgsDict']] spec: spec represents the specification of the CSI Driver.
         """
         ...
     @overload
@@ -144,8 +149,8 @@ class CSIDriverPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['CSIDriverSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['CSIDriverSpecPatchArgs', 'CSIDriverSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/storage/v1/CSINode.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1/CSINode.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -92,8 +97,8 @@ class CSINode(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['CSINodeSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['CSINodeSpecArgs', 'CSINodeSpecArgsDict']]] = None,
                  __props__=None):
         """
         CSINode holds information about all CSI drivers installed on a node. CSI drivers do not need to create the CSINode object directly. As long as they use the node-driver-registrar sidecar container, the kubelet will automatically populate the CSINode object for the CSI driver as part of kubelet plugin registration. CSINode has the same name as a node. If the object is missing, it means either there are no CSI Drivers available on the node, or the Kubelet version is low enough that it doesn't create this object. CSINode has an OwnerReference that points to the corresponding node object.
@@ -102,8 +107,8 @@ class CSINode(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata. metadata.name must be the Kubernetes node name.
-        :param pulumi.Input[pulumi.InputType['CSINodeSpecArgs']] spec: spec is the specification of CSINode
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata. metadata.name must be the Kubernetes node name.
+        :param pulumi.Input[Union['CSINodeSpecArgs', 'CSINodeSpecArgsDict']] spec: spec is the specification of CSINode
         """
         ...
     @overload
@@ -131,8 +136,8 @@ class CSINode(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['CSINodeSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['CSINodeSpecArgs', 'CSINodeSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/storage/v1/CSINodeList.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1/CSINodeList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class CSINodeList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['CSINodeArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['CSINodeArgs', 'CSINodeArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         CSINodeList is a collection of CSINode objects.
@@ -101,9 +106,9 @@ class CSINodeList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['CSINodeArgs']]]] items: items is the list of CSINode
+        :param pulumi.Input[Sequence[pulumi.Input[Union['CSINodeArgs', 'CSINodeArgsDict']]]] items: items is the list of CSINode
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class CSINodeList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['CSINodeArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['CSINodeArgs', 'CSINodeArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/storage/v1/CSINodePatch.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1/CSINodePatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class CSINodePatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['CSINodeSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['CSINodeSpecPatchArgs', 'CSINodeSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -109,8 +114,8 @@ class CSINodePatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata. metadata.name must be the Kubernetes node name.
-        :param pulumi.Input[pulumi.InputType['CSINodeSpecPatchArgs']] spec: spec is the specification of CSINode
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata. metadata.name must be the Kubernetes node name.
+        :param pulumi.Input[Union['CSINodeSpecPatchArgs', 'CSINodeSpecPatchArgsDict']] spec: spec is the specification of CSINode
         """
         ...
     @overload
@@ -144,8 +149,8 @@ class CSINodePatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['CSINodeSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['CSINodeSpecPatchArgs', 'CSINodeSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/storage/v1/CSIStorageCapacity.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1/CSIStorageCapacity.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import meta as _meta
 
@@ -156,8 +161,8 @@ class CSIStorageCapacity(pulumi.CustomResource):
                  capacity: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
                  maximum_volume_size: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 node_topology: Optional[pulumi.Input[pulumi.InputType['_meta.v1.LabelSelectorArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 node_topology: Optional[pulumi.Input[Union['_meta.v1.LabelSelectorArgs', '_meta.v1.LabelSelectorArgsDict']]] = None,
                  storage_class_name: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         """
@@ -181,12 +186,12 @@ class CSIStorageCapacity(pulumi.CustomResource):
         :param pulumi.Input[str] maximum_volume_size: maximumVolumeSize is the value reported by the CSI driver in its GetCapacityResponse for a GetCapacityRequest with topology and parameters that match the previous fields.
                
                This is defined since CSI spec 1.4.0 as the largest size that may be used in a CreateVolumeRequest.capacity_range.required_bytes field to create a volume with the same parameters as those in GetCapacityRequest. The corresponding value in the Kubernetes API is ResourceRequirements.Requests in a volume claim.
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata. The name has no particular meaning. It must be a DNS subdomain (dots allowed, 253 characters). To ensure that there are no conflicts with other CSI drivers on the cluster, the recommendation is to use csisc-<uuid>, a generated name, or a reverse-domain name which ends with the unique CSI driver name.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata. The name has no particular meaning. It must be a DNS subdomain (dots allowed, 253 characters). To ensure that there are no conflicts with other CSI drivers on the cluster, the recommendation is to use csisc-<uuid>, a generated name, or a reverse-domain name which ends with the unique CSI driver name.
                
                Objects are namespaced.
                
                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['_meta.v1.LabelSelectorArgs']] node_topology: nodeTopology defines which nodes have access to the storage for which capacity was reported. If not set, the storage is not accessible from any node in the cluster. If empty, the storage is accessible from all nodes. This field is immutable.
+        :param pulumi.Input[Union['_meta.v1.LabelSelectorArgs', '_meta.v1.LabelSelectorArgsDict']] node_topology: nodeTopology defines which nodes have access to the storage for which capacity was reported. If not set, the storage is not accessible from any node in the cluster. If empty, the storage is accessible from all nodes. This field is immutable.
         :param pulumi.Input[str] storage_class_name: storageClassName represents the name of the StorageClass that the reported capacity applies to. It must meet the same requirements as the name of a StorageClass object (non-empty, DNS subdomain). If that object no longer exists, the CSIStorageCapacity object is obsolete and should be removed by its creator. This field is immutable.
         """
         ...
@@ -225,8 +230,8 @@ class CSIStorageCapacity(pulumi.CustomResource):
                  capacity: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
                  maximum_volume_size: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 node_topology: Optional[pulumi.Input[pulumi.InputType['_meta.v1.LabelSelectorArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 node_topology: Optional[pulumi.Input[Union['_meta.v1.LabelSelectorArgs', '_meta.v1.LabelSelectorArgsDict']]] = None,
                  storage_class_name: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)

--- a/sdk/python/pulumi_kubernetes/storage/v1/CSIStorageCapacityList.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1/CSIStorageCapacityList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class CSIStorageCapacityList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['CSIStorageCapacityArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['CSIStorageCapacityArgs', 'CSIStorageCapacityArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         CSIStorageCapacityList is a collection of CSIStorageCapacity objects.
@@ -101,9 +106,9 @@ class CSIStorageCapacityList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['CSIStorageCapacityArgs']]]] items: items is the list of CSIStorageCapacity objects.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['CSIStorageCapacityArgs', 'CSIStorageCapacityArgsDict']]]] items: items is the list of CSIStorageCapacity objects.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class CSIStorageCapacityList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['CSIStorageCapacityArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['CSIStorageCapacityArgs', 'CSIStorageCapacityArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/storage/v1/CSIStorageCapacityPatch.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1/CSIStorageCapacityPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import meta as _meta
 
@@ -157,8 +162,8 @@ class CSIStorageCapacityPatch(pulumi.CustomResource):
                  capacity: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
                  maximum_volume_size: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 node_topology: Optional[pulumi.Input[pulumi.InputType['_meta.v1.LabelSelectorPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 node_topology: Optional[pulumi.Input[Union['_meta.v1.LabelSelectorPatchArgs', '_meta.v1.LabelSelectorPatchArgsDict']]] = None,
                  storage_class_name: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         """
@@ -188,12 +193,12 @@ class CSIStorageCapacityPatch(pulumi.CustomResource):
         :param pulumi.Input[str] maximum_volume_size: maximumVolumeSize is the value reported by the CSI driver in its GetCapacityResponse for a GetCapacityRequest with topology and parameters that match the previous fields.
                
                This is defined since CSI spec 1.4.0 as the largest size that may be used in a CreateVolumeRequest.capacity_range.required_bytes field to create a volume with the same parameters as those in GetCapacityRequest. The corresponding value in the Kubernetes API is ResourceRequirements.Requests in a volume claim.
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata. The name has no particular meaning. It must be a DNS subdomain (dots allowed, 253 characters). To ensure that there are no conflicts with other CSI drivers on the cluster, the recommendation is to use csisc-<uuid>, a generated name, or a reverse-domain name which ends with the unique CSI driver name.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata. The name has no particular meaning. It must be a DNS subdomain (dots allowed, 253 characters). To ensure that there are no conflicts with other CSI drivers on the cluster, the recommendation is to use csisc-<uuid>, a generated name, or a reverse-domain name which ends with the unique CSI driver name.
                
                Objects are namespaced.
                
                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['_meta.v1.LabelSelectorPatchArgs']] node_topology: nodeTopology defines which nodes have access to the storage for which capacity was reported. If not set, the storage is not accessible from any node in the cluster. If empty, the storage is accessible from all nodes. This field is immutable.
+        :param pulumi.Input[Union['_meta.v1.LabelSelectorPatchArgs', '_meta.v1.LabelSelectorPatchArgsDict']] node_topology: nodeTopology defines which nodes have access to the storage for which capacity was reported. If not set, the storage is not accessible from any node in the cluster. If empty, the storage is accessible from all nodes. This field is immutable.
         :param pulumi.Input[str] storage_class_name: storageClassName represents the name of the StorageClass that the reported capacity applies to. It must meet the same requirements as the name of a StorageClass object (non-empty, DNS subdomain). If that object no longer exists, the CSIStorageCapacity object is obsolete and should be removed by its creator. This field is immutable.
         """
         ...
@@ -238,8 +243,8 @@ class CSIStorageCapacityPatch(pulumi.CustomResource):
                  capacity: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
                  maximum_volume_size: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 node_topology: Optional[pulumi.Input[pulumi.InputType['_meta.v1.LabelSelectorPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 node_topology: Optional[pulumi.Input[Union['_meta.v1.LabelSelectorPatchArgs', '_meta.v1.LabelSelectorPatchArgsDict']]] = None,
                  storage_class_name: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)

--- a/sdk/python/pulumi_kubernetes/storage/v1/StorageClass.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1/StorageClass.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import core as _core
 from ... import meta as _meta
@@ -186,10 +191,10 @@ class StorageClass(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  allow_volume_expansion: Optional[pulumi.Input[bool]] = None,
-                 allowed_topologies: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['_core.v1.TopologySelectorTermArgs']]]]] = None,
+                 allowed_topologies: Optional[pulumi.Input[Sequence[pulumi.Input[Union['_core.v1.TopologySelectorTermArgs', '_core.v1.TopologySelectorTermArgsDict']]]]] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
                  mount_options: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  parameters: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  provisioner: Optional[pulumi.Input[str]] = None,
@@ -204,10 +209,10 @@ class StorageClass(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[bool] allow_volume_expansion: allowVolumeExpansion shows whether the storage class allow volume expand.
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['_core.v1.TopologySelectorTermArgs']]]] allowed_topologies: allowedTopologies restrict the node topologies where volumes can be dynamically provisioned. Each volume plugin defines its own supported topology specifications. An empty TopologySelectorTerm list means there is no topology restriction. This field is only honored by servers that enable the VolumeScheduling feature.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['_core.v1.TopologySelectorTermArgs', '_core.v1.TopologySelectorTermArgsDict']]]] allowed_topologies: allowedTopologies restrict the node topologies where volumes can be dynamically provisioned. Each volume plugin defines its own supported topology specifications. An empty TopologySelectorTerm list means there is no topology restriction. This field is only honored by servers that enable the VolumeScheduling feature.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         :param pulumi.Input[Sequence[pulumi.Input[str]]] mount_options: mountOptions controls the mountOptions for dynamically provisioned PersistentVolumes of this storage class. e.g. ["ro", "soft"]. Not validated - mount of the PVs will simply fail if one is invalid.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] parameters: parameters holds the parameters for the provisioner that should create volumes of this storage class.
         :param pulumi.Input[str] provisioner: provisioner indicates the type of the provisioner.
@@ -241,10 +246,10 @@ class StorageClass(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  allow_volume_expansion: Optional[pulumi.Input[bool]] = None,
-                 allowed_topologies: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['_core.v1.TopologySelectorTermArgs']]]]] = None,
+                 allowed_topologies: Optional[pulumi.Input[Sequence[pulumi.Input[Union['_core.v1.TopologySelectorTermArgs', '_core.v1.TopologySelectorTermArgsDict']]]]] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
                  mount_options: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  parameters: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  provisioner: Optional[pulumi.Input[str]] = None,

--- a/sdk/python/pulumi_kubernetes/storage/v1/StorageClassList.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1/StorageClassList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -92,9 +97,9 @@ class StorageClassList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['StorageClassArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['StorageClassArgs', 'StorageClassArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         StorageClassList is a collection of storage classes.
@@ -102,9 +107,9 @@ class StorageClassList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['StorageClassArgs']]]] items: items is the list of StorageClasses
+        :param pulumi.Input[Sequence[pulumi.Input[Union['StorageClassArgs', 'StorageClassArgsDict']]]] items: items is the list of StorageClasses
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -131,9 +136,9 @@ class StorageClassList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['StorageClassArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['StorageClassArgs', 'StorageClassArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/storage/v1/StorageClassPatch.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1/StorageClassPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import core as _core
 from ... import meta as _meta
@@ -187,10 +192,10 @@ class StorageClassPatch(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  allow_volume_expansion: Optional[pulumi.Input[bool]] = None,
-                 allowed_topologies: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['_core.v1.TopologySelectorTermPatchArgs']]]]] = None,
+                 allowed_topologies: Optional[pulumi.Input[Sequence[pulumi.Input[Union['_core.v1.TopologySelectorTermPatchArgs', '_core.v1.TopologySelectorTermPatchArgsDict']]]]] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
                  mount_options: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  parameters: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  provisioner: Optional[pulumi.Input[str]] = None,
@@ -211,10 +216,10 @@ class StorageClassPatch(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[bool] allow_volume_expansion: allowVolumeExpansion shows whether the storage class allow volume expand.
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['_core.v1.TopologySelectorTermPatchArgs']]]] allowed_topologies: allowedTopologies restrict the node topologies where volumes can be dynamically provisioned. Each volume plugin defines its own supported topology specifications. An empty TopologySelectorTerm list means there is no topology restriction. This field is only honored by servers that enable the VolumeScheduling feature.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['_core.v1.TopologySelectorTermPatchArgs', '_core.v1.TopologySelectorTermPatchArgsDict']]]] allowed_topologies: allowedTopologies restrict the node topologies where volumes can be dynamically provisioned. Each volume plugin defines its own supported topology specifications. An empty TopologySelectorTerm list means there is no topology restriction. This field is only honored by servers that enable the VolumeScheduling feature.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         :param pulumi.Input[Sequence[pulumi.Input[str]]] mount_options: mountOptions controls the mountOptions for dynamically provisioned PersistentVolumes of this storage class. e.g. ["ro", "soft"]. Not validated - mount of the PVs will simply fail if one is invalid.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] parameters: parameters holds the parameters for the provisioner that should create volumes of this storage class.
         :param pulumi.Input[str] provisioner: provisioner indicates the type of the provisioner.
@@ -254,10 +259,10 @@ class StorageClassPatch(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  allow_volume_expansion: Optional[pulumi.Input[bool]] = None,
-                 allowed_topologies: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['_core.v1.TopologySelectorTermPatchArgs']]]]] = None,
+                 allowed_topologies: Optional[pulumi.Input[Sequence[pulumi.Input[Union['_core.v1.TopologySelectorTermPatchArgs', '_core.v1.TopologySelectorTermPatchArgsDict']]]]] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
                  mount_options: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  parameters: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  provisioner: Optional[pulumi.Input[str]] = None,

--- a/sdk/python/pulumi_kubernetes/storage/v1/VolumeAttachment.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1/VolumeAttachment.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -93,8 +98,8 @@ class VolumeAttachment(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['VolumeAttachmentSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['VolumeAttachmentSpecArgs', 'VolumeAttachmentSpecArgsDict']]] = None,
                  __props__=None):
         """
         VolumeAttachment captures the intent to attach or detach the specified volume to/from the specified node.
@@ -105,8 +110,8 @@ class VolumeAttachment(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['VolumeAttachmentSpecArgs']] spec: spec represents specification of the desired attach/detach volume behavior. Populated by the Kubernetes system.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['VolumeAttachmentSpecArgs', 'VolumeAttachmentSpecArgsDict']] spec: spec represents specification of the desired attach/detach volume behavior. Populated by the Kubernetes system.
         """
         ...
     @overload
@@ -136,8 +141,8 @@ class VolumeAttachment(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['VolumeAttachmentSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['VolumeAttachmentSpecArgs', 'VolumeAttachmentSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/storage/v1/VolumeAttachmentList.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1/VolumeAttachmentList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -92,9 +97,9 @@ class VolumeAttachmentList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['VolumeAttachmentArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['VolumeAttachmentArgs', 'VolumeAttachmentArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         VolumeAttachmentList is a collection of VolumeAttachment objects.
@@ -102,9 +107,9 @@ class VolumeAttachmentList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['VolumeAttachmentArgs']]]] items: items is the list of VolumeAttachments
+        :param pulumi.Input[Sequence[pulumi.Input[Union['VolumeAttachmentArgs', 'VolumeAttachmentArgsDict']]]] items: items is the list of VolumeAttachments
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -131,9 +136,9 @@ class VolumeAttachmentList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['VolumeAttachmentArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['VolumeAttachmentArgs', 'VolumeAttachmentArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/storage/v1/VolumeAttachmentPatch.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1/VolumeAttachmentPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -94,8 +99,8 @@ class VolumeAttachmentPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['VolumeAttachmentSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['VolumeAttachmentSpecPatchArgs', 'VolumeAttachmentSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -112,8 +117,8 @@ class VolumeAttachmentPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['VolumeAttachmentSpecPatchArgs']] spec: spec represents specification of the desired attach/detach volume behavior. Populated by the Kubernetes system.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['VolumeAttachmentSpecPatchArgs', 'VolumeAttachmentSpecPatchArgsDict']] spec: spec represents specification of the desired attach/detach volume behavior. Populated by the Kubernetes system.
         """
         ...
     @overload
@@ -149,8 +154,8 @@ class VolumeAttachmentPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['VolumeAttachmentSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['VolumeAttachmentSpecPatchArgs', 'VolumeAttachmentSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/storage/v1/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1/_inputs.py
@@ -4,36 +4,147 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import core as _core
 from ... import meta as _meta
 
 __all__ = [
     'CSIDriverSpecPatchArgs',
+    'CSIDriverSpecPatchArgsDict',
     'CSIDriverSpecArgs',
+    'CSIDriverSpecArgsDict',
     'CSIDriverArgs',
+    'CSIDriverArgsDict',
     'CSINodeDriverPatchArgs',
+    'CSINodeDriverPatchArgsDict',
     'CSINodeDriverArgs',
+    'CSINodeDriverArgsDict',
     'CSINodeSpecPatchArgs',
+    'CSINodeSpecPatchArgsDict',
     'CSINodeSpecArgs',
+    'CSINodeSpecArgsDict',
     'CSINodeArgs',
+    'CSINodeArgsDict',
     'CSIStorageCapacityArgs',
+    'CSIStorageCapacityArgsDict',
     'StorageClassArgs',
+    'StorageClassArgsDict',
     'TokenRequestPatchArgs',
+    'TokenRequestPatchArgsDict',
     'TokenRequestArgs',
+    'TokenRequestArgsDict',
     'VolumeAttachmentSourcePatchArgs',
+    'VolumeAttachmentSourcePatchArgsDict',
     'VolumeAttachmentSourceArgs',
+    'VolumeAttachmentSourceArgsDict',
     'VolumeAttachmentSpecPatchArgs',
+    'VolumeAttachmentSpecPatchArgsDict',
     'VolumeAttachmentSpecArgs',
+    'VolumeAttachmentSpecArgsDict',
     'VolumeAttachmentStatusArgs',
+    'VolumeAttachmentStatusArgsDict',
     'VolumeAttachmentArgs',
+    'VolumeAttachmentArgsDict',
     'VolumeErrorArgs',
+    'VolumeErrorArgsDict',
     'VolumeNodeResourcesPatchArgs',
+    'VolumeNodeResourcesPatchArgsDict',
     'VolumeNodeResourcesArgs',
+    'VolumeNodeResourcesArgsDict',
 ]
+
+MYPY = False
+
+if not MYPY:
+    class CSIDriverSpecPatchArgsDict(TypedDict):
+        """
+        CSIDriverSpec is the specification of a CSIDriver.
+        """
+        attach_required: NotRequired[pulumi.Input[bool]]
+        """
+        attachRequired indicates this CSI volume driver requires an attach operation (because it implements the CSI ControllerPublishVolume() method), and that the Kubernetes attach detach controller should call the attach volume interface which checks the volumeattachment status and waits until the volume is attached before proceeding to mounting. The CSI external-attacher coordinates with CSI volume driver and updates the volumeattachment status when the attach operation is complete. If the CSIDriverRegistry feature gate is enabled and the value is specified to false, the attach operation will be skipped. Otherwise the attach operation will be called.
+
+        This field is immutable.
+        """
+        fs_group_policy: NotRequired[pulumi.Input[str]]
+        """
+        fsGroupPolicy defines if the underlying volume supports changing ownership and permission of the volume before being mounted. Refer to the specific FSGroupPolicy values for additional details.
+
+        This field was immutable in Kubernetes < 1.29 and now is mutable.
+
+        Defaults to ReadWriteOnceWithFSType, which will examine each volume to determine if Kubernetes should modify ownership and permissions of the volume. With the default policy the defined fsGroup will only be applied if a fstype is defined and the volume's access mode contains ReadWriteOnce.
+        """
+        pod_info_on_mount: NotRequired[pulumi.Input[bool]]
+        """
+        podInfoOnMount indicates this CSI volume driver requires additional pod information (like podName, podUID, etc.) during mount operations, if set to true. If set to false, pod information will not be passed on mount. Default is false.
+
+        The CSI driver specifies podInfoOnMount as part of driver deployment. If true, Kubelet will pass pod information as VolumeContext in the CSI NodePublishVolume() calls. The CSI driver is responsible for parsing and validating the information passed in as VolumeContext.
+
+        The following VolumeContext will be passed if podInfoOnMount is set to true. This list might grow, but the prefix will be used. "csi.storage.k8s.io/pod.name": pod.Name "csi.storage.k8s.io/pod.namespace": pod.Namespace "csi.storage.k8s.io/pod.uid": string(pod.UID) "csi.storage.k8s.io/ephemeral": "true" if the volume is an ephemeral inline volume
+                                        defined by a CSIVolumeSource, otherwise "false"
+
+        "csi.storage.k8s.io/ephemeral" is a new feature in Kubernetes 1.16. It is only required for drivers which support both the "Persistent" and "Ephemeral" VolumeLifecycleMode. Other drivers can leave pod info disabled and/or ignore this field. As Kubernetes 1.15 doesn't support this field, drivers can only support one mode when deployed on such a cluster and the deployment determines which mode that is, for example via a command line parameter of the driver.
+
+        This field was immutable in Kubernetes < 1.29 and now is mutable.
+        """
+        requires_republish: NotRequired[pulumi.Input[bool]]
+        """
+        requiresRepublish indicates the CSI driver wants `NodePublishVolume` being periodically called to reflect any possible change in the mounted volume. This field defaults to false.
+
+        Note: After a successful initial NodePublishVolume call, subsequent calls to NodePublishVolume should only update the contents of the volume. New mount points will not be seen by a running container.
+        """
+        se_linux_mount: NotRequired[pulumi.Input[bool]]
+        """
+        seLinuxMount specifies if the CSI driver supports "-o context" mount option.
+
+        When "true", the CSI driver must ensure that all volumes provided by this CSI driver can be mounted separately with different `-o context` options. This is typical for storage backends that provide volumes as filesystems on block devices or as independent shared volumes. Kubernetes will call NodeStage / NodePublish with "-o context=xyz" mount option when mounting a ReadWriteOncePod volume used in Pod that has explicitly set SELinux context. In the future, it may be expanded to other volume AccessModes. In any case, Kubernetes will ensure that the volume is mounted only with a single SELinux context.
+
+        When "false", Kubernetes won't pass any special SELinux mount options to the driver. This is typical for volumes that represent subdirectories of a bigger shared filesystem.
+
+        Default is "false".
+        """
+        storage_capacity: NotRequired[pulumi.Input[bool]]
+        """
+        storageCapacity indicates that the CSI volume driver wants pod scheduling to consider the storage capacity that the driver deployment will report by creating CSIStorageCapacity objects with capacity information, if set to true.
+
+        The check can be enabled immediately when deploying a driver. In that case, provisioning new volumes with late binding will pause until the driver deployment has published some suitable CSIStorageCapacity object.
+
+        Alternatively, the driver can be deployed with the field unset or false and it can be flipped later when storage capacity information has been published.
+
+        This field was immutable in Kubernetes <= 1.22 and now is mutable.
+        """
+        token_requests: NotRequired[pulumi.Input[Sequence[pulumi.Input['TokenRequestPatchArgsDict']]]]
+        """
+        tokenRequests indicates the CSI driver needs pods' service account tokens it is mounting volume for to do necessary authentication. Kubelet will pass the tokens in VolumeContext in the CSI NodePublishVolume calls. The CSI driver should parse and validate the following VolumeContext: "csi.storage.k8s.io/serviceAccount.tokens": {
+          "<audience>": {
+            "token": <token>,
+            "expirationTimestamp": <expiration timestamp in RFC3339>,
+          },
+          ...
+        }
+
+        Note: Audience in each TokenRequest should be different and at most one token is empty string. To receive a new token after expiry, RequiresRepublish can be used to trigger NodePublishVolume periodically.
+        """
+        volume_lifecycle_modes: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        volumeLifecycleModes defines what kind of volumes this CSI volume driver supports. The default if the list is empty is "Persistent", which is the usage defined by the CSI specification and implemented in Kubernetes via the usual PV/PVC mechanism.
+
+        The other mode is "Ephemeral". In this mode, volumes are defined inline inside the pod spec with CSIVolumeSource and their lifecycle is tied to the lifecycle of that pod. A driver has to be aware of this because it is only going to get a NodePublishVolume call for such a volume.
+
+        For more information about implementing this mode, see https://kubernetes-csi.github.io/docs/ephemeral-local-volumes.html A driver can support one or more of these modes and more modes may be added in the future.
+
+        This field is beta. This field is immutable.
+        """
+elif False:
+    CSIDriverSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class CSIDriverSpecPatchArgs:
@@ -257,6 +368,89 @@ class CSIDriverSpecPatchArgs:
         pulumi.set(self, "volume_lifecycle_modes", value)
 
 
+if not MYPY:
+    class CSIDriverSpecArgsDict(TypedDict):
+        """
+        CSIDriverSpec is the specification of a CSIDriver.
+        """
+        attach_required: NotRequired[pulumi.Input[bool]]
+        """
+        attachRequired indicates this CSI volume driver requires an attach operation (because it implements the CSI ControllerPublishVolume() method), and that the Kubernetes attach detach controller should call the attach volume interface which checks the volumeattachment status and waits until the volume is attached before proceeding to mounting. The CSI external-attacher coordinates with CSI volume driver and updates the volumeattachment status when the attach operation is complete. If the CSIDriverRegistry feature gate is enabled and the value is specified to false, the attach operation will be skipped. Otherwise the attach operation will be called.
+
+        This field is immutable.
+        """
+        fs_group_policy: NotRequired[pulumi.Input[str]]
+        """
+        fsGroupPolicy defines if the underlying volume supports changing ownership and permission of the volume before being mounted. Refer to the specific FSGroupPolicy values for additional details.
+
+        This field was immutable in Kubernetes < 1.29 and now is mutable.
+
+        Defaults to ReadWriteOnceWithFSType, which will examine each volume to determine if Kubernetes should modify ownership and permissions of the volume. With the default policy the defined fsGroup will only be applied if a fstype is defined and the volume's access mode contains ReadWriteOnce.
+        """
+        pod_info_on_mount: NotRequired[pulumi.Input[bool]]
+        """
+        podInfoOnMount indicates this CSI volume driver requires additional pod information (like podName, podUID, etc.) during mount operations, if set to true. If set to false, pod information will not be passed on mount. Default is false.
+
+        The CSI driver specifies podInfoOnMount as part of driver deployment. If true, Kubelet will pass pod information as VolumeContext in the CSI NodePublishVolume() calls. The CSI driver is responsible for parsing and validating the information passed in as VolumeContext.
+
+        The following VolumeContext will be passed if podInfoOnMount is set to true. This list might grow, but the prefix will be used. "csi.storage.k8s.io/pod.name": pod.Name "csi.storage.k8s.io/pod.namespace": pod.Namespace "csi.storage.k8s.io/pod.uid": string(pod.UID) "csi.storage.k8s.io/ephemeral": "true" if the volume is an ephemeral inline volume
+                                        defined by a CSIVolumeSource, otherwise "false"
+
+        "csi.storage.k8s.io/ephemeral" is a new feature in Kubernetes 1.16. It is only required for drivers which support both the "Persistent" and "Ephemeral" VolumeLifecycleMode. Other drivers can leave pod info disabled and/or ignore this field. As Kubernetes 1.15 doesn't support this field, drivers can only support one mode when deployed on such a cluster and the deployment determines which mode that is, for example via a command line parameter of the driver.
+
+        This field was immutable in Kubernetes < 1.29 and now is mutable.
+        """
+        requires_republish: NotRequired[pulumi.Input[bool]]
+        """
+        requiresRepublish indicates the CSI driver wants `NodePublishVolume` being periodically called to reflect any possible change in the mounted volume. This field defaults to false.
+
+        Note: After a successful initial NodePublishVolume call, subsequent calls to NodePublishVolume should only update the contents of the volume. New mount points will not be seen by a running container.
+        """
+        se_linux_mount: NotRequired[pulumi.Input[bool]]
+        """
+        seLinuxMount specifies if the CSI driver supports "-o context" mount option.
+
+        When "true", the CSI driver must ensure that all volumes provided by this CSI driver can be mounted separately with different `-o context` options. This is typical for storage backends that provide volumes as filesystems on block devices or as independent shared volumes. Kubernetes will call NodeStage / NodePublish with "-o context=xyz" mount option when mounting a ReadWriteOncePod volume used in Pod that has explicitly set SELinux context. In the future, it may be expanded to other volume AccessModes. In any case, Kubernetes will ensure that the volume is mounted only with a single SELinux context.
+
+        When "false", Kubernetes won't pass any special SELinux mount options to the driver. This is typical for volumes that represent subdirectories of a bigger shared filesystem.
+
+        Default is "false".
+        """
+        storage_capacity: NotRequired[pulumi.Input[bool]]
+        """
+        storageCapacity indicates that the CSI volume driver wants pod scheduling to consider the storage capacity that the driver deployment will report by creating CSIStorageCapacity objects with capacity information, if set to true.
+
+        The check can be enabled immediately when deploying a driver. In that case, provisioning new volumes with late binding will pause until the driver deployment has published some suitable CSIStorageCapacity object.
+
+        Alternatively, the driver can be deployed with the field unset or false and it can be flipped later when storage capacity information has been published.
+
+        This field was immutable in Kubernetes <= 1.22 and now is mutable.
+        """
+        token_requests: NotRequired[pulumi.Input[Sequence[pulumi.Input['TokenRequestArgsDict']]]]
+        """
+        tokenRequests indicates the CSI driver needs pods' service account tokens it is mounting volume for to do necessary authentication. Kubelet will pass the tokens in VolumeContext in the CSI NodePublishVolume calls. The CSI driver should parse and validate the following VolumeContext: "csi.storage.k8s.io/serviceAccount.tokens": {
+          "<audience>": {
+            "token": <token>,
+            "expirationTimestamp": <expiration timestamp in RFC3339>,
+          },
+          ...
+        }
+
+        Note: Audience in each TokenRequest should be different and at most one token is empty string. To receive a new token after expiry, RequiresRepublish can be used to trigger NodePublishVolume periodically.
+        """
+        volume_lifecycle_modes: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        volumeLifecycleModes defines what kind of volumes this CSI volume driver supports. The default if the list is empty is "Persistent", which is the usage defined by the CSI specification and implemented in Kubernetes via the usual PV/PVC mechanism.
+
+        The other mode is "Ephemeral". In this mode, volumes are defined inline inside the pod spec with CSIVolumeSource and their lifecycle is tied to the lifecycle of that pod. A driver has to be aware of this because it is only going to get a NodePublishVolume call for such a volume.
+
+        For more information about implementing this mode, see https://kubernetes-csi.github.io/docs/ephemeral-local-volumes.html A driver can support one or more of these modes and more modes may be added in the future.
+
+        This field is beta. This field is immutable.
+        """
+elif False:
+    CSIDriverSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CSIDriverSpecArgs:
     def __init__(__self__, *,
@@ -479,6 +673,30 @@ class CSIDriverSpecArgs:
         pulumi.set(self, "volume_lifecycle_modes", value)
 
 
+if not MYPY:
+    class CSIDriverArgsDict(TypedDict):
+        """
+        CSIDriver captures information about a Container Storage Interface (CSI) volume driver deployed on the cluster. Kubernetes attach detach controller uses this object to determine whether attach is required. Kubelet uses this object to determine whether pod information needs to be passed on mount. CSIDriver objects are non-namespaced.
+        """
+        spec: pulumi.Input['CSIDriverSpecArgsDict']
+        """
+        spec represents the specification of the CSI Driver.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object metadata. metadata.Name indicates the name of the CSI driver that this object refers to; it MUST be the same name returned by the CSI GetPluginName() call for that driver. The driver name must be 63 characters or less, beginning and ending with an alphanumeric character ([a-z0-9A-Z]) with dashes (-), dots (.), and alphanumerics between. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+elif False:
+    CSIDriverArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CSIDriverArgs:
     def __init__(__self__, *,
@@ -549,6 +767,30 @@ class CSIDriverArgs:
     def metadata(self, value: Optional[pulumi.Input['_meta.v1.ObjectMetaArgs']]):
         pulumi.set(self, "metadata", value)
 
+
+if not MYPY:
+    class CSINodeDriverPatchArgsDict(TypedDict):
+        """
+        CSINodeDriver holds information about the specification of one CSI driver installed on a node
+        """
+        allocatable: NotRequired[pulumi.Input['VolumeNodeResourcesPatchArgsDict']]
+        """
+        allocatable represents the volume resources of a node that are available for scheduling. This field is beta.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        name represents the name of the CSI driver that this object refers to. This MUST be the same name returned by the CSI GetPluginName() call for that driver.
+        """
+        node_id: NotRequired[pulumi.Input[str]]
+        """
+        nodeID of the node from the driver point of view. This field enables Kubernetes to communicate with storage systems that do not share the same nomenclature for nodes. For example, Kubernetes may refer to a given node as "node1", but the storage system may refer to the same node as "nodeA". When Kubernetes issues a command to the storage system to attach a volume to a specific node, it can use this field to refer to the node name using the ID that the storage system will understand, e.g. "nodeA" instead of "node1". This field is required.
+        """
+        topology_keys: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        topologyKeys is the list of keys supported by the driver. When a driver is initialized on a cluster, it provides a set of topology keys that it understands (e.g. "company.com/zone", "company.com/region"). When a driver is initialized on a node, it provides the same topology keys along with values. Kubelet will expose these topology keys as labels on its own node object. When Kubernetes does topology aware provisioning, it can use this list to determine which labels it should retrieve from the node object and pass back to the driver. It is possible for different nodes to use different topology keys. This can be empty if driver does not support topology.
+        """
+elif False:
+    CSINodeDriverPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class CSINodeDriverPatchArgs:
@@ -622,6 +864,30 @@ class CSINodeDriverPatchArgs:
         pulumi.set(self, "topology_keys", value)
 
 
+if not MYPY:
+    class CSINodeDriverArgsDict(TypedDict):
+        """
+        CSINodeDriver holds information about the specification of one CSI driver installed on a node
+        """
+        name: pulumi.Input[str]
+        """
+        name represents the name of the CSI driver that this object refers to. This MUST be the same name returned by the CSI GetPluginName() call for that driver.
+        """
+        node_id: pulumi.Input[str]
+        """
+        nodeID of the node from the driver point of view. This field enables Kubernetes to communicate with storage systems that do not share the same nomenclature for nodes. For example, Kubernetes may refer to a given node as "node1", but the storage system may refer to the same node as "nodeA". When Kubernetes issues a command to the storage system to attach a volume to a specific node, it can use this field to refer to the node name using the ID that the storage system will understand, e.g. "nodeA" instead of "node1". This field is required.
+        """
+        allocatable: NotRequired[pulumi.Input['VolumeNodeResourcesArgsDict']]
+        """
+        allocatable represents the volume resources of a node that are available for scheduling. This field is beta.
+        """
+        topology_keys: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        topologyKeys is the list of keys supported by the driver. When a driver is initialized on a cluster, it provides a set of topology keys that it understands (e.g. "company.com/zone", "company.com/region"). When a driver is initialized on a node, it provides the same topology keys along with values. Kubelet will expose these topology keys as labels on its own node object. When Kubernetes does topology aware provisioning, it can use this list to determine which labels it should retrieve from the node object and pass back to the driver. It is possible for different nodes to use different topology keys. This can be empty if driver does not support topology.
+        """
+elif False:
+    CSINodeDriverArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CSINodeDriverArgs:
     def __init__(__self__, *,
@@ -692,6 +958,18 @@ class CSINodeDriverArgs:
         pulumi.set(self, "topology_keys", value)
 
 
+if not MYPY:
+    class CSINodeSpecPatchArgsDict(TypedDict):
+        """
+        CSINodeSpec holds information about the specification of all CSI drivers installed on a node
+        """
+        drivers: NotRequired[pulumi.Input[Sequence[pulumi.Input['CSINodeDriverPatchArgsDict']]]]
+        """
+        drivers is a list of information of all CSI Drivers existing on a node. If all drivers in the list are uninstalled, this can become empty.
+        """
+elif False:
+    CSINodeSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CSINodeSpecPatchArgs:
     def __init__(__self__, *,
@@ -716,6 +994,18 @@ class CSINodeSpecPatchArgs:
         pulumi.set(self, "drivers", value)
 
 
+if not MYPY:
+    class CSINodeSpecArgsDict(TypedDict):
+        """
+        CSINodeSpec holds information about the specification of all CSI drivers installed on a node
+        """
+        drivers: pulumi.Input[Sequence[pulumi.Input['CSINodeDriverArgsDict']]]
+        """
+        drivers is a list of information of all CSI Drivers existing on a node. If all drivers in the list are uninstalled, this can become empty.
+        """
+elif False:
+    CSINodeSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CSINodeSpecArgs:
     def __init__(__self__, *,
@@ -738,6 +1028,30 @@ class CSINodeSpecArgs:
     def drivers(self, value: pulumi.Input[Sequence[pulumi.Input['CSINodeDriverArgs']]]):
         pulumi.set(self, "drivers", value)
 
+
+if not MYPY:
+    class CSINodeArgsDict(TypedDict):
+        """
+        CSINode holds information about all CSI drivers installed on a node. CSI drivers do not need to create the CSINode object directly. As long as they use the node-driver-registrar sidecar container, the kubelet will automatically populate the CSINode object for the CSI driver as part of kubelet plugin registration. CSINode has the same name as a node. If the object is missing, it means either there are no CSI Drivers available on the node, or the Kubelet version is low enough that it doesn't create this object. CSINode has an OwnerReference that points to the corresponding node object.
+        """
+        spec: pulumi.Input['CSINodeSpecArgsDict']
+        """
+        spec is the specification of CSINode
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata. metadata.name must be the Kubernetes node name.
+        """
+elif False:
+    CSINodeArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class CSINodeArgs:
@@ -809,6 +1123,58 @@ class CSINodeArgs:
     def metadata(self, value: Optional[pulumi.Input['_meta.v1.ObjectMetaArgs']]):
         pulumi.set(self, "metadata", value)
 
+
+if not MYPY:
+    class CSIStorageCapacityArgsDict(TypedDict):
+        """
+        CSIStorageCapacity stores the result of one CSI GetCapacity call. For a given StorageClass, this describes the available capacity in a particular topology segment.  This can be used when considering where to instantiate new PersistentVolumes.
+
+        For example this can express things like: - StorageClass "standard" has "1234 GiB" available in "topology.kubernetes.io/zone=us-east1" - StorageClass "localssd" has "10 GiB" available in "kubernetes.io/hostname=knode-abc123"
+
+        The following three cases all imply that no capacity is available for a certain combination: - no object exists with suitable topology and storage class name - such an object exists, but the capacity is unset - such an object exists, but the capacity is zero
+
+        The producer of these objects can decide which approach is more suitable.
+
+        They are consumed by the kube-scheduler when a CSI driver opts into capacity-aware scheduling with CSIDriverSpec.StorageCapacity. The scheduler compares the MaximumVolumeSize against the requested size of pending volumes to filter out unsuitable nodes. If MaximumVolumeSize is unset, it falls back to a comparison against the less precise Capacity. If that is also unset, the scheduler assumes that capacity is insufficient and tries some other node.
+        """
+        storage_class_name: pulumi.Input[str]
+        """
+        storageClassName represents the name of the StorageClass that the reported capacity applies to. It must meet the same requirements as the name of a StorageClass object (non-empty, DNS subdomain). If that object no longer exists, the CSIStorageCapacity object is obsolete and should be removed by its creator. This field is immutable.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        capacity: NotRequired[pulumi.Input[str]]
+        """
+        capacity is the value reported by the CSI driver in its GetCapacityResponse for a GetCapacityRequest with topology and parameters that match the previous fields.
+
+        The semantic is currently (CSI spec 1.2) defined as: The available capacity, in bytes, of the storage that can be used to provision volumes. If not set, that information is currently unavailable.
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        maximum_volume_size: NotRequired[pulumi.Input[str]]
+        """
+        maximumVolumeSize is the value reported by the CSI driver in its GetCapacityResponse for a GetCapacityRequest with topology and parameters that match the previous fields.
+
+        This is defined since CSI spec 1.4.0 as the largest size that may be used in a CreateVolumeRequest.capacity_range.required_bytes field to create a volume with the same parameters as those in GetCapacityRequest. The corresponding value in the Kubernetes API is ResourceRequirements.Requests in a volume claim.
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata. The name has no particular meaning. It must be a DNS subdomain (dots allowed, 253 characters). To ensure that there are no conflicts with other CSI drivers on the cluster, the recommendation is to use csisc-<uuid>, a generated name, or a reverse-domain name which ends with the unique CSI driver name.
+
+        Objects are namespaced.
+
+        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        node_topology: NotRequired[pulumi.Input['_meta.v1.LabelSelectorArgsDict']]
+        """
+        nodeTopology defines which nodes have access to the storage for which capacity was reported. If not set, the storage is not accessible from any node in the cluster. If empty, the storage is accessible from all nodes. This field is immutable.
+        """
+elif False:
+    CSIStorageCapacityArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class CSIStorageCapacityArgs:
@@ -952,6 +1318,56 @@ class CSIStorageCapacityArgs:
     def node_topology(self, value: Optional[pulumi.Input['_meta.v1.LabelSelectorArgs']]):
         pulumi.set(self, "node_topology", value)
 
+
+if not MYPY:
+    class StorageClassArgsDict(TypedDict):
+        """
+        StorageClass describes the parameters for a class of storage for which PersistentVolumes can be dynamically provisioned.
+
+        StorageClasses are non-namespaced; the name of the storage class according to etcd is in ObjectMeta.Name.
+        """
+        provisioner: pulumi.Input[str]
+        """
+        provisioner indicates the type of the provisioner.
+        """
+        allow_volume_expansion: NotRequired[pulumi.Input[bool]]
+        """
+        allowVolumeExpansion shows whether the storage class allow volume expand.
+        """
+        allowed_topologies: NotRequired[pulumi.Input[Sequence[pulumi.Input['_core.v1.TopologySelectorTermArgsDict']]]]
+        """
+        allowedTopologies restrict the node topologies where volumes can be dynamically provisioned. Each volume plugin defines its own supported topology specifications. An empty TopologySelectorTerm list means there is no topology restriction. This field is only honored by servers that enable the VolumeScheduling feature.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        mount_options: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        mountOptions controls the mountOptions for dynamically provisioned PersistentVolumes of this storage class. e.g. ["ro", "soft"]. Not validated - mount of the PVs will simply fail if one is invalid.
+        """
+        parameters: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        parameters holds the parameters for the provisioner that should create volumes of this storage class.
+        """
+        reclaim_policy: NotRequired[pulumi.Input[str]]
+        """
+        reclaimPolicy controls the reclaimPolicy for dynamically provisioned PersistentVolumes of this storage class. Defaults to Delete.
+        """
+        volume_binding_mode: NotRequired[pulumi.Input[str]]
+        """
+        volumeBindingMode indicates how PersistentVolumeClaims should be provisioned and bound.  When unset, VolumeBindingImmediate is used. This field is only honored by servers that enable the VolumeScheduling feature.
+        """
+elif False:
+    StorageClassArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class StorageClassArgs:
@@ -1122,6 +1538,22 @@ class StorageClassArgs:
         pulumi.set(self, "volume_binding_mode", value)
 
 
+if not MYPY:
+    class TokenRequestPatchArgsDict(TypedDict):
+        """
+        TokenRequest contains parameters of a service account token.
+        """
+        audience: NotRequired[pulumi.Input[str]]
+        """
+        audience is the intended audience of the token in "TokenRequestSpec". It will default to the audiences of kube apiserver.
+        """
+        expiration_seconds: NotRequired[pulumi.Input[int]]
+        """
+        expirationSeconds is the duration of validity of the token in "TokenRequestSpec". It has the same default value of "ExpirationSeconds" in "TokenRequestSpec".
+        """
+elif False:
+    TokenRequestPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class TokenRequestPatchArgs:
     def __init__(__self__, *,
@@ -1162,6 +1594,22 @@ class TokenRequestPatchArgs:
         pulumi.set(self, "expiration_seconds", value)
 
 
+if not MYPY:
+    class TokenRequestArgsDict(TypedDict):
+        """
+        TokenRequest contains parameters of a service account token.
+        """
+        audience: pulumi.Input[str]
+        """
+        audience is the intended audience of the token in "TokenRequestSpec". It will default to the audiences of kube apiserver.
+        """
+        expiration_seconds: NotRequired[pulumi.Input[int]]
+        """
+        expirationSeconds is the duration of validity of the token in "TokenRequestSpec". It has the same default value of "ExpirationSeconds" in "TokenRequestSpec".
+        """
+elif False:
+    TokenRequestArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class TokenRequestArgs:
     def __init__(__self__, *,
@@ -1200,6 +1648,22 @@ class TokenRequestArgs:
     def expiration_seconds(self, value: Optional[pulumi.Input[int]]):
         pulumi.set(self, "expiration_seconds", value)
 
+
+if not MYPY:
+    class VolumeAttachmentSourcePatchArgsDict(TypedDict):
+        """
+        VolumeAttachmentSource represents a volume that should be attached. Right now only PersistenVolumes can be attached via external attacher, in future we may allow also inline volumes in pods. Exactly one member can be set.
+        """
+        inline_volume_spec: NotRequired[pulumi.Input['_core.v1.PersistentVolumeSpecPatchArgsDict']]
+        """
+        inlineVolumeSpec contains all the information necessary to attach a persistent volume defined by a pod's inline VolumeSource. This field is populated only for the CSIMigration feature. It contains translated fields from a pod's inline VolumeSource to a PersistentVolumeSpec. This field is beta-level and is only honored by servers that enabled the CSIMigration feature.
+        """
+        persistent_volume_name: NotRequired[pulumi.Input[str]]
+        """
+        persistentVolumeName represents the name of the persistent volume to attach.
+        """
+elif False:
+    VolumeAttachmentSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class VolumeAttachmentSourcePatchArgs:
@@ -1241,6 +1705,22 @@ class VolumeAttachmentSourcePatchArgs:
         pulumi.set(self, "persistent_volume_name", value)
 
 
+if not MYPY:
+    class VolumeAttachmentSourceArgsDict(TypedDict):
+        """
+        VolumeAttachmentSource represents a volume that should be attached. Right now only PersistenVolumes can be attached via external attacher, in future we may allow also inline volumes in pods. Exactly one member can be set.
+        """
+        inline_volume_spec: NotRequired[pulumi.Input['_core.v1.PersistentVolumeSpecArgsDict']]
+        """
+        inlineVolumeSpec contains all the information necessary to attach a persistent volume defined by a pod's inline VolumeSource. This field is populated only for the CSIMigration feature. It contains translated fields from a pod's inline VolumeSource to a PersistentVolumeSpec. This field is beta-level and is only honored by servers that enabled the CSIMigration feature.
+        """
+        persistent_volume_name: NotRequired[pulumi.Input[str]]
+        """
+        persistentVolumeName represents the name of the persistent volume to attach.
+        """
+elif False:
+    VolumeAttachmentSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class VolumeAttachmentSourceArgs:
     def __init__(__self__, *,
@@ -1280,6 +1760,26 @@ class VolumeAttachmentSourceArgs:
     def persistent_volume_name(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "persistent_volume_name", value)
 
+
+if not MYPY:
+    class VolumeAttachmentSpecPatchArgsDict(TypedDict):
+        """
+        VolumeAttachmentSpec is the specification of a VolumeAttachment request.
+        """
+        attacher: NotRequired[pulumi.Input[str]]
+        """
+        attacher indicates the name of the volume driver that MUST handle this request. This is the name returned by GetPluginName().
+        """
+        node_name: NotRequired[pulumi.Input[str]]
+        """
+        nodeName represents the node that the volume should be attached to.
+        """
+        source: NotRequired[pulumi.Input['VolumeAttachmentSourcePatchArgsDict']]
+        """
+        source represents the volume that should be attached.
+        """
+elif False:
+    VolumeAttachmentSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class VolumeAttachmentSpecPatchArgs:
@@ -1337,6 +1837,26 @@ class VolumeAttachmentSpecPatchArgs:
         pulumi.set(self, "source", value)
 
 
+if not MYPY:
+    class VolumeAttachmentSpecArgsDict(TypedDict):
+        """
+        VolumeAttachmentSpec is the specification of a VolumeAttachment request.
+        """
+        attacher: pulumi.Input[str]
+        """
+        attacher indicates the name of the volume driver that MUST handle this request. This is the name returned by GetPluginName().
+        """
+        node_name: pulumi.Input[str]
+        """
+        nodeName represents the node that the volume should be attached to.
+        """
+        source: pulumi.Input['VolumeAttachmentSourceArgsDict']
+        """
+        source represents the volume that should be attached.
+        """
+elif False:
+    VolumeAttachmentSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class VolumeAttachmentSpecArgs:
     def __init__(__self__, *,
@@ -1389,6 +1909,30 @@ class VolumeAttachmentSpecArgs:
     def source(self, value: pulumi.Input['VolumeAttachmentSourceArgs']):
         pulumi.set(self, "source", value)
 
+
+if not MYPY:
+    class VolumeAttachmentStatusArgsDict(TypedDict):
+        """
+        VolumeAttachmentStatus is the status of a VolumeAttachment request.
+        """
+        attached: pulumi.Input[bool]
+        """
+        attached indicates the volume is successfully attached. This field must only be set by the entity completing the attach operation, i.e. the external-attacher.
+        """
+        attach_error: NotRequired[pulumi.Input['VolumeErrorArgsDict']]
+        """
+        attachError represents the last error encountered during attach operation, if any. This field must only be set by the entity completing the attach operation, i.e. the external-attacher.
+        """
+        attachment_metadata: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        attachmentMetadata is populated with any information returned by the attach operation, upon successful attach, that must be passed into subsequent WaitForAttach or Mount calls. This field must only be set by the entity completing the attach operation, i.e. the external-attacher.
+        """
+        detach_error: NotRequired[pulumi.Input['VolumeErrorArgsDict']]
+        """
+        detachError represents the last error encountered during detach operation, if any. This field must only be set by the entity completing the detach operation, i.e. the external-attacher.
+        """
+elif False:
+    VolumeAttachmentStatusArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class VolumeAttachmentStatusArgs:
@@ -1460,6 +2004,36 @@ class VolumeAttachmentStatusArgs:
     def detach_error(self, value: Optional[pulumi.Input['VolumeErrorArgs']]):
         pulumi.set(self, "detach_error", value)
 
+
+if not MYPY:
+    class VolumeAttachmentArgsDict(TypedDict):
+        """
+        VolumeAttachment captures the intent to attach or detach the specified volume to/from the specified node.
+
+        VolumeAttachment objects are non-namespaced.
+        """
+        spec: pulumi.Input['VolumeAttachmentSpecArgsDict']
+        """
+        spec represents specification of the desired attach/detach volume behavior. Populated by the Kubernetes system.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        status: NotRequired[pulumi.Input['VolumeAttachmentStatusArgsDict']]
+        """
+        status represents status of the VolumeAttachment request. Populated by the entity completing the attach or detach operation, i.e. the external-attacher.
+        """
+elif False:
+    VolumeAttachmentArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class VolumeAttachmentArgs:
@@ -1550,6 +2124,22 @@ class VolumeAttachmentArgs:
         pulumi.set(self, "status", value)
 
 
+if not MYPY:
+    class VolumeErrorArgsDict(TypedDict):
+        """
+        VolumeError captures an error encountered during a volume operation.
+        """
+        message: NotRequired[pulumi.Input[str]]
+        """
+        message represents the error encountered during Attach or Detach operation. This string may be logged, so it should not contain sensitive information.
+        """
+        time: NotRequired[pulumi.Input[str]]
+        """
+        time represents the time the error was encountered.
+        """
+elif False:
+    VolumeErrorArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class VolumeErrorArgs:
     def __init__(__self__, *,
@@ -1590,6 +2180,18 @@ class VolumeErrorArgs:
         pulumi.set(self, "time", value)
 
 
+if not MYPY:
+    class VolumeNodeResourcesPatchArgsDict(TypedDict):
+        """
+        VolumeNodeResources is a set of resource limits for scheduling of volumes.
+        """
+        count: NotRequired[pulumi.Input[int]]
+        """
+        count indicates the maximum number of unique volumes managed by the CSI driver that can be used on a node. A volume that is both attached and mounted on a node is considered to be used once, not twice. The same rule applies for a unique volume that is shared among multiple pods on the same node. If this field is not specified, then the supported number of volumes on this node is unbounded.
+        """
+elif False:
+    VolumeNodeResourcesPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class VolumeNodeResourcesPatchArgs:
     def __init__(__self__, *,
@@ -1613,6 +2215,18 @@ class VolumeNodeResourcesPatchArgs:
     def count(self, value: Optional[pulumi.Input[int]]):
         pulumi.set(self, "count", value)
 
+
+if not MYPY:
+    class VolumeNodeResourcesArgsDict(TypedDict):
+        """
+        VolumeNodeResources is a set of resource limits for scheduling of volumes.
+        """
+        count: NotRequired[pulumi.Input[int]]
+        """
+        count indicates the maximum number of unique volumes managed by the CSI driver that can be used on a node. A volume that is both attached and mounted on a node is considered to be used once, not twice. The same rule applies for a unique volume that is shared among multiple pods on the same node. If this field is not specified, then the supported number of volumes on this node is unbounded.
+        """
+elif False:
+    VolumeNodeResourcesArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class VolumeNodeResourcesArgs:

--- a/sdk/python/pulumi_kubernetes/storage/v1/outputs.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1/outputs.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core

--- a/sdk/python/pulumi_kubernetes/storage/v1alpha1/VolumeAttachment.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1alpha1/VolumeAttachment.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -93,8 +98,8 @@ class VolumeAttachment(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['VolumeAttachmentSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['VolumeAttachmentSpecArgs', 'VolumeAttachmentSpecArgsDict']]] = None,
                  __props__=None):
         """
         VolumeAttachment captures the intent to attach or detach the specified volume to/from the specified node.
@@ -105,8 +110,8 @@ class VolumeAttachment(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['VolumeAttachmentSpecArgs']] spec: Specification of the desired attach/detach volume behavior. Populated by the Kubernetes system.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['VolumeAttachmentSpecArgs', 'VolumeAttachmentSpecArgsDict']] spec: Specification of the desired attach/detach volume behavior. Populated by the Kubernetes system.
         """
         ...
     @overload
@@ -136,8 +141,8 @@ class VolumeAttachment(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['VolumeAttachmentSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['VolumeAttachmentSpecArgs', 'VolumeAttachmentSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/storage/v1alpha1/VolumeAttachmentList.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1alpha1/VolumeAttachmentList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -92,9 +97,9 @@ class VolumeAttachmentList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['VolumeAttachmentArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['VolumeAttachmentArgs', 'VolumeAttachmentArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         VolumeAttachmentList is a collection of VolumeAttachment objects.
@@ -102,9 +107,9 @@ class VolumeAttachmentList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['VolumeAttachmentArgs']]]] items: Items is the list of VolumeAttachments
+        :param pulumi.Input[Sequence[pulumi.Input[Union['VolumeAttachmentArgs', 'VolumeAttachmentArgsDict']]]] items: Items is the list of VolumeAttachments
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -131,9 +136,9 @@ class VolumeAttachmentList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['VolumeAttachmentArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['VolumeAttachmentArgs', 'VolumeAttachmentArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/storage/v1alpha1/VolumeAttachmentPatch.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1alpha1/VolumeAttachmentPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -94,8 +99,8 @@ class VolumeAttachmentPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['VolumeAttachmentSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['VolumeAttachmentSpecPatchArgs', 'VolumeAttachmentSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -112,8 +117,8 @@ class VolumeAttachmentPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['VolumeAttachmentSpecPatchArgs']] spec: Specification of the desired attach/detach volume behavior. Populated by the Kubernetes system.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['VolumeAttachmentSpecPatchArgs', 'VolumeAttachmentSpecPatchArgsDict']] spec: Specification of the desired attach/detach volume behavior. Populated by the Kubernetes system.
         """
         ...
     @overload
@@ -149,8 +154,8 @@ class VolumeAttachmentPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['VolumeAttachmentSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['VolumeAttachmentSpecPatchArgs', 'VolumeAttachmentSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/storage/v1alpha1/VolumeAttributesClass.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1alpha1/VolumeAttributesClass.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import meta as _meta
 
@@ -111,7 +116,7 @@ class VolumeAttributesClass(pulumi.CustomResource):
                  api_version: Optional[pulumi.Input[str]] = None,
                  driver_name: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
                  parameters: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  __props__=None):
         """
@@ -122,7 +127,7 @@ class VolumeAttributesClass(pulumi.CustomResource):
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] driver_name: Name of the CSI driver This field is immutable.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] parameters: parameters hold volume attributes defined by the CSI driver. These values are opaque to the Kubernetes and are passed directly to the CSI driver. The underlying storage provider supports changing these attributes on an existing volume, however the parameters field itself is immutable. To invoke a volume update, a new VolumeAttributesClass should be created with new parameters, and the PersistentVolumeClaim should be updated to reference the new VolumeAttributesClass.
                
                This field is required and must contain at least one key/value pair. The keys cannot be empty, and the maximum number of parameters is 512, with a cumulative max size of 256K. If the CSI driver rejects invalid parameters, the target PersistentVolumeClaim will be set to an "Infeasible" state in the modifyVolumeStatus field.
@@ -154,7 +159,7 @@ class VolumeAttributesClass(pulumi.CustomResource):
                  api_version: Optional[pulumi.Input[str]] = None,
                  driver_name: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
                  parameters: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)

--- a/sdk/python/pulumi_kubernetes/storage/v1alpha1/VolumeAttributesClassList.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1alpha1/VolumeAttributesClassList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class VolumeAttributesClassList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['VolumeAttributesClassArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['VolumeAttributesClassArgs', 'VolumeAttributesClassArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         VolumeAttributesClassList is a collection of VolumeAttributesClass objects.
@@ -101,9 +106,9 @@ class VolumeAttributesClassList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['VolumeAttributesClassArgs']]]] items: items is the list of VolumeAttributesClass objects.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['VolumeAttributesClassArgs', 'VolumeAttributesClassArgsDict']]]] items: items is the list of VolumeAttributesClass objects.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class VolumeAttributesClassList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['VolumeAttributesClassArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['VolumeAttributesClassArgs', 'VolumeAttributesClassArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/storage/v1alpha1/VolumeAttributesClassPatch.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1alpha1/VolumeAttributesClassPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import meta as _meta
 
@@ -112,7 +117,7 @@ class VolumeAttributesClassPatch(pulumi.CustomResource):
                  api_version: Optional[pulumi.Input[str]] = None,
                  driver_name: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
                  parameters: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  __props__=None):
         """
@@ -129,7 +134,7 @@ class VolumeAttributesClassPatch(pulumi.CustomResource):
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] driver_name: Name of the CSI driver This field is immutable.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] parameters: parameters hold volume attributes defined by the CSI driver. These values are opaque to the Kubernetes and are passed directly to the CSI driver. The underlying storage provider supports changing these attributes on an existing volume, however the parameters field itself is immutable. To invoke a volume update, a new VolumeAttributesClass should be created with new parameters, and the PersistentVolumeClaim should be updated to reference the new VolumeAttributesClass.
                
                This field is required and must contain at least one key/value pair. The keys cannot be empty, and the maximum number of parameters is 512, with a cumulative max size of 256K. If the CSI driver rejects invalid parameters, the target PersistentVolumeClaim will be set to an "Infeasible" state in the modifyVolumeStatus field.
@@ -167,7 +172,7 @@ class VolumeAttributesClassPatch(pulumi.CustomResource):
                  api_version: Optional[pulumi.Input[str]] = None,
                  driver_name: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
                  parameters: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)

--- a/sdk/python/pulumi_kubernetes/storage/v1alpha1/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1alpha1/_inputs.py
@@ -4,23 +4,54 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import core as _core
 from ... import meta as _meta
 
 __all__ = [
     'VolumeAttachmentSourcePatchArgs',
+    'VolumeAttachmentSourcePatchArgsDict',
     'VolumeAttachmentSourceArgs',
+    'VolumeAttachmentSourceArgsDict',
     'VolumeAttachmentSpecPatchArgs',
+    'VolumeAttachmentSpecPatchArgsDict',
     'VolumeAttachmentSpecArgs',
+    'VolumeAttachmentSpecArgsDict',
     'VolumeAttachmentStatusArgs',
+    'VolumeAttachmentStatusArgsDict',
     'VolumeAttachmentArgs',
+    'VolumeAttachmentArgsDict',
     'VolumeAttributesClassArgs',
+    'VolumeAttributesClassArgsDict',
     'VolumeErrorArgs',
+    'VolumeErrorArgsDict',
 ]
+
+MYPY = False
+
+if not MYPY:
+    class VolumeAttachmentSourcePatchArgsDict(TypedDict):
+        """
+        VolumeAttachmentSource represents a volume that should be attached. Right now only PersistenVolumes can be attached via external attacher, in future we may allow also inline volumes in pods. Exactly one member can be set.
+        """
+        inline_volume_spec: NotRequired[pulumi.Input['_core.v1.PersistentVolumeSpecPatchArgsDict']]
+        """
+        inlineVolumeSpec contains all the information necessary to attach a persistent volume defined by a pod's inline VolumeSource. This field is populated only for the CSIMigration feature. It contains translated fields from a pod's inline VolumeSource to a PersistentVolumeSpec. This field is alpha-level and is only honored by servers that enabled the CSIMigration feature.
+        """
+        persistent_volume_name: NotRequired[pulumi.Input[str]]
+        """
+        Name of the persistent volume to attach.
+        """
+elif False:
+    VolumeAttachmentSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class VolumeAttachmentSourcePatchArgs:
@@ -62,6 +93,22 @@ class VolumeAttachmentSourcePatchArgs:
         pulumi.set(self, "persistent_volume_name", value)
 
 
+if not MYPY:
+    class VolumeAttachmentSourceArgsDict(TypedDict):
+        """
+        VolumeAttachmentSource represents a volume that should be attached. Right now only PersistenVolumes can be attached via external attacher, in future we may allow also inline volumes in pods. Exactly one member can be set.
+        """
+        inline_volume_spec: NotRequired[pulumi.Input['_core.v1.PersistentVolumeSpecArgsDict']]
+        """
+        inlineVolumeSpec contains all the information necessary to attach a persistent volume defined by a pod's inline VolumeSource. This field is populated only for the CSIMigration feature. It contains translated fields from a pod's inline VolumeSource to a PersistentVolumeSpec. This field is alpha-level and is only honored by servers that enabled the CSIMigration feature.
+        """
+        persistent_volume_name: NotRequired[pulumi.Input[str]]
+        """
+        Name of the persistent volume to attach.
+        """
+elif False:
+    VolumeAttachmentSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class VolumeAttachmentSourceArgs:
     def __init__(__self__, *,
@@ -101,6 +148,26 @@ class VolumeAttachmentSourceArgs:
     def persistent_volume_name(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "persistent_volume_name", value)
 
+
+if not MYPY:
+    class VolumeAttachmentSpecPatchArgsDict(TypedDict):
+        """
+        VolumeAttachmentSpec is the specification of a VolumeAttachment request.
+        """
+        attacher: NotRequired[pulumi.Input[str]]
+        """
+        Attacher indicates the name of the volume driver that MUST handle this request. This is the name returned by GetPluginName().
+        """
+        node_name: NotRequired[pulumi.Input[str]]
+        """
+        The node that the volume should be attached to.
+        """
+        source: NotRequired[pulumi.Input['VolumeAttachmentSourcePatchArgsDict']]
+        """
+        Source represents the volume that should be attached.
+        """
+elif False:
+    VolumeAttachmentSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class VolumeAttachmentSpecPatchArgs:
@@ -158,6 +225,26 @@ class VolumeAttachmentSpecPatchArgs:
         pulumi.set(self, "source", value)
 
 
+if not MYPY:
+    class VolumeAttachmentSpecArgsDict(TypedDict):
+        """
+        VolumeAttachmentSpec is the specification of a VolumeAttachment request.
+        """
+        attacher: pulumi.Input[str]
+        """
+        Attacher indicates the name of the volume driver that MUST handle this request. This is the name returned by GetPluginName().
+        """
+        node_name: pulumi.Input[str]
+        """
+        The node that the volume should be attached to.
+        """
+        source: pulumi.Input['VolumeAttachmentSourceArgsDict']
+        """
+        Source represents the volume that should be attached.
+        """
+elif False:
+    VolumeAttachmentSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class VolumeAttachmentSpecArgs:
     def __init__(__self__, *,
@@ -210,6 +297,30 @@ class VolumeAttachmentSpecArgs:
     def source(self, value: pulumi.Input['VolumeAttachmentSourceArgs']):
         pulumi.set(self, "source", value)
 
+
+if not MYPY:
+    class VolumeAttachmentStatusArgsDict(TypedDict):
+        """
+        VolumeAttachmentStatus is the status of a VolumeAttachment request.
+        """
+        attached: pulumi.Input[bool]
+        """
+        Indicates the volume is successfully attached. This field must only be set by the entity completing the attach operation, i.e. the external-attacher.
+        """
+        attach_error: NotRequired[pulumi.Input['VolumeErrorArgsDict']]
+        """
+        The last error encountered during attach operation, if any. This field must only be set by the entity completing the attach operation, i.e. the external-attacher.
+        """
+        attachment_metadata: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        Upon successful attach, this field is populated with any information returned by the attach operation that must be passed into subsequent WaitForAttach or Mount calls. This field must only be set by the entity completing the attach operation, i.e. the external-attacher.
+        """
+        detach_error: NotRequired[pulumi.Input['VolumeErrorArgsDict']]
+        """
+        The last error encountered during detach operation, if any. This field must only be set by the entity completing the detach operation, i.e. the external-attacher.
+        """
+elif False:
+    VolumeAttachmentStatusArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class VolumeAttachmentStatusArgs:
@@ -281,6 +392,36 @@ class VolumeAttachmentStatusArgs:
     def detach_error(self, value: Optional[pulumi.Input['VolumeErrorArgs']]):
         pulumi.set(self, "detach_error", value)
 
+
+if not MYPY:
+    class VolumeAttachmentArgsDict(TypedDict):
+        """
+        VolumeAttachment captures the intent to attach or detach the specified volume to/from the specified node.
+
+        VolumeAttachment objects are non-namespaced.
+        """
+        spec: pulumi.Input['VolumeAttachmentSpecArgsDict']
+        """
+        Specification of the desired attach/detach volume behavior. Populated by the Kubernetes system.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        status: NotRequired[pulumi.Input['VolumeAttachmentStatusArgsDict']]
+        """
+        Status of the VolumeAttachment request. Populated by the entity completing the attach or detach operation, i.e. the external-attacher.
+        """
+elif False:
+    VolumeAttachmentArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class VolumeAttachmentArgs:
@@ -370,6 +511,36 @@ class VolumeAttachmentArgs:
     def status(self, value: Optional[pulumi.Input['VolumeAttachmentStatusArgs']]):
         pulumi.set(self, "status", value)
 
+
+if not MYPY:
+    class VolumeAttributesClassArgsDict(TypedDict):
+        """
+        VolumeAttributesClass represents a specification of mutable volume attributes defined by the CSI driver. The class can be specified during dynamic provisioning of PersistentVolumeClaims, and changed in the PersistentVolumeClaim spec after provisioning.
+        """
+        driver_name: pulumi.Input[str]
+        """
+        Name of the CSI driver This field is immutable.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        parameters: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        parameters hold volume attributes defined by the CSI driver. These values are opaque to the Kubernetes and are passed directly to the CSI driver. The underlying storage provider supports changing these attributes on an existing volume, however the parameters field itself is immutable. To invoke a volume update, a new VolumeAttributesClass should be created with new parameters, and the PersistentVolumeClaim should be updated to reference the new VolumeAttributesClass.
+
+        This field is required and must contain at least one key/value pair. The keys cannot be empty, and the maximum number of parameters is 512, with a cumulative max size of 256K. If the CSI driver rejects invalid parameters, the target PersistentVolumeClaim will be set to an "Infeasible" state in the modifyVolumeStatus field.
+        """
+elif False:
+    VolumeAttributesClassArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class VolumeAttributesClassArgs:
@@ -461,6 +632,22 @@ class VolumeAttributesClassArgs:
     def parameters(self, value: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]):
         pulumi.set(self, "parameters", value)
 
+
+if not MYPY:
+    class VolumeErrorArgsDict(TypedDict):
+        """
+        VolumeError captures an error encountered during a volume operation.
+        """
+        message: NotRequired[pulumi.Input[str]]
+        """
+        String detailing the error encountered during Attach or Detach operation. This string maybe logged, so it should not contain sensitive information.
+        """
+        time: NotRequired[pulumi.Input[str]]
+        """
+        Time the error was encountered.
+        """
+elif False:
+    VolumeErrorArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class VolumeErrorArgs:

--- a/sdk/python/pulumi_kubernetes/storage/v1alpha1/outputs.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1alpha1/outputs.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core

--- a/sdk/python/pulumi_kubernetes/storage/v1beta1/CSIDriver.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1beta1/CSIDriver.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -92,8 +97,8 @@ class CSIDriver(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['CSIDriverSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['CSIDriverSpecArgs', 'CSIDriverSpecArgsDict']]] = None,
                  __props__=None):
         """
         CSIDriver captures information about a Container Storage Interface (CSI) volume driver deployed on the cluster. CSI drivers do not need to create the CSIDriver object directly. Instead they may use the cluster-driver-registrar sidecar container. When deployed with a CSI driver it automatically creates a CSIDriver object representing the driver. Kubernetes attach detach controller uses this object to determine whether attach is required. Kubelet uses this object to determine whether pod information needs to be passed on mount. CSIDriver objects are non-namespaced.
@@ -102,8 +107,8 @@ class CSIDriver(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object metadata. metadata.Name indicates the name of the CSI driver that this object refers to; it MUST be the same name returned by the CSI GetPluginName() call for that driver. The driver name must be 63 characters or less, beginning and ending with an alphanumeric character ([a-z0-9A-Z]) with dashes (-), dots (.), and alphanumerics between. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['CSIDriverSpecArgs']] spec: Specification of the CSI Driver.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object metadata. metadata.Name indicates the name of the CSI driver that this object refers to; it MUST be the same name returned by the CSI GetPluginName() call for that driver. The driver name must be 63 characters or less, beginning and ending with an alphanumeric character ([a-z0-9A-Z]) with dashes (-), dots (.), and alphanumerics between. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['CSIDriverSpecArgs', 'CSIDriverSpecArgsDict']] spec: Specification of the CSI Driver.
         """
         ...
     @overload
@@ -131,8 +136,8 @@ class CSIDriver(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['CSIDriverSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['CSIDriverSpecArgs', 'CSIDriverSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/storage/v1beta1/CSIDriverList.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1beta1/CSIDriverList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class CSIDriverList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['CSIDriverArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['CSIDriverArgs', 'CSIDriverArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         CSIDriverList is a collection of CSIDriver objects.
@@ -101,9 +106,9 @@ class CSIDriverList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['CSIDriverArgs']]]] items: items is the list of CSIDriver
+        :param pulumi.Input[Sequence[pulumi.Input[Union['CSIDriverArgs', 'CSIDriverArgsDict']]]] items: items is the list of CSIDriver
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class CSIDriverList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['CSIDriverArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['CSIDriverArgs', 'CSIDriverArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/storage/v1beta1/CSIDriverPatch.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1beta1/CSIDriverPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class CSIDriverPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['CSIDriverSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['CSIDriverSpecPatchArgs', 'CSIDriverSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -109,8 +114,8 @@ class CSIDriverPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object metadata. metadata.Name indicates the name of the CSI driver that this object refers to; it MUST be the same name returned by the CSI GetPluginName() call for that driver. The driver name must be 63 characters or less, beginning and ending with an alphanumeric character ([a-z0-9A-Z]) with dashes (-), dots (.), and alphanumerics between. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['CSIDriverSpecPatchArgs']] spec: Specification of the CSI Driver.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object metadata. metadata.Name indicates the name of the CSI driver that this object refers to; it MUST be the same name returned by the CSI GetPluginName() call for that driver. The driver name must be 63 characters or less, beginning and ending with an alphanumeric character ([a-z0-9A-Z]) with dashes (-), dots (.), and alphanumerics between. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['CSIDriverSpecPatchArgs', 'CSIDriverSpecPatchArgsDict']] spec: Specification of the CSI Driver.
         """
         ...
     @overload
@@ -144,8 +149,8 @@ class CSIDriverPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['CSIDriverSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['CSIDriverSpecPatchArgs', 'CSIDriverSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/storage/v1beta1/CSINode.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1beta1/CSINode.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -92,8 +97,8 @@ class CSINode(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['CSINodeSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['CSINodeSpecArgs', 'CSINodeSpecArgsDict']]] = None,
                  __props__=None):
         """
         CSINode holds information about all CSI drivers installed on a node. CSI drivers do not need to create the CSINode object directly. As long as they use the node-driver-registrar sidecar container, the kubelet will automatically populate the CSINode object for the CSI driver as part of kubelet plugin registration. CSINode has the same name as a node. If the object is missing, it means either there are no CSI Drivers available on the node, or the Kubelet version is low enough that it doesn't create this object. CSINode has an OwnerReference that points to the corresponding node object.
@@ -102,8 +107,8 @@ class CSINode(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: metadata.name must be the Kubernetes node name.
-        :param pulumi.Input[pulumi.InputType['CSINodeSpecArgs']] spec: spec is the specification of CSINode
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: metadata.name must be the Kubernetes node name.
+        :param pulumi.Input[Union['CSINodeSpecArgs', 'CSINodeSpecArgsDict']] spec: spec is the specification of CSINode
         """
         ...
     @overload
@@ -131,8 +136,8 @@ class CSINode(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['CSINodeSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['CSINodeSpecArgs', 'CSINodeSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/storage/v1beta1/CSINodeList.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1beta1/CSINodeList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class CSINodeList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['CSINodeArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['CSINodeArgs', 'CSINodeArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         CSINodeList is a collection of CSINode objects.
@@ -101,9 +106,9 @@ class CSINodeList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['CSINodeArgs']]]] items: items is the list of CSINode
+        :param pulumi.Input[Sequence[pulumi.Input[Union['CSINodeArgs', 'CSINodeArgsDict']]]] items: items is the list of CSINode
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class CSINodeList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['CSINodeArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['CSINodeArgs', 'CSINodeArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/storage/v1beta1/CSINodePatch.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1beta1/CSINodePatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class CSINodePatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['CSINodeSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['CSINodeSpecPatchArgs', 'CSINodeSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -109,8 +114,8 @@ class CSINodePatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: metadata.name must be the Kubernetes node name.
-        :param pulumi.Input[pulumi.InputType['CSINodeSpecPatchArgs']] spec: spec is the specification of CSINode
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: metadata.name must be the Kubernetes node name.
+        :param pulumi.Input[Union['CSINodeSpecPatchArgs', 'CSINodeSpecPatchArgsDict']] spec: spec is the specification of CSINode
         """
         ...
     @overload
@@ -144,8 +149,8 @@ class CSINodePatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['CSINodeSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['CSINodeSpecPatchArgs', 'CSINodeSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/storage/v1beta1/CSIStorageCapacity.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1beta1/CSIStorageCapacity.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import meta as _meta
 
@@ -156,8 +161,8 @@ class CSIStorageCapacity(pulumi.CustomResource):
                  capacity: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
                  maximum_volume_size: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 node_topology: Optional[pulumi.Input[pulumi.InputType['_meta.v1.LabelSelectorArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 node_topology: Optional[pulumi.Input[Union['_meta.v1.LabelSelectorArgs', '_meta.v1.LabelSelectorArgsDict']]] = None,
                  storage_class_name: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         """
@@ -181,12 +186,12 @@ class CSIStorageCapacity(pulumi.CustomResource):
         :param pulumi.Input[str] maximum_volume_size: MaximumVolumeSize is the value reported by the CSI driver in its GetCapacityResponse for a GetCapacityRequest with topology and parameters that match the previous fields.
                
                This is defined since CSI spec 1.4.0 as the largest size that may be used in a CreateVolumeRequest.capacity_range.required_bytes field to create a volume with the same parameters as those in GetCapacityRequest. The corresponding value in the Kubernetes API is ResourceRequirements.Requests in a volume claim.
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata. The name has no particular meaning. It must be be a DNS subdomain (dots allowed, 253 characters). To ensure that there are no conflicts with other CSI drivers on the cluster, the recommendation is to use csisc-<uuid>, a generated name, or a reverse-domain name which ends with the unique CSI driver name.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata. The name has no particular meaning. It must be be a DNS subdomain (dots allowed, 253 characters). To ensure that there are no conflicts with other CSI drivers on the cluster, the recommendation is to use csisc-<uuid>, a generated name, or a reverse-domain name which ends with the unique CSI driver name.
                
                Objects are namespaced.
                
                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['_meta.v1.LabelSelectorArgs']] node_topology: NodeTopology defines which nodes have access to the storage for which capacity was reported. If not set, the storage is not accessible from any node in the cluster. If empty, the storage is accessible from all nodes. This field is immutable.
+        :param pulumi.Input[Union['_meta.v1.LabelSelectorArgs', '_meta.v1.LabelSelectorArgsDict']] node_topology: NodeTopology defines which nodes have access to the storage for which capacity was reported. If not set, the storage is not accessible from any node in the cluster. If empty, the storage is accessible from all nodes. This field is immutable.
         :param pulumi.Input[str] storage_class_name: The name of the StorageClass that the reported capacity applies to. It must meet the same requirements as the name of a StorageClass object (non-empty, DNS subdomain). If that object no longer exists, the CSIStorageCapacity object is obsolete and should be removed by its creator. This field is immutable.
         """
         ...
@@ -225,8 +230,8 @@ class CSIStorageCapacity(pulumi.CustomResource):
                  capacity: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
                  maximum_volume_size: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 node_topology: Optional[pulumi.Input[pulumi.InputType['_meta.v1.LabelSelectorArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 node_topology: Optional[pulumi.Input[Union['_meta.v1.LabelSelectorArgs', '_meta.v1.LabelSelectorArgsDict']]] = None,
                  storage_class_name: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)

--- a/sdk/python/pulumi_kubernetes/storage/v1beta1/CSIStorageCapacityList.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1beta1/CSIStorageCapacityList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class CSIStorageCapacityList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['CSIStorageCapacityArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['CSIStorageCapacityArgs', 'CSIStorageCapacityArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         CSIStorageCapacityList is a collection of CSIStorageCapacity objects.
@@ -101,9 +106,9 @@ class CSIStorageCapacityList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['CSIStorageCapacityArgs']]]] items: Items is the list of CSIStorageCapacity objects.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['CSIStorageCapacityArgs', 'CSIStorageCapacityArgsDict']]]] items: Items is the list of CSIStorageCapacity objects.
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class CSIStorageCapacityList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['CSIStorageCapacityArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['CSIStorageCapacityArgs', 'CSIStorageCapacityArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/storage/v1beta1/CSIStorageCapacityPatch.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1beta1/CSIStorageCapacityPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import meta as _meta
 
@@ -157,8 +162,8 @@ class CSIStorageCapacityPatch(pulumi.CustomResource):
                  capacity: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
                  maximum_volume_size: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 node_topology: Optional[pulumi.Input[pulumi.InputType['_meta.v1.LabelSelectorPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 node_topology: Optional[pulumi.Input[Union['_meta.v1.LabelSelectorPatchArgs', '_meta.v1.LabelSelectorPatchArgsDict']]] = None,
                  storage_class_name: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         """
@@ -188,12 +193,12 @@ class CSIStorageCapacityPatch(pulumi.CustomResource):
         :param pulumi.Input[str] maximum_volume_size: MaximumVolumeSize is the value reported by the CSI driver in its GetCapacityResponse for a GetCapacityRequest with topology and parameters that match the previous fields.
                
                This is defined since CSI spec 1.4.0 as the largest size that may be used in a CreateVolumeRequest.capacity_range.required_bytes field to create a volume with the same parameters as those in GetCapacityRequest. The corresponding value in the Kubernetes API is ResourceRequirements.Requests in a volume claim.
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata. The name has no particular meaning. It must be be a DNS subdomain (dots allowed, 253 characters). To ensure that there are no conflicts with other CSI drivers on the cluster, the recommendation is to use csisc-<uuid>, a generated name, or a reverse-domain name which ends with the unique CSI driver name.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata. The name has no particular meaning. It must be be a DNS subdomain (dots allowed, 253 characters). To ensure that there are no conflicts with other CSI drivers on the cluster, the recommendation is to use csisc-<uuid>, a generated name, or a reverse-domain name which ends with the unique CSI driver name.
                
                Objects are namespaced.
                
                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['_meta.v1.LabelSelectorPatchArgs']] node_topology: NodeTopology defines which nodes have access to the storage for which capacity was reported. If not set, the storage is not accessible from any node in the cluster. If empty, the storage is accessible from all nodes. This field is immutable.
+        :param pulumi.Input[Union['_meta.v1.LabelSelectorPatchArgs', '_meta.v1.LabelSelectorPatchArgsDict']] node_topology: NodeTopology defines which nodes have access to the storage for which capacity was reported. If not set, the storage is not accessible from any node in the cluster. If empty, the storage is accessible from all nodes. This field is immutable.
         :param pulumi.Input[str] storage_class_name: The name of the StorageClass that the reported capacity applies to. It must meet the same requirements as the name of a StorageClass object (non-empty, DNS subdomain). If that object no longer exists, the CSIStorageCapacity object is obsolete and should be removed by its creator. This field is immutable.
         """
         ...
@@ -238,8 +243,8 @@ class CSIStorageCapacityPatch(pulumi.CustomResource):
                  capacity: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
                  maximum_volume_size: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 node_topology: Optional[pulumi.Input[pulumi.InputType['_meta.v1.LabelSelectorPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 node_topology: Optional[pulumi.Input[Union['_meta.v1.LabelSelectorPatchArgs', '_meta.v1.LabelSelectorPatchArgsDict']]] = None,
                  storage_class_name: Optional[pulumi.Input[str]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)

--- a/sdk/python/pulumi_kubernetes/storage/v1beta1/StorageClass.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1beta1/StorageClass.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import core as _core
 from ... import meta as _meta
@@ -186,10 +191,10 @@ class StorageClass(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  allow_volume_expansion: Optional[pulumi.Input[bool]] = None,
-                 allowed_topologies: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['_core.v1.TopologySelectorTermArgs']]]]] = None,
+                 allowed_topologies: Optional[pulumi.Input[Sequence[pulumi.Input[Union['_core.v1.TopologySelectorTermArgs', '_core.v1.TopologySelectorTermArgsDict']]]]] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
                  mount_options: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  parameters: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  provisioner: Optional[pulumi.Input[str]] = None,
@@ -204,10 +209,10 @@ class StorageClass(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[bool] allow_volume_expansion: AllowVolumeExpansion shows whether the storage class allow volume expand
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['_core.v1.TopologySelectorTermArgs']]]] allowed_topologies: Restrict the node topologies where volumes can be dynamically provisioned. Each volume plugin defines its own supported topology specifications. An empty TopologySelectorTerm list means there is no topology restriction. This field is only honored by servers that enable the VolumeScheduling feature.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['_core.v1.TopologySelectorTermArgs', '_core.v1.TopologySelectorTermArgsDict']]]] allowed_topologies: Restrict the node topologies where volumes can be dynamically provisioned. Each volume plugin defines its own supported topology specifications. An empty TopologySelectorTerm list means there is no topology restriction. This field is only honored by servers that enable the VolumeScheduling feature.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         :param pulumi.Input[Sequence[pulumi.Input[str]]] mount_options: Dynamically provisioned PersistentVolumes of this storage class are created with these mountOptions, e.g. ["ro", "soft"]. Not validated - mount of the PVs will simply fail if one is invalid.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] parameters: Parameters holds the parameters for the provisioner that should create volumes of this storage class.
         :param pulumi.Input[str] provisioner: Provisioner indicates the type of the provisioner.
@@ -241,10 +246,10 @@ class StorageClass(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  allow_volume_expansion: Optional[pulumi.Input[bool]] = None,
-                 allowed_topologies: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['_core.v1.TopologySelectorTermArgs']]]]] = None,
+                 allowed_topologies: Optional[pulumi.Input[Sequence[pulumi.Input[Union['_core.v1.TopologySelectorTermArgs', '_core.v1.TopologySelectorTermArgsDict']]]]] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
                  mount_options: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  parameters: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  provisioner: Optional[pulumi.Input[str]] = None,

--- a/sdk/python/pulumi_kubernetes/storage/v1beta1/StorageClassList.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1beta1/StorageClassList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -92,9 +97,9 @@ class StorageClassList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['StorageClassArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['StorageClassArgs', 'StorageClassArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         StorageClassList is a collection of storage classes.
@@ -102,9 +107,9 @@ class StorageClassList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['StorageClassArgs']]]] items: Items is the list of StorageClasses
+        :param pulumi.Input[Sequence[pulumi.Input[Union['StorageClassArgs', 'StorageClassArgsDict']]]] items: Items is the list of StorageClasses
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -131,9 +136,9 @@ class StorageClassList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['StorageClassArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['StorageClassArgs', 'StorageClassArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/storage/v1beta1/StorageClassPatch.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1beta1/StorageClassPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import core as _core
 from ... import meta as _meta
@@ -187,10 +192,10 @@ class StorageClassPatch(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  allow_volume_expansion: Optional[pulumi.Input[bool]] = None,
-                 allowed_topologies: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['_core.v1.TopologySelectorTermPatchArgs']]]]] = None,
+                 allowed_topologies: Optional[pulumi.Input[Sequence[pulumi.Input[Union['_core.v1.TopologySelectorTermPatchArgs', '_core.v1.TopologySelectorTermPatchArgsDict']]]]] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
                  mount_options: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  parameters: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  provisioner: Optional[pulumi.Input[str]] = None,
@@ -211,10 +216,10 @@ class StorageClassPatch(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[bool] allow_volume_expansion: AllowVolumeExpansion shows whether the storage class allow volume expand
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['_core.v1.TopologySelectorTermPatchArgs']]]] allowed_topologies: Restrict the node topologies where volumes can be dynamically provisioned. Each volume plugin defines its own supported topology specifications. An empty TopologySelectorTerm list means there is no topology restriction. This field is only honored by servers that enable the VolumeScheduling feature.
+        :param pulumi.Input[Sequence[pulumi.Input[Union['_core.v1.TopologySelectorTermPatchArgs', '_core.v1.TopologySelectorTermPatchArgsDict']]]] allowed_topologies: Restrict the node topologies where volumes can be dynamically provisioned. Each volume plugin defines its own supported topology specifications. An empty TopologySelectorTerm list means there is no topology restriction. This field is only honored by servers that enable the VolumeScheduling feature.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         :param pulumi.Input[Sequence[pulumi.Input[str]]] mount_options: Dynamically provisioned PersistentVolumes of this storage class are created with these mountOptions, e.g. ["ro", "soft"]. Not validated - mount of the PVs will simply fail if one is invalid.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] parameters: Parameters holds the parameters for the provisioner that should create volumes of this storage class.
         :param pulumi.Input[str] provisioner: Provisioner indicates the type of the provisioner.
@@ -254,10 +259,10 @@ class StorageClassPatch(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  allow_volume_expansion: Optional[pulumi.Input[bool]] = None,
-                 allowed_topologies: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['_core.v1.TopologySelectorTermPatchArgs']]]]] = None,
+                 allowed_topologies: Optional[pulumi.Input[Sequence[pulumi.Input[Union['_core.v1.TopologySelectorTermPatchArgs', '_core.v1.TopologySelectorTermPatchArgsDict']]]]] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
                  mount_options: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  parameters: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  provisioner: Optional[pulumi.Input[str]] = None,

--- a/sdk/python/pulumi_kubernetes/storage/v1beta1/VolumeAttachment.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1beta1/VolumeAttachment.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -93,8 +98,8 @@ class VolumeAttachment(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['VolumeAttachmentSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['VolumeAttachmentSpecArgs', 'VolumeAttachmentSpecArgsDict']]] = None,
                  __props__=None):
         """
         VolumeAttachment captures the intent to attach or detach the specified volume to/from the specified node.
@@ -105,8 +110,8 @@ class VolumeAttachment(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['VolumeAttachmentSpecArgs']] spec: Specification of the desired attach/detach volume behavior. Populated by the Kubernetes system.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['VolumeAttachmentSpecArgs', 'VolumeAttachmentSpecArgsDict']] spec: Specification of the desired attach/detach volume behavior. Populated by the Kubernetes system.
         """
         ...
     @overload
@@ -136,8 +141,8 @@ class VolumeAttachment(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['VolumeAttachmentSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['VolumeAttachmentSpecArgs', 'VolumeAttachmentSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/storage/v1beta1/VolumeAttachmentList.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1beta1/VolumeAttachmentList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -92,9 +97,9 @@ class VolumeAttachmentList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['VolumeAttachmentArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['VolumeAttachmentArgs', 'VolumeAttachmentArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         VolumeAttachmentList is a collection of VolumeAttachment objects.
@@ -102,9 +107,9 @@ class VolumeAttachmentList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['VolumeAttachmentArgs']]]] items: Items is the list of VolumeAttachments
+        :param pulumi.Input[Sequence[pulumi.Input[Union['VolumeAttachmentArgs', 'VolumeAttachmentArgsDict']]]] items: Items is the list of VolumeAttachments
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -131,9 +136,9 @@ class VolumeAttachmentList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['VolumeAttachmentArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['VolumeAttachmentArgs', 'VolumeAttachmentArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/storage/v1beta1/VolumeAttachmentPatch.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1beta1/VolumeAttachmentPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core
@@ -94,8 +99,8 @@ class VolumeAttachmentPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['VolumeAttachmentSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['VolumeAttachmentSpecPatchArgs', 'VolumeAttachmentSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -112,8 +117,8 @@ class VolumeAttachmentPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['VolumeAttachmentSpecPatchArgs']] spec: Specification of the desired attach/detach volume behavior. Populated by the Kubernetes system.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['VolumeAttachmentSpecPatchArgs', 'VolumeAttachmentSpecPatchArgsDict']] spec: Specification of the desired attach/detach volume behavior. Populated by the Kubernetes system.
         """
         ...
     @overload
@@ -149,8 +154,8 @@ class VolumeAttachmentPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['VolumeAttachmentSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['VolumeAttachmentSpecPatchArgs', 'VolumeAttachmentSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/storage/v1beta1/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1beta1/_inputs.py
@@ -4,36 +4,123 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import core as _core
 from ... import meta as _meta
 
 __all__ = [
     'CSIDriverSpecPatchArgs',
+    'CSIDriverSpecPatchArgsDict',
     'CSIDriverSpecArgs',
+    'CSIDriverSpecArgsDict',
     'CSIDriverArgs',
+    'CSIDriverArgsDict',
     'CSINodeDriverPatchArgs',
+    'CSINodeDriverPatchArgsDict',
     'CSINodeDriverArgs',
+    'CSINodeDriverArgsDict',
     'CSINodeSpecPatchArgs',
+    'CSINodeSpecPatchArgsDict',
     'CSINodeSpecArgs',
+    'CSINodeSpecArgsDict',
     'CSINodeArgs',
+    'CSINodeArgsDict',
     'CSIStorageCapacityArgs',
+    'CSIStorageCapacityArgsDict',
     'StorageClassArgs',
+    'StorageClassArgsDict',
     'TokenRequestPatchArgs',
+    'TokenRequestPatchArgsDict',
     'TokenRequestArgs',
+    'TokenRequestArgsDict',
     'VolumeAttachmentSourcePatchArgs',
+    'VolumeAttachmentSourcePatchArgsDict',
     'VolumeAttachmentSourceArgs',
+    'VolumeAttachmentSourceArgsDict',
     'VolumeAttachmentSpecPatchArgs',
+    'VolumeAttachmentSpecPatchArgsDict',
     'VolumeAttachmentSpecArgs',
+    'VolumeAttachmentSpecArgsDict',
     'VolumeAttachmentStatusArgs',
+    'VolumeAttachmentStatusArgsDict',
     'VolumeAttachmentArgs',
+    'VolumeAttachmentArgsDict',
     'VolumeErrorArgs',
+    'VolumeErrorArgsDict',
     'VolumeNodeResourcesPatchArgs',
+    'VolumeNodeResourcesPatchArgsDict',
     'VolumeNodeResourcesArgs',
+    'VolumeNodeResourcesArgsDict',
 ]
+
+MYPY = False
+
+if not MYPY:
+    class CSIDriverSpecPatchArgsDict(TypedDict):
+        """
+        CSIDriverSpec is the specification of a CSIDriver.
+        """
+        attach_required: NotRequired[pulumi.Input[bool]]
+        """
+        attachRequired indicates this CSI volume driver requires an attach operation (because it implements the CSI ControllerPublishVolume() method), and that the Kubernetes attach detach controller should call the attach volume interface which checks the volumeattachment status and waits until the volume is attached before proceeding to mounting. The CSI external-attacher coordinates with CSI volume driver and updates the volumeattachment status when the attach operation is complete. If the CSIDriverRegistry feature gate is enabled and the value is specified to false, the attach operation will be skipped. Otherwise the attach operation will be called.
+        """
+        fs_group_policy: NotRequired[pulumi.Input[str]]
+        """
+        Defines if the underlying volume supports changing ownership and permission of the volume before being mounted. Refer to the specific FSGroupPolicy values for additional details. This field is alpha-level, and is only honored by servers that enable the CSIVolumeFSGroupPolicy feature gate.
+        """
+        pod_info_on_mount: NotRequired[pulumi.Input[bool]]
+        """
+        If set to true, podInfoOnMount indicates this CSI volume driver requires additional pod information (like podName, podUID, etc.) during mount operations. If set to false, pod information will not be passed on mount. Default is false. The CSI driver specifies podInfoOnMount as part of driver deployment. If true, Kubelet will pass pod information as VolumeContext in the CSI NodePublishVolume() calls. The CSI driver is responsible for parsing and validating the information passed in as VolumeContext. The following VolumeConext will be passed if podInfoOnMount is set to true. This list might grow, but the prefix will be used. "csi.storage.k8s.io/pod.name": pod.Name "csi.storage.k8s.io/pod.namespace": pod.Namespace "csi.storage.k8s.io/pod.uid": string(pod.UID) "csi.storage.k8s.io/ephemeral": "true" iff the volume is an ephemeral inline volume
+                                        defined by a CSIVolumeSource, otherwise "false"
+
+        "csi.storage.k8s.io/ephemeral" is a new feature in Kubernetes 1.16. It is only required for drivers which support both the "Persistent" and "Ephemeral" VolumeLifecycleMode. Other drivers can leave pod info disabled and/or ignore this field. As Kubernetes 1.15 doesn't support this field, drivers can only support one mode when deployed on such a cluster and the deployment determines which mode that is, for example via a command line parameter of the driver.
+        """
+        requires_republish: NotRequired[pulumi.Input[bool]]
+        """
+        RequiresRepublish indicates the CSI driver wants `NodePublishVolume` being periodically called to reflect any possible change in the mounted volume. This field defaults to false.
+
+        Note: After a successful initial NodePublishVolume call, subsequent calls to NodePublishVolume should only update the contents of the volume. New mount points will not be seen by a running container.
+
+        This is an alpha feature and only available when the CSIServiceAccountToken feature is enabled.
+        """
+        storage_capacity: NotRequired[pulumi.Input[bool]]
+        """
+        If set to true, storageCapacity indicates that the CSI volume driver wants pod scheduling to consider the storage capacity that the driver deployment will report by creating CSIStorageCapacity objects with capacity information.
+
+        The check can be enabled immediately when deploying a driver. In that case, provisioning new volumes with late binding will pause until the driver deployment has published some suitable CSIStorageCapacity object.
+
+        Alternatively, the driver can be deployed with the field unset or false and it can be flipped later when storage capacity information has been published.
+
+        This is an alpha field and only available when the CSIStorageCapacity feature is enabled. The default is false.
+        """
+        token_requests: NotRequired[pulumi.Input[Sequence[pulumi.Input['TokenRequestPatchArgsDict']]]]
+        """
+        TokenRequests indicates the CSI driver needs pods' service account tokens it is mounting volume for to do necessary authentication. Kubelet will pass the tokens in VolumeContext in the CSI NodePublishVolume calls. The CSI driver should parse and validate the following VolumeContext: "csi.storage.k8s.io/serviceAccount.tokens": {
+          "<audience>": {
+            "token": <token>,
+            "expirationTimestamp": <expiration timestamp in RFC3339>,
+          },
+          ...
+        }
+
+        Note: Audience in each TokenRequest should be different and at most one token is empty string. To receive a new token after expiry, RequiresRepublish can be used to trigger NodePublishVolume periodically.
+
+        This is an alpha feature and only available when the CSIServiceAccountToken feature is enabled.
+        """
+        volume_lifecycle_modes: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        VolumeLifecycleModes defines what kind of volumes this CSI volume driver supports. The default if the list is empty is "Persistent", which is the usage defined by the CSI specification and implemented in Kubernetes via the usual PV/PVC mechanism. The other mode is "Ephemeral". In this mode, volumes are defined inline inside the pod spec with CSIVolumeSource and their lifecycle is tied to the lifecycle of that pod. A driver has to be aware of this because it is only going to get a NodePublishVolume call for such a volume. For more information about implementing this mode, see https://kubernetes-csi.github.io/docs/ephemeral-local-volumes.html A driver can support one or more of these modes and more modes may be added in the future.
+        """
+elif False:
+    CSIDriverSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class CSIDriverSpecPatchArgs:
@@ -201,6 +288,65 @@ class CSIDriverSpecPatchArgs:
         pulumi.set(self, "volume_lifecycle_modes", value)
 
 
+if not MYPY:
+    class CSIDriverSpecArgsDict(TypedDict):
+        """
+        CSIDriverSpec is the specification of a CSIDriver.
+        """
+        attach_required: NotRequired[pulumi.Input[bool]]
+        """
+        attachRequired indicates this CSI volume driver requires an attach operation (because it implements the CSI ControllerPublishVolume() method), and that the Kubernetes attach detach controller should call the attach volume interface which checks the volumeattachment status and waits until the volume is attached before proceeding to mounting. The CSI external-attacher coordinates with CSI volume driver and updates the volumeattachment status when the attach operation is complete. If the CSIDriverRegistry feature gate is enabled and the value is specified to false, the attach operation will be skipped. Otherwise the attach operation will be called.
+        """
+        fs_group_policy: NotRequired[pulumi.Input[str]]
+        """
+        Defines if the underlying volume supports changing ownership and permission of the volume before being mounted. Refer to the specific FSGroupPolicy values for additional details. This field is alpha-level, and is only honored by servers that enable the CSIVolumeFSGroupPolicy feature gate.
+        """
+        pod_info_on_mount: NotRequired[pulumi.Input[bool]]
+        """
+        If set to true, podInfoOnMount indicates this CSI volume driver requires additional pod information (like podName, podUID, etc.) during mount operations. If set to false, pod information will not be passed on mount. Default is false. The CSI driver specifies podInfoOnMount as part of driver deployment. If true, Kubelet will pass pod information as VolumeContext in the CSI NodePublishVolume() calls. The CSI driver is responsible for parsing and validating the information passed in as VolumeContext. The following VolumeConext will be passed if podInfoOnMount is set to true. This list might grow, but the prefix will be used. "csi.storage.k8s.io/pod.name": pod.Name "csi.storage.k8s.io/pod.namespace": pod.Namespace "csi.storage.k8s.io/pod.uid": string(pod.UID) "csi.storage.k8s.io/ephemeral": "true" iff the volume is an ephemeral inline volume
+                                        defined by a CSIVolumeSource, otherwise "false"
+
+        "csi.storage.k8s.io/ephemeral" is a new feature in Kubernetes 1.16. It is only required for drivers which support both the "Persistent" and "Ephemeral" VolumeLifecycleMode. Other drivers can leave pod info disabled and/or ignore this field. As Kubernetes 1.15 doesn't support this field, drivers can only support one mode when deployed on such a cluster and the deployment determines which mode that is, for example via a command line parameter of the driver.
+        """
+        requires_republish: NotRequired[pulumi.Input[bool]]
+        """
+        RequiresRepublish indicates the CSI driver wants `NodePublishVolume` being periodically called to reflect any possible change in the mounted volume. This field defaults to false.
+
+        Note: After a successful initial NodePublishVolume call, subsequent calls to NodePublishVolume should only update the contents of the volume. New mount points will not be seen by a running container.
+
+        This is an alpha feature and only available when the CSIServiceAccountToken feature is enabled.
+        """
+        storage_capacity: NotRequired[pulumi.Input[bool]]
+        """
+        If set to true, storageCapacity indicates that the CSI volume driver wants pod scheduling to consider the storage capacity that the driver deployment will report by creating CSIStorageCapacity objects with capacity information.
+
+        The check can be enabled immediately when deploying a driver. In that case, provisioning new volumes with late binding will pause until the driver deployment has published some suitable CSIStorageCapacity object.
+
+        Alternatively, the driver can be deployed with the field unset or false and it can be flipped later when storage capacity information has been published.
+
+        This is an alpha field and only available when the CSIStorageCapacity feature is enabled. The default is false.
+        """
+        token_requests: NotRequired[pulumi.Input[Sequence[pulumi.Input['TokenRequestArgsDict']]]]
+        """
+        TokenRequests indicates the CSI driver needs pods' service account tokens it is mounting volume for to do necessary authentication. Kubelet will pass the tokens in VolumeContext in the CSI NodePublishVolume calls. The CSI driver should parse and validate the following VolumeContext: "csi.storage.k8s.io/serviceAccount.tokens": {
+          "<audience>": {
+            "token": <token>,
+            "expirationTimestamp": <expiration timestamp in RFC3339>,
+          },
+          ...
+        }
+
+        Note: Audience in each TokenRequest should be different and at most one token is empty string. To receive a new token after expiry, RequiresRepublish can be used to trigger NodePublishVolume periodically.
+
+        This is an alpha feature and only available when the CSIServiceAccountToken feature is enabled.
+        """
+        volume_lifecycle_modes: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        VolumeLifecycleModes defines what kind of volumes this CSI volume driver supports. The default if the list is empty is "Persistent", which is the usage defined by the CSI specification and implemented in Kubernetes via the usual PV/PVC mechanism. The other mode is "Ephemeral". In this mode, volumes are defined inline inside the pod spec with CSIVolumeSource and their lifecycle is tied to the lifecycle of that pod. A driver has to be aware of this because it is only going to get a NodePublishVolume call for such a volume. For more information about implementing this mode, see https://kubernetes-csi.github.io/docs/ephemeral-local-volumes.html A driver can support one or more of these modes and more modes may be added in the future.
+        """
+elif False:
+    CSIDriverSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CSIDriverSpecArgs:
     def __init__(__self__, *,
@@ -367,6 +513,30 @@ class CSIDriverSpecArgs:
         pulumi.set(self, "volume_lifecycle_modes", value)
 
 
+if not MYPY:
+    class CSIDriverArgsDict(TypedDict):
+        """
+        CSIDriver captures information about a Container Storage Interface (CSI) volume driver deployed on the cluster. CSI drivers do not need to create the CSIDriver object directly. Instead they may use the cluster-driver-registrar sidecar container. When deployed with a CSI driver it automatically creates a CSIDriver object representing the driver. Kubernetes attach detach controller uses this object to determine whether attach is required. Kubelet uses this object to determine whether pod information needs to be passed on mount. CSIDriver objects are non-namespaced.
+        """
+        spec: pulumi.Input['CSIDriverSpecArgsDict']
+        """
+        Specification of the CSI Driver.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object metadata. metadata.Name indicates the name of the CSI driver that this object refers to; it MUST be the same name returned by the CSI GetPluginName() call for that driver. The driver name must be 63 characters or less, beginning and ending with an alphanumeric character ([a-z0-9A-Z]) with dashes (-), dots (.), and alphanumerics between. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+elif False:
+    CSIDriverArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CSIDriverArgs:
     def __init__(__self__, *,
@@ -437,6 +607,30 @@ class CSIDriverArgs:
     def metadata(self, value: Optional[pulumi.Input['_meta.v1.ObjectMetaArgs']]):
         pulumi.set(self, "metadata", value)
 
+
+if not MYPY:
+    class CSINodeDriverPatchArgsDict(TypedDict):
+        """
+        CSINodeDriver holds information about the specification of one CSI driver installed on a node
+        """
+        allocatable: NotRequired[pulumi.Input['VolumeNodeResourcesPatchArgsDict']]
+        """
+        allocatable represents the volume resources of a node that are available for scheduling.
+        """
+        name: NotRequired[pulumi.Input[str]]
+        """
+        This is the name of the CSI driver that this object refers to. This MUST be the same name returned by the CSI GetPluginName() call for that driver.
+        """
+        node_id: NotRequired[pulumi.Input[str]]
+        """
+        nodeID of the node from the driver point of view. This field enables Kubernetes to communicate with storage systems that do not share the same nomenclature for nodes. For example, Kubernetes may refer to a given node as "node1", but the storage system may refer to the same node as "nodeA". When Kubernetes issues a command to the storage system to attach a volume to a specific node, it can use this field to refer to the node name using the ID that the storage system will understand, e.g. "nodeA" instead of "node1". This field is required.
+        """
+        topology_keys: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        topologyKeys is the list of keys supported by the driver. When a driver is initialized on a cluster, it provides a set of topology keys that it understands (e.g. "company.com/zone", "company.com/region"). When a driver is initialized on a node, it provides the same topology keys along with values. Kubelet will expose these topology keys as labels on its own node object. When Kubernetes does topology aware provisioning, it can use this list to determine which labels it should retrieve from the node object and pass back to the driver. It is possible for different nodes to use different topology keys. This can be empty if driver does not support topology.
+        """
+elif False:
+    CSINodeDriverPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class CSINodeDriverPatchArgs:
@@ -510,6 +704,30 @@ class CSINodeDriverPatchArgs:
         pulumi.set(self, "topology_keys", value)
 
 
+if not MYPY:
+    class CSINodeDriverArgsDict(TypedDict):
+        """
+        CSINodeDriver holds information about the specification of one CSI driver installed on a node
+        """
+        name: pulumi.Input[str]
+        """
+        This is the name of the CSI driver that this object refers to. This MUST be the same name returned by the CSI GetPluginName() call for that driver.
+        """
+        node_id: pulumi.Input[str]
+        """
+        nodeID of the node from the driver point of view. This field enables Kubernetes to communicate with storage systems that do not share the same nomenclature for nodes. For example, Kubernetes may refer to a given node as "node1", but the storage system may refer to the same node as "nodeA". When Kubernetes issues a command to the storage system to attach a volume to a specific node, it can use this field to refer to the node name using the ID that the storage system will understand, e.g. "nodeA" instead of "node1". This field is required.
+        """
+        allocatable: NotRequired[pulumi.Input['VolumeNodeResourcesArgsDict']]
+        """
+        allocatable represents the volume resources of a node that are available for scheduling.
+        """
+        topology_keys: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        topologyKeys is the list of keys supported by the driver. When a driver is initialized on a cluster, it provides a set of topology keys that it understands (e.g. "company.com/zone", "company.com/region"). When a driver is initialized on a node, it provides the same topology keys along with values. Kubelet will expose these topology keys as labels on its own node object. When Kubernetes does topology aware provisioning, it can use this list to determine which labels it should retrieve from the node object and pass back to the driver. It is possible for different nodes to use different topology keys. This can be empty if driver does not support topology.
+        """
+elif False:
+    CSINodeDriverArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CSINodeDriverArgs:
     def __init__(__self__, *,
@@ -580,6 +798,18 @@ class CSINodeDriverArgs:
         pulumi.set(self, "topology_keys", value)
 
 
+if not MYPY:
+    class CSINodeSpecPatchArgsDict(TypedDict):
+        """
+        CSINodeSpec holds information about the specification of all CSI drivers installed on a node
+        """
+        drivers: NotRequired[pulumi.Input[Sequence[pulumi.Input['CSINodeDriverPatchArgsDict']]]]
+        """
+        drivers is a list of information of all CSI Drivers existing on a node. If all drivers in the list are uninstalled, this can become empty.
+        """
+elif False:
+    CSINodeSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CSINodeSpecPatchArgs:
     def __init__(__self__, *,
@@ -604,6 +834,18 @@ class CSINodeSpecPatchArgs:
         pulumi.set(self, "drivers", value)
 
 
+if not MYPY:
+    class CSINodeSpecArgsDict(TypedDict):
+        """
+        CSINodeSpec holds information about the specification of all CSI drivers installed on a node
+        """
+        drivers: pulumi.Input[Sequence[pulumi.Input['CSINodeDriverArgsDict']]]
+        """
+        drivers is a list of information of all CSI Drivers existing on a node. If all drivers in the list are uninstalled, this can become empty.
+        """
+elif False:
+    CSINodeSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class CSINodeSpecArgs:
     def __init__(__self__, *,
@@ -626,6 +868,30 @@ class CSINodeSpecArgs:
     def drivers(self, value: pulumi.Input[Sequence[pulumi.Input['CSINodeDriverArgs']]]):
         pulumi.set(self, "drivers", value)
 
+
+if not MYPY:
+    class CSINodeArgsDict(TypedDict):
+        """
+        CSINode holds information about all CSI drivers installed on a node. CSI drivers do not need to create the CSINode object directly. As long as they use the node-driver-registrar sidecar container, the kubelet will automatically populate the CSINode object for the CSI driver as part of kubelet plugin registration. CSINode has the same name as a node. If the object is missing, it means either there are no CSI Drivers available on the node, or the Kubelet version is low enough that it doesn't create this object. CSINode has an OwnerReference that points to the corresponding node object.
+        """
+        spec: pulumi.Input['CSINodeSpecArgsDict']
+        """
+        spec is the specification of CSINode
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        metadata.name must be the Kubernetes node name.
+        """
+elif False:
+    CSINodeArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class CSINodeArgs:
@@ -697,6 +963,58 @@ class CSINodeArgs:
     def metadata(self, value: Optional[pulumi.Input['_meta.v1.ObjectMetaArgs']]):
         pulumi.set(self, "metadata", value)
 
+
+if not MYPY:
+    class CSIStorageCapacityArgsDict(TypedDict):
+        """
+        CSIStorageCapacity stores the result of one CSI GetCapacity call. For a given StorageClass, this describes the available capacity in a particular topology segment.  This can be used when considering where to instantiate new PersistentVolumes.
+
+        For example this can express things like: - StorageClass "standard" has "1234 GiB" available in "topology.kubernetes.io/zone=us-east1" - StorageClass "localssd" has "10 GiB" available in "kubernetes.io/hostname=knode-abc123"
+
+        The following three cases all imply that no capacity is available for a certain combination: - no object exists with suitable topology and storage class name - such an object exists, but the capacity is unset - such an object exists, but the capacity is zero
+
+        The producer of these objects can decide which approach is more suitable.
+
+        They are consumed by the kube-scheduler when a CSI driver opts into capacity-aware scheduling with CSIDriverSpec.StorageCapacity. The scheduler compares the MaximumVolumeSize against the requested size of pending volumes to filter out unsuitable nodes. If MaximumVolumeSize is unset, it falls back to a comparison against the less precise Capacity. If that is also unset, the scheduler assumes that capacity is insufficient and tries some other node.
+        """
+        storage_class_name: pulumi.Input[str]
+        """
+        The name of the StorageClass that the reported capacity applies to. It must meet the same requirements as the name of a StorageClass object (non-empty, DNS subdomain). If that object no longer exists, the CSIStorageCapacity object is obsolete and should be removed by its creator. This field is immutable.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        capacity: NotRequired[pulumi.Input[str]]
+        """
+        Capacity is the value reported by the CSI driver in its GetCapacityResponse for a GetCapacityRequest with topology and parameters that match the previous fields.
+
+        The semantic is currently (CSI spec 1.2) defined as: The available capacity, in bytes, of the storage that can be used to provision volumes. If not set, that information is currently unavailable.
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        maximum_volume_size: NotRequired[pulumi.Input[str]]
+        """
+        MaximumVolumeSize is the value reported by the CSI driver in its GetCapacityResponse for a GetCapacityRequest with topology and parameters that match the previous fields.
+
+        This is defined since CSI spec 1.4.0 as the largest size that may be used in a CreateVolumeRequest.capacity_range.required_bytes field to create a volume with the same parameters as those in GetCapacityRequest. The corresponding value in the Kubernetes API is ResourceRequirements.Requests in a volume claim.
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata. The name has no particular meaning. It must be be a DNS subdomain (dots allowed, 253 characters). To ensure that there are no conflicts with other CSI drivers on the cluster, the recommendation is to use csisc-<uuid>, a generated name, or a reverse-domain name which ends with the unique CSI driver name.
+
+        Objects are namespaced.
+
+        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        node_topology: NotRequired[pulumi.Input['_meta.v1.LabelSelectorArgsDict']]
+        """
+        NodeTopology defines which nodes have access to the storage for which capacity was reported. If not set, the storage is not accessible from any node in the cluster. If empty, the storage is accessible from all nodes. This field is immutable.
+        """
+elif False:
+    CSIStorageCapacityArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class CSIStorageCapacityArgs:
@@ -840,6 +1158,56 @@ class CSIStorageCapacityArgs:
     def node_topology(self, value: Optional[pulumi.Input['_meta.v1.LabelSelectorArgs']]):
         pulumi.set(self, "node_topology", value)
 
+
+if not MYPY:
+    class StorageClassArgsDict(TypedDict):
+        """
+        StorageClass describes the parameters for a class of storage for which PersistentVolumes can be dynamically provisioned.
+
+        StorageClasses are non-namespaced; the name of the storage class according to etcd is in ObjectMeta.Name.
+        """
+        provisioner: pulumi.Input[str]
+        """
+        Provisioner indicates the type of the provisioner.
+        """
+        allow_volume_expansion: NotRequired[pulumi.Input[bool]]
+        """
+        AllowVolumeExpansion shows whether the storage class allow volume expand
+        """
+        allowed_topologies: NotRequired[pulumi.Input[Sequence[pulumi.Input['_core.v1.TopologySelectorTermArgsDict']]]]
+        """
+        Restrict the node topologies where volumes can be dynamically provisioned. Each volume plugin defines its own supported topology specifications. An empty TopologySelectorTerm list means there is no topology restriction. This field is only honored by servers that enable the VolumeScheduling feature.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        mount_options: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
+        """
+        Dynamically provisioned PersistentVolumes of this storage class are created with these mountOptions, e.g. ["ro", "soft"]. Not validated - mount of the PVs will simply fail if one is invalid.
+        """
+        parameters: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        Parameters holds the parameters for the provisioner that should create volumes of this storage class.
+        """
+        reclaim_policy: NotRequired[pulumi.Input[str]]
+        """
+        Dynamically provisioned PersistentVolumes of this storage class are created with this reclaimPolicy. Defaults to Delete.
+        """
+        volume_binding_mode: NotRequired[pulumi.Input[str]]
+        """
+        VolumeBindingMode indicates how PersistentVolumeClaims should be provisioned and bound.  When unset, VolumeBindingImmediate is used. This field is only honored by servers that enable the VolumeScheduling feature.
+        """
+elif False:
+    StorageClassArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class StorageClassArgs:
@@ -1010,6 +1378,22 @@ class StorageClassArgs:
         pulumi.set(self, "volume_binding_mode", value)
 
 
+if not MYPY:
+    class TokenRequestPatchArgsDict(TypedDict):
+        """
+        TokenRequest contains parameters of a service account token.
+        """
+        audience: NotRequired[pulumi.Input[str]]
+        """
+        Audience is the intended audience of the token in "TokenRequestSpec". It will default to the audiences of kube apiserver.
+        """
+        expiration_seconds: NotRequired[pulumi.Input[int]]
+        """
+        ExpirationSeconds is the duration of validity of the token in "TokenRequestSpec". It has the same default value of "ExpirationSeconds" in "TokenRequestSpec"
+        """
+elif False:
+    TokenRequestPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class TokenRequestPatchArgs:
     def __init__(__self__, *,
@@ -1050,6 +1434,22 @@ class TokenRequestPatchArgs:
         pulumi.set(self, "expiration_seconds", value)
 
 
+if not MYPY:
+    class TokenRequestArgsDict(TypedDict):
+        """
+        TokenRequest contains parameters of a service account token.
+        """
+        audience: pulumi.Input[str]
+        """
+        Audience is the intended audience of the token in "TokenRequestSpec". It will default to the audiences of kube apiserver.
+        """
+        expiration_seconds: NotRequired[pulumi.Input[int]]
+        """
+        ExpirationSeconds is the duration of validity of the token in "TokenRequestSpec". It has the same default value of "ExpirationSeconds" in "TokenRequestSpec"
+        """
+elif False:
+    TokenRequestArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class TokenRequestArgs:
     def __init__(__self__, *,
@@ -1088,6 +1488,22 @@ class TokenRequestArgs:
     def expiration_seconds(self, value: Optional[pulumi.Input[int]]):
         pulumi.set(self, "expiration_seconds", value)
 
+
+if not MYPY:
+    class VolumeAttachmentSourcePatchArgsDict(TypedDict):
+        """
+        VolumeAttachmentSource represents a volume that should be attached. Right now only PersistenVolumes can be attached via external attacher, in future we may allow also inline volumes in pods. Exactly one member can be set.
+        """
+        inline_volume_spec: NotRequired[pulumi.Input['_core.v1.PersistentVolumeSpecPatchArgsDict']]
+        """
+        inlineVolumeSpec contains all the information necessary to attach a persistent volume defined by a pod's inline VolumeSource. This field is populated only for the CSIMigration feature. It contains translated fields from a pod's inline VolumeSource to a PersistentVolumeSpec. This field is alpha-level and is only honored by servers that enabled the CSIMigration feature.
+        """
+        persistent_volume_name: NotRequired[pulumi.Input[str]]
+        """
+        Name of the persistent volume to attach.
+        """
+elif False:
+    VolumeAttachmentSourcePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class VolumeAttachmentSourcePatchArgs:
@@ -1129,6 +1545,22 @@ class VolumeAttachmentSourcePatchArgs:
         pulumi.set(self, "persistent_volume_name", value)
 
 
+if not MYPY:
+    class VolumeAttachmentSourceArgsDict(TypedDict):
+        """
+        VolumeAttachmentSource represents a volume that should be attached. Right now only PersistenVolumes can be attached via external attacher, in future we may allow also inline volumes in pods. Exactly one member can be set.
+        """
+        inline_volume_spec: NotRequired[pulumi.Input['_core.v1.PersistentVolumeSpecArgsDict']]
+        """
+        inlineVolumeSpec contains all the information necessary to attach a persistent volume defined by a pod's inline VolumeSource. This field is populated only for the CSIMigration feature. It contains translated fields from a pod's inline VolumeSource to a PersistentVolumeSpec. This field is alpha-level and is only honored by servers that enabled the CSIMigration feature.
+        """
+        persistent_volume_name: NotRequired[pulumi.Input[str]]
+        """
+        Name of the persistent volume to attach.
+        """
+elif False:
+    VolumeAttachmentSourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class VolumeAttachmentSourceArgs:
     def __init__(__self__, *,
@@ -1168,6 +1600,26 @@ class VolumeAttachmentSourceArgs:
     def persistent_volume_name(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "persistent_volume_name", value)
 
+
+if not MYPY:
+    class VolumeAttachmentSpecPatchArgsDict(TypedDict):
+        """
+        VolumeAttachmentSpec is the specification of a VolumeAttachment request.
+        """
+        attacher: NotRequired[pulumi.Input[str]]
+        """
+        Attacher indicates the name of the volume driver that MUST handle this request. This is the name returned by GetPluginName().
+        """
+        node_name: NotRequired[pulumi.Input[str]]
+        """
+        The node that the volume should be attached to.
+        """
+        source: NotRequired[pulumi.Input['VolumeAttachmentSourcePatchArgsDict']]
+        """
+        Source represents the volume that should be attached.
+        """
+elif False:
+    VolumeAttachmentSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class VolumeAttachmentSpecPatchArgs:
@@ -1225,6 +1677,26 @@ class VolumeAttachmentSpecPatchArgs:
         pulumi.set(self, "source", value)
 
 
+if not MYPY:
+    class VolumeAttachmentSpecArgsDict(TypedDict):
+        """
+        VolumeAttachmentSpec is the specification of a VolumeAttachment request.
+        """
+        attacher: pulumi.Input[str]
+        """
+        Attacher indicates the name of the volume driver that MUST handle this request. This is the name returned by GetPluginName().
+        """
+        node_name: pulumi.Input[str]
+        """
+        The node that the volume should be attached to.
+        """
+        source: pulumi.Input['VolumeAttachmentSourceArgsDict']
+        """
+        Source represents the volume that should be attached.
+        """
+elif False:
+    VolumeAttachmentSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class VolumeAttachmentSpecArgs:
     def __init__(__self__, *,
@@ -1277,6 +1749,30 @@ class VolumeAttachmentSpecArgs:
     def source(self, value: pulumi.Input['VolumeAttachmentSourceArgs']):
         pulumi.set(self, "source", value)
 
+
+if not MYPY:
+    class VolumeAttachmentStatusArgsDict(TypedDict):
+        """
+        VolumeAttachmentStatus is the status of a VolumeAttachment request.
+        """
+        attached: pulumi.Input[bool]
+        """
+        Indicates the volume is successfully attached. This field must only be set by the entity completing the attach operation, i.e. the external-attacher.
+        """
+        attach_error: NotRequired[pulumi.Input['VolumeErrorArgsDict']]
+        """
+        The last error encountered during attach operation, if any. This field must only be set by the entity completing the attach operation, i.e. the external-attacher.
+        """
+        attachment_metadata: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+        """
+        Upon successful attach, this field is populated with any information returned by the attach operation that must be passed into subsequent WaitForAttach or Mount calls. This field must only be set by the entity completing the attach operation, i.e. the external-attacher.
+        """
+        detach_error: NotRequired[pulumi.Input['VolumeErrorArgsDict']]
+        """
+        The last error encountered during detach operation, if any. This field must only be set by the entity completing the detach operation, i.e. the external-attacher.
+        """
+elif False:
+    VolumeAttachmentStatusArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class VolumeAttachmentStatusArgs:
@@ -1348,6 +1844,36 @@ class VolumeAttachmentStatusArgs:
     def detach_error(self, value: Optional[pulumi.Input['VolumeErrorArgs']]):
         pulumi.set(self, "detach_error", value)
 
+
+if not MYPY:
+    class VolumeAttachmentArgsDict(TypedDict):
+        """
+        VolumeAttachment captures the intent to attach or detach the specified volume to/from the specified node.
+
+        VolumeAttachment objects are non-namespaced.
+        """
+        spec: pulumi.Input['VolumeAttachmentSpecArgsDict']
+        """
+        Specification of the desired attach/detach volume behavior. Populated by the Kubernetes system.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        status: NotRequired[pulumi.Input['VolumeAttachmentStatusArgsDict']]
+        """
+        Status of the VolumeAttachment request. Populated by the entity completing the attach or detach operation, i.e. the external-attacher.
+        """
+elif False:
+    VolumeAttachmentArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class VolumeAttachmentArgs:
@@ -1438,6 +1964,22 @@ class VolumeAttachmentArgs:
         pulumi.set(self, "status", value)
 
 
+if not MYPY:
+    class VolumeErrorArgsDict(TypedDict):
+        """
+        VolumeError captures an error encountered during a volume operation.
+        """
+        message: NotRequired[pulumi.Input[str]]
+        """
+        String detailing the error encountered during Attach or Detach operation. This string may be logged, so it should not contain sensitive information.
+        """
+        time: NotRequired[pulumi.Input[str]]
+        """
+        Time the error was encountered.
+        """
+elif False:
+    VolumeErrorArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class VolumeErrorArgs:
     def __init__(__self__, *,
@@ -1478,6 +2020,18 @@ class VolumeErrorArgs:
         pulumi.set(self, "time", value)
 
 
+if not MYPY:
+    class VolumeNodeResourcesPatchArgsDict(TypedDict):
+        """
+        VolumeNodeResources is a set of resource limits for scheduling of volumes.
+        """
+        count: NotRequired[pulumi.Input[int]]
+        """
+        Maximum number of unique volumes managed by the CSI driver that can be used on a node. A volume that is both attached and mounted on a node is considered to be used once, not twice. The same rule applies for a unique volume that is shared among multiple pods on the same node. If this field is nil, then the supported number of volumes on this node is unbounded.
+        """
+elif False:
+    VolumeNodeResourcesPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class VolumeNodeResourcesPatchArgs:
     def __init__(__self__, *,
@@ -1501,6 +2055,18 @@ class VolumeNodeResourcesPatchArgs:
     def count(self, value: Optional[pulumi.Input[int]]):
         pulumi.set(self, "count", value)
 
+
+if not MYPY:
+    class VolumeNodeResourcesArgsDict(TypedDict):
+        """
+        VolumeNodeResources is a set of resource limits for scheduling of volumes.
+        """
+        count: NotRequired[pulumi.Input[int]]
+        """
+        Maximum number of unique volumes managed by the CSI driver that can be used on a node. A volume that is both attached and mounted on a node is considered to be used once, not twice. The same rule applies for a unique volume that is shared among multiple pods on the same node. If this field is nil, then the supported number of volumes on this node is unbounded.
+        """
+elif False:
+    VolumeNodeResourcesArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class VolumeNodeResourcesArgs:

--- a/sdk/python/pulumi_kubernetes/storage/v1beta1/outputs.py
+++ b/sdk/python/pulumi_kubernetes/storage/v1beta1/outputs.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import core as _core

--- a/sdk/python/pulumi_kubernetes/storagemigration/v1alpha1/StorageVersionMigration.py
+++ b/sdk/python/pulumi_kubernetes/storagemigration/v1alpha1/StorageVersionMigration.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class StorageVersionMigration(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['StorageVersionMigrationSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['StorageVersionMigrationSpecArgs', 'StorageVersionMigrationSpecArgsDict']]] = None,
                  __props__=None):
         """
         StorageVersionMigration represents a migration of stored data to the latest storage version.
@@ -103,8 +108,8 @@ class StorageVersionMigration(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']] metadata: Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['StorageVersionMigrationSpecArgs']] spec: Specification of the migration.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']] metadata: Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['StorageVersionMigrationSpecArgs', 'StorageVersionMigrationSpecArgsDict']] spec: Specification of the migration.
         """
         ...
     @overload
@@ -132,8 +137,8 @@ class StorageVersionMigration(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['StorageVersionMigrationSpecArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaArgs', '_meta.v1.ObjectMetaArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['StorageVersionMigrationSpecArgs', 'StorageVersionMigrationSpecArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/storagemigration/v1alpha1/StorageVersionMigrationList.py
+++ b/sdk/python/pulumi_kubernetes/storagemigration/v1alpha1/StorageVersionMigrationList.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -91,9 +96,9 @@ class StorageVersionMigrationList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['StorageVersionMigrationArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['StorageVersionMigrationArgs', 'StorageVersionMigrationArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         """
         StorageVersionMigrationList is a collection of storage version migrations.
@@ -101,9 +106,9 @@ class StorageVersionMigrationList(pulumi.CustomResource):
         :param str resource_name: The name of the resource.
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-        :param pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['StorageVersionMigrationArgs']]]] items: Items is the list of StorageVersionMigration
+        :param pulumi.Input[Sequence[pulumi.Input[Union['StorageVersionMigrationArgs', 'StorageVersionMigrationArgsDict']]]] items: Items is the list of StorageVersionMigration
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']] metadata: Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']] metadata: Standard list metadata More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
         """
         ...
     @overload
@@ -130,9 +135,9 @@ class StorageVersionMigrationList(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
-                 items: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['StorageVersionMigrationArgs']]]]] = None,
+                 items: Optional[pulumi.Input[Sequence[pulumi.Input[Union['StorageVersionMigrationArgs', 'StorageVersionMigrationArgsDict']]]]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ListMetaArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ListMetaArgs', '_meta.v1.ListMetaArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/storagemigration/v1alpha1/StorageVersionMigrationPatch.py
+++ b/sdk/python/pulumi_kubernetes/storagemigration/v1alpha1/StorageVersionMigrationPatch.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta
@@ -93,8 +98,8 @@ class StorageVersionMigrationPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['StorageVersionMigrationSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['StorageVersionMigrationSpecPatchArgs', 'StorageVersionMigrationSpecPatchArgsDict']]] = None,
                  __props__=None):
         """
         Patch resources are used to modify existing Kubernetes resources by using
@@ -109,8 +114,8 @@ class StorageVersionMigrationPatch(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[str] api_version: APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
         :param pulumi.Input[str] kind: Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-        :param pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']] metadata: Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-        :param pulumi.Input[pulumi.InputType['StorageVersionMigrationSpecPatchArgs']] spec: Specification of the migration.
+        :param pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']] metadata: Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        :param pulumi.Input[Union['StorageVersionMigrationSpecPatchArgs', 'StorageVersionMigrationSpecPatchArgsDict']] spec: Specification of the migration.
         """
         ...
     @overload
@@ -144,8 +149,8 @@ class StorageVersionMigrationPatch(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  api_version: Optional[pulumi.Input[str]] = None,
                  kind: Optional[pulumi.Input[str]] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['_meta.v1.ObjectMetaPatchArgs']]] = None,
-                 spec: Optional[pulumi.Input[pulumi.InputType['StorageVersionMigrationSpecPatchArgs']]] = None,
+                 metadata: Optional[pulumi.Input[Union['_meta.v1.ObjectMetaPatchArgs', '_meta.v1.ObjectMetaPatchArgsDict']]] = None,
+                 spec: Optional[pulumi.Input[Union['StorageVersionMigrationSpecPatchArgs', 'StorageVersionMigrationSpecPatchArgsDict']]] = None,
                  __props__=None):
         opts = pulumi.ResourceOptions.merge(_utilities.get_resource_opts_defaults(), opts)
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/sdk/python/pulumi_kubernetes/storagemigration/v1alpha1/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/storagemigration/v1alpha1/_inputs.py
@@ -4,21 +4,55 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from ... import meta as _meta
 
 __all__ = [
     'GroupVersionResourcePatchArgs',
+    'GroupVersionResourcePatchArgsDict',
     'GroupVersionResourceArgs',
+    'GroupVersionResourceArgsDict',
     'MigrationConditionArgs',
+    'MigrationConditionArgsDict',
     'StorageVersionMigrationSpecPatchArgs',
+    'StorageVersionMigrationSpecPatchArgsDict',
     'StorageVersionMigrationSpecArgs',
+    'StorageVersionMigrationSpecArgsDict',
     'StorageVersionMigrationStatusArgs',
+    'StorageVersionMigrationStatusArgsDict',
     'StorageVersionMigrationArgs',
+    'StorageVersionMigrationArgsDict',
 ]
+
+MYPY = False
+
+if not MYPY:
+    class GroupVersionResourcePatchArgsDict(TypedDict):
+        """
+        The names of the group, the version, and the resource.
+        """
+        group: NotRequired[pulumi.Input[str]]
+        """
+        The name of the group.
+        """
+        resource: NotRequired[pulumi.Input[str]]
+        """
+        The name of the resource.
+        """
+        version: NotRequired[pulumi.Input[str]]
+        """
+        The name of the version.
+        """
+elif False:
+    GroupVersionResourcePatchArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class GroupVersionResourcePatchArgs:
@@ -76,6 +110,26 @@ class GroupVersionResourcePatchArgs:
         pulumi.set(self, "version", value)
 
 
+if not MYPY:
+    class GroupVersionResourceArgsDict(TypedDict):
+        """
+        The names of the group, the version, and the resource.
+        """
+        group: NotRequired[pulumi.Input[str]]
+        """
+        The name of the group.
+        """
+        resource: NotRequired[pulumi.Input[str]]
+        """
+        The name of the resource.
+        """
+        version: NotRequired[pulumi.Input[str]]
+        """
+        The name of the version.
+        """
+elif False:
+    GroupVersionResourceArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class GroupVersionResourceArgs:
     def __init__(__self__, *,
@@ -131,6 +185,34 @@ class GroupVersionResourceArgs:
     def version(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "version", value)
 
+
+if not MYPY:
+    class MigrationConditionArgsDict(TypedDict):
+        """
+        Describes the state of a migration at a certain point.
+        """
+        status: pulumi.Input[str]
+        """
+        Status of the condition, one of True, False, Unknown.
+        """
+        type: pulumi.Input[str]
+        """
+        Type of the condition.
+        """
+        last_update_time: NotRequired[pulumi.Input[str]]
+        """
+        The last time this condition was updated.
+        """
+        message: NotRequired[pulumi.Input[str]]
+        """
+        A human readable message indicating details about the transition.
+        """
+        reason: NotRequired[pulumi.Input[str]]
+        """
+        The reason for the condition's last transition.
+        """
+elif False:
+    MigrationConditionArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class MigrationConditionArgs:
@@ -218,6 +300,22 @@ class MigrationConditionArgs:
         pulumi.set(self, "reason", value)
 
 
+if not MYPY:
+    class StorageVersionMigrationSpecPatchArgsDict(TypedDict):
+        """
+        Spec of the storage version migration.
+        """
+        continue_token: NotRequired[pulumi.Input[str]]
+        """
+        The token used in the list options to get the next chunk of objects to migrate. When the .status.conditions indicates the migration is "Running", users can use this token to check the progress of the migration.
+        """
+        resource: NotRequired[pulumi.Input['GroupVersionResourcePatchArgsDict']]
+        """
+        The resource that is being migrated. The migrator sends requests to the endpoint serving the resource. Immutable.
+        """
+elif False:
+    StorageVersionMigrationSpecPatchArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class StorageVersionMigrationSpecPatchArgs:
     def __init__(__self__, *,
@@ -258,6 +356,22 @@ class StorageVersionMigrationSpecPatchArgs:
         pulumi.set(self, "resource", value)
 
 
+if not MYPY:
+    class StorageVersionMigrationSpecArgsDict(TypedDict):
+        """
+        Spec of the storage version migration.
+        """
+        resource: pulumi.Input['GroupVersionResourceArgsDict']
+        """
+        The resource that is being migrated. The migrator sends requests to the endpoint serving the resource. Immutable.
+        """
+        continue_token: NotRequired[pulumi.Input[str]]
+        """
+        The token used in the list options to get the next chunk of objects to migrate. When the .status.conditions indicates the migration is "Running", users can use this token to check the progress of the migration.
+        """
+elif False:
+    StorageVersionMigrationSpecArgsDict: TypeAlias = Mapping[str, Any]
+
 @pulumi.input_type
 class StorageVersionMigrationSpecArgs:
     def __init__(__self__, *,
@@ -296,6 +410,22 @@ class StorageVersionMigrationSpecArgs:
     def continue_token(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "continue_token", value)
 
+
+if not MYPY:
+    class StorageVersionMigrationStatusArgsDict(TypedDict):
+        """
+        Status of the storage version migration.
+        """
+        conditions: NotRequired[pulumi.Input[Sequence[pulumi.Input['MigrationConditionArgsDict']]]]
+        """
+        The latest available observations of the migration's current state.
+        """
+        resource_version: NotRequired[pulumi.Input[str]]
+        """
+        ResourceVersion to compare with the GC cache for performing the migration. This is the current resource version of given group, version and resource when kube-controller-manager first observes this StorageVersionMigration resource.
+        """
+elif False:
+    StorageVersionMigrationStatusArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class StorageVersionMigrationStatusArgs:
@@ -336,6 +466,34 @@ class StorageVersionMigrationStatusArgs:
     def resource_version(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "resource_version", value)
 
+
+if not MYPY:
+    class StorageVersionMigrationArgsDict(TypedDict):
+        """
+        StorageVersionMigration represents a migration of stored data to the latest storage version.
+        """
+        api_version: NotRequired[pulumi.Input[str]]
+        """
+        APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+        """
+        kind: NotRequired[pulumi.Input[str]]
+        """
+        Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+        """
+        metadata: NotRequired[pulumi.Input['_meta.v1.ObjectMetaArgsDict']]
+        """
+        Standard object metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+        """
+        spec: NotRequired[pulumi.Input['StorageVersionMigrationSpecArgsDict']]
+        """
+        Specification of the migration.
+        """
+        status: NotRequired[pulumi.Input['StorageVersionMigrationStatusArgsDict']]
+        """
+        Status of the migration.
+        """
+elif False:
+    StorageVersionMigrationArgsDict: TypeAlias = Mapping[str, Any]
 
 @pulumi.input_type
 class StorageVersionMigrationArgs:

--- a/sdk/python/pulumi_kubernetes/storagemigration/v1alpha1/outputs.py
+++ b/sdk/python/pulumi_kubernetes/storagemigration/v1alpha1/outputs.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 from . import outputs
 from ... import meta as _meta

--- a/sdk/python/pulumi_kubernetes/yaml/v2/ConfigFile.py
+++ b/sdk/python/pulumi_kubernetes/yaml/v2/ConfigFile.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 
 __all__ = ['ConfigFileArgs', 'ConfigFile']

--- a/sdk/python/pulumi_kubernetes/yaml/v2/ConfigGroup.py
+++ b/sdk/python/pulumi_kubernetes/yaml/v2/ConfigGroup.py
@@ -4,9 +4,14 @@
 
 import copy
 import warnings
+import sys
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
+if sys.version_info >= (3, 11):
+    from typing import NotRequired, TypedDict, TypeAlias
+else:
+    from typing_extensions import NotRequired, TypedDict, TypeAlias
 from ... import _utilities
 
 __all__ = ['ConfigGroupArgs', 'ConfigGroup']

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
   name = "pulumi_kubernetes"
   description = "A Pulumi package for creating and managing Kubernetes resources."
-  dependencies = ["parver>=0.2.1", "pulumi>=3.109.0,<4.0.0", "requests>=2.21,<3.0", "semver>=2.8.1"]
+  dependencies = ["parver>=0.2.1", "pulumi>=3.109.0,<4.0.0", "requests>=2.21,<3.0", "semver>=2.8.1", "typing-extensions>=4.11; python_version < \"3.11\""]
   keywords = ["pulumi", "kubernetes", "category/cloud", "kind/native"]
   readme = "README.md"
   requires-python = ">=3.8"
-  version = "4.14.0a1718665781"
+  version = "4.0.0a0+dev"
   [project.license]
     text = "Apache-2.0"
   [project.urls]


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

This PR requires pulumi/pulumi 3.121.0 and is stacked on top of https://github.com/pulumi/pulumi-kubernetes/pull/3066.

Enable TypedDict input types for the Python SDK. The only manual change is to set `inputTypes` flag in the python language features of the schema. This is done here https://github.com/pulumi/pulumi-kubernetes/commit/20314f5451f9fc7aec4fc8a1e0d649398159d3ec. This flag is currently opt in, but will default to `classes-and-dicts` in the future.

I ran `make build` afterwards.

### Related issues (optional)

Epic https://github.com/pulumi/pulumi/issues/12689
