### PR TITLE
fix(chartv3): update blogpost link to chart-v4 announcement

### DIFF
--- a/provider/pkg/gen/examples/overlays/chartV3.md
+++ b/provider/pkg/gen/examples/overlays/chartV3.md
@@ -1,6 +1,6 @@
 {{% notes type="info" %}}
 A newer version of this resource is available as [kubernetes.helm.sh/v4.Chart](/registry/packages/kubernetes/api-docs/helm/v4/chart/).
-See the corresponding [blog post](/blog/kubernetes-yaml-v2/) for more information.
+See the corresponding [blog post](/blog/kubernetes-chart-v4/) for more information.
 {{% /notes %}}
 
 Chart is a component representing a collection of resources described by an arbitrary Helm Chart.


### PR DESCRIPTION
### Proposed changes

Corrects a link on the [kubernetes.helm.sh/v3.Chart](https://www.pulumi.com/registry/packages/kubernetes/api-docs/helm/v3/chart/) to point to the correct blog post.

### Related issues (optional)

Fixes pulumi/docs#13136