### PR TITLE
Fix schemagen canonical group determination to be more specific

### DIFF
--- a/provider/go.mod
+++ b/provider/go.mod
@@ -8,7 +8,6 @@ replace (
 )
 
 require (
-	github.com/ahmetb/go-linq v3.0.0+incompatible
 	github.com/evanphx/json-patch v5.7.0+incompatible
 	github.com/fluxcd/pkg/ssa v0.28.1
 	github.com/golang/protobuf v1.5.4
@@ -203,7 +202,7 @@ require (
 	google.golang.org/protobuf v1.34.2
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/apiextensions-apiserver v0.31.0
 	k8s.io/apiserver v0.31.0
 	k8s.io/component-base v0.31.0 // indirect

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -104,8 +104,6 @@ github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da h1:KjTM2ks9d14ZYCvmH
 github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da/go.mod h1:eHEWzANqSiWQsof+nXEI9bUVUyV6F53Fp89EuCh2EAA=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
-github.com/ahmetb/go-linq v3.0.0+incompatible h1:qQkjjOXKrKOTy83X8OpRmnKflXKQIL/mC/gMVVDMhOA=
-github.com/ahmetb/go-linq v3.0.0+incompatible/go.mod h1:PFffvbdbtw+QTB0WKRP0cNht7vnCfnGlEpak/DVg5cY=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=

--- a/provider/pkg/gen/additionalComments.go
+++ b/provider/pkg/gen/additionalComments.go
@@ -17,6 +17,7 @@ package gen
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/pulumi/pulumi-kubernetes/provider/v4/pkg/await"
 	"github.com/pulumi/pulumi-kubernetes/provider/v4/pkg/kinds"
@@ -167,6 +168,16 @@ func PulumiComment(kind string) string {
 func APIVersionComment(gvk schema.GroupVersionKind) string {
 	const deprecatedTemplate = `%s is deprecated by %s`
 	const notSupportedTemplate = ` and not supported by Kubernetes v%v+ clusters.`
+
+	// Get only the last segment of the group.
+	t := strings.Split(gvk.Group, ".")
+	groupBackwardsCompatible := t[len(t)-1]
+	gvk = schema.GroupVersionKind{
+		Group:   groupBackwardsCompatible,
+		Version: gvk.Version,
+		Kind:    gvk.Kind,
+	}
+
 	gvkStr := gvk.GroupVersion().String() + "/" + gvk.Kind
 	removedIn := kinds.RemovedInVersion(gvk)
 

--- a/provider/pkg/gen/additionalComments_test.go
+++ b/provider/pkg/gen/additionalComments_test.go
@@ -26,19 +26,19 @@ func TestAPIVersionComment(t *testing.T) {
 		expected string
 	}{
 		{
-			gvk:      schema.GroupVersionKind{Group: "apps", Version: "v1beta1", Kind: "Deployment"},
+			gvk:      schema.GroupVersionKind{Group: "io.k8s.api.apps", Version: "v1beta1", Kind: "Deployment"},
 			expected: "apps/v1beta1/Deployment is deprecated by apps/v1/Deployment and not supported by Kubernetes v1.16+ clusters.",
 		},
 		{
-			gvk:      schema.GroupVersionKind{Group: "extensions", Version: "v1beta1", Kind: "Ingress"},
+			gvk:      schema.GroupVersionKind{Group: "io.k8s.api.extensions", Version: "v1beta1", Kind: "Ingress"},
 			expected: "extensions/v1beta1/Ingress is deprecated by networking.k8s.io/v1beta1/Ingress and not supported by Kubernetes v1.20+ clusters.",
 		},
 		{
-			gvk:      schema.GroupVersionKind{Group: "batch", Version: "v1beta1", Kind: "CronJob"},
+			gvk:      schema.GroupVersionKind{Group: "io.k8s.api.batch", Version: "v1beta1", Kind: "CronJob"},
 			expected: "batch/v1beta1/CronJob is deprecated by batch/v1beta1/CronJob.",
 		},
 		{
-			gvk:      schema.GroupVersionKind{Group: "core", Version: "v1", Kind: "Pod"},
+			gvk:      schema.GroupVersionKind{Group: "io.k8s.api.core", Version: "v1", Kind: "Pod"},
 			expected: "core/v1/Pod is deprecated by core/v1/Pod.",
 		},
 	}

--- a/provider/pkg/gen/additionalComments_test.go
+++ b/provider/pkg/gen/additionalComments_test.go
@@ -1,0 +1,124 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gen
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestAPIVersionComment(t *testing.T) {
+	tests := []struct {
+		gvk      schema.GroupVersionKind
+		expected string
+	}{
+		{
+			gvk:      schema.GroupVersionKind{Group: "apps", Version: "v1beta1", Kind: "Deployment"},
+			expected: "apps/v1beta1/Deployment is deprecated by apps/v1/Deployment and not supported by Kubernetes v1.16+ clusters.",
+		},
+		{
+			gvk:      schema.GroupVersionKind{Group: "extensions", Version: "v1beta1", Kind: "Ingress"},
+			expected: "extensions/v1beta1/Ingress is deprecated by networking.k8s.io/v1beta1/Ingress and not supported by Kubernetes v1.20+ clusters.",
+		},
+		{
+			gvk:      schema.GroupVersionKind{Group: "batch", Version: "v1beta1", Kind: "CronJob"},
+			expected: "batch/v1beta1/CronJob is deprecated by batch/v1beta1/CronJob.",
+		},
+		{
+			gvk:      schema.GroupVersionKind{Group: "core", Version: "v1", Kind: "Pod"},
+			expected: "core/v1/Pod is deprecated by core/v1/Pod.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.gvk.String(), func(t *testing.T) {
+			actual := APIVersionComment(tt.gvk)
+			if actual != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, actual)
+			}
+		})
+	}
+}
+
+// TODO: The tests, and function itself, are rather brittle. We should find a way to make this more robust.
+func TestPulumiComment(t *testing.T) {
+	tests := []struct {
+		kind     string
+		expected string
+	}{
+		{
+			kind: "Deployment",
+			expected: "\n\nThis resource waits until its status is ready before registering success\n" +
+				"for create/update, and populating output properties from the current state of the resource.\n" +
+				"The following conditions are used to determine whether the resource creation has\n" +
+				"succeeded or failed:\n\n" +
+				"1. The Deployment has begun to be updated by the Deployment controller. If the current\n" +
+				"   generation of the Deployment is > 1, then this means that the current generation must\n" +
+				"   be different from the generation reported by the last outputs.\n" +
+				"2. There exists a ReplicaSet whose revision is equal to the current revision of the\n" +
+				"   Deployment.\n" +
+				"3. The Deployment's '.status.conditions' has a status of type 'Available' whose 'status'\n" +
+				"   member is set to 'True'.\n" +
+				"4. If the Deployment has generation > 1, then '.status.conditions' has a status of type\n" +
+				"   'Progressing', whose 'status' member is set to 'True', and whose 'reason' is\n" +
+				"   'NewReplicaSetAvailable'. For generation <= 1, this status field does not exist,\n" +
+				"   because it doesn't do a rollout (i.e., it simply creates the Deployment and\n" +
+				"   corresponding ReplicaSet), and therefore there is no rollout to mark as 'Progressing'.\n\n" +
+				"If the Deployment has not reached a Ready state after 10 minutes, it will\n" +
+				"time out and mark the resource update as Failed. You can override the default timeout value\n" +
+				"by setting the 'customTimeouts' option on the resource.",
+		},
+		{
+			kind: "Secret",
+			expected: "\n\nNote: While Pulumi automatically encrypts the 'data' and 'stringData'\n" +
+				"fields, this encryption only applies to Pulumi's context, including the state file, \n" +
+				"the Service, the CLI, etc. Kubernetes does not encrypt Secret resources by default,\n" +
+				"and the contents are visible to users with access to the Secret in Kubernetes using\n" +
+				"tools like 'kubectl'.\n\n" +
+				"For more information on securing Kubernetes Secrets, see the following links:\n" +
+				"https://kubernetes.io/docs/concepts/configuration/secret/#security-properties\n" +
+				"https://kubernetes.io/docs/concepts/configuration/secret/#risks",
+		},
+		{
+			kind: "Job",
+			expected: "\n\nThis resource waits until its status is ready before registering success\n" +
+				"for create/update, and populating output properties from the current state of the resource.\n" +
+				"The following conditions are used to determine whether the resource creation has\n" +
+				"succeeded or failed:\n\n" +
+				"1. The Job's '.status.startTime' is set, which indicates that the Job has started running.\n" +
+				"2. The Job's '.status.conditions' has a status of type 'Complete', and a 'status' set\n" +
+				"   to 'True'.\n" +
+				"3. The Job's '.status.conditions' do not have a status of type 'Failed', with a\n" +
+				"	'status' set to 'True'. If this condition is set, we should fail the Job immediately.\n\n" +
+				"If the Job has not reached a Ready state after 10 minutes, it will\n" +
+				"time out and mark the resource update as Failed. You can override the default timeout value\n" +
+				"by setting the 'customTimeouts' option on the resource.\n\n" +
+				"By default, if a resource failed to become ready in a previous update, \n" +
+				"Pulumi will continue to wait for readiness on the next update. If you would prefer\n" +
+				"to schedule a replacement for an unready resource on the next update, you can add the\n" +
+				"\"pulumi.com/replaceUnready\": \"true\" annotation to the resource definition.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.kind, func(t *testing.T) {
+			actual := PulumiComment(tt.kind)
+			if actual != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, actual)
+			}
+		})
+	}
+}

