### PR TITLE
Don't delete resources unless field managers match

### DIFF
--- a/provider/pkg/await/await_test.go
+++ b/provider/pkg/await/await_test.go
@@ -787,6 +787,34 @@ func TestDeletion(t *testing.T) {
 		}
 	}
 
+	field := []byte(`{
+			"f:metadata": {
+				"f:generateName": {},
+				"f:labels": {},
+				"f:ownerReferences": {}
+			}
+		}`)
+
+	original := validPodUnstructured.DeepCopy()
+	original.SetManagedFields([]metav1.ManagedFieldsEntry{{
+		Manager:    "pulumi-kubernetes-123",
+		Operation:  "Update",
+		FieldsType: "FieldsV1",
+		FieldsV1: &metav1.FieldsV1{
+			Raw: field,
+		},
+	}})
+
+	upserted := validPodUnstructured.DeepCopy()
+	upserted.SetManagedFields([]metav1.ManagedFieldsEntry{{
+		Manager:    "pulumi-kubernetes-XYZ",
+		Operation:  "Update",
+		FieldsType: "FieldsV1",
+		FieldsV1: &metav1.FieldsV1{
+			Raw: field,
+		},
+	}})
+
 	tests := []struct {
 		name      string
 		client    client
@@ -906,6 +934,19 @@ func TestDeletion(t *testing.T) {
 				outputs: validPodUnstructured,
 			},
 			reaction:  []reactionF{cancelAwait},
+			condition: awaitNoop,
+			expect:    []expectF{succeeded()},
+		},
+		{
+			name: "Field manager mismatch",
+			args: args{
+				resType:         tokens.Type("kubernetes:core/v1:Pod"),
+				name:            "foo",
+				objects:         []runtime.Object{original},
+				inputs:          original,
+				outputs:         original,
+				serverSideApply: true,
+			},
 			condition: awaitNoop,
 			expect:    []expectF{succeeded()},
 		},

--- a/tests/sdk/java/delete_test.go
+++ b/tests/sdk/java/delete_test.go
@@ -1,0 +1,79 @@
+// Copyright 2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/pulumi/providertest/pulumitest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeleteDueToRename(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	test := pulumitest.NewPulumiTest(t, "testdata/delete/rename")
+	t.Cleanup(func() {
+		test.Destroy(t)
+	})
+
+	test.Up(t)
+
+	// Change our Pod's resource name
+	test.UpdateSource(t, "testdata/delete/rename/step2")
+	test.Up(t)
+
+	// Renaming the namespace should not have deleted it. Perform a refresh and
+	// make sure our pod is still running -- if it's not, Pulumi will have
+	// deleted it from our state.
+	refresh, err := test.CurrentStack().Refresh(ctx)
+	assert.NoError(t, err)
+	assert.NotContains(t, refresh.StdOut, "deleted", refresh.StdOut)
+}
+
+func TestDeletePatchResource(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	test := pulumitest.NewPulumiTest(t, "testdata/delete/patch")
+	t.Cleanup(func() {
+		test.Destroy(t)
+	})
+
+	test.Up(t)
+
+	time.Sleep(60 * time.Second)
+
+	outputs, err := test.CurrentStack().Outputs(ctx)
+	require.NoError(t, err)
+
+	// The ConfigMap should have 2 managed fields.
+	mf, ok := outputs["managedFields"]
+	require.True(t, ok)
+	assert.Len(t, mf.Value, 2)
+
+	// Delete a patch.
+	test.UpdateSource(t, "testdata/delete/patch/step2")
+	test.Up(t)
+
+	// One ConfigMapPatch should still be applied.
+	outputs, err = test.CurrentStack().Outputs(ctx)
+	require.NoError(t, err)
+	mf, ok = outputs["managedFields"]
+	require.True(t, ok)
+	assert.Len(t, mf.Value, 1)
+}

