### PR TITLE
Fix Typo in Kubernetes API Docs

### DIFF
--- a/provider/pkg/gen/overlays.go
+++ b/provider/pkg/gen/overlays.go
@@ -363,7 +363,7 @@ var helmV3RepoOpts = pschema.ComplexTypeSpec{
 				TypeSpec: pschema.TypeSpec{
 					Type: "string",
 				},
-				Description: "Repository where to locate the requested chart. If is a URL the chart is installed without installing the repository.",
+				Description: "Repository where to locate the requested chart. If it's a URL the chart is installed without installing the repository.",
 			},
 			"keyFile": { // TODO: Content or file
 				TypeSpec: pschema.TypeSpec{
@@ -420,7 +420,7 @@ var helmV4RepoOpts = pschema.ComplexTypeSpec{
 				TypeSpec: pschema.TypeSpec{
 					Type: "string",
 				},
-				Description: "Repository where to locate the requested chart. If is a URL the chart is installed without installing the repository.",
+				Description: "Repository where to locate the requested chart. If it's a URL the chart is installed without installing the repository.",
 			},
 			"keyFile": {
 				TypeSpec: pschema.TypeSpec{

--- a/provider/pkg/provider/helm_release.go
+++ b/provider/pkg/provider/helm_release.go
@@ -140,7 +140,7 @@ type ReleaseSpec struct{}
 
 // Specification defining the Helm chart repository to use.
 type RepositoryOpts struct {
-	// Repository where to locate the requested chart. If is a URL the chart is installed without installing the repository.
+	// Repository where to locate the requested chart. If it's a URL the chart is installed without installing the repository.
 	Repo string `json:"repo,omitempty"`
 	// The Repositories CA File
 	CAFile string `json:"caFile,omitempty"`

--- a/sdk/dotnet/Helm/V3/Inputs/RepositoryOptsArgs.cs
+++ b/sdk/dotnet/Helm/V3/Inputs/RepositoryOptsArgs.cs
@@ -50,7 +50,7 @@ namespace Pulumi.Kubernetes.Types.Inputs.Helm.V3
         }
 
         /// <summary>
-        /// Repository where to locate the requested chart. If is a URL the chart is installed without installing the repository.
+        /// Repository where to locate the requested chart. If it's a URL the chart is installed without installing the repository.
         /// </summary>
         [Input("repo")]
         public Input<string>? Repo { get; set; }

--- a/sdk/dotnet/Helm/V3/Inputs/RepositorySpecArgs.cs
+++ b/sdk/dotnet/Helm/V3/Inputs/RepositorySpecArgs.cs
@@ -16,7 +16,7 @@ namespace Pulumi.Kubernetes.Types.Inputs.Helm.V3
     public class RepositorySpecArgs : Pulumi.ResourceArgs
     {
         /// <summary>
-        /// Repository where to locate the requested chart. If is a URL the chart is installed without installing the repository.
+        /// Repository where to locate the requested chart. If it's a URL the chart is installed without installing the repository.
         /// </summary>
         [Input("repository")]
         public Input<string>? Repository { get; set; }

--- a/sdk/dotnet/Helm/V3/Outputs/RepositoryOpts.cs
+++ b/sdk/dotnet/Helm/V3/Outputs/RepositoryOpts.cs
@@ -33,7 +33,7 @@ namespace Pulumi.Kubernetes.Types.Outputs.Helm.V3
         /// </summary>
         public readonly string Password;
         /// <summary>
-        /// Repository where to locate the requested chart. If is a URL the chart is installed without installing the repository.
+        /// Repository where to locate the requested chart. If it's a URL the chart is installed without installing the repository.
         /// </summary>
         public readonly string Repo;
         /// <summary>

--- a/sdk/dotnet/Helm/V3/Outputs/RepositorySpec.cs
+++ b/sdk/dotnet/Helm/V3/Outputs/RepositorySpec.cs
@@ -17,7 +17,7 @@ namespace Pulumi.Kubernetes.Types.Outputs.Helm.V3
     public sealed class RepositorySpec
     {
         /// <summary>
-        /// Repository where to locate the requested chart. If is a URL the chart is installed without installing the repository.
+        /// Repository where to locate the requested chart. If it's a URL the chart is installed without installing the repository.
         /// </summary>
         public readonly string Repository;
         /// <summary>

--- a/sdk/dotnet/Helm/V4/Inputs/RepositoryOptsArgs.cs
+++ b/sdk/dotnet/Helm/V4/Inputs/RepositoryOptsArgs.cs
@@ -50,7 +50,7 @@ namespace Pulumi.Kubernetes.Types.Inputs.Helm.V4
         }
 
         /// <summary>
-        /// Repository where to locate the requested chart. If is a URL the chart is installed without installing the repository.
+        /// Repository where to locate the requested chart. If it's a URL the chart is installed without installing the repository.
         /// </summary>
         [Input("repo")]
         public Input<string>? Repo { get; set; }

--- a/sdk/go/kubernetes/helm/v3/pulumiTypes.go
+++ b/sdk/go/kubernetes/helm/v3/pulumiTypes.go
@@ -129,7 +129,7 @@ type RepositoryOpts struct {
 	KeyFile *string `pulumi:"keyFile"`
 	// Password for HTTP basic authentication
 	Password *string `pulumi:"password"`
-	// Repository where to locate the requested chart. If is a URL the chart is installed without installing the repository.
+	// Repository where to locate the requested chart. If it's a URL the chart is installed without installing the repository.
 	Repo *string `pulumi:"repo"`
 	// Username for HTTP basic authentication
 	Username *string `pulumi:"username"`
@@ -156,7 +156,7 @@ type RepositoryOptsArgs struct {
 	KeyFile pulumi.StringPtrInput `pulumi:"keyFile"`
 	// Password for HTTP basic authentication
 	Password pulumi.StringPtrInput `pulumi:"password"`
-	// Repository where to locate the requested chart. If is a URL the chart is installed without installing the repository.
+	// Repository where to locate the requested chart. If it's a URL the chart is installed without installing the repository.
 	Repo pulumi.StringPtrInput `pulumi:"repo"`
 	// Username for HTTP basic authentication
 	Username pulumi.StringPtrInput `pulumi:"username"`
@@ -260,7 +260,7 @@ func (o RepositoryOptsOutput) Password() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v RepositoryOpts) *string { return v.Password }).(pulumi.StringPtrOutput)
 }
 
-// Repository where to locate the requested chart. If is a URL the chart is installed without installing the repository.
+// Repository where to locate the requested chart. If it's a URL the chart is installed without installing the repository.
 func (o RepositoryOptsOutput) Repo() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v RepositoryOpts) *string { return v.Repo }).(pulumi.StringPtrOutput)
 }
@@ -334,7 +334,7 @@ func (o RepositoryOptsPtrOutput) Password() pulumi.StringPtrOutput {
 	}).(pulumi.StringPtrOutput)
 }
 