--- a/provider/pkg/gen/dotnet_test.go
+++ b/provider/pkg/gen/dotnet_test.go
@@ -1,0 +1,46 @@
+// Copyright 2016-2024, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gen
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCaseMapping_Add(t *testing.T) {
+	cm := CaseMapping{mapping: make(map[string]string)}
+
+	err := cm.Add("test", "Test")
+	assert.NoError(t, err)
+
+	err = cm.Add("test", "Test")
+	assert.Error(t, err)
+	assert.Equal(t, "case mapping for \"test\" already exists", err.Error())
+}
+
+func TestCaseMapping_Get(t *testing.T) {
+	cm := CaseMapping{mapping: make(map[string]string)}
+
+	cm.Add("test", "Test")
+	assert.Equal(t, "Test", cm.Get("test"))
+
+	assert.Equal(t, "Unknown", cm.Get("unknown"))
+}
+
+func TestPascalCaseMapping(t *testing.T) {
+	assert.Equal(t, "AdmissionRegistration", PascalCaseMapping.Get("admissionregistration"))
+	assert.Equal(t, "Unknown", PascalCaseMapping.Get("unknown"))
+}

--- a/provider/pkg/gen/testdata/identify-list-kinds/list-kind
+++ b/provider/pkg/gen/testdata/identify-list-kinds/list-kind
@@ -145,9 +145,9 @@
 }
 
 -- kinds --
