### PR TITLE
Makefile: make install_provider depend on k8sprovider

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ lint::
 		pushd $$DIR  > /dev/null; golangci-lint run -c ../.golangci.yml --timeout 10m; popd  > /dev/null; \
 	done
 
-install_provider::
+install_provider:: k8sprovider
 	cp $(WORKING_DIR)/bin/${PROVIDER} ${GOPATH}/bin
 
 install:: install_nodejs_sdk install_dotnet_sdk install_provider


### PR DESCRIPTION
The install_provider target will not be able to do anything without building the k8s provider.  Specify this dependency in the Makefile to make this easier for developers.