### PR TITLE
fix: Do not set default namespace if explicitly set to empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Changed
+
+- Whenever namespace is explicitly set to an empty string, it will not add the default namespace to the namespaced resource.
+
 ### Added
 
 - `clusterIdentifier` configuration can now be used to manually control the

--- a/provider/pkg/provider/provider_configure_test.go
+++ b/provider/pkg/provider/provider_configure_test.go
@@ -106,6 +106,19 @@ var _ = Describe("RPC:Configure", func() {
 				Expect(helmFlags.Namespace).To(PointTo(Equal("pulumi")))
 			})
 		})
+
+		Context("when explicitly configured to use an empty namespace", func() {
+			JustBeforeEach(func() {
+				req.Variables["kubernetes:config:namespace"] = ""
+			})
+			It("should use the empty namespace as the default namespace", func() {
+				_, err := k.Configure(context.Background(), req)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(k.defaultNamespace).To(Equal(""))
+				helmFlags := k.helmSettings.RESTClientGetter().(*genericclioptions.ConfigFlags)
+				Expect(helmFlags.Namespace).To(PointTo(Equal("")))
+			})
+		})
 	})
 
 	Describe("Kubeconfig Parsing", func() {

--- a/provider/pkg/provider/yaml/v2/yaml.go
+++ b/provider/pkg/provider/yaml/v2/yaml.go
@@ -170,7 +170,7 @@ func Normalize(objs []unstructured.Unstructured, defaultNamespace string, client
 		if err != nil {
 			return nil, err
 		}
-		if isNamespaced && obj.GetNamespace() == "" {
+		if isNamespaced && obj.GetNamespace() == "" && defaultNamespace != "" {
 			obj.SetNamespace(defaultNamespace)
 		}
 	}


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

Hello,

With the new `renderToYaml` engine that is experimental, I do want to generate ArgoCD resources in a typesafe way, but there is a mechanism in the `yaml` renderer, which gets called in every other resource type like plain, Helm, Kustomize etc. to always set a default namespace if the resource does not have, so now you have to pass around namespaces and ensure that they are matching with the ArgoCD configuration, which is [here](https://github.com/pulumi/pulumi-kubernetes/blob/master/provider/pkg/provider/yaml/v2/yaml.go#L139).

When setting the `namespace` in the kubernetes provider as below empty, the proposed behavior will not put in the default namespace.

```typescript
const provider = new k8s.Provider(options.name, {
  renderYamlToDirectory: options.path,
  namespace: ''
})
```

Since the order of resolution is the resource, then the provider, then active kubernetes context namespace, this can be easily overwritten when desired, but will allow resources to also generate without a namespace field.

### Related issues (optional)

None