-- k8sversion.test.TestResource
-- k8sversion.test.TestResourceNotRealList
+- com.pulumi.k8sversion.test.TestResource
+- com.pulumi.k8sversion.test.TestResourceNotRealList
 
 -- listKinds --
-- k8sversion.test.TestResourceList
-- k8sversion.test.TestResourceNotRealListList
+- com.pulumi.k8sversion.test.TestResourceList
+- com.pulumi.k8sversion.test.TestResourceNotRealListList

--- a/provider/pkg/gen/typegen_test.go
+++ b/provider/pkg/gen/typegen_test.go
@@ -21,11 +21,27 @@ import (
 	"path/filepath"
 	"testing"
 
+	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/tools/txtar"
 	"gopkg.in/yaml.v2"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
+
+// gvkToString concatenates a group, version, and kind into a string in the format group.version.kind.
+func gvkToString(group, version, kind string) string {
+	return group + "." + version + "." + kind
+}
+
+// sliceToSet converts a slice of strings into a set of strings for easy membership checking.
+func sliceToSet(slice []string) map[string]struct{} {
+	set := make(map[string]struct{})
+	for _, item := range slice {
+		set[item] = struct{}{}
+	}
+	return set
+}
 
 // TestCreateGroups_IdentifyListKinds loads txtar files under testdata/identify-list-kinds and uses them to
 // craft an unstructured map[string]any definitions file for createGroups.
@@ -89,14 +105,641 @@ func TestCreateGroups_IdentifyListKinds(t *testing.T) {
 	}
 }
 
