### PR TITLE
Prepare for v4.17.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 4.17.0 (August 13, 2024)
+
 ### Changed
 
 - Updated Kubernetes schemas and libraries to v1.31.0. (https://github.com/pulumi/pulumi-kubernetes/pull/3144)


### PR DESCRIPTION
### Changed 

- Updated Kubernetes schemas and libraries to v1.31.0. (https://github.com/pulumi/pulumi-kubernetes/pull/3144)

### Fixed

- `Services` with selectors targeting 0 `Pods` will no longer hang indefinitely. (https://github.com/pulumi/pulumi-kubernetes/issues/605)
- `Services` without selectors will no longer hang indefinitely. (https://github.com/pulumi/pulumi-kubernetes/issues/799)