### PR TITLE
CustomResource should have plain apiVersion and kind properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Unreleased
 
+### Added
+
+### Changed
+
+- `CustomResource` should have plain `apiVersion` and `kind` properties (https://github.com/pulumi/pulumi-kubernetes/pull/3079)
+
+### Fixed
+
 ## 4.14.0 (June 28, 2024)
 
 ### Added
@@ -9,7 +17,6 @@
 ### Changed
 
 - The `Release` resource no longer ignores empty lists when merging values. (https://github.com/pulumi/pulumi-kubernetes/pull/2995)
-- `CustomResource` should have plain `apiVersion` and `kind` properties (https://github.com/pulumi/pulumi-kubernetes/pull/3079)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 
 - The `Release` resource no longer ignores empty lists when merging values. (https://github.com/pulumi/pulumi-kubernetes/pull/2995)
+- `CustomResource` should have plain `apiVersion` and `kind` properties (https://github.com/pulumi/pulumi-kubernetes/pull/3079)
 
 ### Fixed
 

--- a/provider/pkg/gen/_go-templates/apiextensions/customResourcePatch.go
+++ b/provider/pkg/gen/_go-templates/apiextensions/customResourcePatch.go
@@ -18,6 +18,7 @@
 package apiextensions
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 
@@ -47,7 +48,11 @@ type CustomResourcePatch struct {
 func NewCustomResourcePatch(ctx *pulumi.Context,
 	name string, args *CustomResourcePatchArgs, opts ...pulumi.ResourceOption) (*CustomResourcePatch, error) {
 	if args == nil {
-		args = &CustomResourcePatchArgs{}
+		return nil, errors.New("missing one or more required arguments")
+	}
+	apiVersion, kind, err := getApiVersionAndKind(ctx.Context(), args.ApiVersion, args.Kind)
+	if err != nil {
+		return nil, err
 	}
 
 	untyped := kubernetes.UntypedArgs{}
@@ -59,7 +64,7 @@ func NewCustomResourcePatch(ctx *pulumi.Context,
 	untyped["metadata"] = args.Metadata
 
 	var resource CustomResourcePatch
-	err := ctx.RegisterResource(fmt.Sprintf("kubernetes:%s:%sPatch", args.ApiVersion, args.Kind), name, untyped, &resource, opts...)
+	err = ctx.RegisterResource(fmt.Sprintf("kubernetes:%s:%sPatch", apiVersion, kind), name, untyped, &resource, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/provider/pkg/gen/java-templates/src/main/java/com/pulumi/kubernetes/apiextensions/CustomResource.java
+++ b/provider/pkg/gen/java-templates/src/main/java/com/pulumi/kubernetes/apiextensions/CustomResource.java
@@ -3,6 +3,7 @@
 
 package com.pulumi.kubernetes.apiextensions;
 
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
@@ -84,7 +85,7 @@ public class CustomResource extends com.pulumi.resources.CustomResource {
      * @param name The _unique_ name of the resulting resource.
      * @param args The arguments to use to populate this resource's properties.
      */
-    public CustomResource(String name, @Nullable CustomResourceArgsBase args) {
+    public CustomResource(String name, CustomResourceArgsBase args) {
         this(name, args, null);
     }
     
@@ -94,7 +95,7 @@ public class CustomResource extends com.pulumi.resources.CustomResource {
      * @param args The arguments to use to populate this resource's properties.
      * @param options A bag of options that control this resource's behavior.
      */
-    public CustomResource(String name, @Nullable CustomResourceArgsBase args, @Nullable com.pulumi.resources.CustomResourceOptions options) {
+    public CustomResource(String name, CustomResourceArgsBase args, @Nullable com.pulumi.resources.CustomResourceOptions options) {
         super(makeType(args), name, makeArgs(args), makeResourceOptions(options, Codegen.empty()));
     }
 
@@ -103,7 +104,8 @@ public class CustomResource extends com.pulumi.resources.CustomResource {
         super(String.format("kubernetes:%s:%s", apiVersion, kind), name, null, makeResourceOptions(options, id));
     }
 
-    private static String makeType(@Nullable CustomResourceArgsBase args) {
+    private static String makeType(CustomResourceArgsBase args) {
+        Objects.requireNonNull(args, "args must not be null");
         String apiVersion = args.apiVersion().map(Internal::of).map(CustomResource::getOutputValue).orElse("");
         String kind = args.kind().map(Internal::of).map(CustomResource::getOutputValue).orElse("");
         return String.format("kubernetes:%s:%s", apiVersion, kind);
@@ -117,10 +119,8 @@ public class CustomResource extends com.pulumi.resources.CustomResource {
         }
     }
 
-    private static ResourceArgs makeArgs(@Nullable CustomResourceArgsBase args) {
-        if (args == null) {
-            return null;
-        }
+    private static ResourceArgs makeArgs(CustomResourceArgsBase args) {
+        Objects.requireNonNull(args, "args must not be null");
         if (args.otherFields().isEmpty() || args.otherFields().get().isEmpty()) {
             // optimization: if there are no "other" fields, we can just return the args as-is.
             // Otherwise we generate a subclass of ResourceArgs that includes the "other" fields.

--- a/provider/pkg/gen/java-templates/src/main/java/com/pulumi/kubernetes/apiextensions/CustomResourcePatch.java
+++ b/provider/pkg/gen/java-templates/src/main/java/com/pulumi/kubernetes/apiextensions/CustomResourcePatch.java
@@ -3,6 +3,7 @@
 
 package com.pulumi.kubernetes.apiextensions;
 
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
@@ -90,7 +91,7 @@ public class CustomResourcePatch extends com.pulumi.resources.CustomResource {
      * @param name The _unique_ name of the resulting resource.
      * @param args The arguments to use to populate this resource's properties.
      */
-    public CustomResourcePatch(String name, @Nullable CustomResourcePatchArgsBase args) {
+    public CustomResourcePatch(String name, CustomResourcePatchArgsBase args) {
         this(name, args, null);
     }
     
@@ -100,11 +101,12 @@ public class CustomResourcePatch extends com.pulumi.resources.CustomResource {
      * @param args The arguments to use to populate this resource's properties.
      * @param options A bag of options that control this resource's behavior.
      */
-    public CustomResourcePatch(String name, @Nullable CustomResourcePatchArgsBase args, @Nullable com.pulumi.resources.CustomResourceOptions options) {
+    public CustomResourcePatch(String name, CustomResourcePatchArgsBase args, @Nullable com.pulumi.resources.CustomResourceOptions options) {
         super(makeType(args), name, makeArgs(args), makeResourceOptions(options, Codegen.empty()));
     }
 
-    private static String makeType(@Nullable CustomResourcePatchArgsBase args) {
+    private static String makeType(CustomResourcePatchArgsBase args) {
+        Objects.requireNonNull(args, "args must not be null");
         String apiVersion = args.apiVersion().map(Internal::of).map(CustomResourcePatch::getOutputValue).orElse("");
         String kind = args.kind().map(Internal::of).map(CustomResourcePatch::getOutputValue).orElse("");
         return String.format("kubernetes:%s:%sPatch", apiVersion, kind);
@@ -119,9 +121,7 @@ public class CustomResourcePatch extends com.pulumi.resources.CustomResource {
     }
 
     private static ResourceArgs makeArgs(@Nullable CustomResourcePatchArgsBase args) {
-        if (args == null) {
-            return null;
-        }
+        Objects.requireNonNull(args, "args must not be null");
         if (args.otherFields().isEmpty() || args.otherFields().get().isEmpty()) {
             // optimization: if there are no "other" fields, we can just use the args as-is.
             // Otherwise we generate a subclass of ResourceArgs that includes the "other" fields.

--- a/provider/pkg/gen/nodejs-templates/apiextensions/customResource.ts
+++ b/provider/pkg/gen/nodejs-templates/apiextensions/customResource.ts
@@ -77,6 +77,12 @@ export class CustomResource extends pulumi.CustomResource {
         let inputs: pulumi.Inputs = {};
         opts = opts || {};
         if (!opts.id) {
+            if ((!args || args.apiVersion === undefined) && !opts.urn) {
+                throw new Error("Missing required property 'apiVersion'");
+            }
+            if ((!args || args.kind === undefined) && !opts.urn) {
+                throw new Error("Missing required property 'kind'");
+            }
             for (const key of Object.keys(args)) {
                 inputs[key] = (args as any)[key];
             }
@@ -106,7 +112,7 @@ export interface CustomResourceArgs {
      * values. More info:
      * https://git.k8s.io/community/contributors/devel/api-conventions.md#resources
      */
-    apiVersion: pulumi.Input<string>;
+    apiVersion: string;
 
     /**
      * Kind is a string value representing the REST resource this object represents. Servers may
@@ -114,7 +120,7 @@ export interface CustomResourceArgs {
      * CamelCase. More info:
      * https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds
      */
-    kind: pulumi.Input<string>;
+    kind: string;
 
     /**
      * Standard object metadata; More info:
@@ -133,13 +139,13 @@ export interface CustomResourceGetOptions extends pulumi.CustomResourceOptions {
      * apiVersion is the API version of the apiExtensions.CustomResource we wish to select,
      * as specified by the CustomResourceDefinition that defines it on the API server.
      */
-    apiVersion: pulumi.Input<string>;
+    apiVersion: string;
 
     /**
      * kind is the kind of the apiextensions.CustomResource we wish to select, as specified by
      * the CustomResourceDefinition that defines it on the API server.
      */
-    kind: pulumi.Input<string>
+    kind: string;
 
     /**
      * An ID for the Kubernetes resource to retrieve. Takes the form [namespace]/[name] or

--- a/provider/pkg/gen/nodejs-templates/apiextensions/customResourcePatch.ts
+++ b/provider/pkg/gen/nodejs-templates/apiextensions/customResourcePatch.ts
@@ -63,6 +63,12 @@ export class CustomResourcePatch extends pulumi.CustomResource {
         let inputs: pulumi.Inputs = {};
         opts = opts || {};
         if (!opts.id) {
+            if ((!args || args.apiVersion === undefined) && !opts.urn) {
+                throw new Error("Missing required property 'apiVersion'");
+            }
+            if ((!args || args.kind === undefined) && !opts.urn) {
+                throw new Error("Missing required property 'kind'");
+            }
             for (const key of Object.keys(args)) {
                 inputs[key] = (args as any)[key];
             }
@@ -92,7 +98,7 @@ export interface CustomResourcePatchArgs {
      * values. More info:
      * https://git.k8s.io/community/contributors/devel/api-conventions.md#resources
      */
-    apiVersion: pulumi.Input<string>;
+    apiVersion: string;
 
     /**
      * Kind is a string value representing the REST resource this object represents. Servers may
@@ -100,7 +106,7 @@ export interface CustomResourcePatchArgs {
      * CamelCase. More info:
      * https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds
      */
-    kind: pulumi.Input<string>;
+    kind: string;
 
     /**
      * Standard object metadata; More info:

--- a/provider/pkg/gen/overlays.go
+++ b/provider/pkg/gen/overlays.go
@@ -1517,20 +1517,22 @@ var yamlConfigGroupV2Resource = pschema.ResourceSpec{
 	},
 }
 
-var apiextentionsCustomResource = pschema.ResourceSpec{
+var apiextensionsCustomResource = pschema.ResourceSpec{
 	ObjectTypeSpec: pschema.ObjectTypeSpec{
 		IsOverlay:   true,
 		Description: "CustomResource represents an instance of a CustomResourceDefinition (CRD). For example, the\n CoreOS Prometheus operator exposes a CRD `monitoring.coreos.com/ServiceMonitor`; to\n instantiate this as a Pulumi resource, one could call `new CustomResource`, passing the\n `ServiceMonitor` resource definition as an argument.",
 		Properties: map[string]pschema.PropertySpec{
 			"apiVersion": {
 				TypeSpec: pschema.TypeSpec{
-					Type: "string",
+					Type:  "string",
+					Plain: true,
 				},
 				Description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
 			},
 			"kind": {
 				TypeSpec: pschema.TypeSpec{
-					Type: "string",
+					Type:  "string",
+					Plain: true,
 				},
 				Description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
 			},
@@ -1582,20 +1584,22 @@ var apiextentionsCustomResource = pschema.ResourceSpec{
 	},
 }
 
-var apiextentionsCustomResourcePatch = pschema.ResourceSpec{
+var apiextensionsCustomResourcePatch = pschema.ResourceSpec{
 	ObjectTypeSpec: pschema.ObjectTypeSpec{
 		IsOverlay:   true,
 		Description: "CustomResourcePatch represents an instance of a CustomResourceDefinition (CRD). For example, the\n CoreOS Prometheus operator exposes a CRD `monitoring.coreos.com/ServiceMonitor`; to\n instantiate this as a Pulumi resource, one could call `new CustomResourcePatch`, passing the\n `ServiceMonitor` resource definition as an argument.",
 		Properties: map[string]pschema.PropertySpec{
 			"apiVersion": {
 				TypeSpec: pschema.TypeSpec{
-					Type: "string",
+					Type:  "string",
+					Plain: true,
 				},
 				Description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
 			},
 			"kind": {
 				TypeSpec: pschema.TypeSpec{
-					Type: "string",
+					Type:  "string",
+					Plain: true,
 				},
 				Description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
 			},
@@ -1658,8 +1662,8 @@ func init() {
 	typeOverlays["kubernetes:index:KubeClientSettings"] = kubeClientSettings
 	typeOverlays["kubernetes:index:HelmReleaseSettings"] = helmReleaseSettings
 
-	resourceOverlays["kubernetes:apiextensions.k8s.io:CustomResource"] = apiextentionsCustomResource
-	resourceOverlays["kubernetes:apiextensions.k8s.io:CustomResourcePatch"] = apiextentionsCustomResourcePatch
+	resourceOverlays["kubernetes:apiextensions.k8s.io:CustomResource"] = apiextensionsCustomResource
+	resourceOverlays["kubernetes:apiextensions.k8s.io:CustomResourcePatch"] = apiextensionsCustomResourcePatch
 	resourceOverlays["kubernetes:helm.sh/v3:Chart"] = helmV3ChartResource
 	resourceOverlays["kubernetes:helm.sh/v4:Chart"] = helmV4ChartResource
 	resourceOverlays["kubernetes:helm.sh/v3:Release"] = helmV3ReleaseResource

--- a/sdk/go/kubernetes/apiextensions/customResourcePatch.go
+++ b/sdk/go/kubernetes/apiextensions/customResourcePatch.go
@@ -18,6 +18,7 @@
 package apiextensions
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 
@@ -47,7 +48,11 @@ type CustomResourcePatch struct {
 func NewCustomResourcePatch(ctx *pulumi.Context,
 	name string, args *CustomResourcePatchArgs, opts ...pulumi.ResourceOption) (*CustomResourcePatch, error) {
 	if args == nil {
-		args = &CustomResourcePatchArgs{}
+		return nil, errors.New("missing one or more required arguments")
+	}
+	apiVersion, kind, err := getApiVersionAndKind(ctx.Context(), args.ApiVersion, args.Kind)
+	if err != nil {
+		return nil, err
 	}
 
 	untyped := kubernetes.UntypedArgs{}
@@ -59,7 +64,7 @@ func NewCustomResourcePatch(ctx *pulumi.Context,
 	untyped["metadata"] = args.Metadata
 
 	var resource CustomResourcePatch
-	err := ctx.RegisterResource(fmt.Sprintf("kubernetes:%s:%sPatch", args.ApiVersion, args.Kind), name, untyped, &resource, opts...)
+	err = ctx.RegisterResource(fmt.Sprintf("kubernetes:%s:%sPatch", apiVersion, kind), name, untyped, &resource, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/apiextensions/CustomResource.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/apiextensions/CustomResource.java
@@ -3,6 +3,7 @@
 
 package com.pulumi.kubernetes.apiextensions;
 
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
@@ -84,7 +85,7 @@ public class CustomResource extends com.pulumi.resources.CustomResource {
      * @param name The _unique_ name of the resulting resource.
      * @param args The arguments to use to populate this resource's properties.
      */
-    public CustomResource(String name, @Nullable CustomResourceArgsBase args) {
+    public CustomResource(String name, CustomResourceArgsBase args) {
         this(name, args, null);
     }
     
@@ -94,7 +95,7 @@ public class CustomResource extends com.pulumi.resources.CustomResource {
      * @param args The arguments to use to populate this resource's properties.
      * @param options A bag of options that control this resource's behavior.
      */
-    public CustomResource(String name, @Nullable CustomResourceArgsBase args, @Nullable com.pulumi.resources.CustomResourceOptions options) {
+    public CustomResource(String name, CustomResourceArgsBase args, @Nullable com.pulumi.resources.CustomResourceOptions options) {
         super(makeType(args), name, makeArgs(args), makeResourceOptions(options, Codegen.empty()));
     }
 
@@ -103,7 +104,8 @@ public class CustomResource extends com.pulumi.resources.CustomResource {
         super(String.format("kubernetes:%s:%s", apiVersion, kind), name, null, makeResourceOptions(options, id));
     }
 
-    private static String makeType(@Nullable CustomResourceArgsBase args) {
+    private static String makeType(CustomResourceArgsBase args) {
+        Objects.requireNonNull(args, "args must not be null");
         String apiVersion = args.apiVersion().map(Internal::of).map(CustomResource::getOutputValue).orElse("");
         String kind = args.kind().map(Internal::of).map(CustomResource::getOutputValue).orElse("");
         return String.format("kubernetes:%s:%s", apiVersion, kind);
@@ -117,10 +119,8 @@ public class CustomResource extends com.pulumi.resources.CustomResource {
         }
     }
 
-    private static ResourceArgs makeArgs(@Nullable CustomResourceArgsBase args) {
-        if (args == null) {
-            return null;
-        }
+    private static ResourceArgs makeArgs(CustomResourceArgsBase args) {
+        Objects.requireNonNull(args, "args must not be null");
         if (args.otherFields().isEmpty() || args.otherFields().get().isEmpty()) {
             // optimization: if there are no "other" fields, we can just return the args as-is.
             // Otherwise we generate a subclass of ResourceArgs that includes the "other" fields.

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/apiextensions/CustomResourcePatch.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/apiextensions/CustomResourcePatch.java
@@ -3,6 +3,7 @@
 
 package com.pulumi.kubernetes.apiextensions;
 
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
@@ -90,7 +91,7 @@ public class CustomResourcePatch extends com.pulumi.resources.CustomResource {
      * @param name The _unique_ name of the resulting resource.
      * @param args The arguments to use to populate this resource's properties.
      */
-    public CustomResourcePatch(String name, @Nullable CustomResourcePatchArgsBase args) {
+    public CustomResourcePatch(String name, CustomResourcePatchArgsBase args) {
         this(name, args, null);
     }
     
@@ -100,11 +101,12 @@ public class CustomResourcePatch extends com.pulumi.resources.CustomResource {
      * @param args The arguments to use to populate this resource's properties.
      * @param options A bag of options that control this resource's behavior.
      */
-    public CustomResourcePatch(String name, @Nullable CustomResourcePatchArgsBase args, @Nullable com.pulumi.resources.CustomResourceOptions options) {
+    public CustomResourcePatch(String name, CustomResourcePatchArgsBase args, @Nullable com.pulumi.resources.CustomResourceOptions options) {
         super(makeType(args), name, makeArgs(args), makeResourceOptions(options, Codegen.empty()));
     }
 
-    private static String makeType(@Nullable CustomResourcePatchArgsBase args) {
+    private static String makeType(CustomResourcePatchArgsBase args) {
+        Objects.requireNonNull(args, "args must not be null");
         String apiVersion = args.apiVersion().map(Internal::of).map(CustomResourcePatch::getOutputValue).orElse("");
         String kind = args.kind().map(Internal::of).map(CustomResourcePatch::getOutputValue).orElse("");
         return String.format("kubernetes:%s:%sPatch", apiVersion, kind);
@@ -119,9 +121,7 @@ public class CustomResourcePatch extends com.pulumi.resources.CustomResource {
     }
 
     private static ResourceArgs makeArgs(@Nullable CustomResourcePatchArgsBase args) {
-        if (args == null) {
-            return null;
-        }
+        Objects.requireNonNull(args, "args must not be null");
         if (args.otherFields().isEmpty() || args.otherFields().get().isEmpty()) {
             // optimization: if there are no "other" fields, we can just use the args as-is.
             // Otherwise we generate a subclass of ResourceArgs that includes the "other" fields.

--- a/sdk/nodejs/apiextensions/customResource.ts
+++ b/sdk/nodejs/apiextensions/customResource.ts
@@ -77,6 +77,12 @@ export class CustomResource extends pulumi.CustomResource {
         let inputs: pulumi.Inputs = {};
         opts = opts || {};
         if (!opts.id) {
+            if ((!args || args.apiVersion === undefined) && !opts.urn) {
+                throw new Error("Missing required property 'apiVersion'");
+            }
+            if ((!args || args.kind === undefined) && !opts.urn) {
+                throw new Error("Missing required property 'kind'");
+            }
             for (const key of Object.keys(args)) {
                 inputs[key] = (args as any)[key];
             }
@@ -106,7 +112,7 @@ export interface CustomResourceArgs {
      * values. More info:
      * https://git.k8s.io/community/contributors/devel/api-conventions.md#resources
      */
-    apiVersion: pulumi.Input<string>;
+    apiVersion: string;
 
     /**
      * Kind is a string value representing the REST resource this object represents. Servers may
@@ -114,7 +120,7 @@ export interface CustomResourceArgs {
      * CamelCase. More info:
      * https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds
      */
-    kind: pulumi.Input<string>;
+    kind: string;
 
     /**
      * Standard object metadata; More info:
@@ -133,13 +139,13 @@ export interface CustomResourceGetOptions extends pulumi.CustomResourceOptions {
      * apiVersion is the API version of the apiExtensions.CustomResource we wish to select,
      * as specified by the CustomResourceDefinition that defines it on the API server.
      */
-    apiVersion: pulumi.Input<string>;
+    apiVersion: string;
 
     /**
      * kind is the kind of the apiextensions.CustomResource we wish to select, as specified by
      * the CustomResourceDefinition that defines it on the API server.
      */
-    kind: pulumi.Input<string>
+    kind: string;
 
     /**
      * An ID for the Kubernetes resource to retrieve. Takes the form [namespace]/[name] or

--- a/sdk/nodejs/apiextensions/customResourcePatch.ts
+++ b/sdk/nodejs/apiextensions/customResourcePatch.ts
@@ -63,6 +63,12 @@ export class CustomResourcePatch extends pulumi.CustomResource {
         let inputs: pulumi.Inputs = {};
         opts = opts || {};
         if (!opts.id) {
+            if ((!args || args.apiVersion === undefined) && !opts.urn) {
+                throw new Error("Missing required property 'apiVersion'");
+            }
+            if ((!args || args.kind === undefined) && !opts.urn) {
+                throw new Error("Missing required property 'kind'");
+            }
             for (const key of Object.keys(args)) {
                 inputs[key] = (args as any)[key];
             }
@@ -92,7 +98,7 @@ export interface CustomResourcePatchArgs {
      * values. More info:
      * https://git.k8s.io/community/contributors/devel/api-conventions.md#resources
      */
-    apiVersion: pulumi.Input<string>;
+    apiVersion: string;
 
     /**
      * Kind is a string value representing the REST resource this object represents. Servers may
@@ -100,7 +106,7 @@ export interface CustomResourcePatchArgs {
      * CamelCase. More info:
      * https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds
      */
-    kind: pulumi.Input<string>;
+    kind: string;
 
     /**
      * Standard object metadata; More info:

--- a/tests/sdk/nodejs/crds/step1/index.ts
+++ b/tests/sdk/nodejs/crds/step1/index.ts
@@ -64,10 +64,10 @@ new k8s.apiextensions.CustomResource(
     {
         apiVersion: "stable.example.com/v1",
         kind: "FooBar",
-      metadata: {
-        namespace: namespace.metadata.name,
-        name: "my-new-foobar-object",
-      },
+        metadata: {
+            namespace: namespace.metadata.name,
+            name: "my-new-foobar-object",
+        },
         spec: { foo: "such amaze", bar: "wow" }
     },
 );

--- a/tests/sdk/nodejs/crds/step3/index.ts
+++ b/tests/sdk/nodejs/crds/step3/index.ts
@@ -1,0 +1,37 @@
+// Copyright 2016-2019, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as k8s from "@pulumi/kubernetes";
+
+const namespace = new k8s.core.v1.Namespace("test-namespace");
+
+//
+// Delete the CustomResourceDefinition. On the next refresh, the CustomResource will be
+// automatically deleted from the state rather than returning a "kind not found" error.
+// This is a contrived example for testing, and it doesn't make any sense to delete a
+// CRD while leaving related CRs.
+//
+
+new k8s.apiextensions.CustomResource(
+    "my-new-foobar-object",
+    {
+        apiVersion: "stable.example.com/v1",
+        kind: "FooBar",
+        metadata: {
+            namespace: namespace.metadata.name,
+            name: "my-new-foobar-object",
+        },
+        spec: { foo: "such amaze" }
+    },
+);

--- a/tests/sdk/nodejs/nodejs_test.go
+++ b/tests/sdk/nodejs/nodejs_test.go
@@ -433,6 +433,19 @@ func TestCRDs(t *testing.T) {
 				Additive: true,
 				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
 					assert.NotNil(t, stackInfo.Deployment)
+
+					//
+					// Assert that the CR was gotten.
+					//
+					ct1ref := tests.SearchResourcesByName(stackInfo, "", "kubernetes:stable.example.com/v1:FooBar", "my-new-foobar-object-ref")
+					assert.NotNil(t, ct1ref)
+				},
+			},
+			{
+				Dir:      filepath.Join("crds", "step3"),
+				Additive: true,
+				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+					assert.NotNil(t, stackInfo.Deployment)
 					assert.Equal(t, 4, len(stackInfo.Deployment.Resources))
 
 					tests.SortResourcesByURN(stackInfo)


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->
This PR seeks to make the `apiVersion` and `kind` properties be [plain](https://www.pulumi.com/docs/using-pulumi/pulumi-packages/schema/#type) (prompt) values when configuring a `CustomResource`. A plain value is required to eagerly compute the resource type token, e.g. `kubernetes:stable.example.com/v1:CronTab` or `kubernetes:stable.example.com/v1:CronTabPatch`.

Since the SDKs already accept an input, this PR strives to continue to support it, rather than making a breaking change, if possible.  That's accomplished by synchronously waiting on the output data.

Three APIs are considered here:
1. creating or importing a CustomResource using resource args
2. getting an existing custom resource using the `get` helpers
3. patching a CustomResource using the "Patch" variant 

A summary of changes:
- Pulumi Schema - mark the `apiVersion` and `kind` properties to be `plain: true`.
- Go SDK - Use `internals.UnsafeAwaitOutput` to synchronously resolve the value.
- NodeJS SDK - Change to CustomResourceArgs to use plain property type (BREAKING CHANGE)
- Java SDK - add some null checks

### Breaking Changes

#### NodeJS SDK

The args are retyped to `string` with expectation that most programs will be unaffected.

Closes #1115 

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
