### PR TITLE
Emit event logs during await

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,10 @@
     
            `pulumi.com/waitFor: '["jsonpath={.foo}", "condition=Bar"]'` 
 
+- Pulumi will now emit logs for any Kubernetes "Warning" Events associated with
+  resources being created, updated or deleted.
+  (https://github.com/pulumi/pulumi-kubernetes/pull/3135/files)
+
 ### Fixed
 
 - The `immutable` field is now respected for `ConfigMaps` when the provider is configured with `enableConfigMapMutable`.

--- a/provider/pkg/await/await.go
+++ b/provider/pkg/await/await.go
@@ -299,6 +299,9 @@ func Creation(c CreateConfig) (*unstructured.Unstructured, error) {
 
 	awaiter, err := internal.NewAwaiter(
 		internal.WithCondition(ready),
+		internal.WithObservers(
+			NewEventAggregator(ctx, source, c.DedupLogger, outputs),
+		),
 		internal.WithNamespace(outputs.GetNamespace()),
 		internal.WithLogger(c.DedupLogger),
 	)
@@ -456,6 +459,9 @@ func Update(c UpdateConfig) (*unstructured.Unstructured, error) {
 
 	awaiter, err := internal.NewAwaiter(
 		internal.WithCondition(ready),
+		internal.WithObservers(
+			NewEventAggregator(ctx, source, c.DedupLogger, currentOutputs),
+		),
 		internal.WithNamespace(currentOutputs.GetNamespace()),
 		internal.WithLogger(c.DedupLogger),
 	)
@@ -847,6 +853,9 @@ func Deletion(c DeleteConfig) error {
 
 	awaiter, err := internal.NewAwaiter(
 		internal.WithCondition(deleted),
+		internal.WithObservers(
+			NewEventAggregator(ctx, source, c.DedupLogger, c.Outputs),
+		),
 		internal.WithNamespace(c.Outputs.GetNamespace()),
 		internal.WithLogger(c.DedupLogger),
 	)

--- a/provider/pkg/await/watchers.go
+++ b/provider/pkg/await/watchers.go
@@ -17,7 +17,6 @@ package await
 import (
 	"context"
 	"fmt"
-	"strings"
 	"sync"
 
 	"github.com/pulumi/cloud-ready-checks/pkg/checker"
@@ -236,9 +235,7 @@ func NewEventAggregator(
 				return nil
 			}
 			msg := fmt.Sprintf(
-				"[%s/%s] %s: %s",
-				strings.ToLower(e.InvolvedObject.Kind),
-				e.InvolvedObject.Name,
+				"%s: %s",
 				e.Reason,
 				e.Message,
 			)

--- a/provider/pkg/await/watchers.go
+++ b/provider/pkg/await/watchers.go
@@ -15,19 +15,27 @@
 package await
 
 import (
+	"context"
+	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/pulumi/cloud-ready-checks/pkg/checker"
-	"github.com/pulumi/cloud-ready-checks/pkg/checker/logging"
+	checkerlog "github.com/pulumi/cloud-ready-checks/pkg/checker/logging"
+
 	"github.com/pulumi/cloud-ready-checks/pkg/kubernetes/pod"
+	"github.com/pulumi/pulumi-kubernetes/provider/v4/pkg/await/condition"
 	"github.com/pulumi/pulumi-kubernetes/provider/v4/pkg/clients"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	logger "github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 )
+
+var _ condition.Observer = (*Aggregator[*corev1.Event])(nil)
 
 // PodAggregator tracks status for any Pods related to the owner resource, and writes
 // warning/error messages to a channel that can be consumed by a resource awaiter.
@@ -46,7 +54,7 @@ type PodAggregator struct {
 	lister lister
 
 	// Messages
-	messages chan logging.Messages
+	messages chan checkerlog.Messages
 }
 
 // lister lists resources matching a label selector.
@@ -60,7 +68,7 @@ func NewPodAggregator(owner *unstructured.Unstructured, lister lister) *PodAggre
 		owner:    owner,
 		lister:   lister,
 		checker:  pod.NewPodChecker(),
-		messages: make(chan logging.Messages),
+		messages: make(chan checkerlog.Messages),
 	}
 	return pa
 }
@@ -103,8 +111,8 @@ func (pa *PodAggregator) run(informChan <-chan watch.Event) {
 }
 
 // Read lists existing Pods and returns any related warning/error messages.
-func (pa *PodAggregator) Read() logging.Messages {
-	var messages logging.Messages
+func (pa *PodAggregator) Read() checkerlog.Messages {
+	var messages checkerlog.Messages
 	checkPod := func(object runtime.Object) {
 		obj := object.(*unstructured.Unstructured)
 		pod, err := clients.PodFromUnstructured(obj)
@@ -149,7 +157,7 @@ func (pa *PodAggregator) stopping() bool {
 
 // ResultChan returns a reference to the message channel used by the PodAggregator to
 // communicate warning/error messages to a resource awaiter.
-func (pa *PodAggregator) ResultChan() <-chan logging.Messages {
+func (pa *PodAggregator) ResultChan() <-chan checkerlog.Messages {
 	return pa.messages
 }
 
@@ -166,4 +174,83 @@ func (s *staticLister) List(_ labels.Selector) (ret []runtime.Object, err error)
 		objects = append(objects, l.DeepCopyObject())
 	}
 	return objects, nil
+}
+
+// Aggregator is a generic, stateless condition.Observer intended for reporting
+// informational messages about related resources during an Await.
+type Aggregator[T runtime.Object] struct {
+	observer condition.Observer
+	callback func(logMessager, T) error
+	logger   logMessager
+}
+
+// NewAggregator creates a new Aggregator for the given runtime type. The
+// provided condition.Observer must be configured for the corresponding GVK.
+func NewAggregator[T runtime.Object](
+	observer condition.Observer,
+	logger logMessager,
+	callback func(logMessager, T) error,
+) *Aggregator[T] {
+	return &Aggregator[T]{
+		observer: observer,
+		callback: callback,
+		logger:   logger,
+	}
+}
+
+func (i *Aggregator[T]) Observe(e watch.Event) error {
+	obj, ok := e.Object.(*unstructured.Unstructured)
+	if !ok {
+		return nil
+	}
+	var t T
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &t)
+	if err != nil {
+		return err
+	}
+	return i.callback(i.logger, t)
+}
+
+func (i *Aggregator[T]) Range(yield func(watch.Event) bool) {
+	i.observer.Range(yield)
+}
+
+// NewEventAggregator creates a new condition.Observer subscribed to Kubernetes
+// events related to the owner object. Event messages are logged at WARN
+// severity if the event has type Warning; Normal events are discarded to
+// reduce noise.
+func NewEventAggregator(
+	ctx context.Context,
+	source condition.Source,
+	logger logMessager,
+	owner *unstructured.Unstructured,
+) condition.Observer {
+	observer := condition.NewObserver(ctx,
+		source,
+		corev1.SchemeGroupVersion.WithKind("Event"),
+		func(obj *unstructured.Unstructured) bool {
+			uid, _, _ := unstructured.NestedString(obj.Object, "involvedObject", "uid")
+			return uid == string(owner.GetUID())
+		},
+	)
+	return NewAggregator(observer, logger,
+		func(l logMessager, e *corev1.Event) error {
+			if e == nil || e.Type != corev1.EventTypeWarning {
+				return nil
+			}
+			msg := fmt.Sprintf(
+				"[%s/%s] %s: %s",
+				strings.ToLower(e.InvolvedObject.Kind),
+				e.InvolvedObject.Name,
+				e.Reason,
+				e.Message,
+			)
+			logger.LogMessage(checkerlog.WarningMessage(msg))
+			return nil
+		},
+	)
+}
+
+type logMessager interface {
+	LogMessage(checkerlog.Message)
 }

--- a/provider/pkg/await/watchers.go
+++ b/provider/pkg/await/watchers.go
@@ -245,10 +245,9 @@ func NewEventAggregator(
 			m := checkerlog.WarningMessage(msg)
 			switch e.Type {
 			case corev1.EventTypeWarning:
-				logger.LogMessage(m)
+				logger.LogStatus(diag.Warning, m.S)
 			default:
-				m.Severity = diag.Debug
-				logger.LogMessage(m)
+				logger.LogStatus(diag.Debug, m.S)
 			}
 			return nil
 		},
@@ -256,7 +255,8 @@ func NewEventAggregator(
 }
 
 type logMessager interface {
-	LogMessage(checkerlog.Message)
+	Log(diag.Severity, string)
+	LogStatus(diag.Severity, string)
 }
 
 func relatedEvents(owner *unstructured.Unstructured) func(*unstructured.Unstructured) bool {

--- a/provider/pkg/await/watchers_test.go
+++ b/provider/pkg/await/watchers_test.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"testing"
 
-	checkerlog "github.com/pulumi/cloud-ready-checks/pkg/checker/logging"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/watch"
@@ -154,6 +154,9 @@ func TestRelatedEvent(t *testing.T) {
 
 type log struct{ io.Writer }
 
-func (l log) LogMessage(m checkerlog.Message) {
-	fmt.Fprintf(l, "%s %s", m.Severity, m.String())
+func (l log) Log(sev diag.Severity, msg string) {
+	fmt.Fprintf(l, "%s %s", sev, msg)
+}
+func (l log) LogStatus(sev diag.Severity, msg string) {
+	l.Log(sev, msg)
 }

--- a/provider/pkg/await/watchers_test.go
+++ b/provider/pkg/await/watchers_test.go
@@ -1,0 +1,133 @@
+// Copyright 2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package await
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	checkerlog "github.com/pulumi/cloud-ready-checks/pkg/checker/logging"
+	"github.com/pulumi/pulumi-kubernetes/provider/v4/pkg/await/condition"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+func TestEventAggregator(t *testing.T) {
+	owner := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "pulumi.com/v1",
+		"kind":       "Stack",
+		"metadata": map[string]any{
+			"name":      "my-stack-28073241",
+			"namespace": "operator",
+			"uid":       "9bd08f1a-fa5b-40a5-ba41-bf69899a4416",
+		},
+	}}
+
+	tests := []struct {
+		name  string
+		event watch.Event
+		want  string
+	}{
+		{
+			name: "related warning",
+			event: watch.Event{Type: watch.Added, Object: &unstructured.Unstructured{Object: map[string]any{
+				"apiVersion": "v1",
+				"kind":       "Event",
+				"reason":     "StackUpdateFailure",
+				"type":       "Warning",
+				"message":    "Failed to update Stack",
+				"involvedObject": map[string]any{
+					"kind": "Stack",
+					"name": "my-stack-28073241",
+					"uid":  "9bd08f1a-fa5b-40a5-ba41-bf69899a4416",
+				},
+			}}},
+			want: "warning [stack/my-stack-28073241] StackUpdateFailure: Failed to update Stack",
+		},
+		{
+			name: "related info",
+			event: watch.Event{Type: watch.Added, Object: &unstructured.Unstructured{Object: map[string]any{
+				"apiVersion": "v1",
+				"kind":       "Event",
+				"reason":     "Killing",
+				"type":       "Normal",
+				"message":    "frog blast the vent core",
+				"involvedObject": map[string]any{
+					"kind": "Pod",
+					"name": "mypod-7854ff8877-p9ksk",
+					"uid":  "9bd08f1a-fa5b-40a5-ba41-bf69899a4416",
+				},
+			}}},
+			want: "",
+		},
+		{
+			name: "unrelated warning",
+			event: watch.Event{Type: watch.Added, Object: &unstructured.Unstructured{Object: map[string]any{
+				"apiVersion": "v1",
+				"kind":       "Event",
+				"reason":     "Killing",
+				"type":       "Warning",
+				"message":    "Stopping container nginx",
+				"involvedObject": map[string]any{
+					"kind": "Pod",
+					"name": "some-other-name",
+					"uid":  "some-other-uid",
+				},
+			}}},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			source := condition.Static(make(chan watch.Event, 1))
+
+			buf := &strings.Builder{}
+
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+
+			obs := NewEventAggregator(context.Background(), source, log{buf}, owner)
+
+			seen := make(chan struct{})
+			go obs.Range(func(e watch.Event) bool {
+				_ = obs.Observe(e)
+				seen <- struct{}{}
+				return true
+			})
+
+			source <- tt.event
+			select {
+			case <-seen:
+			case <-ctx.Done():
+			}
+			assert.Equal(t, buf.String(), tt.want)
+		})
+	}
+}
+
+type log struct{ io.Writer }
+
+func (l log) LogMessage(m checkerlog.Message) {
+	fmt.Fprintf(l, "%s %s", m.Severity, m.String())
+}

--- a/provider/pkg/await/watchers_test.go
+++ b/provider/pkg/await/watchers_test.go
@@ -57,7 +57,7 @@ func TestEventAggregator(t *testing.T) {
 					"uid":  "9bd08f1a-fa5b-40a5-ba41-bf69899a4416",
 				},
 			}}},
-			want: "warning [stack/my-stack-28073241] StackUpdateFailure: Failed to update Stack",
+			want: "warning StackUpdateFailure: Failed to update Stack",
 		},
 		{
 			name: "normal",
@@ -73,7 +73,7 @@ func TestEventAggregator(t *testing.T) {
 					"uid":  "9bd08f1a-fa5b-40a5-ba41-bf69899a4416",
 				},
 			}}},
