### PR TITLE
Prepare for v4.21.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## Unreleased
 
+## 4.21.1 (January 27, 2025)
+
+### Added
+
+- Windows executable releases are now signed. (<https://github.com/pulumi/pulumi-kubernetes/pull/3455>)
+
 ## 4.21.0 (January 16, 2025)
 
 ### Changed


### PR DESCRIPTION
### Added

- Windows executable releases are now signed. (<https://github.com/pulumi/pulumi-kubernetes/pull/3455>)