### PR TITLE
Allow schemagen to specify p-k provider as a dependency

### DIFF
--- a/provider/pkg/gen/typegen.go
+++ b/provider/pkg/gen/typegen.go
@@ -689,8 +689,9 @@ func createGroups(definitionsJSON map[string]any, allowHyphens bool) []GroupConf
 
 				// We need to sanitize versions to be valid package names.
 				v = validCharRegex.ReplaceAllString(v, "_")
+				gStripped := validCharRegex.ReplaceAllString(gParts[0], "_")
 
-				return fmt.Sprintf("%s/%s", gParts[0], v)
+				return fmt.Sprintf("%s/%s", gStripped, v)
 			}
 			return linq.From([]KindConfig{
 				{


### PR DESCRIPTION
### Proposed changes

Required changes for crd2pulumi to use schemagen from p-k. This PR introduces 2 changes:

1. Allows the schemagen library to add p-k provider as a dependency
2. Sanitize the stripped out group name for package generation. Previously, CRD packages with a group like `test-package.io` would be stripped to `test-package`. However, hyphenation is not valid in package names for dotnet and golang.

This PR will be merged as individual commits to retain the history and de-coupled nature of the 2 commits.