### PR TITLE
[WIP] TF Converter for Helm Release

### DIFF
--- a/provider/cmd/pulumi-resource-kubernetes/helm-mapping.json
+++ b/provider/cmd/pulumi-resource-kubernetes/helm-mapping.json
@@ -1,0 +1,15 @@
+{
+    "dataSources": {},
+    "name": "helm",
+    "provider": {},
+    "resources": {
+        "helm_release": {
+            "fields": {
+                "disable_crd_hooks": {
+                    "name": "disableCRDHooks"
+                }
+            },
+            "tok": "kubernetes:helm.sh/v3:Release"
+        }
+    }
+}

--- a/provider/cmd/pulumi-resource-kubernetes/main.go
+++ b/provider/cmd/pulumi-resource-kubernetes/main.go
@@ -31,6 +31,9 @@ var pulumiSchema []byte
 //go:embed terraform-mapping-embed.json
 var terraformMapping []byte
 
+//go:embed helm-mapping.json
+var helmMapping []byte
+
 func main() {
-	provider.Serve(providerName, version.Version, pulumiSchema, terraformMapping)
+	provider.Serve(providerName, version.Version, pulumiSchema, terraformMapping, helmMapping)
 }

--- a/provider/pkg/provider/serve.go
+++ b/provider/pkg/provider/serve.go
@@ -24,11 +24,11 @@ import (
 )
 
 // Serve launches the gRPC server for the Pulumi Kubernetes resource provider.
-func Serve(providerName, version string, pulumiSchema, terraformMapping []byte) {
+func Serve(providerName, version string, pulumiSchema, terraformMapping, helmMapping []byte) {
 	// Start gRPC service.
 	err := provider.Main(
 		providerName, func(host *provider.HostClient) (lumirpc.ResourceProviderServer, error) {
-			return makeKubeProvider(host, providerName, version, pulumiSchema, terraformMapping)
+			return makeKubeProvider(host, providerName, version, pulumiSchema, terraformMapping, helmMapping)
 		})
 
 	if err != nil {


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

This PR implements support for conversion of a Terraform [helm_release](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) resource into 
a Pulumi [v3.Release](https://www.pulumi.com/registry/packages/kubernetes/api-docs/helm/v3/release/) resource.

A mapping is defined based on the schema defined in pulumi-terraform-bridge ([pkg/tfbridge/info/info.go](https://github.com/pulumi/pulumi-terraform-bridge/blob/master/pkg/tfbridge/info/info.go)).

### Example

Given this TF program:
```tf
resource "helm_release" "example" {
  name  = "redis"
  chart = "redis"
  cleanup_on_fail = true
  atomic = true
  create_namespace = true
  dependency_update = true
  description = "A Helm chart for Kubernetes"
  devel = true
  disable_crd_hooks = true
  disable_openapi_validation = true
  disable_webhooks = true
  force_update = true
  keyring = "./keyring.gpg"
  lint = true
  max_history = 5
  pass_credentials = true
  postrender {
    binary_path = "echo"
    args = [ "foo", "bar" ]
  }
  recreate_pods = true
  render_subchart_notes = true
  replace = true
  repository = "https://charts.bitnami.com/bitnami"
  repository_ca_file = "./ca.pem"
  repository_cert_file = "./cert.pem"
  repository_key_file = "./key.pem"
  repository_password = "password"
  repository_username = "username"
  reset_values = true
  reuse_values = true
  set {
    name  = "set_1"
    value = "value1"
  }
  set_list {
    name  = "set_list_1"
    value = "value1"
  }
  set_sensitive {
    name  = "set_sensitive_1"
    value = "value1"
    type = "string"
  }
  skip_crds = true
  timeout = 60
  values  = [<<-EOT
    fullnameOverride: foo
    EOT
  ]
  version = "10.7.16"
  wait = true
  wait_for_jobs = true
}
```

Do conversion:
```plain
pulumi convert --from terraform --language pcl

Converting to pcl...
warning: main.pp:16,3-18: unsupported attribute 'passCredentials'; unsupported attribute 'passCredentials'
warning: main.pp:17,16-20,5: ; Cannot assign value ({ args: (string, string), binaryPath: string }) to attribute of type "Optional<string>" for resource "kubernetes:helm.sh/v3:Release"
warning: main.pp:24,3-13: unsupported attribute 'repository'; unsupported attribute 'repository'
warning: main.pp:25,3-19: unsupported attribute 'repositoryCaFile'; unsupported attribute 'repositoryCaFile'
warning: main.pp:26,3-21: unsupported attribute 'repositoryCertFile'; unsupported attribute 'repositoryCertFile'
warning: main.pp:27,3-20: unsupported attribute 'repositoryKeyFile'; unsupported attribute 'repositoryKeyFile'
warning: main.pp:28,3-21: unsupported attribute 'repositoryPassword'; unsupported attribute 'repositoryPassword'
warning: main.pp:29,3-21: unsupported attribute 'repositoryUsername'; unsupported attribute 'repositoryUsername'
warning: main.pp:32,3-6: unsupported attribute 'set'; unsupported attribute 'set'
warning: main.pp:36,3-10: unsupported attribute 'setList'; unsupported attribute 'setList'
warning: main.pp:40,3-15: unsupported attribute 'setSensitive'; unsupported attribute 'setSensitive'
warning: main.pp:47,17-44: ; Cannot assign value (string) to attribute of type "Optional<Map<pulumi:pulumi:Any>>" for resource "kubernetes:helm.sh/v3:Release"
warning: main.pp:49,3-7: unsupported attribute 'wait'; unsupported attribute 'wait'
```

We can see that some attributes aren't easily mapped.

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->

Closes #2744 