### PR TITLE
[helm.v4.Chart] Proposal: option to deploy helm hooks

### DIFF
--- a/provider/pkg/gen/examples/overlays/chartV4.md
+++ b/provider/pkg/gen/examples/overlays/chartV4.md
@@ -56,7 +56,9 @@ Use the `dependencyUpdate` input to have Pulumi update the dependencies (see: [H
 The `Chart` resource renders the templates from your chart and then manages the resources directly with the
 Pulumi Kubernetes provider. A default namespace is applied based on the `namespace` input, the provider's
 configured namespace, and the active Kubernetes context. Use the `skipCrds` option to skip installing the
-Custom Resource Definition (CRD) objects located in the chart's `crds/` special directory.
+Custom Resource Definition (CRD) objects located in the chart's `crds/` special directory. By default,
+resources managed by helm hooks are ignored, use `deployHookedResources` to deploy them as regular resources,
+ignoring their `helm.sh/hook*` annotations.
 
 Use the `postRenderer` input to pipe the rendered manifest through a [post-rendering command](https://helm.sh/docs/topics/advanced/#post-rendering).
 

--- a/provider/pkg/gen/overlays.go
+++ b/provider/pkg/gen/overlays.go
@@ -231,6 +231,12 @@ var helmV4ChartResource = pschema.ResourceSpec{
 			},
 			Description: "If set, no CRDs will be installed. By default, CRDs are installed if not already present.",
 		},
+		"deployHookedResourcess": {
+			TypeSpec: pschema.TypeSpec{
+				Type: "boolean",
+			},
+			Description: "If set, deploy all resources that would be managed by Helm hooks as regular resources, ignoring their hook annotations. When disabled (default), these resources are ignored.",
+		},
 		"postRenderer": {
 			TypeSpec: pschema.TypeSpec{
 				Ref: "#/types/kubernetes:helm.sh/v4:PostRenderer",

--- a/provider/pkg/provider/helm/v4/chart_test.go
+++ b/provider/pkg/provider/helm/v4/chart_test.go
@@ -357,6 +357,24 @@ var _ = Describe("Construct", func() {
 			})
 		})
 
+		Describe("DeployHookedResources", func() {
+			Context("given deployHookedResources", func() {
+				BeforeEach(func() {
+					inputs["deployHookedResources"] = resource.NewBoolProperty(true)
+				})
+				It("should deploy hooked resources", func(ctx context.Context) {
+					resp, err := pulumiprovider.Construct(ctx, req, tc.EngineConn(), k.Construct)
+					Expect(err).ShouldNot(HaveOccurred())
+					outputs := unmarshalProperties(GinkgoTB(), resp.State)
+					Expect(outputs).To(MatchProps(IgnoreExtras, Props{
+						"resources": MatchArrayValue(ContainElements(
+							MatchResourceReferenceValue("urn:pulumi:stack::project::kubernetes:helm/v4:Chart$kubernetes:policy/v1:PodDisruptionBudget::test:default/test-reference", "test:default/test-reference"),
+						)),
+					}))
+				})
+			})
+		})
+
 		Describe("Post Renderer", func() {
 			Context("given a postRenderer", func() {
 				var tempdir string

--- a/provider/pkg/provider/helm/v4/testdata/reference/templates/hook_poddisruptionbudget.yaml
+++ b/provider/pkg/provider/helm/v4/testdata/reference/templates/hook_poddisruptionbudget.yaml
@@ -1,0 +1,12 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "reference.fullname" . }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  minAvailable: 0
+  selector:
+    matchLabels: ~


### PR DESCRIPTION
### Proposed changes

`helm.v3.Chart` ignored the `helm.sh/hook*` annotations but still deployed the resources.
The `helm.v4.Chart` resource skips the hooks. This is mentioned [in the blog](https://www.pulumi.com/blog/kubernetes-chart-v4/#not-supported-helm-hooks) but not in the docs BTW.

In this PR I propose to make it configurable so a pulumi user can decide to deploy resources, ignoring the hooks.
The end goal being that helm.v4.Chart comes to feature parity with helm.v3.Chart so we can all move all our charts to v4.

Note that:
* I don't known what I'm doing here, feel free to take over !
* `CONTRIBUTING.md` tells me to install stuff in `/opt` which is not happening, so I did not run the tests locally

### Related issues (optional)

Fixes #3284