### PR TITLE
Prepare for v4.16.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 4.16.0 (August 7, 2024)
+
 ### Added
 
 - `clusterIdentifier` configuration can now be used to manually control the
@@ -26,12 +28,12 @@
 ### Fixed
 
 - Updated logic to accurately detect if a resource is a Patch variant. (https://github.com/pulumi/pulumi-kubernetes/pull/3102)
-- Added java as supported language for CustomResource overlays. (https://github.com/pulumi/pulumi-kubernetes/pull/3120)
+- Added Java as a supported language for `CustomResource` overlays. (https://github.com/pulumi/pulumi-kubernetes/pull/3120)
 - Status messages reported during updates are now more accurately scoped to the
   affected resource. (https://github.com/pulumi/pulumi-kubernetes/pull/3128)
 - `PersistentVolumeClaims` with a bind mode of `WaitForFirstConsumer` will no
   longer hang indefinitely. (https://github.com/pulumi/pulumi-kubernetes/pull/3130)
-- [sdk/java] Child resource cannot be registered by Chart v4 (https://github.com/pulumi/pulumi-kubernetes/pull/3119)
+- [java] Fixed an issue where child resources could not be registered by Chart v4. (https://github.com/pulumi/pulumi-kubernetes/pull/3119)
 
 ## 4.15.0 (July 9, 2024)
 


### PR DESCRIPTION
### Added

- `clusterIdentifier` configuration can now be used to manually control the replacement behavior of a provider resource. (https://github.com/pulumi/pulumi-kubernetes/pull/3068)

- Pod errors now include the pod's last termination state, as well as the pod's termination message if available. (https://github.com/pulumi/pulumi-kubernetes/pull/3091)

  The pod's termination message can be helpful in `CrashLoopBackOff` situations but will only be reported if it was correctly configured.

  By default, the pod's termination message is read from `/dev/termination-log`. This location can be configured with `terminationMessagePath`.

  Use `terminationMessagePolicy: FallbackToLogsOnError` to use the pod's logs as its termination message.

- Documentation is now generated for all languages supported by overlay types. (https://github.com/pulumi/pulumi-kubernetes/pull/3107)

### Fixed

- Updated logic to accurately detect if a resource is a Patch variant. (https://github.com/pulumi/pulumi-kubernetes/pull/3102)
- Added Java as a supported language for `CustomResource` overlays. (https://github.com/pulumi/pulumi-kubernetes/pull/3120)
- Status messages reported during updates are now more accurately scoped to the
  affected resource. (https://github.com/pulumi/pulumi-kubernetes/pull/3128)
- `PersistentVolumeClaims` with a bind mode of `WaitForFirstConsumer` will no
  longer hang indefinitely. (https://github.com/pulumi/pulumi-kubernetes/pull/3130)
- [java] Fixed an issue where child resources could not be registered by Chart v4. (https://github.com/pulumi/pulumi-kubernetes/pull/3119)