### PR TITLE
Define Supported Languages for Overlay Resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Added
 
-- Define Supported Languages for Chart v3 (https://github.com/pulumi/pulumi-kubernetes/pull/3107)
+- Define Supported Languages for Overlays (https://github.com/pulumi/pulumi-kubernetes/pull/3107)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Added
+
+- Define Supported Languages for Chart v3 (https://github.com/pulumi/pulumi-kubernetes/pull/3107)
+
 ### Fixed
 
 - Updated logic to accurately detect if a resource is a Patch variant (https://github.com/pulumi/pulumi-kubernetes/pull/3102)

--- a/provider/pkg/gen/overlays.go
+++ b/provider/pkg/gen/overlays.go
@@ -1174,6 +1174,7 @@ var kustomizeDirectoryResource = pschema.ResourceSpec{
 	IsComponent: true,
 	ObjectTypeSpec: pschema.ObjectTypeSpec{
 		IsOverlay:   true,
+		OverlaySupportedLanguages: []string{"csharp", "go", "python", "nodejs"},
 		Description: kustomizeDirectoryMD,
 		Properties: map[string]pschema.PropertySpec{
 			"directory": {
@@ -1287,6 +1288,7 @@ var yamlConfigFileResource = pschema.ResourceSpec{
 	IsComponent: true,
 	ObjectTypeSpec: pschema.ObjectTypeSpec{
 		IsOverlay:   true,
+		OverlaySupportedLanguages: []string{"csharp", "go", "python", "nodejs"},
 		Description: configFileMD,
 		Properties: map[string]pschema.PropertySpec{
 			"resources": {
@@ -1379,6 +1381,7 @@ var yamlConfigGroupResource = pschema.ResourceSpec{
 	IsComponent: true,
 	ObjectTypeSpec: pschema.ObjectTypeSpec{
 		IsOverlay:   true,
+		OverlaySupportedLanguages: []string{"csharp", "go", "python", "nodejs"},
 		Description: configGroupMD,
 		Properties: map[string]pschema.PropertySpec{
 			"resources": {
@@ -1521,6 +1524,7 @@ var yamlConfigGroupV2Resource = pschema.ResourceSpec{
 var apiextensionsCustomResource = pschema.ResourceSpec{
 	ObjectTypeSpec: pschema.ObjectTypeSpec{
 		IsOverlay:   true,
+		OverlaySupportedLanguages: []string{"csharp", "go", "python", "nodejs"},
 		Description: "CustomResource represents an instance of a CustomResourceDefinition (CRD). For example, the\n CoreOS Prometheus operator exposes a CRD `monitoring.coreos.com/ServiceMonitor`; to\n instantiate this as a Pulumi resource, one could call `new CustomResource`, passing the\n `ServiceMonitor` resource definition as an argument.",
 		Properties: map[string]pschema.PropertySpec{
 			"apiVersion": {
@@ -1588,6 +1592,7 @@ var apiextensionsCustomResource = pschema.ResourceSpec{
 var apiextensionsCustomResourcePatch = pschema.ResourceSpec{
 	ObjectTypeSpec: pschema.ObjectTypeSpec{
 		IsOverlay:   true,
+		OverlaySupportedLanguages: []string{"csharp", "go", "python", "nodejs"},
 		Description: "CustomResourcePatch represents an instance of a CustomResourceDefinition (CRD). For example, the\n CoreOS Prometheus operator exposes a CRD `monitoring.coreos.com/ServiceMonitor`; to\n instantiate this as a Pulumi resource, one could call `new CustomResourcePatch`, passing the\n `ServiceMonitor` resource definition as an argument.",
 		Properties: map[string]pschema.PropertySpec{
 			"apiVersion": {

--- a/provider/pkg/gen/overlays.go
+++ b/provider/pkg/gen/overlays.go
@@ -55,6 +55,7 @@ var helmV3ChartResource = pschema.ResourceSpec{
 	IsComponent: true,
 	ObjectTypeSpec: pschema.ObjectTypeSpec{
 		IsOverlay:   true,
+		OverlaySupportedLanguages: []string{"csharp", "go", "python", "nodejs"},
 		Description: helmV3ChartMD,
 		Properties: map[string]pschema.PropertySpec{
 			"resources": {


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

docsgen supports defining the supported languages of an overlay now.
This will ensure only the supported languages show up in the language choosers
in the registry.

Example for Chart v3:
<img width="1046" alt="Screenshot 2024-07-01 at 16 11 23" src="https://github.com/user-attachments/assets/e6e7b3d1-f21b-4ff0-902a-119d9b06a19a">


### Related issues (optional)

Relates to https://github.com/pulumi/pulumi/issues/13231
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
