### PR TITLE
Prepare for v4.18.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 4.18.4 (December 5, 2024)
+
 ### Changed
 
 - [nodejs] Resolves `punycode` deprecation warnings by using native `fetch` instead of `node-fetch`.


### PR DESCRIPTION
### Changed

- [nodejs] Resolves `punycode` deprecation warnings by using native `fetch` instead of `node-fetch`.
  (https://github.com/pulumi/pulumi-kubernetes/issues/3301)

### Fixed

- `pulumi.com/waitFor` and other await annotations now correctly take precedence over default await logic.
  (https://github.com/pulumi/pulumi-kubernetes/issues/3329)

- JSONPath expressions used with the `pulumi.com/waitFor` annotation will no longer hang indefinitely if they match non-primitive fields.
  (https://github.com/pulumi/pulumi-kubernetes/issues/3345)

- [java] CRDs that contain any `x-kubernetes-*` fields can now be succesfully created and managed by Pulumi.
  (https://github.com/pulumi/pulumi-kubernetes/issues/3325)