### PR TITLE
tests: upgrade GKE test cluster to v1.32

### DIFF
--- a/tests/ci-cluster/gke.ts
+++ b/tests/ci-cluster/gke.ts
@@ -26,8 +26,8 @@ export class GkeCluster extends pulumi.ComponentResource {
                 opts: pulumi.ComponentResourceOptions = {}) {
         super("pulumi-kubernetes:ci:GkeCluster", name, {}, opts);
 
-        // Use the latest 1.28.x engine version.
-        const engineVersion = "1.28";
+        // Use the latest 1.32.x engine version.
+        const engineVersion = "1.32";
 
         // Create the GKE cluster.
         const k8sCluster = new gcp.container.Cluster("ephemeral-ci-cluster", {


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

GKE has dropped support for v1.28 clusters, causing CI to fail when creating a test cluster. This PR upgrades our test clusters to use GKE v1.32.

### Related issues (optional)

Closes: #3503
