### PR TITLE
Add java as supported language for CustomResource overlays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixed
 
 - Updated logic to accurately detect if a resource is a Patch variant. (https://github.com/pulumi/pulumi-kubernetes/pull/3102)
+- Added java as supported language for CustomResource overlays. (https://github.com/pulumi/pulumi-kubernetes/pull/3120)
 
 ## 4.15.0 (July 9, 2024)
 

--- a/provider/pkg/gen/overlays.go
+++ b/provider/pkg/gen/overlays.go
@@ -1524,7 +1524,7 @@ var yamlConfigGroupV2Resource = pschema.ResourceSpec{
 var apiextensionsCustomResource = pschema.ResourceSpec{
 	ObjectTypeSpec: pschema.ObjectTypeSpec{
 		IsOverlay:                 true,
-		OverlaySupportedLanguages: []string{"csharp", "go", "python", "nodejs"},
+		OverlaySupportedLanguages: []string{"csharp", "go", "python", "nodejs", "java"},
 		Description:               "CustomResource represents an instance of a CustomResourceDefinition (CRD). For example, the\n CoreOS Prometheus operator exposes a CRD `monitoring.coreos.com/ServiceMonitor`; to\n instantiate this as a Pulumi resource, one could call `new CustomResource`, passing the\n `ServiceMonitor` resource definition as an argument.",
 		Properties: map[string]pschema.PropertySpec{
 			"apiVersion": {
@@ -1592,7 +1592,7 @@ var apiextensionsCustomResource = pschema.ResourceSpec{
 var apiextensionsCustomResourcePatch = pschema.ResourceSpec{
 	ObjectTypeSpec: pschema.ObjectTypeSpec{
 		IsOverlay:                 true,
-		OverlaySupportedLanguages: []string{"csharp", "go", "python", "nodejs"},
+		OverlaySupportedLanguages: []string{"csharp", "go", "python", "nodejs", "java"},
 		Description:               "CustomResourcePatch represents an instance of a CustomResourceDefinition (CRD). For example, the\n CoreOS Prometheus operator exposes a CRD `monitoring.coreos.com/ServiceMonitor`; to\n instantiate this as a Pulumi resource, one could call `new CustomResourcePatch`, passing the\n `ServiceMonitor` resource definition as an argument.",
 		Properties: map[string]pschema.PropertySpec{
 			"apiVersion": {


### PR DESCRIPTION
### Proposed changes

Java is supported for `CustomResource` and `CustomResourcePatch`. This change adds it to the list of supported languages for the overlays. See https://github.com/pulumi/pulumi-kubernetes/pull/3107#issuecomment-2244091193 for context