-// Repository where to locate the requested chart. If is a URL the chart is installed without installing the repository.
+// Repository where to locate the requested chart. If it's a URL the chart is installed without installing the repository.
 func (o RepositoryOptsPtrOutput) Repo() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *RepositoryOpts) *string {
 		if v == nil {

--- a/sdk/go/kubernetes/helm/v4/pulumiTypes.go
+++ b/sdk/go/kubernetes/helm/v4/pulumiTypes.go
@@ -182,7 +182,7 @@ type RepositoryOpts struct {
 	KeyFile pulumi.AssetOrArchive `pulumi:"keyFile"`
 	// Password for HTTP basic authentication
 	Password *string `pulumi:"password"`
-	// Repository where to locate the requested chart. If is a URL the chart is installed without installing the repository.
+	// Repository where to locate the requested chart. If it's a URL the chart is installed without installing the repository.
 	Repo *string `pulumi:"repo"`
 	// Username for HTTP basic authentication
 	Username *string `pulumi:"username"`
@@ -209,7 +209,7 @@ type RepositoryOptsArgs struct {
 	KeyFile pulumi.AssetOrArchiveInput `pulumi:"keyFile"`
 	// Password for HTTP basic authentication
 	Password pulumi.StringPtrInput `pulumi:"password"`
-	// Repository where to locate the requested chart. If is a URL the chart is installed without installing the repository.
+	// Repository where to locate the requested chart. If it's a URL the chart is installed without installing the repository.
 	Repo pulumi.StringPtrInput `pulumi:"repo"`
 	// Username for HTTP basic authentication
 	Username pulumi.StringPtrInput `pulumi:"username"`
@@ -313,7 +313,7 @@ func (o RepositoryOptsOutput) Password() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v RepositoryOpts) *string { return v.Password }).(pulumi.StringPtrOutput)
 }
 
-// Repository where to locate the requested chart. If is a URL the chart is installed without installing the repository.
+// Repository where to locate the requested chart. If it's a URL the chart is installed without installing the repository.
 func (o RepositoryOptsOutput) Repo() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v RepositoryOpts) *string { return v.Repo }).(pulumi.StringPtrOutput)
 }
@@ -387,7 +387,7 @@ func (o RepositoryOptsPtrOutput) Password() pulumi.StringPtrOutput {
 	}).(pulumi.StringPtrOutput)
 }
 