--- a/tests/sdk/java/testdata/delete/patch/Pulumi.yaml
+++ b/tests/sdk/java/testdata/delete/patch/Pulumi.yaml
@@ -1,0 +1,37 @@
+name: delete-patch-resource
+runtime: yaml
+description: |
+  Deleting a logical patch resource should not delete the underlying physical
+  resource.
+
+outputs:
+  managedFields: ${patch2.metadata.managedFields}
+
+resources:
+  configmap:
+    type: kubernetes:core/v1:ConfigMap
+    properties:
+      metadata:
+        name: patched-configmap
+
+  patch1:
+    type: kubernetes:core/v1:ConfigMapPatch
+    properties:
+      metadata:
+        name: patched-configmap
+      data:
+        foo: bar
+    options:
+      dependsOn:
+        - ${configmap}
+
+  patch2:
+    type: kubernetes:core/v1:ConfigMapPatch
+    properties:
+      metadata:
+        name: patched-configmap
+      data:
+        boo: baz
+    options:
+      dependsOn:
+        - ${patch1}

--- a/tests/sdk/java/testdata/delete/patch/step2/Pulumi.yaml
+++ b/tests/sdk/java/testdata/delete/patch/step2/Pulumi.yaml
@@ -1,0 +1,40 @@
+name: delete-patch-resource
+runtime: yaml
+description: |
+  Deleting a logical patch resource should not delete the underlying physical
+  resource.
+
+outputs:
+  managedFields: ${patch1.metadata.managedFields}
+
+resources:
+  configmap:
+    type: kubernetes:core/v1:ConfigMap
+    properties:
+      metadata:
+        name: patched-configmap
+
+  patch1:
+    type: kubernetes:core/v1:ConfigMapPatch
+    properties:
+      metadata:
+        name: patched-configmap
+      data:
+        foo: bar
+    options:
+      dependsOn:
+        - ${configmap}
+
+  # Delete patch2 - the underlying ConfigMap should not be deleted, and patch1
+  # should still be applied.
+  #
+  # patch2:
+  #   type: kubernetes:core/v1:ConfigMapPatch
+  #   properties:
+  #     metadata:
+  #       name: patched-configmap
+  #     data:
+  #       boo: baz
+  #   options:
+  #     dependsOn:
+  #       - ${patch1}

--- a/tests/sdk/java/testdata/delete/rename/Pulumi.yaml
+++ b/tests/sdk/java/testdata/delete/rename/Pulumi.yaml
@@ -1,0 +1,16 @@
+name: delete-with-rename
+runtime: yaml
+description: |
+  Changing a resource's name, but leaving .metadata untouched, should not
+  result in a deletion from the cluster.
+
+resources:
+  pod:
+    type: kubernetes:core/v1:Pod
+    properties:
+      spec:
+        containers:
+          - image: nginx:1.14.2
+            name: nginx
+            ports:
+              - containerPort: 80

--- a/tests/sdk/java/testdata/delete/rename/step2/Pulumi.yaml
+++ b/tests/sdk/java/testdata/delete/rename/step2/Pulumi.yaml
@@ -1,0 +1,18 @@
+name: delete-with-rename
+runtime: yaml
+description: |
+  Changing a resource's name, but leaving .metadata untouched, should not
+  result in a deletion from the cluster.
+
+resources:
+  # Change the resource's name from "pod" to "mypod" but leave everything
+  # else the same.
+  mypod:
+    type: kubernetes:core/v1:Pod
+    properties:
+      spec:
+        containers:
+          - image: nginx:1.14.2
+            name: nginx
+            ports:
+              - containerPort: 80


### PR DESCRIPTION
This fixes the delete-after-create problem by reviving https://github.com/pulumi/pulumi-kubernetes/pull/2999 using field managers (as Eron suggested) instead of annotations to confirm ownership before deleting a resource.

If the resource was created with SSA, and we don't find the expected field manager, then we no-op instead of deleting the resource. The intended effect is to remove it from our state so the "upserted" manager can continue owning it.

This is technically a breaking change in behavior for some edge cases, but I think it is justified by the potential severity of our delete-after-create bug.