### PR TITLE
fix: enable outputting .metadata fields for nodejs CR overlay

### DIFF
--- a/sdk/nodejs/apiextensions/customResource.ts
+++ b/sdk/nodejs/apiextensions/customResource.ts
@@ -86,10 +86,12 @@ export class CustomResource extends pulumi.CustomResource {
             for (const key of Object.keys(args)) {
                 inputs[key] = (args as any)[key];
             }
+            inputs["metadata"] = args.metadata;
         } else {
             for (const key of Object.keys(args)) {
                 inputs[key] = undefined;
             }
+            inputs["metadata"] = undefined;
         }
         if (!opts.version) {
             opts = pulumi.mergeOptions(opts, { version: utilities.getVersion()});


### PR DESCRIPTION
### Proposed changes

This PR fixes the bug where we cannot grab a CustomResource's metadata field, when one is not specified as an input arg.

But this doesn't.

### Related issues (optional)

Fixes: #3510