-// Repository where to locate the requested chart. If is a URL the chart is installed without installing the repository.
+// Repository where to locate the requested chart. If it's a URL the chart is installed without installing the repository.
 func (o RepositoryOptsPtrOutput) Repo() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *RepositoryOpts) *string {
 		if v == nil {

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/helm/v3/inputs/RepositoryOptsArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/helm/v3/inputs/RepositoryOptsArgs.java
@@ -13,7 +13,7 @@ import javax.annotation.Nullable;
 
 /**
  * Specification defining the Helm chart repository to use.
- * 
+ *
  */
 public final class RepositoryOptsArgs extends com.pulumi.resources.ResourceArgs {
 
@@ -21,14 +21,14 @@ public final class RepositoryOptsArgs extends com.pulumi.resources.ResourceArgs 
 
     /**
      * The Repository&#39;s CA File
-     * 
+     *
      */
     @Import(name="caFile")
     private @Nullable Output<String> caFile;
 
     /**
      * @return The Repository&#39;s CA File
-     * 
+     *
      */
     public Optional<Output<String>> caFile() {
         return Optional.ofNullable(this.caFile);
@@ -36,14 +36,14 @@ public final class RepositoryOptsArgs extends com.pulumi.resources.ResourceArgs 
 
     /**
      * The repository&#39;s cert file
-     * 
+     *
      */
     @Import(name="certFile")
     private @Nullable Output<String> certFile;
 
     /**
      * @return The repository&#39;s cert file
-     * 
+     *
      */
     public Optional<Output<String>> certFile() {
         return Optional.ofNullable(this.certFile);
@@ -51,14 +51,14 @@ public final class RepositoryOptsArgs extends com.pulumi.resources.ResourceArgs 
 
     /**
      * The repository&#39;s cert key file
-     * 
+     *
      */
     @Import(name="keyFile")
     private @Nullable Output<String> keyFile;
 
     /**
      * @return The repository&#39;s cert key file
-     * 
+     *
      */
     public Optional<Output<String>> keyFile() {
         return Optional.ofNullable(this.keyFile);
@@ -66,29 +66,29 @@ public final class RepositoryOptsArgs extends com.pulumi.resources.ResourceArgs 
 
     /**
      * Password for HTTP basic authentication
-     * 
+     *
      */
     @Import(name="password")
     private @Nullable Output<String> password;
 
     /**
      * @return Password for HTTP basic authentication
-     * 
+     *
      */
     public Optional<Output<String>> password() {
         return Optional.ofNullable(this.password);
     }
 
     /**
-     * Repository where to locate the requested chart. If is a URL the chart is installed without installing the repository.
-     * 
+     * Repository where to locate the requested chart. If it's a URL the chart is installed without installing the repository.
+     *
      */
     @Import(name="repo")
     private @Nullable Output<String> repo;
 
     /**
-     * @return Repository where to locate the requested chart. If is a URL the chart is installed without installing the repository.
-     * 
+     * @return Repository where to locate the requested chart. If it's a URL the chart is installed without installing the repository.
+     *
      */
     public Optional<Output<String>> repo() {
         return Optional.ofNullable(this.repo);
@@ -96,14 +96,14 @@ public final class RepositoryOptsArgs extends com.pulumi.resources.ResourceArgs 
 
     /**
      * Username for HTTP basic authentication
-     * 
+     *
      */
     @Import(name="username")
     private @Nullable Output<String> username;
 
     /**
      * @return Username for HTTP basic authentication
-     * 
+     *
      */
     public Optional<Output<String>> username() {
         return Optional.ofNullable(this.username);
@@ -140,9 +140,9 @@ public final class RepositoryOptsArgs extends com.pulumi.resources.ResourceArgs 
 
         /**
          * @param caFile The Repository&#39;s CA File
-         * 
+         *
          * @return builder
-         * 
+         *
          */
         public Builder caFile(@Nullable Output<String> caFile) {
             $.caFile = caFile;
@@ -151,9 +151,9 @@ public final class RepositoryOptsArgs extends com.pulumi.resources.ResourceArgs 
 
         /**
          * @param caFile The Repository&#39;s CA File
-         * 
+         *
          * @return builder
-         * 
+         *
          */
         public Builder caFile(String caFile) {
             return caFile(Output.of(caFile));
@@ -161,9 +161,9 @@ public final class RepositoryOptsArgs extends com.pulumi.resources.ResourceArgs 
 
         /**
          * @param certFile The repository&#39;s cert file
-         * 
+         *
          * @return builder
-         * 
+         *
          */
         public Builder certFile(@Nullable Output<String> certFile) {
             $.certFile = certFile;
@@ -172,9 +172,9 @@ public final class RepositoryOptsArgs extends com.pulumi.resources.ResourceArgs 
 
         /**
          * @param certFile The repository&#39;s cert file
-         * 
+         *
          * @return builder
-         * 
+         *
          */
         public Builder certFile(String certFile) {
             return certFile(Output.of(certFile));
@@ -182,9 +182,9 @@ public final class RepositoryOptsArgs extends com.pulumi.resources.ResourceArgs 
 
         /**
          * @param keyFile The repository&#39;s cert key file
-         * 
+         *
          * @return builder
-         * 
+         *
          */
         public Builder keyFile(@Nullable Output<String> keyFile) {
             $.keyFile = keyFile;
@@ -193,9 +193,9 @@ public final class RepositoryOptsArgs extends com.pulumi.resources.ResourceArgs 
 
         /**
          * @param keyFile The repository&#39;s cert key file
-         * 
+         *
          * @return builder
-         * 
+         *
          */
         public Builder keyFile(String keyFile) {
             return keyFile(Output.of(keyFile));
@@ -203,9 +203,9 @@ public final class RepositoryOptsArgs extends com.pulumi.resources.ResourceArgs 
 
         /**
          * @param password Password for HTTP basic authentication
-         * 
+         *
          * @return builder
-         * 
+         *
          */
         public Builder password(@Nullable Output<String> password) {
             $.password = password;
@@ -214,19 +214,19 @@ public final class RepositoryOptsArgs extends com.pulumi.resources.ResourceArgs 
 
         /**
          * @param password Password for HTTP basic authentication
-         * 
+         *
          * @return builder
-         * 
+         *
          */
         public Builder password(String password) {
             return password(Output.of(password));
         }
 
         /**
-         * @param repo Repository where to locate the requested chart. If is a URL the chart is installed without installing the repository.
-         * 
+         * @param repo Repository where to locate the requested chart. If it's a URL the chart is installed without installing the repository.
+         *
          * @return builder
-         * 
+         *
          */
         public Builder repo(@Nullable Output<String> repo) {
             $.repo = repo;
@@ -234,10 +234,10 @@ public final class RepositoryOptsArgs extends com.pulumi.resources.ResourceArgs 
         }
 
         /**
-         * @param repo Repository where to locate the requested chart. If is a URL the chart is installed without installing the repository.
-         * 
+         * @param repo Repository where to locate the requested chart. If it's a URL the chart is installed without installing the repository.
+         *
          * @return builder
-         * 
+         *
          */
         public Builder repo(String repo) {
             return repo(Output.of(repo));
@@ -245,9 +245,9 @@ public final class RepositoryOptsArgs extends com.pulumi.resources.ResourceArgs 
 
         /**
          * @param username Username for HTTP basic authentication
-         * 
+         *
          * @return builder
-         * 
+         *
          */
         public Builder username(@Nullable Output<String> username) {
             $.username = username;
@@ -256,9 +256,9 @@ public final class RepositoryOptsArgs extends com.pulumi.resources.ResourceArgs 
 
         /**
          * @param username Username for HTTP basic authentication
-         * 
+         *
          * @return builder
-         * 
+         *
          */
         public Builder username(String username) {
             return username(Output.of(username));

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/helm/v3/outputs/RepositoryOpts.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/helm/v3/outputs/RepositoryOpts.java
@@ -13,74 +13,74 @@ import javax.annotation.Nullable;
 public final class RepositoryOpts {
     /**
      * @return The Repository&#39;s CA File
-     * 
+     *
      */
     private @Nullable String caFile;
     /**
      * @return The repository&#39;s cert file
-     * 
+     *
      */
     private @Nullable String certFile;
     /**
      * @return The repository&#39;s cert key file
-     * 
+     *
      */
     private @Nullable String keyFile;
     /**
      * @return Password for HTTP basic authentication
-     * 
+     *
      */
     private @Nullable String password;
     /**
-     * @return Repository where to locate the requested chart. If is a URL the chart is installed without installing the repository.
-     * 
+     * @return Repository where to locate the requested chart. If it's a URL the chart is installed without installing the repository.
+     *
      */
     private @Nullable String repo;
     /**
      * @return Username for HTTP basic authentication
-     * 
+     *
      */
     private @Nullable String username;
 
     private RepositoryOpts() {}
     /**
      * @return The Repository&#39;s CA File
-     * 
+     *
      */
     public Optional<String> caFile() {
         return Optional.ofNullable(this.caFile);
     }
     /**
      * @return The repository&#39;s cert file
-     * 
+     *
      */
     public Optional<String> certFile() {
         return Optional.ofNullable(this.certFile);
     }
     /**
      * @return The repository&#39;s cert key file
-     * 
+     *
      */
     public Optional<String> keyFile() {
         return Optional.ofNullable(this.keyFile);
     }
     /**
      * @return Password for HTTP basic authentication
-     * 
+     *
      */
     public Optional<String> password() {
         return Optional.ofNullable(this.password);
     }
     /**
-     * @return Repository where to locate the requested chart. If is a URL the chart is installed without installing the repository.
-     * 
+     * @return Repository where to locate the requested chart. If it's a URL the chart is installed without installing the repository.
+     *
      */
     public Optional<String> repo() {
         return Optional.ofNullable(this.repo);
     }
     /**
      * @return Username for HTTP basic authentication
-     * 
+     *
      */
     public Optional<String> username() {
         return Optional.ofNullable(this.username);

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/helm/v4/inputs/RepositoryOptsArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/helm/v4/inputs/RepositoryOptsArgs.java
@@ -14,7 +14,7 @@ import javax.annotation.Nullable;
 
 /**
  * Specification defining the Helm chart repository to use.
- * 
+ *
  */
 public final class RepositoryOptsArgs extends com.pulumi.resources.ResourceArgs {
 
@@ -22,14 +22,14 @@ public final class RepositoryOptsArgs extends com.pulumi.resources.ResourceArgs 
 
     /**
      * The Repository&#39;s CA File
-     * 
+     *
      */
     @Import(name="caFile")
     private @Nullable Output<AssetOrArchive> caFile;
 
     /**
      * @return The Repository&#39;s CA File
-     * 
+     *
      */
     public Optional<Output<AssetOrArchive>> caFile() {
         return Optional.ofNullable(this.caFile);
@@ -37,14 +37,14 @@ public final class RepositoryOptsArgs extends com.pulumi.resources.ResourceArgs 
 
     /**
      * The repository&#39;s cert file
-     * 
+     *
      */
     @Import(name="certFile")
     private @Nullable Output<AssetOrArchive> certFile;
 
     /**
      * @return The repository&#39;s cert file
-     * 
+     *
      */
     public Optional<Output<AssetOrArchive>> certFile() {
         return Optional.ofNullable(this.certFile);
@@ -52,14 +52,14 @@ public final class RepositoryOptsArgs extends com.pulumi.resources.ResourceArgs 
 
     /**
      * The repository&#39;s cert key file
-     * 
+     *
      */
     @Import(name="keyFile")
     private @Nullable Output<AssetOrArchive> keyFile;
 
     /**
      * @return The repository&#39;s cert key file
-     * 
+     *
      */
     public Optional<Output<AssetOrArchive>> keyFile() {
         return Optional.ofNullable(this.keyFile);
@@ -67,29 +67,29 @@ public final class RepositoryOptsArgs extends com.pulumi.resources.ResourceArgs 
 
     /**
      * Password for HTTP basic authentication
-     * 
+     *
      */
     @Import(name="password")
     private @Nullable Output<String> password;
 
     /**
      * @return Password for HTTP basic authentication
-     * 
+     *
      */
     public Optional<Output<String>> password() {
         return Optional.ofNullable(this.password);
     }
 
     /**
-     * Repository where to locate the requested chart. If is a URL the chart is installed without installing the repository.
-     * 
+     * Repository where to locate the requested chart. If it's a URL the chart is installed without installing the repository.
+     *
      */
     @Import(name="repo")
     private @Nullable Output<String> repo;
 
     /**
-     * @return Repository where to locate the requested chart. If is a URL the chart is installed without installing the repository.
-     * 
+     * @return Repository where to locate the requested chart. If it's a URL the chart is installed without installing the repository.
+     *
      */
     public Optional<Output<String>> repo() {
         return Optional.ofNullable(this.repo);
@@ -97,14 +97,14 @@ public final class RepositoryOptsArgs extends com.pulumi.resources.ResourceArgs 
 
     /**
      * Username for HTTP basic authentication
-     * 
+     *
      */
     @Import(name="username")
     private @Nullable Output<String> username;
 
     /**
      * @return Username for HTTP basic authentication
-     * 
+     *
      */
     public Optional<Output<String>> username() {
         return Optional.ofNullable(this.username);
@@ -141,9 +141,9 @@ public final class RepositoryOptsArgs extends com.pulumi.resources.ResourceArgs 
 
         /**
          * @param caFile The Repository&#39;s CA File
-         * 
+         *
          * @return builder
-         * 
+         *
          */
         public Builder caFile(@Nullable Output<AssetOrArchive> caFile) {
             $.caFile = caFile;
@@ -152,9 +152,9 @@ public final class RepositoryOptsArgs extends com.pulumi.resources.ResourceArgs 
 
         /**
          * @param caFile The Repository&#39;s CA File
-         * 
+         *
          * @return builder
-         * 
+         *
          */
         public Builder caFile(AssetOrArchive caFile) {
             return caFile(Output.of(caFile));
@@ -162,9 +162,9 @@ public final class RepositoryOptsArgs extends com.pulumi.resources.ResourceArgs 
 
         /**
          * @param certFile The repository&#39;s cert file
-         * 
+         *
          * @return builder
-         * 
+         *
          */
         public Builder certFile(@Nullable Output<AssetOrArchive> certFile) {
             $.certFile = certFile;
@@ -173,9 +173,9 @@ public final class RepositoryOptsArgs extends com.pulumi.resources.ResourceArgs 
 
         /**
          * @param certFile The repository&#39;s cert file
-         * 
+         *
          * @return builder
-         * 
+         *
          */
         public Builder certFile(AssetOrArchive certFile) {
             return certFile(Output.of(certFile));
@@ -183,9 +183,9 @@ public final class RepositoryOptsArgs extends com.pulumi.resources.ResourceArgs 
 
         /**
          * @param keyFile The repository&#39;s cert key file
-         * 
+         *
          * @return builder
-         * 
+         *
          */
         public Builder keyFile(@Nullable Output<AssetOrArchive> keyFile) {
             $.keyFile = keyFile;
@@ -194,9 +194,9 @@ public final class RepositoryOptsArgs extends com.pulumi.resources.ResourceArgs 
 
         /**
          * @param keyFile The repository&#39;s cert key file
-         * 
+         *
          * @return builder
-         * 
+         *
          */
         public Builder keyFile(AssetOrArchive keyFile) {
             return keyFile(Output.of(keyFile));
@@ -204,9 +204,9 @@ public final class RepositoryOptsArgs extends com.pulumi.resources.ResourceArgs 
 
         /**
          * @param password Password for HTTP basic authentication
-         * 
+         *
          * @return builder
-         * 
+         *
          */
         public Builder password(@Nullable Output<String> password) {
             $.password = password;
@@ -215,19 +215,19 @@ public final class RepositoryOptsArgs extends com.pulumi.resources.ResourceArgs 
 
         /**
          * @param password Password for HTTP basic authentication
-         * 
+         *
          * @return builder
-         * 
+         *
          */
         public Builder password(String password) {
             return password(Output.of(password));
         }
 
         /**
-         * @param repo Repository where to locate the requested chart. If is a URL the chart is installed without installing the repository.
-         * 
+         * @param repo Repository where to locate the requested chart. If it's a URL the chart is installed without installing the repository.
+         *
          * @return builder
-         * 
+         *
          */
         public Builder repo(@Nullable Output<String> repo) {
             $.repo = repo;
@@ -235,10 +235,10 @@ public final class RepositoryOptsArgs extends com.pulumi.resources.ResourceArgs 
         }
 
         /**
-         * @param repo Repository where to locate the requested chart. If is a URL the chart is installed without installing the repository.
-         * 
+         * @param repo Repository where to locate the requested chart. If it's a URL the chart is installed without installing the repository.
+         *
          * @return builder
-         * 
+         *
          */
         public Builder repo(String repo) {
             return repo(Output.of(repo));
@@ -246,9 +246,9 @@ public final class RepositoryOptsArgs extends com.pulumi.resources.ResourceArgs 
 
         /**
          * @param username Username for HTTP basic authentication
-         * 
+         *
          * @return builder
-         * 
+         *
          */
         public Builder username(@Nullable Output<String> username) {
             $.username = username;
@@ -257,9 +257,9 @@ public final class RepositoryOptsArgs extends com.pulumi.resources.ResourceArgs 
 
         /**
          * @param username Username for HTTP basic authentication
-         * 
+         *
          * @return builder
-         * 
+         *
          */
         public Builder username(String username) {
             return username(Output.of(username));

--- a/sdk/nodejs/types/helm/v3/input.ts
+++ b/sdk/nodejs/types/helm/v3/input.ts
@@ -28,7 +28,7 @@ export interface RepositoryOpts {
      */
     password?: pulumi.Input<string>;
     /**
-     * Repository where to locate the requested chart. If is a URL the chart is installed without installing the repository.
+     * Repository where to locate the requested chart. If it's a URL the chart is installed without installing the repository.
      */
     repo?: pulumi.Input<string>;
     /**

--- a/sdk/nodejs/types/helm/v3/output.ts
+++ b/sdk/nodejs/types/helm/v3/output.ts
@@ -59,7 +59,7 @@ export interface RepositoryOpts {
      */
     password: string;
     /**
-     * Repository where to locate the requested chart. If is a URL the chart is installed without installing the repository.
+     * Repository where to locate the requested chart. If it's a URL the chart is installed without installing the repository.
      */
     repo: string;
     /**
@@ -67,4 +67,3 @@ export interface RepositoryOpts {
      */
     username: string;
 }
-

--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -10555,7 +10555,7 @@ export namespace batch {
          * time out and mark the resource update as Failed. You can override the default timeout value
          * by setting the 'customTimeouts' option on the resource.
          *
-         * By default, if a resource failed to become ready in a previous update, 
+         * By default, if a resource failed to become ready in a previous update,
          * Pulumi will continue to wait for readiness on the next update. If you would prefer
          * to schedule a replacement for an unready resource on the next update, you can add the
          * "pulumi.com/replaceUnready": "true" annotation to the resource definition.
@@ -19021,7 +19021,7 @@ export namespace core {
          * Secret holds secret data of a certain type. The total bytes of the values in the Data field must be less than MaxSecretSize bytes.
          *
          * Note: While Pulumi automatically encrypts the 'data' and 'stringData'
-         * fields, this encryption only applies to Pulumi's context, including the state file, 
+         * fields, this encryption only applies to Pulumi's context, including the state file,
          * the Service, the CLI, etc. Kubernetes does not encrypt Secret resources by default,
          * and the contents are visible to users with access to the Secret in Kubernetes using
          * tools like 'kubectl'.
@@ -22243,7 +22243,7 @@ export namespace extensions {
         }
 
         /**
-         * Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc. 
+         * Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.
          *
          * This resource waits until its status is ready before registering success
          * for create/update, and populating output properties from the current state of the resource.
@@ -26331,7 +26331,7 @@ export namespace helm {
              */
             password?: pulumi.Input<string>;
             /**
-             * Repository where to locate the requested chart. If is a URL the chart is installed without installing the repository.
+             * Repository where to locate the requested chart. If it's a URL the chart is installed without installing the repository.
              */
             repo?: pulumi.Input<string>;
             /**
@@ -26377,7 +26377,7 @@ export namespace helm {
              */
             password?: pulumi.Input<string>;
             /**
-             * Repository where to locate the requested chart. If is a URL the chart is installed without installing the repository.
+             * Repository where to locate the requested chart. If it's a URL the chart is installed without installing the repository.
              */
             repo?: pulumi.Input<string>;
             /**

--- a/sdk/nodejs/types/output.ts
+++ b/sdk/nodejs/types/output.ts
@@ -12050,7 +12050,7 @@ export namespace batch {
          * time out and mark the resource update as Failed. You can override the default timeout value
          * by setting the 'customTimeouts' option on the resource.
          *
-         * By default, if a resource failed to become ready in a previous update, 
+         * By default, if a resource failed to become ready in a previous update,
          * Pulumi will continue to wait for readiness on the next update. If you would prefer
          * to schedule a replacement for an unready resource on the next update, you can add the
          * "pulumi.com/replaceUnready": "true" annotation to the resource definition.
@@ -21542,7 +21542,7 @@ export namespace core {
          * Secret holds secret data of a certain type. The total bytes of the values in the Data field must be less than MaxSecretSize bytes.
          *
          * Note: While Pulumi automatically encrypts the 'data' and 'stringData'
-         * fields, this encryption only applies to Pulumi's context, including the state file, 
+         * fields, this encryption only applies to Pulumi's context, including the state file,
          * the Service, the CLI, etc. Kubernetes does not encrypt Secret resources by default,
          * and the contents are visible to users with access to the Secret in Kubernetes using
          * tools like 'kubectl'.
@@ -24944,7 +24944,7 @@ export namespace extensions {
         }
 
         /**
-         * Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc. 
+         * Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.
          *
          * This resource waits until its status is ready before registering success
          * for create/update, and populating output properties from the current state of the resource.
@@ -29495,7 +29495,7 @@ export namespace helm {
              */
             password: string;
             /**
-             * Repository where to locate the requested chart. If is a URL the chart is installed without installing the repository.
+             * Repository where to locate the requested chart. If it's a URL the chart is installed without installing the repository.
              */
             repo: string;
             /**

--- a/sdk/python/pulumi_kubernetes/helm/v3/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/helm/v3/_inputs.py
@@ -44,7 +44,7 @@ if not MYPY:
         """
         repo: NotRequired[pulumi.Input[str]]
         """
-        Repository where to locate the requested chart. If is a URL the chart is installed without installing the repository.
+        Repository where to locate the requested chart. If it's a URL the chart is installed without installing the repository.
         """
         username: NotRequired[pulumi.Input[str]]
         """
@@ -68,7 +68,7 @@ class RepositoryOptsArgs:
         :param pulumi.Input[str] cert_file: The repository's cert file
         :param pulumi.Input[str] key_file: The repository's cert key file
         :param pulumi.Input[str] password: Password for HTTP basic authentication
-        :param pulumi.Input[str] repo: Repository where to locate the requested chart. If is a URL the chart is installed without installing the repository.
+        :param pulumi.Input[str] repo: Repository where to locate the requested chart. If it's a URL the chart is installed without installing the repository.
         :param pulumi.Input[str] username: Username for HTTP basic authentication
         """
         if ca_file is not None:
@@ -136,7 +136,7 @@ class RepositoryOptsArgs:
     @pulumi.getter
     def repo(self) -> Optional[pulumi.Input[str]]:
         """
-        Repository where to locate the requested chart. If is a URL the chart is installed without installing the repository.
+        Repository where to locate the requested chart. If it's a URL the chart is installed without installing the repository.
         """
         return pulumi.get(self, "repo")
 
@@ -155,5 +155,3 @@ class RepositoryOptsArgs:
     @username.setter
     def username(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "username", value)
-
-

--- a/sdk/python/pulumi_kubernetes/helm/v3/outputs.py
+++ b/sdk/python/pulumi_kubernetes/helm/v3/outputs.py
@@ -165,7 +165,7 @@ class RepositoryOpts(dict):
         :param str cert_file: The repository's cert file
         :param str key_file: The repository's cert key file
         :param str password: Password for HTTP basic authentication
-        :param str repo: Repository where to locate the requested chart. If is a URL the chart is installed without installing the repository.
+        :param str repo: Repository where to locate the requested chart. If it's a URL the chart is installed without installing the repository.
         :param str username: Username for HTTP basic authentication
         """
         if ca_file is not None:
@@ -217,7 +217,7 @@ class RepositoryOpts(dict):
     @pulumi.getter
     def repo(self) -> Optional[str]:
         """
-        Repository where to locate the requested chart. If is a URL the chart is installed without installing the repository.
+        Repository where to locate the requested chart. If it's a URL the chart is installed without installing the repository.
         """
         return pulumi.get(self, "repo")
 
@@ -228,5 +228,3 @@ class RepositoryOpts(dict):
         Username for HTTP basic authentication
         """
         return pulumi.get(self, "username")
-
-

--- a/sdk/python/pulumi_kubernetes/helm/v4/_inputs.py
+++ b/sdk/python/pulumi_kubernetes/helm/v4/_inputs.py
@@ -101,7 +101,7 @@ if not MYPY:
         """
         repo: NotRequired[pulumi.Input[str]]
         """
-        Repository where to locate the requested chart. If is a URL the chart is installed without installing the repository.
+        Repository where to locate the requested chart. If it's a URL the chart is installed without installing the repository.
         """
         username: NotRequired[pulumi.Input[str]]
         """
@@ -125,7 +125,7 @@ class RepositoryOptsArgs:
         :param pulumi.Input[Union[pulumi.Asset, pulumi.Archive]] cert_file: The repository's cert file
         :param pulumi.Input[Union[pulumi.Asset, pulumi.Archive]] key_file: The repository's cert key file
         :param pulumi.Input[str] password: Password for HTTP basic authentication
-        :param pulumi.Input[str] repo: Repository where to locate the requested chart. If is a URL the chart is installed without installing the repository.
+        :param pulumi.Input[str] repo: Repository where to locate the requested chart. If it's a URL the chart is installed without installing the repository.
         :param pulumi.Input[str] username: Username for HTTP basic authentication
         """
         if ca_file is not None:
@@ -193,7 +193,7 @@ class RepositoryOptsArgs:
     @pulumi.getter
     def repo(self) -> Optional[pulumi.Input[str]]:
         """
-        Repository where to locate the requested chart. If is a URL the chart is installed without installing the repository.
+        Repository where to locate the requested chart. If it's a URL the chart is installed without installing the repository.
         """
         return pulumi.get(self, "repo")
 
@@ -212,5 +212,3 @@ class RepositoryOptsArgs:
     @username.setter
     def username(self, value: Optional[pulumi.Input[str]]):
         pulumi.set(self, "username", value)
-
-


### PR DESCRIPTION
### Proposed changes
This is a simple typo fix to change `is` to `it's`. There's also some linting included that removes trailing spaces and newlines, but I can remove these if that should be a separate PR.