-			want: "debug [pod/mypod-7854ff8877-p9ksk] Killing: frog blast the vent core",
+			want: "debug Killing: frog blast the vent core",
 		},
 	}
 
@@ -157,6 +157,7 @@ type log struct{ io.Writer }
 func (l log) Log(sev diag.Severity, msg string) {
 	fmt.Fprintf(l, "%s %s", sev, msg)
 }
+
 func (l log) LogStatus(sev diag.Severity, msg string) {
 	l.Log(sev, msg)
 }


### PR DESCRIPTION
This adds a new `EventAggregator` and hooks it up to all of our new awaiters.

This has the effect of surfacing Warning events to the user while any await
logic is ongoing, including all of our existing/legacy awaiters.

Note how straightforward it is to add new/similar aggregators/observers. In the
future we can easily supply other informers, for example we might want a
generic awaiter that aggregates any pods/deployments/stateful sets owned by the
resource.

For example, attempting to unseal an invalid secret will show a temporary warning:

```yaml
  type: kubernetes:yaml/v2:ConfigGroup
    properties:
      yaml: |
        apiVersion: bitnami.com/v1alpha1
        kind: SealedSecret
        metadata:
          name: mysecret
          namespace: default
          annotations:
            pulumi.com/waitFor: condition=Synced
        spec:
          encryptedData:
            foo: AgBy3i4OJSWK+PiTySYZZA9rO43cGDEq...
```
```
PULUMI_K8S_AWAIT_ALL=true pulumi up
```

Interactive:
```
 +      └─ kubernetes:bitnami.com/v1alpha1:SealedSecret  secret:default/mysecret  creating (7s)     warning: [sealedsecret/mysecret] ErrUnsealFailed: Failed to unseal: illegal base64 data at input byte 32 (foo)
```

Non-interactive:
```
 +  kubernetes:bitnami.com/v1alpha1:SealedSecret secret:default/mysecret creating (0s) warning: Has no .status.conditions
 +  kubernetes:bitnami.com/v1alpha1:SealedSecret secret:default/mysecret creating (0s) Resource has condition Synced=False (want True)
 +  kubernetes:bitnami.com/v1alpha1:SealedSecret secret:default/mysecret creating (0s) warning: [sealedsecret/mysecret] ErrUnsealFailed: Failed to unseal: illegal base64 data at input byte 32 (foo)
@ updating............
```

Fixes https://github.com/pulumi/pulumi-kubernetes/issues/133.
Refs https://github.com/pulumi/pulumi-kubernetes/issues/2824.
