### PR TITLE
Add functionality for non-ephemeral de-duped logs

### DIFF
--- a/provider/pkg/await/awaiters.go
+++ b/provider/pkg/await/awaiters.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/jonboulle/clockwork"
-	checkerlog "github.com/pulumi/cloud-ready-checks/pkg/checker/logging"
 	"github.com/pulumi/pulumi-kubernetes/provider/v4/pkg/clients"
 	"github.com/pulumi/pulumi-kubernetes/provider/v4/pkg/cluster"
 	"github.com/pulumi/pulumi-kubernetes/provider/v4/pkg/logging"
@@ -51,14 +50,6 @@ type createAwaitConfig struct {
 	timeout           *time.Duration
 	clusterVersion    *cluster.ServerVersion
 	clock             clockwork.Clock
-}
-
-func (cac *createAwaitConfig) logStatus(sev diag.Severity, message string) {
-	cac.logMessage(checkerlog.Message{S: message, Severity: sev})
-}
-
-func (cac *createAwaitConfig) logMessage(message checkerlog.Message) {
-	cac.logger.LogMessage(message)
 }
 
 // Clock returns a real or mock clock for the config as appropriate.

--- a/provider/pkg/await/awaiters.go
+++ b/provider/pkg/await/awaiters.go
@@ -453,9 +453,9 @@ func untilCoreV1PersistentVolumeInitialized(c createAwaitConfig) error {
 		phase, _ := openapi.Pluck(pv.Object, "status", "phase")
 		logger.V(3).Infof("Persistent volume %q status received: %#v", pv.GetName(), phase)
 		if phase == available {
-			c.logStatus(diag.Info, "✅ PV marked available")
+			c.logger.LogStatus(diag.Info, "✅ PV marked available")
 		} else if phase == bound {
-			c.logStatus(diag.Info, "✅ PV has been bound")
+			c.logger.LogStatus(diag.Info, "✅ PV has been bound")
 		}
 		return phase == available || phase == bound
 	}
