### PR TITLE
Fix a panic when diffing config with cluster identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Fixed
+
+- Fixed a panic that could occur when using `clusterIdentifier` provider configuration. (https://github.com/pulumi/pulumi-kubernetes/issues/3168)
+
 ## 4.17.0 (August 13, 2024)
 
 ### Changed

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -396,7 +396,11 @@ func (k *kubeProvider) DiffConfig(_ context.Context, req *pulumirpc.DiffRequest)
 	// what it was previously set to.
 	if diff.Same(clusterIdentifierKey) && news.HasValue(clusterIdentifierKey) {
 		// Modify our response to no longer replace anything.
-		defer func() { resp.Replaces = nil }()
+		defer func() {
+			if resp != nil {
+				resp.Replaces = nil
+			}
+		}()
 	}
 
 	// We can't tell for sure if a computed value has changed, so we make the conservative choice

--- a/provider/pkg/provider/testdata/diffconfig/config-error-with-identifier
+++ b/provider/pkg/provider/testdata/diffconfig/config-error-with-identifier
@@ -1,0 +1,22 @@
+-- olds --
+clusterIdentifier: foobar
+
+kubeconfig: |
+  kind: Config
+  apiVersion: v1
+  clusters: []
+  contexts: []
+  current-context: foo
+  preferences: {}
+  users: []
+
+
+-- news --
+clusterIdentifier: foobar
+
+kubeconfig: |
+  apiVersion: v1
+  clusters: { INVALID KUBECONFIG }
+
+-- wantErr --
+failed to parse kubeconfig


### PR DESCRIPTION
`DiffConfig` will currently panic if we encounter an error (`resp = nil`) while using `clusterIdentifier`.

This adds a nil check and a regression test.

Fixes #3168.