-func gvkToString(group, version, kind string) string {
-	return group + "." + version + "." + kind
+func TestAliasesForKind(t *testing.T) {
+	tests := []struct {
+		kind       string
+		apiVersion string
+		aliases    map[string][]any
+		expected   []string
+	}{
+		// No aliases mapping, should return no types.
+		{
+			kind:       "Deployment",
+			apiVersion: "apps/v1",
+			aliases:    map[string][]any{},
+			expected:   []string{},
+		},
+		{
+			kind:       "Deployment",
+			apiVersion: "apps/v1",
+			aliases: map[string][]any{
+				"Deployment": {
+					"kubernetes:apps/v1beta1:Deployment",
+					"kubernetes:extensions/v1beta1:Deployment",
+				},
+			},
+			expected: []string{
+				"kubernetes:apps/v1beta1:Deployment",
+				"kubernetes:extensions/v1beta1:Deployment",
+			},
+		},
+		{
+			kind:       "CSIStorageCapacity",
+			apiVersion: "storage.k8s.io/v1beta1",
+			aliases: map[string][]any{
+				"CSIStorageCapacity": {
+					"kubernetes:storage.k8s.io/v1alpha1:CSIStorageCapacity",
+				},
+			},
+			expected: []string{
+				"kubernetes:storage.k8s.io/v1alpha1:CSIStorageCapacity",
+				"kubernetes:storage.k8s.io/v1alpha1:CSIStorageCapacity",
+			},
+		},
+		{
+			kind:       "APIService",
+			apiVersion: "apiregistration.k8s.io/v1",
+			aliases: map[string][]any{
+				"APIService": {
+					"kubernetes:apiregistration.k8s.io/v1beta1:APIService",
+				},
+			},
+			expected: []string{
+				"kubernetes:apiregistration.k8s.io/v1beta1:APIService",
+				"kubernetes:apiregistration/v1beta1:APIService",
+				"kubernetes:apiregistration/v1:APIService",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.kind, func(t *testing.T) {
+			actual := aliasesForKind(tt.kind, tt.apiVersion, tt.aliases)
+			assert.ElementsMatch(t, tt.expected, actual)
+		})
+	}
+}
+func TestCreateGroupsFromVersions(t *testing.T) {
+	tests := []struct {
+		name     string
+		versions []VersionConfig
+		expected []GroupConfig
+	}{
+		{
+			name: "single group with single version",
+			versions: []VersionConfig{
+				{
+					version: "v1",
+					gv:      schema.GroupVersion{Group: "apps", Version: "v1"},
+					kinds: []KindConfig{
+						{kind: "Deployment"},
+					},
+				},
+			},
+			expected: []GroupConfig{
+				{
+					group: "apps",
+					versions: []VersionConfig{
+						{
+							version: "v1",
+							gv:      schema.GroupVersion{Group: "apps", Version: "v1"},
+							kinds: []KindConfig{
+								{kind: "Deployment"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "single group with multiple versions",
+			versions: []VersionConfig{
+				{
+					version: "v1",
+					gv:      schema.GroupVersion{Group: "apps", Version: "v1"},
+					kinds: []KindConfig{
+						{kind: "Deployment"},
+					},
+				},
+				{
+					version: "v1beta1",
+					gv:      schema.GroupVersion{Group: "apps", Version: "v1beta1"},
+					kinds: []KindConfig{
+						{kind: "Deployment"},
+					},
+				},
+			},
+			expected: []GroupConfig{
+				{
+					group: "apps",
+					versions: []VersionConfig{
+						{
+							version: "v1",
+							gv:      schema.GroupVersion{Group: "apps", Version: "v1"},
+							kinds: []KindConfig{
+								{kind: "Deployment"},
+							},
+						},
+						{
+							version: "v1beta1",
+							gv:      schema.GroupVersion{Group: "apps", Version: "v1beta1"},
+							kinds: []KindConfig{
+								{kind: "Deployment"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "multiple groups with multiple versions",
+			versions: []VersionConfig{
+				{
+					version: "v1",
+					gv:      schema.GroupVersion{Group: "apps", Version: "v1"},
+					kinds: []KindConfig{
+						{kind: "Deployment"},
+					},
+				},
+				{
+					version: "v1beta1",
+					gv:      schema.GroupVersion{Group: "apps", Version: "v1beta1"},
+					kinds: []KindConfig{
+						{kind: "Deployment"},
+					},
+				},
+				{
+					version: "v1",
+					gv:      schema.GroupVersion{Group: "core", Version: "v1"},
+					kinds: []KindConfig{
+						{kind: "Pod"},
+					},
+				},
+			},
+			expected: []GroupConfig{
+				{
+					group: "apps",
+					versions: []VersionConfig{
+						{
+							version: "v1",
+							gv:      schema.GroupVersion{Group: "apps", Version: "v1"},
+							kinds: []KindConfig{
+								{kind: "Deployment"},
+							},
+						},
+						{
+							version: "v1beta1",
+							gv:      schema.GroupVersion{Group: "apps", Version: "v1beta1"},
+							kinds: []KindConfig{
+								{kind: "Deployment"},
+							},
+						},
+					},
+				},
+				{
+					group: "core",
+					versions: []VersionConfig{
+						{
+							version: "v1",
+							gv:      schema.GroupVersion{Group: "core", Version: "v1"},
+							kinds: []KindConfig{
+								{kind: "Pod"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := createGroupsFromVersions(tt.versions)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+func TestCreateVersions(t *testing.T) {
+	tests := []struct {
+		name     string
+		kinds    []KindConfig
+		expected []VersionConfig
+	}{
+		{
+			name: "single version with single kind",
+			kinds: []KindConfig{
+				{
+					kind:       "Deployment",
+					gvk:        schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"},
+					apiVersion: "apps/v1",
+				},
+			},
+			expected: []VersionConfig{
+				{
+					version:    "v1",
+					gv:         schema.GroupVersion{Group: "apps", Version: "v1"},
+					kinds:      []KindConfig{{kind: "Deployment", gvk: schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}, apiVersion: "apps/v1"}},
+					apiVersion: "apps/v1",
+				},
+			},
+		},
+		{
+			name: "single version with multiple kinds",
+			kinds: []KindConfig{
+				{
+					kind:       "Deployment",
+					gvk:        schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"},
+					apiVersion: "apps/v1",
+				},
+				{
+					kind:       "StatefulSet",
+					gvk:        schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "StatefulSet"},
+					apiVersion: "apps/v1",
+				},
+			},
+			expected: []VersionConfig{
+				{
+					version:    "v1",
+					gv:         schema.GroupVersion{Group: "apps", Version: "v1"},
+					kinds:      []KindConfig{{kind: "Deployment", gvk: schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}, apiVersion: "apps/v1"}, {kind: "StatefulSet", gvk: schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "StatefulSet"}, apiVersion: "apps/v1"}},
+					apiVersion: "apps/v1",
+				},
+			},
+		},
+		{
+			name: "multiple versions with multiple kinds",
+			kinds: []KindConfig{
+				{
+					kind:       "Deployment",
+					gvk:        schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"},
+					apiVersion: "apps/v1",
+				},
+				{
+					kind:       "Deployment",
+					gvk:        schema.GroupVersionKind{Group: "apps", Version: "v1beta1", Kind: "Deployment"},
+					apiVersion: "apps/v1beta1",
+				},
+				{
+					kind:       "Pod",
+					gvk:        schema.GroupVersionKind{Group: "core", Version: "v1", Kind: "Pod"},
+					apiVersion: "core/v1",
+				},
+			},
+			expected: []VersionConfig{
+				{
+					version:    "v1",
+					gv:         schema.GroupVersion{Group: "apps", Version: "v1"},
+					kinds:      []KindConfig{{kind: "Deployment", gvk: schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}, apiVersion: "apps/v1"}},
+					apiVersion: "apps/v1",
+				},
+				{
+					version:    "v1beta1",
+					gv:         schema.GroupVersion{Group: "apps", Version: "v1beta1"},
+					kinds:      []KindConfig{{kind: "Deployment", gvk: schema.GroupVersionKind{Group: "apps", Version: "v1beta1", Kind: "Deployment"}, apiVersion: "apps/v1beta1"}},
+					apiVersion: "apps/v1beta1",
+				},
+				{
+					version:    "v1",
+					gv:         schema.GroupVersion{Group: "core", Version: "v1"},
+					kinds:      []KindConfig{{kind: "Pod", gvk: schema.GroupVersionKind{Group: "core", Version: "v1", Kind: "Pod"}, apiVersion: "core/v1"}},
+					apiVersion: "core/v1",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := createVersions(tt.kinds)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+func TestCreateDefinitions(t *testing.T) {
+	definitionsJSON := map[string]any{
+		"io.k8s.api.apps.v1.Deployment": map[string]any{
+			"properties": map[string]any{
+				"apiVersion": map[string]any{"type": "string"},
+				"kind":       map[string]any{"type": "string"},
+				"metadata":   map[string]any{"$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"},
+			},
+			"x-kubernetes-group-version-kind": []any{
+				map[string]any{"group": "apps", "version": "v1", "kind": "Deployment"},
+			},
+		},
+		"io.k8s.api.core.v1.Pod": map[string]any{
+			"properties": map[string]any{
+				"apiVersion": map[string]any{"type": "string"},
+				"kind":       map[string]any{"type": "string"},
+				"metadata":   map[string]any{"$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"},
+			},
+			"x-kubernetes-group-version-kind": []any{
+				map[string]any{"group": "", "version": "v1", "kind": "Pod"},
+			},
+		},
+	}
+
+	canonicalGroups := map[string]string{
+		"apps": "apps",
+		"core": "core",
+	}
+
+	expected := []definition{
+		{
+			gvk:  schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"},
+			name: "io.k8s.api.apps.v1.Deployment",
+			data: map[string]any{
+				"properties": map[string]any{
+					"apiVersion": map[string]any{"type": "string"},
+					"kind":       map[string]any{"type": "string"},
+					"metadata":   map[string]any{"$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"},
+				},
+				"x-kubernetes-group-version-kind": []any{
+					map[string]any{"group": "apps", "version": "v1", "kind": "Deployment"},
+				},
+			},
+			canonicalGroup: "apps",
+		},
+		{
+			gvk:  schema.GroupVersionKind{Group: "core", Version: "v1", Kind: "Pod"},
+			name: "io.k8s.api.core.v1.Pod",
+			data: map[string]any{
+				"properties": map[string]any{
+					"apiVersion": map[string]any{"type": "string"},
+					"kind":       map[string]any{"type": "string"},
+					"metadata":   map[string]any{"$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"},
+				},
+				"x-kubernetes-group-version-kind": []any{
+					map[string]any{"group": "", "version": "v1", "kind": "Pod"},
+				},
+			},
+			canonicalGroup: "core",
+		},
+	}
+
+	actual := createDefinitions(definitionsJSON, canonicalGroups)
+	assert.Equal(t, expected, actual)
+}
+func TestCreateCanonicalGroups(t *testing.T) {
+	tests := []struct {
+		name            string
+		definitionsJSON map[string]any
+		expectedGroups  map[string]string
+	}{
+		{
+			name: "basic canonical groups",
+			definitionsJSON: map[string]any{
+				"io.k8s.api.core.v1.Pod": map[string]any{
+					"x-kubernetes-group-version-kind": []any{
+						map[string]any{"group": "", "version": "v1", "kind": "Pod"},
+					},
+				},
+				"io.k8s.api.apps.v1.Deployment": map[string]any{
+					"x-kubernetes-group-version-kind": []any{
+						map[string]any{"group": "apps", "version": "v1", "kind": "Deployment"},
+					},
+				},
+			},
+			expectedGroups: map[string]string{
+				"core": "core",
+				"apps": "apps",
+				"meta": "meta",
+			},
+		},
+		{
+			name: "meta group",
+			definitionsJSON: map[string]any{
+				"io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": map[string]any{
+					"x-kubernetes-group-version-kind": []any{
+						map[string]any{"group": "meta", "version": "v1", "kind": "ObjectMeta"},
+					},
+				},
+			},
+			expectedGroups: map[string]string{
+				"meta": "meta",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actualGroups := createCanonicalGroups(tt.definitionsJSON)
+			assert.Equal(t, tt.expectedGroups, actualGroups)
+		})
+	}
+}
+func TestMakeSchemaTypeSpec(t *testing.T) {
+	tests := []struct {
+		name             string
+		prop             map[string]any
+		canonicalGroups  map[string]string
+		expectedTypeSpec pschema.TypeSpec
+	}{
+		{
+			name: "simple string type",
+			prop: map[string]any{
+				"type": "string",
+			},
+			canonicalGroups:  map[string]string{},
+			expectedTypeSpec: pschema.TypeSpec{Type: "string"},
+		},
+		{
+			name: "array type",
+			prop: map[string]any{
+				"type": "array",
+				"items": map[string]any{
+					"type": "string",
+				},
+			},
+			canonicalGroups: map[string]string{},
+			expectedTypeSpec: pschema.TypeSpec{
+				Type: "array",
+				Items: &pschema.TypeSpec{
+					Type: "string",
+				},
+			},
+		},
+		{
+			name: "object type with additional properties",
+			prop: map[string]any{
+				"type": "object",
+				"additionalProperties": map[string]any{
+					"type": "string",
+				},
+			},
+			canonicalGroups: map[string]string{},
+			expectedTypeSpec: pschema.TypeSpec{
+				Type: "object",
+				AdditionalProperties: &pschema.TypeSpec{
+					Type: "string",
+				},
+			},
+		},
+		{
+			name: "preserve unknown fields",
+			prop: map[string]any{
+				"x-kubernetes-preserve-unknown-fields": true,
+			},
+			canonicalGroups: map[string]string{},
+			expectedTypeSpec: pschema.TypeSpec{
+				Type:                 "object",
+				AdditionalProperties: &pschema.TypeSpec{Ref: "pulumi.json#/Any"},
+			},
+		},
+		{
+			name: "int or string",
+			prop: map[string]any{
+				"x-kubernetes-int-or-string": true,
+			},
+			canonicalGroups: map[string]string{},
+			expectedTypeSpec: pschema.TypeSpec{
+				OneOf: []pschema.TypeSpec{
+					{Type: "integer"},
+					{Type: "string"},
+				},
+			},
+		},
+		{
+			name: "quantity type",
+			prop: map[string]any{
+				"$ref": "io.k8s.apimachinery.pkg.api.resource.Quantity",
+			},
+			canonicalGroups:  map[string]string{},
+			expectedTypeSpec: pschema.TypeSpec{Type: "string"},
+		},
+		{
+			name: "GVK reference",
+			prop: map[string]any{
+				"$ref": "#/definitions/io.k8s.api.apps.v1.Deployment",
+			},
+			canonicalGroups: map[string]string{
+				"apps": "apps",
+			},
+			expectedTypeSpec: pschema.TypeSpec{
+				Ref: "#/types/kubernetes:apps/v1:Deployment",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := makeSchemaTypeSpec(tt.prop, tt.canonicalGroups)
+			assert.Equal(t, tt.expectedTypeSpec, actual)
+		})
+	}
 }
 
-func sliceToSet(slice []string) map[string]struct{} {
-	set := make(map[string]struct{})
-	for _, item := range slice {
-		set[item] = struct{}{}
+func TestIsTopLevel(t *testing.T) {
+	tests := []struct {
+		name       string
+		definition definition
+		expected   bool
+	}{
+		{
+			name: "top-level resource with ObjectMeta",
+			definition: definition{
+				gvk: schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"},
+				data: map[string]any{
+					"properties": map[string]any{
+						"metadata": map[string]any{
+							"$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+						},
+					},
+					"x-kubernetes-group-version-kind": []any{
+						map[string]any{"group": "apps", "version": "v1", "kind": "Deployment"},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "top-level resource with ListMeta",
+			definition: definition{
+				gvk: schema.GroupVersionKind{Group: "core", Version: "v1", Kind: "PodList"},
+				data: map[string]any{
+					"properties": map[string]any{
+						"metadata": map[string]any{
+							"$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta",
+						},
+					},
+					"x-kubernetes-group-version-kind": []any{
+						map[string]any{"group": "core", "version": "v1", "kind": "PodList"},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "non-top-level resource",
+			definition: definition{
+				gvk: schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "ReplicaSet"},
+				data: map[string]any{
+					"properties": map[string]any{
+						"spec": map[string]any{
+							"type": "object",
+						},
+					},
+					"x-kubernetes-group-version-kind": []any{
+						map[string]any{"group": "apps", "version": "v1", "kind": "ReplicaSet"},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "imperative resource type",
+			definition: definition{
+				gvk: schema.GroupVersionKind{Group: "core", Version: "v1", Kind: "Status"},
+				data: map[string]any{
+					"x-kubernetes-group-version-kind": []any{
+						map[string]any{"group": "core", "version": "v1", "kind": "Status"},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "missing properties",
+			definition: definition{
+				gvk: schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"},
+				data: map[string]any{
+					"x-kubernetes-group-version-kind": []any{
+						map[string]any{"group": "apps", "version": "v1", "kind": "Deployment"},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "missing metadata",
+			definition: definition{
+				gvk: schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"},
+				data: map[string]any{
+					"properties": map[string]any{
+						"spec": map[string]any{
+							"type": "object",
+						},
+					},
+					"x-kubernetes-group-version-kind": []any{
+						map[string]any{"group": "apps", "version": "v1", "kind": "Deployment"},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "missing $ref in metadata",
+			definition: definition{
+				gvk: schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"},
+				data: map[string]any{
+					"properties": map[string]any{
+						"metadata": map[string]any{
+							"type": "object",
+						},
+					},
+					"x-kubernetes-group-version-kind": []any{
+						map[string]any{"group": "apps", "version": "v1", "kind": "Deployment"},
+					},
+				},
+			},
+			expected: false,
+		},
 	}
-	return set
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := tt.definition.isTopLevel()
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
 }

--- a/provider/pkg/gen/typegen_test.go
+++ b/provider/pkg/gen/typegen_test.go
@@ -430,13 +430,13 @@ func TestCreateDefinitions(t *testing.T) {
 	}
 
 	canonicalGroups := map[string]string{
-		"apps": "apps",
-		"core": "core",
+		"io.k8s.api.apps": "apps",
+		"io.k8s.api.core": "core",
 	}
 
 	expected := []definition{
 		{
-			gvk:  schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"},
+			gvk:  schema.GroupVersionKind{Group: "io.k8s.api.apps", Version: "v1", Kind: "Deployment"},
 			name: "io.k8s.api.apps.v1.Deployment",
 			data: map[string]any{
 				"properties": map[string]any{
@@ -451,7 +451,7 @@ func TestCreateDefinitions(t *testing.T) {
 			canonicalGroup: "apps",
 		},
 		{
-			gvk:  schema.GroupVersionKind{Group: "core", Version: "v1", Kind: "Pod"},
+			gvk:  schema.GroupVersionKind{Group: "io.k8s.api.core", Version: "v1", Kind: "Pod"},
 			name: "io.k8s.api.core.v1.Pod",
 			data: map[string]any{
 				"properties": map[string]any{
@@ -468,8 +468,9 @@ func TestCreateDefinitions(t *testing.T) {
 	}
 
 	actual := createDefinitions(definitionsJSON, canonicalGroups)
-	assert.Equal(t, expected, actual)
+	assert.ElementsMatch(t, expected, actual)
 }
+
 func TestCreateCanonicalGroups(t *testing.T) {
 	tests := []struct {
 		name            string
@@ -491,9 +492,10 @@ func TestCreateCanonicalGroups(t *testing.T) {
 				},
 			},
 			expectedGroups: map[string]string{
-				"core": "core",
-				"apps": "apps",
-				"meta": "meta",
+				"io.k8s.api.core":                   "core",
+				"io.k8s.api.apps":                   "apps",
+				"io.k8s.apimachinery.pkg.apis.meta": "meta",
+				"io.k8s.apimachinery.pkg":           "pkg",
 			},
 		},
 		{
@@ -506,7 +508,8 @@ func TestCreateCanonicalGroups(t *testing.T) {
 				},
 			},
 			expectedGroups: map[string]string{
-				"meta": "meta",
+				"io.k8s.apimachinery.pkg.apis.meta": "meta",
+				"io.k8s.apimachinery.pkg":           "pkg",
 			},
 		},
 	}
@@ -603,7 +606,7 @@ func TestMakeSchemaTypeSpec(t *testing.T) {
 				"$ref": "#/definitions/io.k8s.api.apps.v1.Deployment",
 			},
 			canonicalGroups: map[string]string{
-				"apps": "apps",
+				"io.k8s.api.apps": "apps",
 			},
 			expectedTypeSpec: pschema.TypeSpec{
 				Ref: "#/types/kubernetes:apps/v1:Deployment",
@@ -628,7 +631,7 @@ func TestIsTopLevel(t *testing.T) {
 		{
 			name: "top-level resource with ObjectMeta",
 			definition: definition{
-				gvk: schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"},
+				gvk: schema.GroupVersionKind{Group: "io.k8s.api.apps", Version: "v1", Kind: "Deployment"},
 				data: map[string]any{
 					"properties": map[string]any{
 						"metadata": map[string]any{
@@ -645,7 +648,7 @@ func TestIsTopLevel(t *testing.T) {
 		{
 			name: "top-level resource with ListMeta",
 			definition: definition{
-				gvk: schema.GroupVersionKind{Group: "core", Version: "v1", Kind: "PodList"},
+				gvk: schema.GroupVersionKind{Group: "io.k8s.api.core", Version: "v1", Kind: "PodList"},
 				data: map[string]any{
 					"properties": map[string]any{
 						"metadata": map[string]any{
@@ -662,7 +665,7 @@ func TestIsTopLevel(t *testing.T) {
 		{
 			name: "non-top-level resource",
 			definition: definition{
-				gvk: schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "ReplicaSet"},
+				gvk: schema.GroupVersionKind{Group: "io.k8s.api.apps", Version: "v1", Kind: "ReplicaSet"},
 				data: map[string]any{
 					"properties": map[string]any{
 						"spec": map[string]any{
@@ -679,10 +682,10 @@ func TestIsTopLevel(t *testing.T) {
 		{
 			name: "imperative resource type",
 			definition: definition{
-				gvk: schema.GroupVersionKind{Group: "core", Version: "v1", Kind: "Status"},
+				gvk: schema.GroupVersionKind{Group: "io.k8s.api.authentication", Version: "v1", Kind: "TokenRequest"},
 				data: map[string]any{
 					"x-kubernetes-group-version-kind": []any{
-						map[string]any{"group": "core", "version": "v1", "kind": "Status"},
+						map[string]any{"group": "authentication", "version": "v1", "kind": "TokenRequest"},
 					},
 				},
 			},
@@ -691,7 +694,7 @@ func TestIsTopLevel(t *testing.T) {
 		{
 			name: "missing properties",
 			definition: definition{
-				gvk: schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"},
+				gvk: schema.GroupVersionKind{Group: "io.k8s.api.apps", Version: "v1", Kind: "Deployment"},
 				data: map[string]any{
 					"x-kubernetes-group-version-kind": []any{
 						map[string]any{"group": "apps", "version": "v1", "kind": "Deployment"},
@@ -703,7 +706,7 @@ func TestIsTopLevel(t *testing.T) {
 		{
 			name: "missing metadata",
 			definition: definition{
-				gvk: schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"},
+				gvk: schema.GroupVersionKind{Group: "io.k8s.api.apps", Version: "v1", Kind: "Deployment"},
 				data: map[string]any{
 					"properties": map[string]any{
 						"spec": map[string]any{
@@ -720,7 +723,7 @@ func TestIsTopLevel(t *testing.T) {
 		{
 			name: "missing $ref in metadata",
 			definition: definition{
-				gvk: schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"},
+				gvk: schema.GroupVersionKind{Group: "io.k8s.api.apps", Version: "v1", Kind: "Deployment"},
 				data: map[string]any{
 					"properties": map[string]any{
 						"metadata": map[string]any{
@@ -739,6 +742,53 @@ func TestIsTopLevel(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			actual := tt.definition.isTopLevel()
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestGVKFromRef(t *testing.T) {
+	tests := []struct {
+		ref      string
+		expected schema.GroupVersionKind
+	}{
+		{
+			ref: "io.k8s.api.apps.v1.Deployment",
+			expected: schema.GroupVersionKind{
+				Group:   "io.k8s.api.apps",
+				Version: "v1",
+				Kind:    "Deployment",
+			},
+		},
+		{
+			ref: "io.k8s.api.core.v1.Pod",
+			expected: schema.GroupVersionKind{
+				Group:   "io.k8s.api.core",
+				Version: "v1",
+				Kind:    "Pod",
+			},
+		},
+		{
+			ref: "io.k8s.api.extensions.v1beta1.Ingress",
+			expected: schema.GroupVersionKind{
+				Group:   "io.k8s.api.extensions",
+				Version: "v1beta1",
+				Kind:    "Ingress",
+			},
+		},
+		{
+			ref: "io.k8s.api.networking.v1.NetworkPolicy",
+			expected: schema.GroupVersionKind{
+				Group:   "io.k8s.api.networking",
+				Version: "v1",
+				Kind:    "NetworkPolicy",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.ref, func(t *testing.T) {
+			actual := GVKFromRef(tt.ref)
 			assert.Equal(t, tt.expected, actual)
 		})
 	}


### PR DESCRIPTION
### Proposed Changes
This PR includes a major refactor of the `createGroups` function in the `gen` package and addresses a bug that could lead to map key collisions when storing groups derived from swagger paths. Previously, consumers of the `gen` package could encounter key collisions when different CRDs used the same key. For instance, both `io.k8s.api.apps` and `com.testpackage.apps` would result in the key `apps`. This PR resolves this by using the full group name (e.g., `io.k8s.api.apps`) as the map key instead of just the last segment. Since no such collisions exist in the standard Kubernetes GVKs, no schema changes are expected.

To support these changes, the `typegen.go` file has been significantly refactored. The `createGroups` function has been modularized for easier testing and maintainability. Additionally, the `go-linq` dependency has been removed in favor of idiomatic Go code, allowing for static type checking and reducing runtime type errors.

### Changes Made:

- Refactored `createGroups` into modular subfunctions
- Increased test coverage of the `gen` package from 36.8% to 49.6% with new tests
- Replaced `github.com/ahmetb/go-linq` with idiomatic Go for better maintainability and static type checking
- Fixed map key creation to use the full group name, preventing collisions, with no schema changes required in the p-k provider

### Related Issues (optional)

Fixes: #3227 and resolves https://github.com/pulumi/crd2pulumi/issues/152