### PR TITLE
Prepare for 4.18.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 4.18.3 (October 31, 2024)
+
 ### Fixed
 
 - Objects created on clusters older than 1.18 will no longer see a


### PR DESCRIPTION
### Fixed

- Objects created on clusters older than 1.18 will no longer see a `before-first-apply` conflict when Pulumi performs a server-side apply for the first time. (https://github.com/pulumi/pulumi-kubernetes/pull/3275)

- The provider's user agent is now set correctly when communicating with the Kubernetes API server. (https://github.com/pulumi/pulumi-kubernetes/issues/3267)