### PR TITLE
Implement autonaming configuration protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Unreleased
 
-- Respect autonaming configuration specified by the engine.
+### Added
+
+- Added support for autonaming configuration specified by the engine.
   (https://github.com/pulumi/pulumi-kubernetes/issues/3363)
 
 ## 4.19.0 (December 11, 2024)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+- Respect autonaming configuration specified by the engine.
+  (https://github.com/pulumi/pulumi-kubernetes/issues/3363)
+
 ## 4.19.0 (December 11, 2024)
 
 ### Changed

--- a/provider/pkg/metadata/naming.go
+++ b/provider/pkg/metadata/naming.go
@@ -37,8 +37,9 @@ func AssignNameIfAutonamable(randomSeed []byte, engineAutonaming *pulumirpc.Chec
 	if engineAutonaming != nil {
 		switch engineAutonaming.Mode {
 		case pulumirpc.CheckRequest_AutonamingOptions_DISABLE:
-			return errors.New("autonaming is disabled, please provide a name or generateName value")
+			return errors.New("autonaming is disabled, resource requires the .metadata.name field to be set")
 		case pulumirpc.CheckRequest_AutonamingOptions_ENFORCE, pulumirpc.CheckRequest_AutonamingOptions_PROPOSE:
+			contract.Assertf(engineAutonaming.ProposedName != "", "expected proposed name to be non-empty: %v", engineAutonaming)
 			autoname = engineAutonaming.ProposedName
 		}
 	}

--- a/provider/pkg/metadata/naming.go
+++ b/provider/pkg/metadata/naming.go
@@ -15,6 +15,8 @@
 package metadata
 
 import (
+	"errors"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
@@ -24,23 +26,25 @@ import (
 // AssignNameIfAutonamable generates a name for an object. Uses DNS-1123-compliant characters.
 // All auto-named resources get the annotation `pulumi.com/autonamed` for tooling purposes.
 func AssignNameIfAutonamable(randomSeed []byte, engineAutonaming *pulumirpc.CheckRequest_AutonamingOptions,
-	obj *unstructured.Unstructured, propMap resource.PropertyMap, urn resource.URN) {
+	obj *unstructured.Unstructured, propMap resource.PropertyMap, urn resource.URN) error {
 	contract.Assertf(urn.Name() != "", "expected non-empty name in URN: %s", urn)
-	if !IsNamed(obj, propMap) && !IsGenerateName(obj, propMap) {
-		prefix := urn.Name() + "-"
-		autoname, err := resource.NewUniqueName(randomSeed, prefix, 0, 0, nil)
-		contract.AssertNoErrorf(err, "unexpected error while creating NewUniqueName")
-		if engineAutonaming != nil {
-			switch engineAutonaming.Mode {
-			case pulumirpc.CheckRequest_AutonamingOptions_DISABLE:
-				return
-			case pulumirpc.CheckRequest_AutonamingOptions_ENFORCE, pulumirpc.CheckRequest_AutonamingOptions_PROPOSE:
-				autoname = engineAutonaming.ProposedName
-			}
-		}
-		obj.SetName(autoname)
-		SetAnnotationTrue(obj, AnnotationAutonamed)
+	if IsNamed(obj, propMap) || IsGenerateName(obj, propMap) {
+		return nil
 	}
+	prefix := urn.Name() + "-"
+	autoname, err := resource.NewUniqueName(randomSeed, prefix, 0, 0, nil)
+	contract.AssertNoErrorf(err, "unexpected error while creating NewUniqueName")
+	if engineAutonaming != nil {
+		switch engineAutonaming.Mode {
+		case pulumirpc.CheckRequest_AutonamingOptions_DISABLE:
+			return errors.New("autonaming is disabled, please provide a name or generateName value")
+		case pulumirpc.CheckRequest_AutonamingOptions_ENFORCE, pulumirpc.CheckRequest_AutonamingOptions_PROPOSE:
+			autoname = engineAutonaming.ProposedName
+		}
+	}
+	obj.SetName(autoname)
+	SetAnnotationTrue(obj, AnnotationAutonamed)
+	return nil
 }
 
 // AdoptOldAutonameIfUnnamed checks if `newObj` has a name, and if not, "adopts" the name of `oldObj`

--- a/provider/pkg/metadata/naming.go
+++ b/provider/pkg/metadata/naming.go
@@ -17,17 +17,27 @@ package metadata
 import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 // AssignNameIfAutonamable generates a name for an object. Uses DNS-1123-compliant characters.
 // All auto-named resources get the annotation `pulumi.com/autonamed` for tooling purposes.
-func AssignNameIfAutonamable(randomSeed []byte, obj *unstructured.Unstructured, propMap resource.PropertyMap, urn resource.URN) {
+func AssignNameIfAutonamable(randomSeed []byte, engineAutonaming *pulumirpc.CheckRequest_AutonamingOptions,
+	obj *unstructured.Unstructured, propMap resource.PropertyMap, urn resource.URN) {
 	contract.Assertf(urn.Name() != "", "expected non-empty name in URN: %s", urn)
 	if !IsNamed(obj, propMap) && !IsGenerateName(obj, propMap) {
 		prefix := urn.Name() + "-"
 		autoname, err := resource.NewUniqueName(randomSeed, prefix, 0, 0, nil)
 		contract.AssertNoErrorf(err, "unexpected error while creating NewUniqueName")
+		if engineAutonaming != nil {
+			switch engineAutonaming.Mode {
+			case pulumirpc.CheckRequest_AutonamingOptions_DISABLE:
+				return
+			case pulumirpc.CheckRequest_AutonamingOptions_ENFORCE, pulumirpc.CheckRequest_AutonamingOptions_PROPOSE:
+				autoname = engineAutonaming.ProposedName
+			}
+		}
 		obj.SetName(autoname)
 		SetAnnotationTrue(obj, AnnotationAutonamed)
 	}

--- a/provider/pkg/metadata/naming_test.go
+++ b/provider/pkg/metadata/naming_test.go
@@ -32,8 +32,9 @@ func TestAssignNameIfAutonamable(t *testing.T) {
 	// o1 has no name, so autonaming succeeds.
 	o1 := &unstructured.Unstructured{}
 	pm1 := resource.NewPropertyMap(struct{}{})
-	AssignNameIfAutonamable(nil, nil, o1, pm1, resource.NewURN(tokens.QName("teststack"), tokens.PackageName("testproj"),
+	err := AssignNameIfAutonamable(nil, nil, o1, pm1, resource.NewURN(tokens.QName("teststack"), tokens.PackageName("testproj"),
 		tokens.Type(""), tokens.Type("bang:boom/fizzle:MajorResource"), "foo"))
+	assert.NoError(t, err)
 	assert.True(t, IsAutonamed(o1))
 	assert.True(t, strings.HasPrefix(o1.GetName(), "foo-"))
 	assert.Len(t, o1.GetName(), 12)
@@ -45,8 +46,9 @@ func TestAssignNameIfAutonamable(t *testing.T) {
 		}),
 	}
 	o2 := propMapToUnstructured(pm2)
-	AssignNameIfAutonamable(nil, nil, o2, pm2, resource.NewURN(tokens.QName("teststack"), tokens.PackageName("testproj"),
+	err = AssignNameIfAutonamable(nil, nil, o2, pm2, resource.NewURN(tokens.QName("teststack"), tokens.PackageName("testproj"),
 		tokens.Type(""), tokens.Type("bang:boom/fizzle:AnotherResource"), "bar"))
+	assert.NoError(t, err)
 	assert.False(t, IsAutonamed(o2))
 	assert.Equal(t, "bar", o2.GetName())
 
@@ -57,8 +59,9 @@ func TestAssignNameIfAutonamable(t *testing.T) {
 		}),
 	}
 	o3 := propMapToUnstructured(pm3)
-	AssignNameIfAutonamable(nil, nil, o3, pm3, resource.NewURN(tokens.QName("teststack"), tokens.PackageName("testproj"),
+	err = AssignNameIfAutonamable(nil, nil, o3, pm3, resource.NewURN(tokens.QName("teststack"), tokens.PackageName("testproj"),
 		tokens.Type(""), tokens.Type("bang:boom/fizzle:MajorResource"), "foo"))
+	assert.NoError(t, err)
 	assert.False(t, IsAutonamed(o3))
 	assert.Equal(t, "", o3.GetName())
 
@@ -69,8 +72,9 @@ func TestAssignNameIfAutonamable(t *testing.T) {
 		}),
 	}
 	o4 := propMapToUnstructured(pm4)
-	AssignNameIfAutonamable(nil, nil, o4, pm4, resource.NewURN(tokens.QName("teststack"), tokens.PackageName("testproj"),
+	err = AssignNameIfAutonamable(nil, nil, o4, pm4, resource.NewURN(tokens.QName("teststack"), tokens.PackageName("testproj"),
 		tokens.Type(""), tokens.Type("bang:boom/fizzle:AnotherResource"), "bar"))
+	assert.NoError(t, err)
 	assert.False(t, IsAutonamed(o4))
 	assert.Equal(t, "bar-", o4.GetGenerateName())
 	assert.Equal(t, "", o4.GetName())
@@ -82,8 +86,9 @@ func TestAssignNameIfAutonamable(t *testing.T) {
 		}),
 	}
 	o5 := propMapToUnstructured(pm5)
-	AssignNameIfAutonamable(nil, nil, o5, pm5, resource.NewURN(tokens.QName("teststack"), tokens.PackageName("testproj"),
+	err = AssignNameIfAutonamable(nil, nil, o5, pm5, resource.NewURN(tokens.QName("teststack"), tokens.PackageName("testproj"),
 		tokens.Type(""), tokens.Type("bang:boom/fizzle:MajorResource"), "foo"))
+	assert.NoError(t, err)
 	assert.False(t, IsAutonamed(o5))
 	assert.Equal(t, "", o5.GetGenerateName())
 	assert.Equal(t, "", o5.GetName())
@@ -94,8 +99,9 @@ func TestAssignNameIfAutonamable(t *testing.T) {
 		Mode:         pulumirpc.CheckRequest_AutonamingOptions_PROPOSE,
 		ProposedName: "bar",
 	}
-	AssignNameIfAutonamable(nil, autonamingProposed, o6, pm1, resource.NewURN(tokens.QName("teststack"), tokens.PackageName("testproj"),
+	err = AssignNameIfAutonamable(nil, autonamingProposed, o6, pm1, resource.NewURN(tokens.QName("teststack"), tokens.PackageName("testproj"),
 		tokens.Type(""), tokens.Type("bang:boom/fizzle:MajorResource"), "foo"))
+	assert.NoError(t, err)
 	assert.True(t, IsAutonamed(o6))
 	assert.Equal(t, "bar", o6.GetName())
 
@@ -104,8 +110,10 @@ func TestAssignNameIfAutonamable(t *testing.T) {
 	autonamingDisabled := &pulumirpc.CheckRequest_AutonamingOptions{
 		Mode: pulumirpc.CheckRequest_AutonamingOptions_DISABLE,
 	}
-	AssignNameIfAutonamable(nil, autonamingDisabled, o7, pm1, resource.NewURN(tokens.QName("teststack"), tokens.PackageName("testproj"),
+	err = AssignNameIfAutonamable(nil, autonamingDisabled, o7, pm1, resource.NewURN(tokens.QName("teststack"), tokens.PackageName("testproj"),
 		tokens.Type(""), tokens.Type("bang:boom/fizzle:MajorResource"), "foo"))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "autonaming is disabled")
 	assert.False(t, IsAutonamed(o7))
 	assert.Equal(t, "", o7.GetGenerateName())
 	assert.Equal(t, "", o7.GetName())

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -1459,7 +1459,10 @@ func (k *kubeProvider) Check(ctx context.Context, req *pulumirpc.CheckRequest) (
 			}
 		}
 	} else {
-		metadata.AssignNameIfAutonamable(req.RandomSeed, req.Autonaming, newInputs, news, urn)
+		err = metadata.AssignNameIfAutonamable(req.RandomSeed, req.Autonaming, newInputs, news, urn)
+		if err != nil {
+			return nil, err
+		}
 
 		// Set a "managed-by: pulumi" label on resources created with Client-Side Apply. Do not set this label for SSA
 		// resources since the fieldManagers field contains granular information about the managers.

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -903,8 +903,9 @@ func (k *kubeProvider) Configure(_ context.Context, req *pulumirpc.ConfigureRequ
 	}
 
 	return &pulumirpc.ConfigureResponse{
-		AcceptSecrets:   true,
-		SupportsPreview: true,
+		AcceptSecrets:                   true,
+		SupportsPreview:                 true,
+		SupportsAutonamingConfiguration: true,
 	}, nil
 }
 
@@ -1458,7 +1459,7 @@ func (k *kubeProvider) Check(ctx context.Context, req *pulumirpc.CheckRequest) (
 			}
 		}
 	} else {
-		metadata.AssignNameIfAutonamable(req.RandomSeed, newInputs, news, urn)
+		metadata.AssignNameIfAutonamable(req.RandomSeed, req.Autonaming, newInputs, news, urn)
 
 		// Set a "managed-by: pulumi" label on resources created with Client-Side Apply. Do not set this label for SSA
 		// resources since the fieldManagers field contains granular information about the managers.

--- a/tests/sdk/java/autonaming_test.go
+++ b/tests/sdk/java/autonaming_test.go
@@ -1,0 +1,23 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/pulumi/providertest/pulumitest"
+	"github.com/pulumi/providertest/pulumitest/opttest"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestAutonaming ensures that custom resource autonaming configuration works as expected.
+func TestAutonaming(t *testing.T) {
+	test := pulumitest.NewPulumiTest(t, "testdata/autonaming", opttest.SkipInstall(), opttest.Env("PULUMI_EXPERIMENTAL", "1"))
+	t.Logf("into %s", test.Source())
+	t.Cleanup(func() {
+		test.Destroy(t)
+	})
+	test.Preview(t)
+	up := test.Up(t)
+	nsname, ok := up.Outputs["nsname"].Value.(string)
+	assert.True(t, ok)
+	assert.Contains(t, nsname, "autonaming-ns-") // project + name + random suffix
+}

--- a/tests/sdk/java/testdata/autonaming/Pulumi.yaml
+++ b/tests/sdk/java/testdata/autonaming/Pulumi.yaml
@@ -1,0 +1,11 @@
+name: autonaming
+runtime: yaml
+config:
+  pulumi:autonaming:
+    value:
+      pattern: ${project}-${name}-${alphanum(6)}
+outputs:
+  nsname: ${ns.metadata.name}
+resources:
+  ns:
+    type: kubernetes:core/v1:Namespace


### PR DESCRIPTION
### Proposed changes

This PR implement the Kubernetes part of https://github.com/pulumi/pulumi/issues/1518. See https://github.com/pulumi/pulumi/discussions/17592 for the full design.

In short, https://github.com/pulumi/pulumi/pull/17810 introduced the protobuf changes required for the provider-side implementation. With those, a provider can:

- Declare that it supports autonaming configurations with a response flag in Configure
- Accept two extra properties in CheckRequest: a proposed name and a mode to apply it

This PR applies those parameters to auto-name calculation if they are specified:

- In Disabled mode, we don't calculate auto-names at all
- In Enforce or Propose mode, we use whatever ProposedName is supplied by the engine

### Related issues (optional)

Resolves https://github.com/pulumi/pulumi-kubernetes/issues/3363