@@ -481,7 +481,7 @@ func untilCoreV1PersistentVolumeClaimReady(c createAwaitConfig) error {
 		if bindMode == "" {
 			b, err := pvcBindMode(c.ctx, c.clientSet, pvc)
 			if err != nil {
-				c.logStatus(diag.Warning, err.Error())
+				c.logger.LogStatus(diag.Warning, err.Error())
 			}
 			bindMode = b
 		}

--- a/provider/pkg/await/daemonset.go
+++ b/provider/pkg/await/daemonset.go
@@ -108,7 +108,7 @@ func (dsa *dsAwaiter) Delete() error {
 			return true
 		}
 		misscheduled, _ := openapi.Pluck(dsa.ds.Object, "status", "numberMisscheduled")
-		dsa.config.logStatus(
+		dsa.config.logger.LogStatus(
 			diag.Info,
 			fmt.Sprintf(
 				"DaemonSet %q still exists (%v pods misscheduled)",
@@ -240,18 +240,18 @@ func (dsa *dsAwaiter) await(done func() bool) error {
 func (dsa *dsAwaiter) rolloutComplete() bool {
 	res, err := status.Compute(dsa.ds)
 	if err != nil {
-		dsa.config.logStatus(diag.Error, err.Error())
+		dsa.config.logger.LogStatus(diag.Error, err.Error())
 		return false
 	}
 
 	done := res.Status == status.CurrentStatus
 
 	if done {
-		dsa.config.logStatus(diag.Info, fmt.Sprintf("%s%s", cmdutil.EmojiOr("✅ ", ""), res.Message))
+		dsa.config.logger.LogStatus(diag.Info, fmt.Sprintf("%s%s", cmdutil.EmojiOr("✅ ", ""), res.Message))
 		return true
 	}
 
-	dsa.config.logStatus(diag.Info, res.Message)
+	dsa.config.logger.LogStatus(diag.Info, res.Message)
 	return false
 }
 
@@ -284,7 +284,7 @@ func (dsa *dsAwaiter) processDaemonSetEvent(event watch.Event) {
 // processPodMessages logs pod messages from a PodAggregator.
 func (dsa *dsAwaiter) processPodMessages(messages logging.Messages) {
 	for _, message := range messages {
-		dsa.config.logMessage(message)
+		dsa.config.logger.LogStatus(message.Severity, message.S)
 	}
 }
 

--- a/provider/pkg/await/deployment.go
+++ b/provider/pkg/await/deployment.go
@@ -362,7 +362,7 @@ func (dia *deploymentInitAwaiter) await(
 		case <-aggregateErrorTicker:
 			messages := dia.aggregatePodErrors()
 			for _, message := range messages {
-				dia.config.logMessage(message)
+				dia.config.logger.LogStatus(message.Severity, message.S)
 			}
 		case event := <-deploymentEvents:
 			dia.processDeploymentEvent(event)
@@ -440,7 +440,7 @@ func (dia *deploymentInitAwaiter) checkAndLogStatus() bool {
 				return false
 			}
 
-			dia.config.logStatus(diag.Info,
+			dia.config.logger.LogStatus(diag.Info,
 				fmt.Sprintf("%sDeployment initialization complete", cmdutil.EmojiOr("✅ ", "")))
 			return true
 		}
@@ -450,7 +450,7 @@ func (dia *deploymentInitAwaiter) checkAndLogStatus() bool {
 				return false
 			}
 
-			dia.config.logStatus(diag.Info,
+			dia.config.logger.LogStatus(diag.Info,
 				fmt.Sprintf("%sDeployment initialization complete", cmdutil.EmojiOr("✅ ", "")))
 			return true
 		}
@@ -546,7 +546,7 @@ func (dia *deploymentInitAwaiter) processDeploymentEvent(event watch.Event) {
 				}
 				message = fmt.Sprintf("[%s] %s", reason, message)
 				dia.deploymentErrors[reason] = message
-				dia.config.logStatus(diag.Warning, message)
+				dia.config.logger.LogStatus(diag.Warning, message)
 			}
 
 			dia.replicaSetAvailable = condition["reason"] == "NewReplicaSetAvailable" && isProgressing
@@ -567,7 +567,7 @@ func (dia *deploymentInitAwaiter) processDeploymentEvent(event watch.Event) {
 				}
 				message = fmt.Sprintf("[%s] %s", reason, message)
 				dia.deploymentErrors[reason] = message
-				dia.config.logStatus(diag.Warning, message)
+				dia.config.logger.LogStatus(diag.Warning, message)
 			}
 		}
 	}
@@ -714,14 +714,14 @@ func (dia *deploymentInitAwaiter) checkReplicaSetStatus() {
 	}
 
 	if !dia.updatedReplicaSetReady {
-		dia.config.logStatus(
+		dia.config.logger.LogStatus(
 			diag.Info,
 			fmt.Sprintf("Waiting for app ReplicaSet to be available (%d/%d Pods available)",
 				readyReplicas, specReplicas))
 	}
 
 	if dia.updatedReplicaSetReady && specReplicasExists && specReplicas == 0 {
-		dia.config.logStatus(
+		dia.config.logger.LogStatus(
 			diag.Warning,
 			fmt.Sprintf("Replicas scaled to 0 for Deployment %q", dia.deployment.GetName()))
 	}
@@ -754,7 +754,7 @@ func (dia *deploymentInitAwaiter) checkPersistentVolumeClaimStatus() {
 			allPVCsReady = false
 			message := fmt.Sprintf(
 				"PersistentVolumeClaim: [%s] is not ready. status.phase currently at: %s", pvc.GetName(), phase)
-			dia.config.logStatus(diag.Warning, message)
+			dia.config.logger.LogStatus(diag.Warning, message)
 		}
 	}
 

--- a/provider/pkg/await/job.go
+++ b/provider/pkg/await/job.go
@@ -188,7 +188,7 @@ func (jia *jobInitAwaiter) Read() error {
 	messages := podAggregator.Read()
 	for _, message := range messages {
 		jia.errors.Add(message)
-		jia.config.logMessage(message)
+		jia.config.logger.LogStatus(message.Severity, message.S)
 	}
 
 	return &initializationError{
@@ -220,7 +220,7 @@ func (jia *jobInitAwaiter) processJobEvent(event watch.Event) error {
 		jia.errors.Add(message)
 	}
 	for _, result := range results {
-		jia.config.logStatus(diag.Info, result.Description)
+		jia.config.logger.LogStatus(diag.Info, result.Description)
 	}
 
 	if len(messages.Errors()) > 0 {
@@ -242,7 +242,7 @@ func (jia *jobInitAwaiter) processPodMessages(messages checkerlog.Messages) {
 		if strings.Contains(message.S, "containers with unready status") {
 			continue
 		}
-		jia.config.logMessage(message)
+		jia.config.logger.LogStatus(message.Severity, message.S)
 	}
 }
 

--- a/provider/pkg/await/pod.go
+++ b/provider/pkg/await/pod.go
@@ -231,6 +231,6 @@ func (pia *podInitAwaiter) processPodEvent(event watch.Event) {
 	pia.ready, results = pia.checker.ReadyDetails(pod)
 	pia.messages = results.Messages()
 	for _, result := range results {
-		pia.config.logStatus(diag.Info, result.Description)
+		pia.config.logger.LogStatus(diag.Info, result.Description)
 	}
 }

--- a/provider/pkg/await/service.go
+++ b/provider/pkg/await/service.go
@@ -232,7 +232,7 @@ func (sia *serviceInitAwaiter) await(
 	settled chan struct{},
 	version cluster.ServerVersion,
 ) error {
-	sia.config.logStatus(diag.Info, "[1/3] Finding Pods to direct traffic to")
+	sia.config.logger.LogStatus(diag.Info, "[1/3] Finding Pods to direct traffic to")
 
 	for {
 		// Check whether we've succeeded.
@@ -405,10 +405,10 @@ func (sia *serviceInitAwaiter) checkAndLogStatus() bool {
 
 	success := sia.serviceReady && sia.endpointsSettled && sia.endpointsReady
 	if success {
-		sia.config.logStatus(diag.Info,
+		sia.config.logger.LogStatus(diag.Info,
 			fmt.Sprintf("%sService initialization complete", cmdutil.EmojiOr("✅ ", "")))
 	} else if sia.endpointsSettled && sia.endpointsReady {
-		sia.config.logStatus(diag.Info, "[2/3] Attempting to allocate IP address to Service")
+		sia.config.logger.LogStatus(diag.Info, "[2/3] Attempting to allocate IP address to Service")
 	}
 
 	return success
@@ -422,14 +422,12 @@ func (sia *serviceInitAwaiter) makeClients() (
 	if err != nil {
 		return nil, nil, fmt.Errorf("Could not make client to read Service %q: %w",
 			sia.config.currentOutputs.GetName(), err)
-
 	}
 	endpointClient, err = clients.ResourceClient(
 		kinds.Endpoints, sia.config.currentOutputs.GetNamespace(), sia.config.clientSet)
 	if err != nil {
 		return nil, nil, fmt.Errorf("Could not make client to read Endpoints associated with Service %q: %w",
 			sia.config.currentOutputs.GetName(), err)
-
 	}
 
 	return serviceClient, endpointClient, nil

--- a/provider/pkg/logging/dedup_logger_test.go
+++ b/provider/pkg/logging/dedup_logger_test.go
@@ -1,0 +1,60 @@
+package logging
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/urn"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+)
+
+type mockhost struct {
+	status strings.Builder
+	perm   strings.Builder
+}
+
+func (h *mockhost) Log(_ context.Context, sev diag.Severity, urn resource.URN, msg string) error {
+	_, _ = h.perm.WriteString(fmt.Sprintf("%s (%s): %s\n", urn, sev, msg))
+	return nil
+}
+
+func (h *mockhost) LogStatus(_ context.Context, sev diag.Severity, urn resource.URN, msg string) error {
+	_, _ = h.status.WriteString(fmt.Sprintf("%s (%s): %s\n", urn, sev, msg))
+	return nil
+}
+
+func (*mockhost) EngineConn() *grpc.ClientConn { return nil }
+
+func TestDedupeLogger(t *testing.T) {
+	h := &mockhost{}
+	l := NewLogger(context.Background(), h, urn.New("stack", "proj", "", "type", "name"))
+
+	l.Log(diag.Warning, "first message")
+	l.Log(diag.Info, "second message")
+	l.Log(diag.Info, "second message")
+	l.Log(diag.Warning, "third message")
+	l.Log(diag.Warning, "first message")
+	l.Log(diag.Info, "second message")
+
+	l.LogStatus(diag.Warning, "first status message")
+	l.LogStatus(diag.Info, "second status message")
+	l.LogStatus(diag.Info, "second status message")
+	l.LogStatus(diag.Warning, "third status message")
+	l.LogStatus(diag.Warning, "first status message")
+	l.LogStatus(diag.Info, "second status message")
+
+	want := `urn:pulumi:stack::proj::type::name (warning): first message
+urn:pulumi:stack::proj::type::name (info): second message
+urn:pulumi:stack::proj::type::name (warning): third message
+urn:pulumi:stack::proj::type::name (warning): first status message
+urn:pulumi:stack::proj::type::name (info): second status message
+urn:pulumi:stack::proj::type::name (warning): third status message
+`
+
+	assert.Equal(t, want, h.perm.String()+h.status.String())
+}


### PR DESCRIPTION
First commit:
* Add a `Log` method to `DedupLogger` to enable emitting persistent logs.
* Modify `LogMessage` to take a severity/string instead of a `checkerlog.Message`. Depending directly on cloud-ready-checks like this is awkward, and we're going have check messages coming from other sources like kstatus so it doesn't make sense to couple these. 
* Remove log methods on `createAwaitConfig` since they were just mucking with `checkerlog.Message`.
* Rename `LogMessage` → `LogStatus` to make it clearer that these are ephemeral/status logs.
* Add a smoke test.

Second commit:
* Update `logMessage` and `logStatus` call sites to use the logger directly.