### PR TITLE
Fix: prevent CRDs from always applying during preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+- Prevent CustomResourceDefinitions from always being applied to the cluster during preview operations (https://github.com/pulumi/pulumi-kubernetes/pull/3096)
+
 ## 4.14.0 (June 28, 2024)
 
 ### Added

--- a/provider/pkg/await/await.go
+++ b/provider/pkg/await/await.go
@@ -496,7 +496,16 @@ func updateResource(c *UpdateConfig, liveOldObj *unstructured.Unstructured, clie
 		// results in the immediate replacement of the CRD without deleting it, or any CustomResources that depend on
 		// it. The PUT operation is still validated by the api server, so a badly formed request will fail as usual.
 		c.Inputs.SetResourceVersion(liveOldObj.GetResourceVersion())
-		currentOutputs, err = client.Update(c.Context, c.Inputs, metav1.UpdateOptions{})
+
+		options := metav1.UpdateOptions{
+			FieldManager: c.FieldManager,
+		}
+
+		if c.Preview {
+			options.DryRun = []string{metav1.DryRunAll}
+		}
+
+		currentOutputs, err = client.Update(c.Context, c.Inputs, options)
 	case c.ServerSideApply:
 		currentOutputs, err = ssaUpdate(c, liveOldObj, client)
 	default:

--- a/tests/sdk/java/preview_test.go
+++ b/tests/sdk/java/preview_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/pulumi/providertest/pulumitest"
 	"github.com/pulumi/providertest/pulumitest/opttest"
+	"github.com/pulumi/pulumi-kubernetes/tests/v4"
+	"github.com/stretchr/testify/require"
 )
 
 // TestPreviewReplacements ensures that replacements for immutable fields are correctly previewed.
@@ -20,4 +22,35 @@ func TestPreviewReplacements(t *testing.T) {
 	// Preview should not fail when there is a replacement due to immutable fields.
 	test.UpdateSource("testdata/preview-replacements", "step2")
 	test.Preview()
+}
+
+// TestCRDPreviews ensures that CRDs are correctly previewed, and are not created or updated on the cluster.
+// https://github.com/pulumi/pulumi-kubernetes/issues/3094
+func TestCRDPreviews(t *testing.T) {
+	const (
+		crdName    = "crontabs.previewtest.pulumi.com"
+		testFolder = "testdata/crd-previews"
+	)
+
+	// 1. Create the CRD resource
+	test := pulumitest.NewPulumiTest(t, testFolder, opttest.SkipInstall())
+	t.Logf("into %s", test.Source())
+	t.Cleanup(func() {
+		test.Destroy()
+	})
+	test.Up()
+
+	// 2. Preview should not actually update the CRD resource. Step 2 adds a new field ("testNewField") to the CRD.
+	test.UpdateSource(testFolder, "step2")
+	test.Preview()
+
+	out, err := tests.Kubectl("get", "crd", crdName, "-o", "yaml")
+	require.NoError(t, err, "unable to get CRD with kubectl")
+	require.NotContains(t, string(out), "testNewField", "expected CRD to not have new field added in preview")
+
+	// 3. Update should actually update the CRD resource.
+	test.Up()
+	out, err = tests.Kubectl("get", "crd", crdName, "-o", "yaml")
+	require.NoError(t, err, "unable to get CRD with kubectl")
+	require.Contains(t, string(out), "testNewField", "expected CRD to have new field added in update operation")
 }

--- a/tests/sdk/java/testdata/crd-previews/Pulumi.yaml
+++ b/tests/sdk/java/testdata/crd-previews/Pulumi.yaml
@@ -1,0 +1,37 @@
+name: crd-previews
+runtime: yaml
+resources:
+  provider:
+    type: pulumi:providers:kubernetes
+  crd:
+    type: kubernetes:apiextensions.k8s.io/v1:CustomResourceDefinition
+    properties:
+      metadata:
+        name: crontabs.previewtest.pulumi.com
+      spec:
+        conversion:
+          strategy: None
+        group: previewtest.pulumi.com
+        names:
+          kind: CronTab
+          listKind: CronTabList
+          plural: crontabs
+          singular: crontab
+        scope: Namespaced
+        versions:
+        - name: v1
+          schema:
+            openAPIV3Schema:
+              properties:
+                spec:
+                  properties:
+                    cronSpec:
+                      type: string
+                    image:
+                      type: string
+                  type: object
+              type: object
+          served: true
+          storage: true
+    options:
+      provider: ${provider}

--- a/tests/sdk/java/testdata/crd-previews/step2/Pulumi.yaml
+++ b/tests/sdk/java/testdata/crd-previews/step2/Pulumi.yaml
@@ -1,0 +1,39 @@
+name: crd-previews
+runtime: yaml
+resources:
+  provider:
+    type: pulumi:providers:kubernetes
+  crd:
+    type: kubernetes:apiextensions.k8s.io/v1:CustomResourceDefinition
+    properties:
+      metadata:
+        name: crontabs.previewtest.pulumi.com
+      spec:
+        conversion:
+          strategy: None
+        group: previewtest.pulumi.com
+        names:
+          kind: CronTab
+          listKind: CronTabList
+          plural: crontabs
+          singular: crontab
+        scope: Namespaced
+        versions:
+        - name: v1
+          schema:
+            openAPIV3Schema:
+              properties:
+                spec:
+                  properties:
+                    cronSpec:
+                      type: string
+                    image:
+                      type: string
+                    testNewField:
+                      type: string
+                  type: object
+              type: object
+          served: true
+          storage: true
+    options:
+      provider: ${provider}


### PR DESCRIPTION
### Proposed changes

This PR ensures the correct `metav1.UpdateOptions` are set for CRD resources. The FieldManager and DryRun options need to be propagated to ensure we are updating CRD resources correctly.

This PR adds a regression test that fails without the added changes in this PR.

### Related issues (optional)

Fixes: #3094