### PR TITLE
Consolidate updateAwaitConfig/createAwaitConfig

### DIFF
--- a/provider/pkg/await/await.go
+++ b/provider/pkg/await/await.go
@@ -265,9 +265,9 @@ func Creation(c CreateConfig) (*unstructured.Unstructured, error) {
 		if metadata.SkipAwaitLogic(c.Inputs) {
 			logger.V(1).Infof("Skipping await logic for %v", outputs.GetName())
 		} else {
-			if awaiter.awaitCreation != nil {
+			if awaiter.await != nil {
 				timeout := metadata.TimeoutDuration(c.Timeout, c.Inputs)
-				conf := createAwaitConfig{
+				conf := awaitConfig{
 					ctx:               c.Context,
 					urn:               c.URN,
 					initialAPIVersion: c.InitialAPIVersion,
@@ -278,7 +278,7 @@ func Creation(c CreateConfig) (*unstructured.Unstructured, error) {
 					clusterVersion:    c.ClusterVersion,
 					clock:             c.clock,
 				}
-				waitErr := awaiter.awaitCreation(conf)
+				waitErr := awaiter.await(conf)
 				if waitErr != nil {
 					return nil, waitErr
 				}
@@ -332,7 +332,7 @@ func Read(c ReadConfig) (*unstructured.Unstructured, error) {
 			logger.V(1).Infof("Skipping await logic for %v", c.Inputs.GetName())
 		} else {
 			if awaiter.awaitRead != nil {
-				conf := createAwaitConfig{
+				conf := awaitConfig{
 					ctx:               c.Context,
 					urn:               c.URN,
 					initialAPIVersion: c.InitialAPIVersion,
@@ -414,9 +414,9 @@ func Update(c UpdateConfig) (*unstructured.Unstructured, error) {
 		if metadata.SkipAwaitLogic(c.Inputs) {
 			logger.V(1).Infof("Skipping await logic for %v", currentOutputs.GetName())
 		} else {
-			if awaiter.awaitCreation != nil {
+			if awaiter.await != nil {
 				timeout := metadata.TimeoutDuration(c.Timeout, c.Inputs)
-				conf := createAwaitConfig{
+				conf := awaitConfig{
 					ctx:               c.Context,
 					urn:               c.URN,
 					initialAPIVersion: c.InitialAPIVersion,
@@ -428,7 +428,7 @@ func Update(c UpdateConfig) (*unstructured.Unstructured, error) {
 					clusterVersion:    c.ClusterVersion,
 					clock:             c.clock,
 				}
-				waitErr := awaiter.awaitCreation(conf)
+				waitErr := awaiter.await(conf)
 				if waitErr != nil {
 					return nil, waitErr
 				}
@@ -832,7 +832,7 @@ func Deletion(c DeleteConfig) error {
 		} else {
 			timeout := metadata.TimeoutDuration(c.Timeout, c.Inputs)
 			waitErr = awaiter.awaitDeletion(deleteAwaitConfig{
-				createAwaitConfig: createAwaitConfig{
+				awaitConfig: awaitConfig{
 					ctx:               c.Context,
 					urn:               c.URN,
 					initialAPIVersion: c.InitialAPIVersion,

--- a/provider/pkg/await/await.go
+++ b/provider/pkg/await/await.go
@@ -414,23 +414,21 @@ func Update(c UpdateConfig) (*unstructured.Unstructured, error) {
 		if metadata.SkipAwaitLogic(c.Inputs) {
 			logger.V(1).Infof("Skipping await logic for %v", currentOutputs.GetName())
 		} else {
-			if awaiter.awaitUpdate != nil {
+			if awaiter.awaitCreation != nil {
 				timeout := metadata.TimeoutDuration(c.Timeout, c.Inputs)
-				conf := updateAwaitConfig{
-					createAwaitConfig: createAwaitConfig{
-						ctx:               c.Context,
-						urn:               c.URN,
-						initialAPIVersion: c.InitialAPIVersion,
-						clientSet:         c.ClientSet,
-						currentOutputs:    currentOutputs,
-						logger:            c.DedupLogger,
-						timeout:           timeout,
-						clusterVersion:    c.ClusterVersion,
-						clock:             c.clock,
-					},
-					lastOutputs: liveOldObj,
+				conf := createAwaitConfig{
+					ctx:               c.Context,
+					urn:               c.URN,
+					initialAPIVersion: c.InitialAPIVersion,
+					clientSet:         c.ClientSet,
+					currentOutputs:    currentOutputs,
+					lastOutputs:       liveOldObj,
+					logger:            c.DedupLogger,
+					timeout:           timeout,
+					clusterVersion:    c.ClusterVersion,
+					clock:             c.clock,
 				}
-				waitErr := awaiter.awaitUpdate(conf)
+				waitErr := awaiter.awaitCreation(conf)
 				if waitErr != nil {
 					return nil, waitErr
 				}

--- a/provider/pkg/await/await_test.go
+++ b/provider/pkg/await/await_test.go
@@ -85,7 +85,7 @@ var (
 	removedAPIErr         = &kinds.RemovedAPIError{}
 )
 
-func Test_Creation(t *testing.T) {
+func TestCreation(t *testing.T) {
 	type testCtx struct {
 		host   *fakehost.HostClient
 		config *CreateConfig
@@ -352,7 +352,278 @@ func Test_Creation(t *testing.T) {
 	}
 }
 
-func Test_Deletion(t *testing.T) {
+func TestUpdate(t *testing.T) {
+	type testCtx struct {
+		host   *fakehost.HostClient
+		config *UpdateConfig
+		disco  *fake.SimpleDiscovery
+		mapper *fake.SimpleRESTMapper
+		client *fake.SimpleDynamicClient
+	}
+	type args struct {
+		preview         bool
+		serverSideApply bool
+		resType         tokens.Type
+		inputs          *unstructured.Unstructured
+		oldInputs       *unstructured.Unstructured
+		oldOutputs      *unstructured.Unstructured
+	}
+	type client struct {
+		RESTMapperF    func(mapper meta.ResettableRESTMapper) meta.ResettableRESTMapper
+		GenericClientF func(client dynamic.Interface) dynamic.Interface
+	}
+
+	type expectF func(t *testing.T, ctx testCtx, actual *unstructured.Unstructured, err error)
+
+	// awaiters
+
+	touch := func(t *testing.T, ctx testCtx) awaiter {
+		return func(cac awaitConfig) error {
+			require.False(t, metadata.SkipAwaitLogic(cac.currentOutputs), "Await logic should not execute when SkipWait is set")
+
+			// get the live object from the fake API Server
+			require.Equal(t, cac.currentOutputs.GetNamespace(), cac.currentOutputs.GetNamespace(), "Live object should have a namespace")
+			require.Equal(t, cac.currentOutputs.GetName(), cac.currentOutputs.GetName(), "Live object should have a name")
+			gvr, err := clients.GVRForGVK(cac.clientSet.RESTMapper, cac.currentOutputs.GroupVersionKind())
+			require.NoError(t, err)
+			live, err := ctx.client.Tracker().Get(gvr, cac.currentOutputs.GetNamespace(), cac.currentOutputs.GetName())
+			require.NoError(t, err, "Live object should exist in the API Server")
+			pod, ok := live.(*unstructured.Unstructured)
+			require.True(t, ok)
+
+			// mutate the live object to simulate a observable status update.
+			err = unstructured.SetNestedField(pod.Object, "Running", "status", "phase")
+			require.NoError(t, err)
+			err = ctx.client.Tracker().Update(gvr, live, cac.currentOutputs.GetNamespace())
+			require.NoError(t, err)
+			return nil
+		}
+	}
+
+	awaitError := func(t *testing.T, ctx testCtx) awaiter {
+		return func(cac awaitConfig) error {
+			return serviceUnavailableErr
+		}
+	}
+
+	awaitUnexpected := func(t *testing.T, ctx testCtx) awaiter {
+		return func(cac awaitConfig) error {
+			require.Fail(t, "Unexpected call to awaiter")
+			return nil
+		}
+	}
+
+	// expectations
+
+	failed := func(target error) expectF {
+		return func(t *testing.T, ctx testCtx, actual *unstructured.Unstructured, err error) {
+			require.ErrorAs(t, err, &target)
+		}
+	}
+	previewed := func(ns, name string) expectF {
+		return func(t *testing.T, ctx testCtx, actual *unstructured.Unstructured, err error) {
+			require.NoError(t, err)
+			require.NotNil(t, actual)
+			require.Equal(t, ns, actual.GetNamespace(), "Object should have the expected namespace")
+			require.Equal(t, name, actual.GetName(), "Object should have the expected name")
+		}
+	}
+	updated := func(ns, name string) expectF {
+		return func(t *testing.T, ctx testCtx, actual *unstructured.Unstructured, err error) {
+			require.NoError(t, err)
+			require.NotNil(t, actual)
+			require.Equal(t, ns, actual.GetNamespace(), "Object should have the expected namespace")
+			require.Equal(t, name, actual.GetName(), "Object should have the expected name")
+
+			gvr, err := clients.GVRForGVK(ctx.mapper, ctx.config.Inputs.GroupVersionKind())
+			require.NoError(t, err)
+			_, err = ctx.client.Tracker().Get(gvr, ns, name)
+			require.NoError(t, err, "Live object should exist in the API Server")
+		}
+	}
+	touched := func() expectF {
+		return func(t *testing.T, ctx testCtx, actual *unstructured.Unstructured, err error) {
+			require.NoError(t, err)
+			actualPhase, ok, err := unstructured.NestedString(actual.Object, "status", "phase")
+			require.NoError(t, err)
+			require.True(t, ok, "Object should have a status.phase field")
+			require.Equal(t, actualPhase, "Running", "Object should have status.phase of 'Running'")
+		}
+	}
+	logged := func() expectF {
+		return func(t *testing.T, ctx testCtx, actual *unstructured.Unstructured, err error) {
+			// FUTURE: assert that a log message was emitted to the fake host
+		}
+	}
+
+	tests := []struct {
+		name    string
+		client  client
+		args    args
+		expect  []expectF
+		awaiter func(t *testing.T, ctx testCtx) awaiter
+	}{
+		{
+			name: "NoMatchError",
+			client: client{
+				RESTMapperF: func(mapper meta.ResettableRESTMapper) meta.ResettableRESTMapper {
+					// return a mapper that returns a NoMatchError until it is reset
+					return FlakyRESTMapper(mapper, &meta.NoResourceMatchError{PartialResource: podGVR})
+				},
+			},
+			args: args{
+				resType: tokens.Type("kubernetes:core/v1:Pod"),
+				inputs:  validPodUnstructured,
+			},
+			expect: []expectF{updated("default", "foo" /* after retry */)},
+		},
+		{
+			name: "ServiceUnavailable",
+			client: client{
+				RESTMapperF: func(mapper meta.ResettableRESTMapper) meta.ResettableRESTMapper {
+					return FailedRESTMapper(mapper, serviceUnavailableErr)
+				},
+			},
+			args: args{
+				resType: tokens.Type("kubernetes:core/v1:Pod"),
+				inputs:  validPodUnstructured,
+			},
+			expect: []expectF{failed(serviceUnavailableErr)},
+		},
+		{
+			name: "RemovedAPI",
+			args: args{
+				resType: tokens.Type("kubernetes:rbac.authorization.k8s.io/v1beta1:ClusterRole"),
+				inputs:  deprecatedClusterRoleUnstructured,
+			},
+			expect: []expectF{failed(removedAPIErr)},
+		},
+		{
+			name: "Namespaced",
+			args: args{
+				resType: tokens.Type("kubernetes:core/v1:Pod"),
+				inputs:  validPodUnstructured,
+			},
+			awaiter: touch,
+			expect:  []expectF{updated("default", "foo"), touched()},
+		},
+		{
+			name: "NonNamespaced",
+			args: args{
+				resType: tokens.Type("kubernetes:rbac.authorization.k8s.io/v1:ClusterRole"),
+				inputs:  validClusterRoleUnstructured,
+			},
+			awaiter: touch,
+			expect:  []expectF{updated("", "foo"), touched()},
+		},
+		{
+			name: "SkipAwait",
+			args: args{
+				resType: tokens.Type("kubernetes:core/v1:Pod"),
+				inputs:  withSkipAwait(validPodUnstructured),
+			},
+			awaiter: awaitUnexpected,
+			expect:  []expectF{updated("default", "foo")},
+		},
+		{
+			name: "NoAwaiter",
+			args: args{
+				resType: tokens.Type("kubernetes:core/v1:Pod"),
+				inputs:  validPodUnstructured,
+			},
+			awaiter: nil,
+			expect:  []expectF{updated("default", "foo"), logged()},
+		},
+		{
+			name: "AwaitError",
+			args: args{
+				resType: tokens.Type("kubernetes:core/v1:Pod"),
+				inputs:  validPodUnstructured,
+			},
+			awaiter: awaitError,
+			expect:  []expectF{failed(serviceUnavailableErr)},
+		},
+		{
+			name:   "Preview",
+			client: client{
+				// FUTURE: return a client that requires dry-run mode
+			},
+			args: args{
+				resType: tokens.Type("kubernetes:core/v1:Pod"),
+				inputs:  validPodUnstructured,
+				preview: true,
+			},
+			awaiter: awaitUnexpected,
+			expect:  []expectF{previewed("default", "foo")},
+		},
+		// FUTURE: test server-side apply (depends on https://github.com/kubernetes/kubernetes/issues/115598)
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			host := &fakehost.HostClient{}
+			oldInputs, oldOutputs := tt.args.inputs, tt.args.inputs
+			if tt.args.oldInputs != nil {
+				oldInputs = tt.args.oldInputs
+			}
+			if tt.args.oldOutputs != nil {
+				oldOutputs = tt.args.oldOutputs
+				oldOutputs = oldOutputs.DeepCopy()
+				oldOutputs.SetName("old-outputs-name")
+			}
+			client, disco, mapper, clientset := fake.NewSimpleDynamicClient(fake.WithObjects(oldOutputs))
+			resources, err := openapi.GetResourceSchemasForClient(disco)
+			require.NoError(t, err)
+
+			if tt.client.GenericClientF != nil {
+				client.GenericClient = tt.client.GenericClientF(client.GenericClient)
+			}
+			if tt.client.RESTMapperF != nil {
+				client.RESTMapper = tt.client.RESTMapperF(client.RESTMapper)
+			}
+
+			urn := resource.NewURN(tokens.QName("teststack"), tokens.PackageName("testproj"), tokens.Type(""), tt.args.resType, "testresource")
+			config := UpdateConfig{
+				ProviderConfig: ProviderConfig{
+					Context:           context.Background(),
+					Host:              host,
+					URN:               urn,
+					InitialAPIVersion: corev1.SchemeGroupVersion.String(),
+					FieldManager:      "test",
+					ClusterVersion:    testServerVersion,
+					ClientSet:         client,
+					DedupLogger:       logging.NewLogger(context.Background(), host, urn),
+					Resources:         resources,
+					ServerSideApply:   tt.args.serverSideApply,
+					awaiters:          map[string]awaitSpec{},
+				},
+				OldInputs:  oldInputs,
+				OldOutputs: oldOutputs,
+				Inputs:     tt.args.inputs,
+				Preview:    tt.args.preview,
+			}
+			testCtx := testCtx{
+				host:   host,
+				config: &config,
+				disco:  disco,
+				mapper: mapper,
+				client: clientset,
+			}
+			if tt.awaiter != nil {
+				id := fmt.Sprintf("%s/%s", tt.args.inputs.GetAPIVersion(), tt.args.inputs.GetKind())
+				config.awaiters[id] = awaitSpec{
+					await: tt.awaiter(t, testCtx),
+				}
+			}
+			actual, err := Update(config)
+			for _, e := range tt.expect {
+				e(t, testCtx, actual, err)
+			}
+		})
+	}
+}
+
+func TestDeletion(t *testing.T) {
 	type testCtx struct {
 		ctx    context.Context
 		cancel context.CancelFunc

--- a/provider/pkg/await/await_test.go
+++ b/provider/pkg/await/await_test.go
@@ -108,8 +108,8 @@ func Test_Creation(t *testing.T) {
 
 	// awaiters
 
-	touch := func(t *testing.T, ctx testCtx) createAwaiter {
-		return func(cac createAwaitConfig) error {
+	touch := func(t *testing.T, ctx testCtx) awaiter {
+		return func(cac awaitConfig) error {
 			require.False(t, metadata.SkipAwaitLogic(cac.currentOutputs), "Await logic should not execute when SkipWait is set")
 
 			// get the live object from the fake API Server
@@ -131,14 +131,14 @@ func Test_Creation(t *testing.T) {
 		}
 	}
 
-	awaitError := func(t *testing.T, ctx testCtx) createAwaiter {
-		return func(cac createAwaitConfig) error {
+	awaitError := func(t *testing.T, ctx testCtx) awaiter {
+		return func(cac awaitConfig) error {
 			return serviceUnavailableErr
 		}
 	}
 
-	awaitUnexpected := func(t *testing.T, ctx testCtx) createAwaiter {
-		return func(cac createAwaitConfig) error {
+	awaitUnexpected := func(t *testing.T, ctx testCtx) awaiter {
+		return func(cac awaitConfig) error {
 			require.Fail(t, "Unexpected call to awaiter")
 			return nil
 		}
@@ -192,7 +192,7 @@ func Test_Creation(t *testing.T) {
 		client  client
 		args    args
 		expect  []expectF
-		awaiter func(t *testing.T, ctx testCtx) createAwaiter
+		awaiter func(t *testing.T, ctx testCtx) awaiter
 	}{
 		{
 			name: "NoMatchError",
@@ -341,7 +341,7 @@ func Test_Creation(t *testing.T) {
 			if tt.awaiter != nil {
 				id := fmt.Sprintf("%s/%s", tt.args.inputs.GetAPIVersion(), tt.args.inputs.GetKind())
 				config.awaiters[id] = awaitSpec{
-					awaitCreation: tt.awaiter(t, testCtx),
+					await: tt.awaiter(t, testCtx),
 				}
 			}
 			actual, err := Creation(config)

--- a/provider/pkg/await/daemonset.go
+++ b/provider/pkg/await/daemonset.go
@@ -66,13 +66,13 @@ const (
 // Importantly, this means OnDelete rollouts will wait until pods have been
 // manually cleaned up unless the skipAwait annotation is present.
 type dsAwaiter struct {
-	config  updateAwaitConfig
+	config  createAwaitConfig
 	ds      *unstructured.Unstructured
 	deleted bool
 }
 
 // newDaemonSetAwaiter returns a new dsAwaiter.
-func newDaemonSetAwaiter(c updateAwaitConfig) *dsAwaiter {
+func newDaemonSetAwaiter(c createAwaitConfig) *dsAwaiter {
 	return &dsAwaiter{
 		config: c,
 		ds:     c.currentOutputs,

--- a/provider/pkg/await/daemonset.go
+++ b/provider/pkg/await/daemonset.go
@@ -66,13 +66,13 @@ const (
 // Importantly, this means OnDelete rollouts will wait until pods have been
 // manually cleaned up unless the skipAwait annotation is present.
 type dsAwaiter struct {
-	config  createAwaitConfig
+	config  awaitConfig
 	ds      *unstructured.Unstructured
 	deleted bool
 }
 
 // newDaemonSetAwaiter returns a new dsAwaiter.
-func newDaemonSetAwaiter(c createAwaitConfig) *dsAwaiter {
+func newDaemonSetAwaiter(c awaitConfig) *dsAwaiter {
 	return &dsAwaiter{
 		config: c,
 		ds:     c.currentOutputs,

--- a/provider/pkg/await/deployment.go
+++ b/provider/pkg/await/deployment.go
@@ -107,7 +107,7 @@ const (
 )
 
 type deploymentInitAwaiter struct {
-	config                 updateAwaitConfig
+	config                 createAwaitConfig
 	deploymentAvailable    bool
 	replicaSetAvailable    bool
 	pvcsAvailable          bool
@@ -122,7 +122,7 @@ type deploymentInitAwaiter struct {
 	pvcs        map[string]*unstructured.Unstructured
 }
 
-func makeDeploymentInitAwaiter(c updateAwaitConfig) *deploymentInitAwaiter {
+func makeDeploymentInitAwaiter(c createAwaitConfig) *deploymentInitAwaiter {
 	return &deploymentInitAwaiter{
 		config:                 c,
 		deploymentAvailable:    false,

--- a/provider/pkg/await/deployment.go
+++ b/provider/pkg/await/deployment.go
@@ -107,7 +107,7 @@ const (
 )
 
 type deploymentInitAwaiter struct {
-	config                 createAwaitConfig
+	config                 awaitConfig
 	deploymentAvailable    bool
 	replicaSetAvailable    bool
 	pvcsAvailable          bool
@@ -122,7 +122,7 @@ type deploymentInitAwaiter struct {
 	pvcs        map[string]*unstructured.Unstructured
 }
 
-func makeDeploymentInitAwaiter(c createAwaitConfig) *deploymentInitAwaiter {
+func makeDeploymentInitAwaiter(c awaitConfig) *deploymentInitAwaiter {
 	return &deploymentInitAwaiter{
 		config:                 c,
 		deploymentAvailable:    false,

--- a/provider/pkg/await/deployment_test.go
+++ b/provider/pkg/await/deployment_test.go
@@ -599,9 +599,8 @@ func Test_Apps_Deployment(t *testing.T) {
 
 	for _, test := range tests {
 		awaiter := makeDeploymentInitAwaiter(
-			updateAwaitConfig{
-				createAwaitConfig: mockAwaitConfig(deploymentInput(inputNamespace, deploymentInputName)),
-			})
+			mockAwaitConfig(deploymentInput(inputNamespace, deploymentInputName)),
+		)
 		deployments := make(chan watch.Event)
 		replicaSets := make(chan watch.Event)
 		pods := make(chan watch.Event)
@@ -657,9 +656,8 @@ func Test_Apps_Deployment_With_PersistentVolumeClaims(t *testing.T) {
 
 	for _, test := range tests {
 		awaiter := makeDeploymentInitAwaiter(
-			updateAwaitConfig{
-				createAwaitConfig: mockAwaitConfig(deploymentWithPVCInput(inputNamespace, deploymentInputName, pvcInputName)),
-			})
+			mockAwaitConfig(deploymentWithPVCInput(inputNamespace, deploymentInputName, pvcInputName)),
+		)
 		// Channels should be buffered to avoid blocking.
 		deployments := make(chan watch.Event)
 		replicaSets := make(chan watch.Event)
@@ -711,9 +709,8 @@ func Test_Apps_Deployment_Without_PersistentVolumeClaims(t *testing.T) {
 
 	for _, test := range tests {
 		awaiter := makeDeploymentInitAwaiter(
-			updateAwaitConfig{
-				createAwaitConfig: mockAwaitConfig(deploymentInput(inputNamespace, deploymentInputName)),
-			})
+			mockAwaitConfig(deploymentInput(inputNamespace, deploymentInputName)),
+		)
 		deployments := make(chan watch.Event)
 		replicaSets := make(chan watch.Event)
 		pods := make(chan watch.Event)
@@ -782,10 +779,8 @@ func Test_Apps_Deployment_MultipleUpdates(t *testing.T) {
 
 	for _, test := range tests {
 		awaiter := makeDeploymentInitAwaiter(
-			updateAwaitConfig{
-				createAwaitConfig: mockAwaitConfig(test.outputs()),
-				lastOutputs:       test.outputs(),
-			})
+			mockUpdateConfig(test.outputs(), test.outputs()),
+		)
 		deployments := make(chan watch.Event)
 		replicaSets := make(chan watch.Event)
 		pods := make(chan watch.Event)
@@ -934,9 +929,8 @@ func Test_Core_Deployment_Read(t *testing.T) {
 
 	for _, test := range tests {
 		awaiter := makeDeploymentInitAwaiter(
-			updateAwaitConfig{
-				createAwaitConfig: mockAwaitConfig(deploymentInput("default", "foo-4setj4y6")),
-			})
+			mockAwaitConfig(deploymentInput("default", "foo-4setj4y6")),
+		)
 		service := test.deployment("default", "foo-4setj4y6", test.deploymentRevision)
 		replicaset := test.replicaset("default", "foo-4setj4y6", "foo-4setj4y6", test.replicaSetRevision)
 		err := awaiter.read(service, unstructuredList(*replicaset), unstructuredList(), unstructuredList())

--- a/provider/pkg/await/ingress.go
+++ b/provider/pkg/await/ingress.go
@@ -96,10 +96,6 @@ func awaitIngressRead(c createAwaitConfig) error {
 	return makeIngressInitAwaiter(c).Read()
 }
 
-func awaitIngressUpdate(u updateAwaitConfig) error {
-	return makeIngressInitAwaiter(u.createAwaitConfig).Await()
-}
-
 func (iia *ingressInitAwaiter) Await() error {
 	//
 	// We succeed only when all of the following are true:

--- a/provider/pkg/await/ingress.go
+++ b/provider/pkg/await/ingress.go
@@ -68,7 +68,7 @@ const (
 )
 
 type ingressInitAwaiter struct {
-	config                    createAwaitConfig
+	config                    awaitConfig
 	ingress                   *unstructured.Unstructured
 	ingressReady              bool
 	endpointsSettled          bool
@@ -77,7 +77,7 @@ type ingressInitAwaiter struct {
 	knownExternalNameServices sets.Set[string]
 }
 
-func makeIngressInitAwaiter(c createAwaitConfig) *ingressInitAwaiter {
+func makeIngressInitAwaiter(c awaitConfig) *ingressInitAwaiter {
 	return &ingressInitAwaiter{
 		config:                    c,
 		ingress:                   c.currentOutputs,
@@ -88,11 +88,11 @@ func makeIngressInitAwaiter(c createAwaitConfig) *ingressInitAwaiter {
 	}
 }
 
-func awaitIngressInit(c createAwaitConfig) error {
+func awaitIngressInit(c awaitConfig) error {
 	return makeIngressInitAwaiter(c).Await()
 }
 
-func awaitIngressRead(c createAwaitConfig) error {
+func awaitIngressRead(c awaitConfig) error {
 	return makeIngressInitAwaiter(c).Read()
 }
 

--- a/provider/pkg/await/job.go
+++ b/provider/pkg/await/job.go
@@ -80,14 +80,14 @@ const (
 
 type jobInitAwaiter struct {
 	job      *unstructured.Unstructured
-	config   createAwaitConfig
+	config   awaitConfig
 	checker  *checker.StateChecker
 	errors   logging.TimeOrderedLogSet
 	resource *unstructured.Unstructured
 	ready    bool
 }
 
-func makeJobInitAwaiter(c createAwaitConfig) *jobInitAwaiter {
+func makeJobInitAwaiter(c awaitConfig) *jobInitAwaiter {
 	return &jobInitAwaiter{
 		config:   c,
 		job:      c.currentOutputs,

--- a/provider/pkg/await/pod.go
+++ b/provider/pkg/await/pod.go
@@ -106,13 +106,13 @@ const (
 
 type podInitAwaiter struct {
 	pod      *unstructured.Unstructured
-	config   createAwaitConfig
+	config   awaitConfig
 	checker  *checker.StateChecker
 	ready    bool
 	messages logging.Messages
 }
 
-func makePodInitAwaiter(c createAwaitConfig) *podInitAwaiter {
+func makePodInitAwaiter(c awaitConfig) *podInitAwaiter {
 	return &podInitAwaiter{
 		config:  c,
 		pod:     c.currentOutputs,
@@ -132,11 +132,11 @@ func (pia *podInitAwaiter) errorMessages() []string {
 	return messages
 }
 
-func awaitPodInit(c createAwaitConfig) error {
+func awaitPodInit(c awaitConfig) error {
 	return makePodInitAwaiter(c).Await()
 }
 
-func awaitPodRead(c createAwaitConfig) error {
+func awaitPodRead(c awaitConfig) error {
 	return makePodInitAwaiter(c).Read()
 }
 

--- a/provider/pkg/await/pod.go
+++ b/provider/pkg/await/pod.go
@@ -140,10 +140,6 @@ func awaitPodRead(c createAwaitConfig) error {
 	return makePodInitAwaiter(c).Read()
 }
 
-func awaitPodUpdate(u updateAwaitConfig) error {
-	return makePodInitAwaiter(u.createAwaitConfig).Await()
-}
-
 func (pia *podInitAwaiter) Await() error {
 	stopper := make(chan struct{})
 	defer close(stopper)

--- a/provider/pkg/await/service.go
+++ b/provider/pkg/await/service.go
@@ -80,7 +80,7 @@ const (
 )
 
 type serviceInitAwaiter struct {
-	config           createAwaitConfig
+	config           awaitConfig
 	service          *unstructured.Unstructured
 	serviceReady     bool
 	endpointsReady   bool
@@ -88,7 +88,7 @@ type serviceInitAwaiter struct {
 	serviceType      string
 }
 
-func makeServiceInitAwaiter(c createAwaitConfig) *serviceInitAwaiter {
+func makeServiceInitAwaiter(c awaitConfig) *serviceInitAwaiter {
 	specType, _ := openapi.Pluck(c.currentOutputs.Object, "spec", "type")
 	var t string
 	if specTypeString, isString := specType.(string); isString {
@@ -108,11 +108,11 @@ func makeServiceInitAwaiter(c createAwaitConfig) *serviceInitAwaiter {
 	}
 }
 
-func awaitServiceInit(c createAwaitConfig) error {
+func awaitServiceInit(c awaitConfig) error {
 	return makeServiceInitAwaiter(c).Await()
 }
 
-func awaitServiceRead(c createAwaitConfig) error {
+func awaitServiceRead(c awaitConfig) error {
 	return makeServiceInitAwaiter(c).Read()
 }
 

--- a/provider/pkg/await/service.go
+++ b/provider/pkg/await/service.go
@@ -116,10 +116,6 @@ func awaitServiceRead(c createAwaitConfig) error {
 	return makeServiceInitAwaiter(c).Read()
 }
 
-func awaitServiceUpdate(u updateAwaitConfig) error {
-	return makeServiceInitAwaiter(u.createAwaitConfig).Await()
-}
-
 func (sia *serviceInitAwaiter) Await() error {
 	//
 	// We succeed only when all of the following are true:

--- a/provider/pkg/await/statefulset.go
+++ b/provider/pkg/await/statefulset.go
@@ -151,7 +151,7 @@ const (
 )
 
 type statefulsetInitAwaiter struct {
-	config            createAwaitConfig
+	config            awaitConfig
 	revisionReady     bool
 	replicasReady     bool
 	currentGeneration int64
@@ -164,7 +164,7 @@ type statefulsetInitAwaiter struct {
 	targetRevision  string
 }
 
-func makeStatefulSetInitAwaiter(c createAwaitConfig) *statefulsetInitAwaiter {
+func makeStatefulSetInitAwaiter(c awaitConfig) *statefulsetInitAwaiter {
 	return &statefulsetInitAwaiter{
 		config:        c,
 		revisionReady: false,

--- a/provider/pkg/await/statefulset.go
+++ b/provider/pkg/await/statefulset.go
@@ -151,7 +151,7 @@ const (
 )
 
 type statefulsetInitAwaiter struct {
-	config            updateAwaitConfig
+	config            createAwaitConfig
 	revisionReady     bool
 	replicasReady     bool
 	currentGeneration int64
@@ -164,7 +164,7 @@ type statefulsetInitAwaiter struct {
 	targetRevision  string
 }
 
-func makeStatefulSetInitAwaiter(c updateAwaitConfig) *statefulsetInitAwaiter {
+func makeStatefulSetInitAwaiter(c createAwaitConfig) *statefulsetInitAwaiter {
 	return &statefulsetInitAwaiter{
 		config:        c,
 		revisionReady: false,

--- a/provider/pkg/await/statefulset_test.go
+++ b/provider/pkg/await/statefulset_test.go
@@ -252,9 +252,8 @@ func Test_Apps_StatefulSet(t *testing.T) {
 
 	for _, test := range tests {
 		awaiter := makeStatefulSetInitAwaiter(
-			updateAwaitConfig{
-				createAwaitConfig: mockAwaitConfig(statefulsetInput(inputNamespace, inputName, targetService, "")),
-			})
+			mockAwaitConfig(statefulsetInput(inputNamespace, inputName, targetService, "")),
+		)
 		statefulsets := make(chan watch.Event)
 		pods := make(chan watch.Event)
 
@@ -305,10 +304,8 @@ func Test_Apps_StatefulSet_MultipleUpdates(t *testing.T) {
 
 	for _, test := range tests {
 		awaiter := makeStatefulSetInitAwaiter(
-			updateAwaitConfig{
-				createAwaitConfig: mockAwaitConfig(test.outputs()),
-				lastOutputs:       statefulsetFailed(),
-			})
+			mockUpdateConfig(test.outputs(), statefulsetFailed()),
+		)
 		statefulsets := make(chan watch.Event)
 		pods := make(chan watch.Event)
 
@@ -369,9 +366,8 @@ func Test_Apps_StatefulSetRead(t *testing.T) {
 
 	for _, test := range tests {
 		awaiter := makeStatefulSetInitAwaiter(
-			updateAwaitConfig{
-				createAwaitConfig: mockAwaitConfig(statefulsetInput(inputNamespace, inputName, targetService, "")),
-			})
+			mockAwaitConfig(statefulsetInput(inputNamespace, inputName, targetService, "")),
+		)
 		statefulset := test.statefulset(inputNamespace, inputName, targetService, "")
 		err := awaiter.read(statefulset, unstructuredList())
 		if test.expectedSubErrors != nil {

--- a/provider/pkg/await/util_test.go
+++ b/provider/pkg/await/util_test.go
@@ -16,15 +16,15 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-func mockAwaitConfig(outputs *unstructured.Unstructured) createAwaitConfig {
-	return createAwaitConfig{
+func mockAwaitConfig(outputs *unstructured.Unstructured) awaitConfig {
+	return awaitConfig{
 		ctx:            context.Background(),
 		currentOutputs: outputs,
 		logger:         logging.NewLogger(context.Background(), nil, ""),
 	}
 }
 
-func mockUpdateConfig(outputs *unstructured.Unstructured, previous *unstructured.Unstructured) createAwaitConfig {
+func mockUpdateConfig(outputs *unstructured.Unstructured, previous *unstructured.Unstructured) awaitConfig {
 	c := mockAwaitConfig(outputs)
 	c.lastOutputs = previous
 	return c

--- a/provider/pkg/await/util_test.go
+++ b/provider/pkg/await/util_test.go
@@ -24,6 +24,12 @@ func mockAwaitConfig(outputs *unstructured.Unstructured) createAwaitConfig {
 	}
 }
 
+func mockUpdateConfig(outputs *unstructured.Unstructured, previous *unstructured.Unstructured) createAwaitConfig {
+	c := mockAwaitConfig(outputs)
+	c.lastOutputs = previous
+	return c
+}
+
 func decodeUnstructured(text string) (*unstructured.Unstructured, error) {
 	obj, _, err := unstructured.UnstructuredJSONScheme.Decode([]byte(text), nil, nil)
 	if err != nil {


### PR DESCRIPTION
There's no functional difference between our "update" and "create" await logic
-- in every case, our update awaiters simply invoke the create awaiter, or vice
versa.

(The only minor exception to this is `untilCoreV1ResourceQuotaUpdated`, which
has a little logic to [short-circuit] but otherwise still calls into the
corresponding create awaiter.)

This PR consolidates the create/update configs into one. This will make it more
straightforward to glue together our legacy awaiters.

The first commit replaces `updateAwaitConfig` with `createAwaitConfig`, and the
second commit is just renaming.

The third commit adds test coverage for the `Update` path, essentially
copy-pasted from the `Creation` tests. This will help guarantee that subsequent
PRs preserve existing behavior.

Fixes https://github.com/pulumi/pulumi-kubernetes/issues/2799.
Refs https://github.com/pulumi/pulumi-kubernetes/issues/2824.

[short-circuit]: https://github.com/pulumi/pulumi-kubernetes/blob/06b05ce7a3fb5358bdc03a1d105c42a6c695363f/provider/pkg/await/awaiters.go#L686-L691
