### PR TITLE
Fix deprecated linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,32 +1,29 @@
 linters:
   enable-all: false
   enable:
-    - deadcode
+    - unused
     - errcheck
     - goconst
     - gofmt
-    - golint
+    - staticcheck
     - gosec
     - govet
     - ineffassign
     - misspell
     - nakedret
-    - structcheck
     - unconvert
-    - varcheck
+    - gosimple
   disable:
     - lll
-    - megacheck # Disabled due to OOM errors in golangci-lint@v1.18.0
-    - staticcheck # Disabled due to OOM errors in golangci-lint@v1.18.0
 run:
   skip-files:
-  - schema.go
+    - schema.go
   skip-dirs:
-  - provider/pkg/gen
+    - provider/pkg/gen
   skip-dirs-use-default: true
   modules-download-mode: readonly
   timeout: 10m
 issues:
   exclude-rules:
-      path: "provider/cmd/pulumi-resource-kubernetes"
-      source: "^//go:embed"
+    path: "provider/cmd/pulumi-resource-kubernetes"
+    source: "^//go:embed"

--- a/provider/pkg/await/await_test.go
+++ b/provider/pkg/await/await_test.go
@@ -377,8 +377,6 @@ func Test_Deletion(t *testing.T) {
 
 	type reactionF func(t *testing.T, ctx testCtx, action kubetesting.Action) (handled bool, ret runtime.Object, err error)
 
-	type watchReactionF func(t *testing.T, ctx testCtx, action kubetesting.Action) (handled bool, ret watch.Interface, err error)
-
 	type expectF func(t *testing.T, ctx testCtx, err error)
 
 	// reactions
@@ -427,7 +425,7 @@ func Test_Deletion(t *testing.T) {
 		}
 	}
 	deleted := func(ns, name string) expectF {
-		return func(t *testing.T, ctx testCtx, err error) {
+		return func(t *testing.T, ctx testCtx, _ error) {
 			gvr, err := clients.GVRForGVK(ctx.mapper, ctx.config.Inputs.GroupVersionKind())
 			require.NoError(t, err)
 			_, err = ctx.client.Tracker().Get(gvr, ns, name)

--- a/provider/pkg/await/ingress.go
+++ b/provider/pkg/await/ingress.go
@@ -73,8 +73,8 @@ type ingressInitAwaiter struct {
 	ingressReady              bool
 	endpointsSettled          bool
 	endpointEventsCount       uint64
-	knownEndpointObjects      sets.String
-	knownExternalNameServices sets.String
+	knownEndpointObjects      sets.Set[string]
+	knownExternalNameServices sets.Set[string]
 }
 
 func makeIngressInitAwaiter(c createAwaitConfig) *ingressInitAwaiter {
@@ -83,8 +83,8 @@ func makeIngressInitAwaiter(c createAwaitConfig) *ingressInitAwaiter {
 		ingress:                   c.currentOutputs,
 		ingressReady:              false,
 		endpointsSettled:          false,
-		knownEndpointObjects:      sets.NewString(),
-		knownExternalNameServices: sets.NewString(),
+		knownEndpointObjects:      sets.Set[string]{},
+		knownExternalNameServices: sets.Set[string]{},
 	}
 }
 

--- a/provider/pkg/clients/fake/discovery.go
+++ b/provider/pkg/clients/fake/discovery.go
@@ -57,7 +57,7 @@ var serverresources embed.FS
 
 func loadServerResources() ([]*metav1.APIResourceList, error) {
 	all := []*metav1.APIResourceList{}
-	err := fs.WalkDir(serverresources, ".", func(path string, d fs.DirEntry, err error) error {
+	err := fs.WalkDir(serverresources, ".", func(path string, d fs.DirEntry, _ error) error {
 		if d.IsDir() || d.Name() != "serverresources.json" {
 			return nil
 		}

--- a/provider/pkg/gen/overlays.go
+++ b/provider/pkg/gen/overlays.go
@@ -54,9 +54,9 @@ var helmV3ChartMD string
 var helmV3ChartResource = pschema.ResourceSpec{
 	IsComponent: true,
 	ObjectTypeSpec: pschema.ObjectTypeSpec{
-		IsOverlay:   true,
+		IsOverlay:                 true,
 		OverlaySupportedLanguages: []string{"csharp", "go", "python", "nodejs"},
-		Description: helmV3ChartMD,
+		Description:               helmV3ChartMD,
 		Properties: map[string]pschema.PropertySpec{
 			"resources": {
 				TypeSpec: pschema.TypeSpec{
@@ -1173,9 +1173,9 @@ var kustomizeDirectoryMD string
 var kustomizeDirectoryResource = pschema.ResourceSpec{
 	IsComponent: true,
 	ObjectTypeSpec: pschema.ObjectTypeSpec{
-		IsOverlay:   true,
+		IsOverlay:                 true,
 		OverlaySupportedLanguages: []string{"csharp", "go", "python", "nodejs"},
-		Description: kustomizeDirectoryMD,
+		Description:               kustomizeDirectoryMD,
 		Properties: map[string]pschema.PropertySpec{
 			"directory": {
 				TypeSpec: pschema.TypeSpec{
@@ -1287,9 +1287,9 @@ var configFileMD string
 var yamlConfigFileResource = pschema.ResourceSpec{
 	IsComponent: true,
 	ObjectTypeSpec: pschema.ObjectTypeSpec{
-		IsOverlay:   true,
+		IsOverlay:                 true,
 		OverlaySupportedLanguages: []string{"csharp", "go", "python", "nodejs"},
-		Description: configFileMD,
+		Description:               configFileMD,
 		Properties: map[string]pschema.PropertySpec{
 			"resources": {
 				TypeSpec: pschema.TypeSpec{
@@ -1380,9 +1380,9 @@ var configGroupMD string
 var yamlConfigGroupResource = pschema.ResourceSpec{
 	IsComponent: true,
 	ObjectTypeSpec: pschema.ObjectTypeSpec{
-		IsOverlay:   true,
+		IsOverlay:                 true,
 		OverlaySupportedLanguages: []string{"csharp", "go", "python", "nodejs"},
-		Description: configGroupMD,
+		Description:               configGroupMD,
 		Properties: map[string]pschema.PropertySpec{
 			"resources": {
 				TypeSpec: pschema.TypeSpec{
@@ -1523,9 +1523,9 @@ var yamlConfigGroupV2Resource = pschema.ResourceSpec{
 
 var apiextensionsCustomResource = pschema.ResourceSpec{
 	ObjectTypeSpec: pschema.ObjectTypeSpec{
-		IsOverlay:   true,
+		IsOverlay:                 true,
 		OverlaySupportedLanguages: []string{"csharp", "go", "python", "nodejs"},
-		Description: "CustomResource represents an instance of a CustomResourceDefinition (CRD). For example, the\n CoreOS Prometheus operator exposes a CRD `monitoring.coreos.com/ServiceMonitor`; to\n instantiate this as a Pulumi resource, one could call `new CustomResource`, passing the\n `ServiceMonitor` resource definition as an argument.",
+		Description:               "CustomResource represents an instance of a CustomResourceDefinition (CRD). For example, the\n CoreOS Prometheus operator exposes a CRD `monitoring.coreos.com/ServiceMonitor`; to\n instantiate this as a Pulumi resource, one could call `new CustomResource`, passing the\n `ServiceMonitor` resource definition as an argument.",
 		Properties: map[string]pschema.PropertySpec{
 			"apiVersion": {
 				TypeSpec: pschema.TypeSpec{
@@ -1591,9 +1591,9 @@ var apiextensionsCustomResource = pschema.ResourceSpec{
 
 var apiextensionsCustomResourcePatch = pschema.ResourceSpec{
 	ObjectTypeSpec: pschema.ObjectTypeSpec{
-		IsOverlay:   true,
+		IsOverlay:                 true,
 		OverlaySupportedLanguages: []string{"csharp", "go", "python", "nodejs"},
-		Description: "CustomResourcePatch represents an instance of a CustomResourceDefinition (CRD). For example, the\n CoreOS Prometheus operator exposes a CRD `monitoring.coreos.com/ServiceMonitor`; to\n instantiate this as a Pulumi resource, one could call `new CustomResourcePatch`, passing the\n `ServiceMonitor` resource definition as an argument.",
+		Description:               "CustomResourcePatch represents an instance of a CustomResourceDefinition (CRD). For example, the\n CoreOS Prometheus operator exposes a CRD `monitoring.coreos.com/ServiceMonitor`; to\n instantiate this as a Pulumi resource, one could call `new CustomResourcePatch`, passing the\n `ServiceMonitor` resource definition as an argument.",
 		Properties: map[string]pschema.PropertySpec{
 			"apiVersion": {
 				TypeSpec: pschema.TypeSpec{

--- a/provider/pkg/gen/types.go
+++ b/provider/pkg/gen/types.go
@@ -32,7 +32,7 @@ type TemplateProperty struct {
 // Type returns the property type. This could be either a constant value or the type definition.
 func (tp TemplateProperty) Type() string {
 	if len(tp.ConstValue) > 0 {
-		return fmt.Sprintf("%s", tp.ConstValue)
+		return tp.ConstValue
 	}
 	return tp.Package
 }
@@ -123,7 +123,7 @@ func (gv GroupVersion) GVConstName() string {
 	contract.Assertf(len(parts) == 2, "expected GroupVersion to have two parts: %s", gv)
 
 	group, version := parts[0], parts[1]
-	groupName := strings.Title(strings.SplitN(group, ".", 2)[0])
+	groupName := strings.Title(strings.SplitN(group, ".", 2)[0]) //nolint:staticcheck // Not unicode input.
 	version = strings.Replace(version, "v", "V", -1)
 	version = strings.Replace(version, "alpha", "A", -1)
 	version = strings.Replace(version, "beta", "B", -1)

--- a/provider/pkg/provider/helm_release.go
+++ b/provider/pkg/provider/helm_release.go
@@ -1658,7 +1658,7 @@ func resolveChartName(repository, name string) (string, string, error) {
 		return repository, name, nil
 	}
 
-	if strings.Index(name, "/") == -1 && repository != "" {
+	if !strings.Contains(name, "/") && repository != "" {
 		name = fmt.Sprintf("%s/%s", repository, name)
 	}
 

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -301,19 +301,19 @@ func (k *kubeProvider) CheckConfig(ctx context.Context, req *pulumirpc.CheckRequ
 
 		if providers.IsDefaultProvider(urn) {
 			failures = append(failures, &pulumirpc.CheckFailure{
-				Reason: fmt.Sprintf("strict mode prohibits default provider"),
+				Reason: "strict mode prohibits default provider",
 			})
 		}
 		if v := news["kubeconfig"]; !v.HasValue() || v.StringValue() == "" {
 			failures = append(failures, &pulumirpc.CheckFailure{
 				Property: "kubeconfig",
-				Reason:   fmt.Sprintf(`strict mode requires Provider "kubeconfig" argument`),
+				Reason:   `strict mode requires Provider "kubeconfig" argument`,
 			})
 		}
 		if v := news["context"]; !v.HasValue() || v.StringValue() == "" {
 			failures = append(failures, &pulumirpc.CheckFailure{
 				Property: "context",
-				Reason:   fmt.Sprintf(`strict mode requires Provider "context" argument`),
+				Reason:   `strict mode requires Provider "context" argument`,
 			})
 		}
 
@@ -1542,6 +1542,8 @@ func (k *kubeProvider) Check(ctx context.Context, req *pulumirpc.CheckRequest) (
 	return &pulumirpc.CheckResponse{Inputs: autonamedInputs, Failures: failures}, nil
 }
 
+var testHooks = regexp.MustCompile(`test|test-success|test-failure`)
+
 // helmHookWarning logs a warning if a Chart contains unsupported hooks. The warning can be disabled by setting
 // the suppressHelmHookWarnings provider flag or related ENV var.
 func (k *kubeProvider) helmHookWarning(ctx context.Context, newInputs *unstructured.Unstructured, urn resource.URN) {
@@ -1556,7 +1558,7 @@ func (k *kubeProvider) helmHookWarning(ctx context.Context, newInputs *unstructu
 		// If the Helm hook annotation is found, set the hasHelmHook flag.
 		if has := metadata.IsHelmHookAnnotation(key); has {
 			// Test hooks are handled, so ignore this one.
-			if match, _ := regexp.MatchString(`test|test-success|test-failure`, value); !match {
+			if testHooks.MatchString(value) {
 				hasHelmHook = hasHelmHook || has
 			}
 		}


### PR DESCRIPTION
We have a few linters that have been deprecated/disabled for a while:
```
ERRO [linters_context] deadcode: This linter is fully inactivated: it will not produce any reports.
ERRO [linters_context] golint: This linter is fully inactivated: it will not produce any reports.
ERRO [linters_context] structcheck: This linter is fully inactivated: it will not produce any reports.
ERRO [linters_context] varcheck: This linter is fully inactivated: it will not produce any reports.
```

`deadcode`, `structcheck`, and `varcheck` can be replaced with `unused`.

`golint` can be replaced with `staticcheck` and re-enabled.

`megacheck` can be replaced with `gosimple` and re-enabled.