### PR TITLE
Fix tests

### DIFF
--- a/tests/sdk/nodejs/examples/provider/index.ts
+++ b/tests/sdk/nodejs/examples/provider/index.ts
@@ -14,7 +14,7 @@ const myk8s2 = new k8s.Provider("myk8s2", {
 const nginxcontainer = new k8s.core.v1.Pod("nginx", {
     spec: {
         containers: [{
-            image: "nginx:1.7.9",
+            image: "nginx:1.27.2",
             name: "nginx",
             ports: [{ containerPort: 80 }],
         }],
@@ -25,7 +25,7 @@ const nginxcontainer = new k8s.core.v1.Pod("nginx", {
 const nginxcontainer2 = new k8s.core.v1.Pod("nginx2", {
     spec: {
         containers: [{
-            image: "nginx:1.7.9",
+            image: "nginx:1.27.2",
             name: "nginx",
             ports: [{ containerPort: 80 }],
         }],

--- a/tests/sdk/nodejs/namespace/step1/index.ts
+++ b/tests/sdk/nodejs/namespace/step1/index.ts
@@ -30,7 +30,7 @@ new k8s.core.v1.Pod("no-metadata-pod", {
         containers: [
             {
                 name: "nginx",
-                image: "nginx:1.7.9",
+                image: "nginx:1.27.2",
                 ports: [{containerPort: 80}]
             }
         ]
@@ -49,7 +49,7 @@ new k8s.core.v1.Pod("default-ns-pod", {
         containers: [
             {
                 name: "nginx",
-                image: "nginx:1.7.9",
+                image: "nginx:1.27.2",
                 ports: [{containerPort: 80}]
             }
         ]

--- a/tests/sdk/nodejs/namespace/step2/index.ts
+++ b/tests/sdk/nodejs/namespace/step2/index.ts
@@ -35,7 +35,7 @@ new k8s.core.v1.Pod("no-metadata-pod", {
         containers: [
             {
                 name: "nginx",
-                image: "nginx:1.7.9",
+                image: "nginx:1.27.2",
                 ports: [{containerPort: 80}]
             }
         ]
@@ -54,7 +54,7 @@ new k8s.core.v1.Pod("default-ns-pod", {
         containers: [
             {
                 name: "nginx",
-                image: "nginx:1.7.9",
+                image: "nginx:1.27.2",
                 ports: [{containerPort: 80}]
             }
         ]

--- a/tests/sdk/nodejs/namespace/step3/index.ts
+++ b/tests/sdk/nodejs/namespace/step3/index.ts
@@ -39,7 +39,7 @@ new k8s.core.v1.Pod("no-metadata-pod", {
         containers: [
             {
                 name: "nginx",
-                image: "nginx:1.7.9",
+                image: "nginx:1.27.2",
                 ports: [{containerPort: 80}]
             }
         ]
@@ -56,7 +56,7 @@ new k8s.core.v1.Pod("default-ns-pod", {
         containers: [
             {
                 name: "nginx",
-                image: "nginx:1.7.9",
+                image: "nginx:1.27.2",
                 ports: [{containerPort: 80}]
             }
         ]

--- a/tests/sdk/nodejs/provider/step1/index.ts
+++ b/tests/sdk/nodejs/provider/step1/index.ts
@@ -39,7 +39,7 @@ const kubeconfigPathProvider = new k8s.Provider("kubeconfigPathProvider", {
 new k8s.core.v1.Pod("nginx1", {
     spec: {
         containers: [{
-            image: "nginx:1.7.9",
+            image: "nginx:1.27.2",
             name: "nginx",
             ports: [{ containerPort: 80 }],
         }],
@@ -51,7 +51,7 @@ new k8s.core.v1.Pod("nginx1", {
 new k8s.core.v1.Pod("nginx2", {
     spec: {
         containers: [{
-            image: "nginx:1.7.9",
+            image: "nginx:1.27.2",
             name: "nginx",
             ports: [{ containerPort: 80 }],
         }],
@@ -64,7 +64,7 @@ new k8s.core.v1.Pod("namespaced-nginx", {
     metadata: { namespace: ns2.metadata.name },
     spec: {
         containers: [{
-            image: "nginx:1.7.9",
+            image: "nginx:1.27.2",
             name: "nginx",
             ports: [{ containerPort: 80 }],
         }],

--- a/tests/sdk/nodejs/retry/step1/index.ts
+++ b/tests/sdk/nodejs/retry/step1/index.ts
@@ -41,7 +41,7 @@ new k8s.core.v1.Pod("nginx", {
         containers: [
             {
                 name: "nginx",
-                image: "nginx:1.7.9",
+                image: "nginx:1.27.2",
                 ports: [{ containerPort: 80 }]
             }
         ]

--- a/tests/sdk/python/provider-old/__main__.py
+++ b/tests/sdk/python/provider-old/__main__.py
@@ -27,7 +27,7 @@ nginx = Pod(
     },
     spec={
         "containers": [{
-            "image": "nginx:1.7.9",
+            "image": "nginx:1.27.2",
             "name": "nginx",
             "ports": [{
                 "container_port": 80,

--- a/tests/sdk/python/provider/__main__.py
+++ b/tests/sdk/python/provider/__main__.py
@@ -28,7 +28,7 @@ nginx = Pod(
     ),
     spec=PodSpecArgs(
         containers=[ContainerArgs(
-            image="nginx:1.7.9",
+            image="nginx:1.27.2",
             name="nginx",
             ports=[ContainerPortArgs(
                 container_port=80,


### PR DESCRIPTION
The `nginx:1.7.9` image is 9-years-old and we've recently had issues pulling it.

Tests on master time out after this:
```
 +  kubernetes:core/v1:Pod nginx creating (1s) warning: Failed: Failed to pull image "nginx:1.7.9": failed to pull and unpack image "docker.io/library/nginx:1.7.9": no signatures
 +  kubernetes:core/v1:Pod nginx creating (1s) warning: Failed: Error: ErrImagePull
@ updating....
 +  kubernetes:core/v1:Pod nginx creating (2s) warning: Failed: Error: ImagePullBackOff
```

Even locally I'm not able to pull it:
```
❯ docker pull nginx:1.7.9
Error response from daemon: missing signature key
```

Various support articles suggest this is due to an older version of Docker, but I'm running v27.

Rather than attempt to debug this further, let's update these tests to use a more recent image which doesn't have this problem.

Update: the pull error was transient and probably had something to do with this:

> [DEPRECATION NOTICE] Docker Image Format v1 and Docker Image manifest version 2, schema 1 support is disabled by default and will be removed in an upcoming release. Suggest the author of docker.io/library/nginx:1.7.9 to upgrade the image to the OCI Format or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/