### PR TITLE
Remove labels from service objects in `TestDotnet_Guestbook`

### DIFF
--- a/tests/sdk/dotnet/guestbook/Program.cs
+++ b/tests/sdk/dotnet/guestbook/Program.cs
@@ -73,10 +73,6 @@ class Program
 
             var redisMasterService = new Pulumi.Kubernetes.Core.V1.Service("redis-master", new ServiceArgs
             {
-                Metadata = new ObjectMetaArgs
-                {
-                    Labels = redisMasterDeployment.Metadata.Apply(metadata => metadata.Labels),
-                },
                 Spec = new ServiceSpecArgs
                 {
                     Ports =
@@ -152,10 +148,6 @@ class Program
 
             var redisReplicaService = new Pulumi.Kubernetes.Core.V1.Service("redis-replica", new ServiceArgs
             {
-                Metadata = new ObjectMetaArgs
-                {
-                    Labels = redisReplicaDeployment.Metadata.Apply(metadata => metadata.Labels),
-                },
                 Spec = new ServiceSpecArgs
                 {
                     Ports =
@@ -231,10 +223,6 @@ class Program
 
             var frontendService = new Pulumi.Kubernetes.Core.V1.Service("frontend", new ServiceArgs
             {
-                Metadata = new ObjectMetaArgs
-                {
-                    Labels = frontendDeployment.Metadata.Apply(metadata => metadata.Labels),
-                },
                 Spec = new ServiceSpecArgs
                 {
                     Type = isMiniKube ? "ClusterIP" : "LoadBalancer",


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

Test failures identified in #3480 surfaced a regression in upstream pulumi/pulumi. The usage of the deployment's labels as the service object's label is unnecessary, since it is empty and can be removed. This PR removes them to unblock CI.

### Related issues (optional)

Closes: #3480
