### PR TITLE
Make v2 YAML more forgiving when checking GVK for namespaced-ness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,10 @@
 
 - Fixed a panic that could occur during deletion. (https://github.com/pulumi/pulumi-kubernetes/issues/3157)
 
+- Fixed an error that could occur when previewing `yaml/v2` resources which
+  depend on CRDs created in the same update.
+  (https://github.com/pulumi/pulumi-kubernetes/issues/3176)
+
 ## 4.17.1 (August 16, 2024)
 
 ### Fixed

--- a/provider/pkg/provider/yaml/v2/yaml_test.go
+++ b/provider/pkg/provider/yaml/v2/yaml_test.go
@@ -553,6 +553,28 @@ var _ = Describe("Normalize", func() {
 				))
 			})
 		})
+
+		Context("when the object is an unrecognized custom resource", func() {
+			BeforeEach(func() {
+				objs = []unstructured.Unstructured{{
+					Object: map[string]any{
+						"apiVersion": "test.pulumi.com/v1",
+						"kind":       "Unknown",
+						"metadata": map[string]any{
+							"name": "foo",
+						},
+					},
+				}}
+			})
+
+			It("should assume it is namespaced", func(ctx context.Context) {
+				objs, err := Normalize(objs, defaultNamespace, clientSet)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(objs).To(HaveExactElements(
+					matchUnstructured(Keys{"metadata": MatchKeys(IgnoreExtras, Keys{"namespace": Equal("default")})}),
+				))
+			})
+		})
 	})
 
 	Describe("special-case kinds", func() {


### PR DESCRIPTION
This changes our error handling in `Normalize` to degrade gracefully in the case when we can't determine namespaced-ness, probably due to the CRD not existing yet. Instead of failing, we assume the resource is namespaced to allow the preview to succeed.

This is consistent with our error handling for this case elsewhere:
* Check https://github.com/pulumi/pulumi-kubernetes/blob/0f834c8b0d89e0003f0dc2d527d4ca8e2cde26e9/provider/pkg/provider/provider.go#L1481-L1488
* Diff https://github.com/pulumi/pulumi-kubernetes/blob/0f834c8b0d89e0003f0dc2d527d4ca8e2cde26e9/provider/pkg/provider/provider.go#L1666-L1674
* Invoke: https://github.com/pulumi/pulumi-kubernetes/blob/0f834c8b0d89e0003f0dc2d527d4ca8e2cde26e9/provider/pkg/provider/invoke_decode_yaml.go#L49-L56

Added a failing unit test.

Fixes #3176