### PR TITLE
Ensure module versions match the downloaded API's minor

### DIFF
--- a/provider/pkg/version/version_test.go
+++ b/provider/pkg/version/version_test.go
@@ -1,11 +1,33 @@
 package version
 
 import (
+	"fmt"
+	"os"
 	"testing"
 
+	"github.com/blang/semver"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestUserAgent(t *testing.T) {
 	assert.Regexp(t, "^pulumi-kubernetes/dev (.*/.*) client-go/unknown$", UserAgent)
+}
+
+func TestKubernetesMinorVersion(t *testing.T) {
+	v := os.Getenv("KUBE_VERSION")
+	if v == "" {
+		t.Skip("KUBE_VERSION isn't set")
+	}
+
+	version, err := semver.ParseTolerant(v)
+	require.NoError(t, err)
+
+	mod, err := os.ReadFile("../../go.mod")
+	require.NoError(t, err)
+
+	want := fmt.Sprintf("k8s.io/api v0.%d", version.Minor)
+
+	assert.Contains(t, string(mod), want, "KUBE_VERSION=%s doesn't match go.mod's minor version", v)
+
 }

--- a/provider/pkg/version/version_test.go
+++ b/provider/pkg/version/version_test.go
@@ -3,6 +3,7 @@ package version
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"testing"
 
 	"github.com/blang/semver"
@@ -15,12 +16,17 @@ func TestUserAgent(t *testing.T) {
 }
 
 func TestKubernetesMinorVersion(t *testing.T) {
-	v := os.Getenv("KUBE_VERSION")
-	if v == "" {
-		t.Skip("KUBE_VERSION isn't set")
-	}
 
-	version, err := semver.ParseTolerant(v)
+	re, err := regexp.Compile(`KUBE_VERSION\s+\?=\s+v(?P<version>.*)`)
+	require.NoError(t, err)
+
+	mf, err := os.ReadFile("../../../Makefile")
+	require.NoError(t, err)
+
+	matches := re.FindStringSubmatch(string(mf))
+	require.Len(t, matches, 2)
+
+	version, err := semver.ParseTolerant(matches[1])
 	require.NoError(t, err)
 
 	mod, err := os.ReadFile("../../go.mod")
@@ -28,6 +34,5 @@ func TestKubernetesMinorVersion(t *testing.T) {
 
 	want := fmt.Sprintf("k8s.io/api v0.%d", version.Minor)
 
-	assert.Contains(t, string(mod), want, "KUBE_VERSION=%s doesn't match go.mod's minor version", v)
-
+	assert.Contains(t, string(mod), want, "KUBE_VERSION=v%s doesn't match go.mod's minor version", version)
 }


### PR DESCRIPTION
This is a safeguard to prevent us from accidentally bumping our `k8s.io/api` module dependency to a new minor without a corresponding update to `KUBE_VERSION`.

Essentially this will prevent us from auto-merging any minor updates, as those will always need to be handled manually. This is more likely to happen now that we have Renovate automatically updating dependencies for us.