### PR TITLE
Add option to treat secrets as mutable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 ## Unreleased
 
--  Make Secrets mutable unless marked explicitly (enabled with provider config option) (https://github.com/pulumi/pulumi-kubernetes/pull/1926)
-   *NOTE*: With this change, once `enableSecretMutable` is enabled, all data changes to Secrets will be seen as mutable (changes to `type` will still trigger a replacement). In this mode, you can opt-in to the previous replacement behavior for a particular Secret by setting its `replaceOnChanges` resource option to `[".stringData", ".data"]`.
-   By default, the provider will continue to treat Secrets as immutable, and will replace them if the `stringData` or `data` properties are changed.
+### Added
+
+- A new provider configuration option `enableSecretMutable` allows treating changes to `Secrets` as updates instead of replacements.
+  This is similar to the `enableConfigMapMutable` option.
+  The default replacement behavior can be preserved for a particular Secret by setting its `replaceOnChanges` resource option to `[".stringData", ".data"]`.
+  (https://github.com/pulumi/pulumi-kubernetes/issues/2291)
 
 ## 4.17.1 (August 16, 2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,24 @@
 
 ### Added
 
-- A new provider configuration option `enableSecretMutable` allows treating changes to `Secrets` as updates instead of replacements.
-  This is similar to the `enableConfigMapMutable` option.
-  The default replacement behavior can be preserved for a particular Secret by setting its `replaceOnChanges` resource option to `[".stringData", ".data"]`.
+- The new `enableSecretMutable` provider configuration option treats changes to
+  `Secrets` as updates instead of replacements (similar to the
+  `enableConfigMapMutable` option).
+
+  The default replacement behavior can be preserved for a particular `Secret`
+  by setting its `immutable` field to `true`.
   (https://github.com/pulumi/pulumi-kubernetes/issues/2291)
+
+  **Note:** These options (`enableSecretMutable` and `enableConfigMapMutable`)
+  may become the default behavior in a future v5 release of the provider.
+  Programs that depend on the replacement of `Secrets` and `ConfigMaps` (e.g.
+  to trigger updates for downstream dependencies like `Deployments`) are
+  recommended to explicitly specify `immutable: true`.
+
+### Fixed
+
+- The `immutable` field is now respected for `ConfigMaps` when the provider is configured with `enableConfigMapMutable`.
+  (https://github.com/pulumi/pulumi-kubernetes/issues/3181)
 
 ## 4.17.1 (August 16, 2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+-  Make Secrets mutable unless marked explicitly (enabled with provider config option) (https://github.com/pulumi/pulumi-kubernetes/pull/1926)
+   *NOTE*: With this change, once `enableSecretMutable` is enabled, all data changes to Secrets will be seen as mutable (changes to `type` will still trigger a replacement). In this mode, you can opt-in to the previous replacement behavior for a particular Secret by setting its `replaceOnChanges` resource option to `[".stringData", ".data"]`.
+   By default, the provider will continue to treat Secrets as immutable, and will replace them if the `stringData` or `data` properties are changed.
+
 ## 4.17.1 (August 16, 2024)
 
 ### Fixed

--- a/provider/pkg/clients/clients.go
+++ b/provider/pkg/clients/clients.go
@@ -316,10 +316,18 @@ func IsSecret(obj *unstructured.Unstructured) bool {
 	return (gvk.Group == corev1.GroupName || gvk.Group == "core") && gvk.Kind == string(kinds.Secret)
 }
 
-// IsConfigMap returns true if the resource is a configmap marked as immutable.
 func IsConfigMap(obj *unstructured.Unstructured) bool {
 	gvk := obj.GroupVersionKind()
 	return (gvk.Group == corev1.GroupName || gvk.Group == "core") && gvk.Kind == string(kinds.ConfigMap)
+}
+
+// Checks whether the given ConfigMap or Secret is marked as immutable.
+func IsImmutable(obj *unstructured.Unstructured) bool {
+	val, found, err := unstructured.NestedBool(obj.Object, "immutable")
+	if !found || err != nil {
+		val = false
+	}
+	return val
 }
 
 func GVRForGVK(mapper meta.RESTMapper, gvk schema.GroupVersionKind) (schema.GroupVersionResource, error) {

--- a/provider/pkg/clients/clients.go
+++ b/provider/pkg/clients/clients.go
@@ -311,22 +311,21 @@ func FindCRD(objs []unstructured.Unstructured, kind schema.GroupKind) *unstructu
 	return nil
 }
 
+// IsSecret returns true if the resource has a Secret GVK.
 func IsSecret(obj *unstructured.Unstructured) bool {
 	gvk := obj.GroupVersionKind()
 	return (gvk.Group == corev1.GroupName || gvk.Group == "core") && gvk.Kind == string(kinds.Secret)
 }
 
+// IsConfigMap returns true if the resource has a ConfigMap GVK.
 func IsConfigMap(obj *unstructured.Unstructured) bool {
 	gvk := obj.GroupVersionKind()
 	return (gvk.Group == corev1.GroupName || gvk.Group == "core") && gvk.Kind == string(kinds.ConfigMap)
 }
 
-// Checks whether the given ConfigMap or Secret is marked as immutable.
+// IsMutable returns true if given ConfigMap or Secret is marked as immutable.
 func IsImmutable(obj *unstructured.Unstructured) bool {
-	val, found, err := unstructured.NestedBool(obj.Object, "immutable")
-	if !found || err != nil {
-		val = false
-	}
+	val, _, _ := unstructured.NestedBool(obj.Object, "immutable")
 	return val
 }
 

--- a/provider/pkg/gen/schema.go
+++ b/provider/pkg/gen/schema.go
@@ -94,6 +94,10 @@ func PulumiSchema(swagger map[string]any) pschema.PackageSpec {
 					Description: "BETA FEATURE - If present and set to true, allow ConfigMaps to be mutated.\nThis feature is in developer preview, and is disabled by default.\n\nThis config can be specified in the following ways using this precedence:\n1. This `enableConfigMapMutable` parameter.\n2. The `PULUMI_K8S_ENABLE_CONFIGMAP_MUTABLE` environment variable.",
 					TypeSpec:    pschema.TypeSpec{Type: "boolean"},
 				},
+				"enableSecretMutable": {
+					Description: "BETA FEATURE - If present and set to true, allow Secrets to be mutated.\nThis feature is in developer preview, and is disabled by default.\n\nThis config can be specified in the following ways using this precedence:\n1. This `enableSecretMutable` parameter.\n2. The `PULUMI_K8S_ENABLE_SECRET_MUTABLE` environment variable.",
+					TypeSpec:    pschema.TypeSpec{Type: "boolean"},
+				},
 				"renderYamlToDirectory": {
 					Description: "BETA FEATURE - If present, render resource manifests to this directory. In this mode, resources will not\nbe created on a Kubernetes cluster, but the rendered manifests will be kept in sync with changes\nto the Pulumi program. This feature is in developer preview, and is disabled by default.\n\nNote that some computed Outputs such as status fields will not be populated\nsince the resources are not created on a Kubernetes cluster. These Output values will remain undefined,\nand may result in an error if they are referenced by other resources. Also note that any secret values\nused in these resources will be rendered in plaintext to the resulting YAML.",
 					TypeSpec:    pschema.TypeSpec{Type: "string"},
@@ -183,6 +187,15 @@ func PulumiSchema(swagger map[string]any) pschema.PackageSpec {
 						},
 					},
 					Description: "BETA FEATURE - If present and set to true, allow ConfigMaps to be mutated.\nThis feature is in developer preview, and is disabled by default.\n\nThis config can be specified in the following ways using this precedence:\n1. This `enableConfigMapMutable` parameter.\n2. The `PULUMI_K8S_ENABLE_CONFIGMAP_MUTABLE` environment variable.",
+					TypeSpec:    pschema.TypeSpec{Type: "boolean"},
+				},
+				"enableSecretMutable": {
+					DefaultInfo: &pschema.DefaultSpec{
+						Environment: []string{
+							"PULUMI_K8S_ENABLE_SECRET_MUTABLE",
+						},
+					},
+					Description: "BETA FEATURE - If present and set to true, allow Secrets to be mutated.\nThis feature is in developer preview, and is disabled by default.\n\nThis config can be specified in the following ways using this precedence:\n1. This `enableSecretMutable` parameter.\n2. The `PULUMI_K8S_ENABLE_SECRET_MUTABLE` environment variable.",
 					TypeSpec:    pschema.TypeSpec{Type: "boolean"},
 				},
 				"renderYamlToDirectory": {

--- a/provider/pkg/provider/diff.go
+++ b/provider/pkg/provider/diff.go
@@ -24,7 +24,9 @@ func (k *kubeProvider) forceNewProperties(obj *unstructured.Unstructured) []stri
 	props := metadataForceNewProperties(".metadata")
 	if group, groupExists := forceNew[gvk.Group]; groupExists {
 		if version, versionExists := group[gvk.Version]; versionExists {
-			if kindFields, kindExists := version[gvk.Kind]; kindExists {
+			if clients.IsSecret(obj) && !k.enableSecretMutable {
+				props = append(props, properties{".type", ".stringData", ".data"}...)
+			} else if kindFields, kindExists := version[gvk.Kind]; kindExists {
 				props = append(props, kindFields...)
 			} else if clients.IsConfigMap(obj) && !k.enableConfigMapMutable {
 				props = append(props, properties{".binaryData", ".data"}...)
@@ -151,8 +153,6 @@ var core = _versions{
 		},
 		"Secret": properties{
 			".type",
-			".stringData",
-			".data",
 		},
 		"Service": properties{
 			".spec.clusterIP",

--- a/provider/pkg/provider/diff.go
+++ b/provider/pkg/provider/diff.go
@@ -28,7 +28,7 @@ func (k *kubeProvider) forceNewProperties(obj *unstructured.Unstructured) []stri
 				props = append(props, properties{".type", ".stringData", ".data"}...)
 			} else if kindFields, kindExists := version[gvk.Kind]; kindExists {
 				props = append(props, kindFields...)
-			} else if clients.IsConfigMap(obj) && !k.enableConfigMapMutable {
+			} else if clients.IsConfigMap(obj) && !(k.enableConfigMapMutable && !clients.IsImmutable(obj)) {
 				props = append(props, properties{".binaryData", ".data"}...)
 			}
 		}

--- a/provider/pkg/provider/diff.go
+++ b/provider/pkg/provider/diff.go
@@ -24,7 +24,7 @@ func (k *kubeProvider) forceNewProperties(obj *unstructured.Unstructured) []stri
 	props := metadataForceNewProperties(".metadata")
 	if group, groupExists := forceNew[gvk.Group]; groupExists {
 		if version, versionExists := group[gvk.Version]; versionExists {
-			if clients.IsSecret(obj) && !k.enableSecretMutable {
+			if clients.IsSecret(obj) && !(k.enableSecretMutable && !clients.IsImmutable(obj)) {
 				props = append(props, properties{".type", ".stringData", ".data"}...)
 			} else if kindFields, kindExists := version[gvk.Kind]; kindExists {
 				props = append(props, kindFields...)

--- a/provider/pkg/provider/diff_test.go
+++ b/provider/pkg/provider/diff_test.go
@@ -195,6 +195,39 @@ func TestPatchToDiff(t *testing.T) {
 			},
 		},
 		{
+			name:  `Secret resources don't trigger a replace when mutable.`,
+			group: "core", version: "v1", kind: "Secret",
+			old: object{"data": object{"property1": "3"}},
+			new: object{"data": object{"property1": "4"}},
+			customizeProvider: func(p *kubeProvider) {
+				p.enableSecretMutable = true
+			},
+			expected: expected{
+				"data.property1": U,
+			},
+		},
+		{
+			name:  `Secret resources trigger a replace when enableSecretMutable is not set.`,
+			group: "core", version: "v1", kind: "Secret",
+			old: object{"data": object{"property1": "3"}},
+			new: object{"data": object{"property1": "4"}},
+			expected: expected{
+				"data.property1": UR,
+			},
+		},
+		{
+			name:  `Secret resources trigger a replace when type changes even if enableSecretMutable is set.`,
+			group: "core", version: "v1", kind: "Secret",
+			old: object{"type": "kubernetes.io/dockerconfigjson", "data": object{"property1": "3"}},
+			new: object{"type": "Opaque", "data": object{"property1": "3"}},
+			customizeProvider: func(p *kubeProvider) {
+				p.enableSecretMutable = true
+			},
+			expected: expected{
+				"type": UR,
+			},
+		},
+		{
 			name:  `Changing computed object values results in correct diff`,
 			group: "core", version: "v1", kind: "Pod",
 			old:    object{"spec": object{"containers": list{object{"name": "nginx", "image": "nginx"}}}},

--- a/provider/pkg/provider/diff_test.go
+++ b/provider/pkg/provider/diff_test.go
@@ -228,6 +228,18 @@ func TestPatchToDiff(t *testing.T) {
 			},
 		},
 		{
+			name:  `Secret resources trigger a replace when marked as immutable even if enableSecretMutable is set.`,
+			group: "core", version: "v1", kind: "Secret",
+			old: object{"data": object{"property1": "3"}, "immutable": true},
+			new: object{"data": object{"property1": "4"}, "immutable": true},
+			customizeProvider: func(p *kubeProvider) {
+				p.enableSecretMutable = true
+			},
+			expected: expected{
+				"data.property1": UR,
+			},
+		},
+		{
 			name:  `Changing computed object values results in correct diff`,
 			group: "core", version: "v1", kind: "Pod",
 			old:    object{"spec": object{"containers": list{object{"name": "nginx", "image": "nginx"}}}},

--- a/provider/pkg/provider/diff_test.go
+++ b/provider/pkg/provider/diff_test.go
@@ -195,6 +195,18 @@ func TestPatchToDiff(t *testing.T) {
 			},
 		},
 		{
+			name:  `ConfigMap resources trigger a replace when marked as immutable even when enableConfigMapMutable is set.`,
+			group: "core", version: "v1", kind: "ConfigMap",
+			old: object{"data": object{"property1": "3"}, "immutable": true},
+			new: object{"data": object{"property1": "4"}, "immutable": true},
+			customizeProvider: func(p *kubeProvider) {
+				p.enableConfigMapMutable = true
+			},
+			expected: expected{
+				"data.property1": UR,
+			},
+		},
+		{
 			name:  `Secret resources don't trigger a replace when mutable.`,
 			group: "core", version: "v1", kind: "Secret",
 			old: object{"data": object{"property1": "3"}},

--- a/sdk/dotnet/Config/Config.cs
+++ b/sdk/dotnet/Config/Config.cs
@@ -101,6 +101,21 @@ namespace Pulumi.Kubernetes
             set => _enableReplaceCRD.Set(value);
         }
 
+        private static readonly __Value<bool?> _enableSecretMutable = new __Value<bool?>(() => __config.GetBoolean("enableSecretMutable"));
+        /// <summary>
+        /// BETA FEATURE - If present and set to true, allow Secrets to be mutated.
+        /// This feature is in developer preview, and is disabled by default.
+        /// 
+        /// This config can be specified in the following ways using this precedence:
+        /// 1. This `enableSecretMutable` parameter.
+        /// 2. The `PULUMI_K8S_ENABLE_SECRET_MUTABLE` environment variable.
+        /// </summary>
+        public static bool? EnableSecretMutable
+        {
+            get => _enableSecretMutable.Get();
+            set => _enableSecretMutable.Set(value);
+        }
+
         private static readonly __Value<bool?> _enableServerSideApply = new __Value<bool?>(() => __config.GetBoolean("enableServerSideApply"));
         /// <summary>
         /// If present and set to false, disable Server-Side Apply mode.

--- a/sdk/dotnet/Provider.cs
+++ b/sdk/dotnet/Provider.cs
@@ -86,6 +86,17 @@ namespace Pulumi.Kubernetes
         public Input<bool>? EnableConfigMapMutable { get; set; }
 
         /// <summary>
+        /// BETA FEATURE - If present and set to true, allow Secrets to be mutated.
+        /// This feature is in developer preview, and is disabled by default.
+        /// 
+        /// This config can be specified in the following ways using this precedence:
+        /// 1. This `enableSecretMutable` parameter.
+        /// 2. The `PULUMI_K8S_ENABLE_SECRET_MUTABLE` environment variable.
+        /// </summary>
+        [Input("enableSecretMutable", json: true)]
+        public Input<bool>? EnableSecretMutable { get; set; }
+
+        /// <summary>
         /// If present and set to false, disable Server-Side Apply mode.
         /// See https://github.com/pulumi/pulumi-kubernetes/issues/2011 for additional details.
         /// </summary>
@@ -156,6 +167,7 @@ namespace Pulumi.Kubernetes
         {
             DeleteUnreachable = Utilities.GetEnvBoolean("PULUMI_K8S_DELETE_UNREACHABLE");
             EnableConfigMapMutable = Utilities.GetEnvBoolean("PULUMI_K8S_ENABLE_CONFIGMAP_MUTABLE");
+            EnableSecretMutable = Utilities.GetEnvBoolean("PULUMI_K8S_ENABLE_SECRET_MUTABLE");
             EnableServerSideApply = Utilities.GetEnvBoolean("PULUMI_K8S_ENABLE_SERVER_SIDE_APPLY");
             KubeConfig = Utilities.GetEnv("KUBECONFIG");
             SkipUpdateUnreachable = Utilities.GetEnvBoolean("PULUMI_K8S_SKIP_UPDATE_UNREACHABLE");

--- a/sdk/go/kubernetes/config/config.go
+++ b/sdk/go/kubernetes/config/config.go
@@ -52,6 +52,16 @@ func GetEnableReplaceCRD(ctx *pulumi.Context) bool {
 	return config.GetBool(ctx, "kubernetes:enableReplaceCRD")
 }
 
+// BETA FEATURE - If present and set to true, allow Secrets to be mutated.
+// This feature is in developer preview, and is disabled by default.
+//
+// This config can be specified in the following ways using this precedence:
+// 1. This `enableSecretMutable` parameter.
+// 2. The `PULUMI_K8S_ENABLE_SECRET_MUTABLE` environment variable.
+func GetEnableSecretMutable(ctx *pulumi.Context) bool {
+	return config.GetBool(ctx, "kubernetes:enableSecretMutable")
+}
+
 // If present and set to false, disable Server-Side Apply mode.
 // See https://github.com/pulumi/pulumi-kubernetes/issues/2011 for additional details.
 func GetEnableServerSideApply(ctx *pulumi.Context) bool {

--- a/sdk/go/kubernetes/provider.go
+++ b/sdk/go/kubernetes/provider.go
@@ -33,6 +33,11 @@ func NewProvider(ctx *pulumi.Context,
 			args.EnableConfigMapMutable = pulumi.BoolPtr(d.(bool))
 		}
 	}
+	if args.EnableSecretMutable == nil {
+		if d := utilities.GetEnvOrDefault(nil, utilities.ParseEnvBool, "PULUMI_K8S_ENABLE_SECRET_MUTABLE"); d != nil {
+			args.EnableSecretMutable = pulumi.BoolPtr(d.(bool))
+		}
+	}
 	if args.EnableServerSideApply == nil {
 		if d := utilities.GetEnvOrDefault(nil, utilities.ParseEnvBool, "PULUMI_K8S_ENABLE_SERVER_SIDE_APPLY"); d != nil {
 			args.EnableServerSideApply = pulumi.BoolPtr(d.(bool))
@@ -93,6 +98,13 @@ type providerArgs struct {
 	// 1. This `enableConfigMapMutable` parameter.
 	// 2. The `PULUMI_K8S_ENABLE_CONFIGMAP_MUTABLE` environment variable.
 	EnableConfigMapMutable *bool `pulumi:"enableConfigMapMutable"`
+	// BETA FEATURE - If present and set to true, allow Secrets to be mutated.
+	// This feature is in developer preview, and is disabled by default.
+	//
+	// This config can be specified in the following ways using this precedence:
+	// 1. This `enableSecretMutable` parameter.
+	// 2. The `PULUMI_K8S_ENABLE_SECRET_MUTABLE` environment variable.
+	EnableSecretMutable *bool `pulumi:"enableSecretMutable"`
 	// If present and set to false, disable Server-Side Apply mode.
 	// See https://github.com/pulumi/pulumi-kubernetes/issues/2011 for additional details.
 	EnableServerSideApply *bool `pulumi:"enableServerSideApply"`
@@ -147,6 +159,13 @@ type ProviderArgs struct {
 	// 1. This `enableConfigMapMutable` parameter.
 	// 2. The `PULUMI_K8S_ENABLE_CONFIGMAP_MUTABLE` environment variable.
 	EnableConfigMapMutable pulumi.BoolPtrInput
+	// BETA FEATURE - If present and set to true, allow Secrets to be mutated.
+	// This feature is in developer preview, and is disabled by default.
+	//
+	// This config can be specified in the following ways using this precedence:
+	// 1. This `enableSecretMutable` parameter.
+	// 2. The `PULUMI_K8S_ENABLE_SECRET_MUTABLE` environment variable.
+	EnableSecretMutable pulumi.BoolPtrInput
 	// If present and set to false, disable Server-Side Apply mode.
 	// See https://github.com/pulumi/pulumi-kubernetes/issues/2011 for additional details.
 	EnableServerSideApply pulumi.BoolPtrInput

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/Config.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/Config.java
@@ -63,6 +63,18 @@ public final class Config {
         return Codegen.booleanProp("enableReplaceCRD").config(config).get();
     }
 /**
+ * BETA FEATURE - If present and set to true, allow Secrets to be mutated.
+ * This feature is in developer preview, and is disabled by default.
+ * 
+ * This config can be specified in the following ways using this precedence:
+ * 1. This `enableSecretMutable` parameter.
+ * 2. The `PULUMI_K8S_ENABLE_SECRET_MUTABLE` environment variable.
+ * 
+ */
+    public Optional<Boolean> enableSecretMutable() {
+        return Codegen.booleanProp("enableSecretMutable").config(config).get();
+    }
+/**
  * If present and set to false, disable Server-Side Apply mode.
  * See https://github.com/pulumi/pulumi-kubernetes/issues/2011 for additional details.
  * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/ProviderArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/ProviderArgs.java
@@ -113,6 +113,31 @@ public final class ProviderArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
+     * BETA FEATURE - If present and set to true, allow Secrets to be mutated.
+     * This feature is in developer preview, and is disabled by default.
+     * 
+     * This config can be specified in the following ways using this precedence:
+     * 1. This `enableSecretMutable` parameter.
+     * 2. The `PULUMI_K8S_ENABLE_SECRET_MUTABLE` environment variable.
+     * 
+     */
+    @Import(name="enableSecretMutable", json=true)
+    private @Nullable Output<Boolean> enableSecretMutable;
+
+    /**
+     * @return BETA FEATURE - If present and set to true, allow Secrets to be mutated.
+     * This feature is in developer preview, and is disabled by default.
+     * 
+     * This config can be specified in the following ways using this precedence:
+     * 1. This `enableSecretMutable` parameter.
+     * 2. The `PULUMI_K8S_ENABLE_SECRET_MUTABLE` environment variable.
+     * 
+     */
+    public Optional<Output<Boolean>> enableSecretMutable() {
+        return Optional.ofNullable(this.enableSecretMutable);
+    }
+
+    /**
      * If present and set to false, disable Server-Side Apply mode.
      * See https://github.com/pulumi/pulumi-kubernetes/issues/2011 for additional details.
      * 
@@ -281,6 +306,7 @@ public final class ProviderArgs extends com.pulumi.resources.ResourceArgs {
         this.context = $.context;
         this.deleteUnreachable = $.deleteUnreachable;
         this.enableConfigMapMutable = $.enableConfigMapMutable;
+        this.enableSecretMutable = $.enableSecretMutable;
         this.enableServerSideApply = $.enableServerSideApply;
         this.helmReleaseSettings = $.helmReleaseSettings;
         this.kubeClientSettings = $.kubeClientSettings;
@@ -431,6 +457,37 @@ public final class ProviderArgs extends com.pulumi.resources.ResourceArgs {
          */
         public Builder enableConfigMapMutable(Boolean enableConfigMapMutable) {
             return enableConfigMapMutable(Output.of(enableConfigMapMutable));
+        }
+
+        /**
+         * @param enableSecretMutable BETA FEATURE - If present and set to true, allow Secrets to be mutated.
+         * This feature is in developer preview, and is disabled by default.
+         * 
+         * This config can be specified in the following ways using this precedence:
+         * 1. This `enableSecretMutable` parameter.
+         * 2. The `PULUMI_K8S_ENABLE_SECRET_MUTABLE` environment variable.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder enableSecretMutable(@Nullable Output<Boolean> enableSecretMutable) {
+            $.enableSecretMutable = enableSecretMutable;
+            return this;
+        }
+
+        /**
+         * @param enableSecretMutable BETA FEATURE - If present and set to true, allow Secrets to be mutated.
+         * This feature is in developer preview, and is disabled by default.
+         * 
+         * This config can be specified in the following ways using this precedence:
+         * 1. This `enableSecretMutable` parameter.
+         * 2. The `PULUMI_K8S_ENABLE_SECRET_MUTABLE` environment variable.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder enableSecretMutable(Boolean enableSecretMutable) {
+            return enableSecretMutable(Output.of(enableSecretMutable));
         }
 
         /**
@@ -651,6 +708,7 @@ public final class ProviderArgs extends com.pulumi.resources.ResourceArgs {
         public ProviderArgs build() {
             $.deleteUnreachable = Codegen.booleanProp("deleteUnreachable").output().arg($.deleteUnreachable).env("PULUMI_K8S_DELETE_UNREACHABLE").getNullable();
             $.enableConfigMapMutable = Codegen.booleanProp("enableConfigMapMutable").output().arg($.enableConfigMapMutable).env("PULUMI_K8S_ENABLE_CONFIGMAP_MUTABLE").getNullable();
+            $.enableSecretMutable = Codegen.booleanProp("enableSecretMutable").output().arg($.enableSecretMutable).env("PULUMI_K8S_ENABLE_SECRET_MUTABLE").getNullable();
             $.enableServerSideApply = Codegen.booleanProp("enableServerSideApply").output().arg($.enableServerSideApply).env("PULUMI_K8S_ENABLE_SERVER_SIDE_APPLY").getNullable();
             $.kubeconfig = Codegen.stringProp("kubeconfig").output().arg($.kubeconfig).env("KUBECONFIG").getNullable();
             $.skipUpdateUnreachable = Codegen.booleanProp("skipUpdateUnreachable").output().arg($.skipUpdateUnreachable).env("PULUMI_K8S_SKIP_UPDATE_UNREACHABLE").getNullable();

--- a/sdk/nodejs/provider.ts
+++ b/sdk/nodejs/provider.ts
@@ -42,6 +42,7 @@ export class Provider extends pulumi.ProviderResource {
             resourceInputs["context"] = args ? args.context : undefined;
             resourceInputs["deleteUnreachable"] = pulumi.output((args ? args.deleteUnreachable : undefined) ?? utilities.getEnvBoolean("PULUMI_K8S_DELETE_UNREACHABLE")).apply(JSON.stringify);
             resourceInputs["enableConfigMapMutable"] = pulumi.output((args ? args.enableConfigMapMutable : undefined) ?? utilities.getEnvBoolean("PULUMI_K8S_ENABLE_CONFIGMAP_MUTABLE")).apply(JSON.stringify);
+            resourceInputs["enableSecretMutable"] = pulumi.output((args ? args.enableSecretMutable : undefined) ?? utilities.getEnvBoolean("PULUMI_K8S_ENABLE_SECRET_MUTABLE")).apply(JSON.stringify);
             resourceInputs["enableServerSideApply"] = pulumi.output((args ? args.enableServerSideApply : undefined) ?? utilities.getEnvBoolean("PULUMI_K8S_ENABLE_SERVER_SIDE_APPLY")).apply(JSON.stringify);
             resourceInputs["helmReleaseSettings"] = pulumi.output(args ? (args.helmReleaseSettings ? pulumi.output(args.helmReleaseSettings).apply(inputs.helmReleaseSettingsProvideDefaults) : undefined) : undefined).apply(JSON.stringify);
             resourceInputs["kubeClientSettings"] = pulumi.output(args ? (args.kubeClientSettings ? pulumi.output(args.kubeClientSettings).apply(inputs.kubeClientSettingsProvideDefaults) : undefined) : undefined).apply(JSON.stringify);
@@ -90,6 +91,15 @@ export interface ProviderArgs {
      * 2. The `PULUMI_K8S_ENABLE_CONFIGMAP_MUTABLE` environment variable.
      */
     enableConfigMapMutable?: pulumi.Input<boolean>;
+    /**
+     * BETA FEATURE - If present and set to true, allow Secrets to be mutated.
+     * This feature is in developer preview, and is disabled by default.
+     *
+     * This config can be specified in the following ways using this precedence:
+     * 1. This `enableSecretMutable` parameter.
+     * 2. The `PULUMI_K8S_ENABLE_SECRET_MUTABLE` environment variable.
+     */
+    enableSecretMutable?: pulumi.Input<boolean>;
     /**
      * If present and set to false, disable Server-Side Apply mode.
      * See https://github.com/pulumi/pulumi-kubernetes/issues/2011 for additional details.

--- a/sdk/python/pulumi_kubernetes/provider.py
+++ b/sdk/python/pulumi_kubernetes/provider.py
@@ -25,6 +25,7 @@ class ProviderArgs:
                  context: Optional[pulumi.Input[str]] = None,
                  delete_unreachable: Optional[pulumi.Input[bool]] = None,
                  enable_config_map_mutable: Optional[pulumi.Input[bool]] = None,
+                 enable_secret_mutable: Optional[pulumi.Input[bool]] = None,
                  enable_server_side_apply: Optional[pulumi.Input[bool]] = None,
                  helm_release_settings: Optional[pulumi.Input['HelmReleaseSettingsArgs']] = None,
                  kube_client_settings: Optional[pulumi.Input['KubeClientSettingsArgs']] = None,
@@ -50,6 +51,12 @@ class ProviderArgs:
                This config can be specified in the following ways using this precedence:
                1. This `enableConfigMapMutable` parameter.
                2. The `PULUMI_K8S_ENABLE_CONFIGMAP_MUTABLE` environment variable.
+        :param pulumi.Input[bool] enable_secret_mutable: BETA FEATURE - If present and set to true, allow Secrets to be mutated.
+               This feature is in developer preview, and is disabled by default.
+               
+               This config can be specified in the following ways using this precedence:
+               1. This `enableSecretMutable` parameter.
+               2. The `PULUMI_K8S_ENABLE_SECRET_MUTABLE` environment variable.
         :param pulumi.Input[bool] enable_server_side_apply: If present and set to false, disable Server-Side Apply mode.
                See https://github.com/pulumi/pulumi-kubernetes/issues/2011 for additional details.
         :param pulumi.Input['HelmReleaseSettingsArgs'] helm_release_settings: Options to configure the Helm Release resource.
@@ -87,6 +94,10 @@ class ProviderArgs:
             enable_config_map_mutable = _utilities.get_env_bool('PULUMI_K8S_ENABLE_CONFIGMAP_MUTABLE')
         if enable_config_map_mutable is not None:
             pulumi.set(__self__, "enable_config_map_mutable", enable_config_map_mutable)
+        if enable_secret_mutable is None:
+            enable_secret_mutable = _utilities.get_env_bool('PULUMI_K8S_ENABLE_SECRET_MUTABLE')
+        if enable_secret_mutable is not None:
+            pulumi.set(__self__, "enable_secret_mutable", enable_secret_mutable)
         if enable_server_side_apply is None:
             enable_server_side_apply = _utilities.get_env_bool('PULUMI_K8S_ENABLE_SERVER_SIDE_APPLY')
         if enable_server_side_apply is not None:
@@ -184,6 +195,23 @@ class ProviderArgs:
     @enable_config_map_mutable.setter
     def enable_config_map_mutable(self, value: Optional[pulumi.Input[bool]]):
         pulumi.set(self, "enable_config_map_mutable", value)
+
+    @property
+    @pulumi.getter(name="enableSecretMutable")
+    def enable_secret_mutable(self) -> Optional[pulumi.Input[bool]]:
+        """
+        BETA FEATURE - If present and set to true, allow Secrets to be mutated.
+        This feature is in developer preview, and is disabled by default.
+
+        This config can be specified in the following ways using this precedence:
+        1. This `enableSecretMutable` parameter.
+        2. The `PULUMI_K8S_ENABLE_SECRET_MUTABLE` environment variable.
+        """
+        return pulumi.get(self, "enable_secret_mutable")
+
+    @enable_secret_mutable.setter
+    def enable_secret_mutable(self, value: Optional[pulumi.Input[bool]]):
+        pulumi.set(self, "enable_secret_mutable", value)
 
     @property
     @pulumi.getter(name="enableServerSideApply")
@@ -317,6 +345,7 @@ class Provider(pulumi.ProviderResource):
                  context: Optional[pulumi.Input[str]] = None,
                  delete_unreachable: Optional[pulumi.Input[bool]] = None,
                  enable_config_map_mutable: Optional[pulumi.Input[bool]] = None,
+                 enable_secret_mutable: Optional[pulumi.Input[bool]] = None,
                  enable_server_side_apply: Optional[pulumi.Input[bool]] = None,
                  helm_release_settings: Optional[pulumi.Input[Union['HelmReleaseSettingsArgs', 'HelmReleaseSettingsArgsDict']]] = None,
                  kube_client_settings: Optional[pulumi.Input[Union['KubeClientSettingsArgs', 'KubeClientSettingsArgsDict']]] = None,
@@ -346,6 +375,12 @@ class Provider(pulumi.ProviderResource):
                This config can be specified in the following ways using this precedence:
                1. This `enableConfigMapMutable` parameter.
                2. The `PULUMI_K8S_ENABLE_CONFIGMAP_MUTABLE` environment variable.
+        :param pulumi.Input[bool] enable_secret_mutable: BETA FEATURE - If present and set to true, allow Secrets to be mutated.
+               This feature is in developer preview, and is disabled by default.
+               
+               This config can be specified in the following ways using this precedence:
+               1. This `enableSecretMutable` parameter.
+               2. The `PULUMI_K8S_ENABLE_SECRET_MUTABLE` environment variable.
         :param pulumi.Input[bool] enable_server_side_apply: If present and set to false, disable Server-Side Apply mode.
                See https://github.com/pulumi/pulumi-kubernetes/issues/2011 for additional details.
         :param pulumi.Input[Union['HelmReleaseSettingsArgs', 'HelmReleaseSettingsArgsDict']] helm_release_settings: Options to configure the Helm Release resource.
@@ -398,6 +433,7 @@ class Provider(pulumi.ProviderResource):
                  context: Optional[pulumi.Input[str]] = None,
                  delete_unreachable: Optional[pulumi.Input[bool]] = None,
                  enable_config_map_mutable: Optional[pulumi.Input[bool]] = None,
+                 enable_secret_mutable: Optional[pulumi.Input[bool]] = None,
                  enable_server_side_apply: Optional[pulumi.Input[bool]] = None,
                  helm_release_settings: Optional[pulumi.Input[Union['HelmReleaseSettingsArgs', 'HelmReleaseSettingsArgsDict']]] = None,
                  kube_client_settings: Optional[pulumi.Input[Union['KubeClientSettingsArgs', 'KubeClientSettingsArgsDict']]] = None,
@@ -425,6 +461,9 @@ class Provider(pulumi.ProviderResource):
             if enable_config_map_mutable is None:
                 enable_config_map_mutable = _utilities.get_env_bool('PULUMI_K8S_ENABLE_CONFIGMAP_MUTABLE')
             __props__.__dict__["enable_config_map_mutable"] = pulumi.Output.from_input(enable_config_map_mutable).apply(pulumi.runtime.to_json) if enable_config_map_mutable is not None else None
+            if enable_secret_mutable is None:
+                enable_secret_mutable = _utilities.get_env_bool('PULUMI_K8S_ENABLE_SECRET_MUTABLE')
+            __props__.__dict__["enable_secret_mutable"] = pulumi.Output.from_input(enable_secret_mutable).apply(pulumi.runtime.to_json) if enable_secret_mutable is not None else None
             if enable_server_side_apply is None:
                 enable_server_side_apply = _utilities.get_env_bool('PULUMI_K8S_ENABLE_SERVER_SIDE_APPLY')
             __props__.__dict__["enable_server_side_apply"] = pulumi.Output.from_input(enable_server_side_apply).apply(pulumi.runtime.to_json) if enable_server_side_apply is not None else None

--- a/tests/sdk/java/configmap_test.go
+++ b/tests/sdk/java/configmap_test.go
@@ -1,0 +1,64 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/pulumi/providertest/pulumitest"
+	"github.com/pulumi/providertest/pulumitest/opttest"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfigMapAndSecretImmutability(t *testing.T) {
+	t.Parallel()
+
+	test := pulumitest.NewPulumiTest(t,
+		"testdata/immutability",
+		opttest.SkipInstall(),
+	)
+	t.Cleanup(func() {
+		test.Destroy()
+	})
+
+	// Create the secrets/configmaps.
+	up := test.Up()
+
+	// We will detect update/replacement behavior by observing effects on our
+	// downstream dependencies.
+	secret := up.Outputs["secret"].Value.(string)
+	configmap := up.Outputs["configmap"].Value.(string)
+	autonamedSecret := up.Outputs["autonamedSecret"].Value.(string)
+	autonamedConfigmap := up.Outputs["autonamedConfigmap"].Value.(string)
+	mutableSecret := up.Outputs["mutableSecret"].Value.(string)
+	mutableConfigmap := up.Outputs["mutableConfigmap"].Value.(string)
+
+	// Update the data of all our secrets and configmaps.
+	test.UpdateSource("testdata/immutability/step2")
+	up = test.Up()
+
+	// Only the mutable configmap and secret should have been updated -- so no
+	// impact on those two downstreams.
+	assert.Equal(t, mutableConfigmap, up.Outputs["mutableConfigmap"].Value.(string))
+	assert.Equal(t, mutableSecret, up.Outputs["mutableSecret"].Value.(string))
+	// All others should have been replaced, which should have regenerated our
+	// random pets.
+	assert.NotEqual(t, secret, up.Outputs["secret"].Value.(string))
+	assert.NotEqual(t, configmap, up.Outputs["configmap"].Value.(string))
+	assert.NotEqual(t, autonamedSecret, up.Outputs["autonamedSecret"].Value.(string))
+	assert.NotEqual(t, autonamedConfigmap, up.Outputs["autonamedConfigmap"].Value.(string))
+	// Record the new outputs.
+	secret = up.Outputs["secret"].Value.(string)
+	configmap = up.Outputs["configmap"].Value.(string)
+	autonamedSecret = up.Outputs["autonamedSecret"].Value.(string)
+	autonamedConfigmap = up.Outputs["autonamedConfigmap"].Value.(string)
+
+	// The final step only touches annotations. All resources should have been
+	// updated.
+	test.UpdateSource("testdata/immutability/step3")
+	up = test.Up()
+	assert.Equal(t, secret, up.Outputs["secret"].Value.(string))
+	assert.Equal(t, configmap, up.Outputs["configmap"].Value.(string))
+	assert.Equal(t, autonamedSecret, up.Outputs["autonamedSecret"].Value.(string))
+	assert.Equal(t, autonamedConfigmap, up.Outputs["autonamedConfigmap"].Value.(string))
+	assert.Equal(t, mutableConfigmap, up.Outputs["mutableConfigmap"].Value.(string))
+	assert.Equal(t, mutableSecret, up.Outputs["mutableSecret"].Value.(string))
+}

--- a/tests/sdk/java/testdata/immutability/Pulumi.yaml
+++ b/tests/sdk/java/testdata/immutability/Pulumi.yaml
@@ -1,0 +1,119 @@
+name: immutability
+runtime: yaml
+description: |
+  Test mutability and immutability for Secrets and ConfigMaps, as well as
+  replacement interactions with downstream dependencies.
+
+resources:
+  ns:
+    type: kubernetes:core/v1:Namespace
+
+  provider:
+    type: pulumi:providers:kubernetes
+    properties:
+      enableSecretMutable: true
+      enableConfigMapMutable: true
+      namespace: ${ns.metadata.name}
+
+  secret:
+    type: kubernetes:core/v1:Secret
+    options:
+      provider: ${provider}
+    properties:
+      metadata:
+        name: secret
+      immutable: true
+      stringData:
+        foo: "foo"
+
+  configmap:
+    type: kubernetes:core/v1:ConfigMap
+    options:
+      provider: ${provider}
+    properties:
+      metadata:
+        name: configmap
+      immutable: true
+      data:
+        foo: "foo"
+
+  autonamed-secret:
+    type: kubernetes:core/v1:Secret
+    options:
+      provider: ${provider}
+    properties:
+      immutable: true
+      stringData:
+        foo: "foo"
+
+  autonamed-configmap:
+    type: kubernetes:core/v1:ConfigMap
+    options:
+      provider: ${provider}
+    properties:
+      immutable: true
+      data:
+        foo: "foo"
+
+  mutable-secret:
+    type: kubernetes:core/v1:Secret
+    options:
+      provider: ${provider}
+    properties:
+      stringData:
+        foo: "foo"
+
+  mutable-configmap:
+    type: kubernetes:core/v1:ConfigMap
+    options:
+      provider: ${provider}
+    properties:
+      data:
+        foo: "foo"
+
+  # Downstreams should not be impacted by updates but should be updated when
+  # upstreams are replaced.
+
+  secret-downstream:
+    type: random:RandomPet
+    properties:
+      keepers:
+        upstream: ${secret.metadata.name}
+
+  configmap-downstream:
+    type: random:RandomPet
+    properties:
+      keepers:
+        upstream: ${configmap.metadata.name}
+
+  autonamed-secret-downstream:
+    type: random:RandomPet
+    properties:
+      keepers:
+        upstream: ${autonamed-secret.metadata.name}
+
+  autonamed-configmap-downstream:
+    type: random:RandomPet
+    properties:
+      keepers:
+        upstream: ${autonamed-configmap.metadata.name}
+
+  mutable-secret-downstream:
+    type: random:RandomPet
+    properties:
+      keepers:
+        upstream: ${mutable-secret.metadata.name}
+
+  mutable-configmap-downstream:
+    type: random:RandomPet
+    properties:
+      keepers:
+        upstream: ${mutable-configmap.metadata.name}
+
+outputs:
+  secret: ${secret-downstream.id}
+  configmap: ${configmap-downstream.id}
+  autonamedSecret: ${autonamed-secret-downstream.id}
+  autonamedConfigmap: ${autonamed-configmap-downstream.id}
+  mutableSecret: ${mutable-secret-downstream.id}
+  mutableConfigmap: ${mutable-configmap-downstream.id}

--- a/tests/sdk/java/testdata/immutability/step2/Pulumi.yaml
+++ b/tests/sdk/java/testdata/immutability/step2/Pulumi.yaml
@@ -1,0 +1,125 @@
+name: immutability
+runtime: yaml
+description: |
+  Test mutability and immutability for Secrets and ConfigMaps, as well as
+  replacement interactions with downstream dependencies.
+
+resources:
+  ns:
+    type: kubernetes:core/v1:Namespace
+
+  provider:
+    type: pulumi:providers:kubernetes
+    properties:
+      enableSecretMutable: true
+      enableConfigMapMutable: true
+      namespace: ${ns.metadata.name}
+
+  secret:
+    type: kubernetes:core/v1:Secret
+    options:
+      provider: ${provider}
+    properties:
+      metadata:
+        name: secret
+      immutable: true
+      stringData:
+        # foo -> bar
+        bar: "bar"
+
+  configmap:
+    type: kubernetes:core/v1:ConfigMap
+    options:
+      provider: ${provider}
+    properties:
+      metadata:
+        name: configmap
+      immutable: true
+      data:
+        # foo -> bar
+        bar: "bar"
+
+  autonamed-secret:
+    type: kubernetes:core/v1:Secret
+    options:
+      provider: ${provider}
+    properties:
+      immutable: true
+      stringData:
+        # foo -> bar
+        bar: "bar"
+
+  autonamed-configmap:
+    type: kubernetes:core/v1:ConfigMap
+    options:
+      provider: ${provider}
+    properties:
+      immutable: true
+      data:
+        # foo -> bar
+        bar: "bar"
+
+  mutable-secret:
+    type: kubernetes:core/v1:Secret
+    options:
+      provider: ${provider}
+    properties:
+      stringData:
+        # foo -> bar
+        bar: "bar"
+
+  mutable-configmap:
+    type: kubernetes:core/v1:ConfigMap
+    options:
+      provider: ${provider}
+    properties:
+      data:
+        # foo -> bar
+        bar: "bar"
+
+  # Downstreams should not be impacted by updates but should be updated when
+  # upstreams are replaced.
+
+  secret-downstream:
+    type: random:RandomPet
+    properties:
+      keepers:
+        upstream: ${secret.metadata.name}
+
+  configmap-downstream:
+    type: random:RandomPet
+    properties:
+      keepers:
+        upstream: ${configmap.metadata.name}
+
+  autonamed-secret-downstream:
+    type: random:RandomPet
+    properties:
+      keepers:
+        upstream: ${autonamed-secret.metadata.name}
+
+  autonamed-configmap-downstream:
+    type: random:RandomPet
+    properties:
+      keepers:
+        upstream: ${autonamed-configmap.metadata.name}
+
+  mutable-secret-downstream:
+    type: random:RandomPet
+    properties:
+      keepers:
+        upstream: ${mutable-secret.metadata.name}
+
+  mutable-configmap-downstream:
+    type: random:RandomPet
+    properties:
+      keepers:
+        upstream: ${mutable-configmap.metadata.name}
+
+outputs:
+  secret: ${secret-downstream.id}
+  configmap: ${configmap-downstream.id}
+  autonamedSecret: ${autonamed-secret-downstream.id}
+  autonamedConfigmap: ${autonamed-configmap-downstream.id}
+  mutableSecret: ${mutable-secret-downstream.id}
+  mutableConfigmap: ${mutable-configmap-downstream.id}

--- a/tests/sdk/java/testdata/immutability/step3/Pulumi.yaml
+++ b/tests/sdk/java/testdata/immutability/step3/Pulumi.yaml
@@ -1,0 +1,141 @@
+name: immutability
+runtime: yaml
+description: |
+  Test mutability and immutability for Secrets and ConfigMaps, as well as
+  replacement interactions with downstream dependencies.
+
+resources:
+  ns:
+    type: kubernetes:core/v1:Namespace
+
+  provider:
+    type: pulumi:providers:kubernetes
+    properties:
+      enableSecretMutable: true
+      enableConfigMapMutable: true
+      namespace: ${ns.metadata.name}
+
+  secret:
+    type: kubernetes:core/v1:Secret
+    options:
+      provider: ${provider}
+    properties:
+      metadata:
+        name: secret
+        # Add an annotation.
+        annotations:
+          boo: baz
+      immutable: true
+      stringData:
+        bar: "bar"
+
+  configmap:
+    type: kubernetes:core/v1:ConfigMap
+    options:
+      provider: ${provider}
+    properties:
+      metadata:
+        name: configmap
+        # Add an annotation.
+        annotations:
+          boo: baz
+      immutable: true
+      data:
+        bar: "bar"
+
+  autonamed-secret:
+    type: kubernetes:core/v1:Secret
+    options:
+      provider: ${provider}
+    properties:
+      metadata:
+        # Add an annotation.
+        annotations:
+          boo: baz
+      immutable: true
+      stringData:
+        bar: "bar"
+
+  autonamed-configmap:
+    type: kubernetes:core/v1:ConfigMap
+    options:
+      provider: ${provider}
+    properties:
+      metadata:
+        # Add an annotation.
+        annotations:
+          boo: baz
+      immutable: true
+      data:
+        bar: "bar"
+
+  mutable-secret:
+    type: kubernetes:core/v1:Secret
+    options:
+      provider: ${provider}
+    properties:
+      metadata:
+        # Add an annotation.
+        annotations:
+          boo: baz
+      stringData:
+        bar: "bar"
+
+  mutable-configmap:
+    type: kubernetes:core/v1:ConfigMap
+    options:
+      provider: ${provider}
+    properties:
+      metadata:
+        # Add an annotation.
+        annotations:
+          boo: baz
+      data:
+        bar: "bar"
+
+  # Downstreams should not be impacted by updates but should be updated when
+  # upstreams are replaced.
+
+  secret-downstream:
+    type: random:RandomPet
+    properties:
+      keepers:
+        upstream: ${secret.metadata.name}
+
+  configmap-downstream:
+    type: random:RandomPet
+    properties:
+      keepers:
+        upstream: ${configmap.metadata.name}
+
+  autonamed-secret-downstream:
+    type: random:RandomPet
+    properties:
+      keepers:
+        upstream: ${autonamed-secret.metadata.name}
+
+  autonamed-configmap-downstream:
+    type: random:RandomPet
+    properties:
+      keepers:
+        upstream: ${autonamed-configmap.metadata.name}
+
+  mutable-secret-downstream:
+    type: random:RandomPet
+    properties:
+      keepers:
+        upstream: ${mutable-secret.metadata.name}
+
+  mutable-configmap-downstream:
+    type: random:RandomPet
+    properties:
+      keepers:
+        upstream: ${mutable-configmap.metadata.name}
+
+outputs:
+  secret: ${secret-downstream.id}
+  configmap: ${configmap-downstream.id}
+  autonamedSecret: ${autonamed-secret-downstream.id}
+  autonamedConfigmap: ${autonamed-configmap-downstream.id}
+  mutableSecret: ${mutable-secret-downstream.id}
+  mutableConfigmap: ${mutable-configmap-downstream.id}


### PR DESCRIPTION
### Proposed changes

This introduces the flag `enableSecretMutable` which does for `Secret`s what the existing `enableConfigMapMutable` flag does for `ConfigMap`s. See #1926 for the motivation for this flag. Changes to the `type` field will still trigger a replacement as this field is immutable.

### Related issues (optional)

Fixes #2291.
Fixes #3181.