### PR TITLE
Fix race condition in Deleted condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fix race condition in Deleted condition. (<https://github.com/pulumi/pulumi-kubernetes/pull/3550>)
+
 ## 4.21.1 (January 27, 2025)
 
 ### Added

--- a/provider/pkg/await/condition/deleted.go
+++ b/provider/pkg/await/condition/deleted.go
@@ -58,7 +58,7 @@ func NewDeleted(
 	return dc, nil
 }
 
-// Range establishes an Informer and confirms the object still existsr.
+// Range establishes an Informer and confirms the object still exists.
 // If a Deleted event isn't Observed by the time the underlying Observer is
 // exhausted, we attempt a final lookup on the cluster to be absolutely sure it
 // still exists.
@@ -141,7 +141,6 @@ func (dc *Deleted) refreshClusterState() {
 	_, err := dc.getter.Get(ctx, dc.Object().GetName(), metav1.GetOptions{})
 	if err == nil {
 		// Still exists.
-		dc.deleted.Store(false)
 		return
 	}
 	if k8serrors.IsNotFound(err) {


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

This PR fixes a race condition in the await logic that leads to Pulumi stalling until the await timeout is reached (e.g. after 600s). The condition logic races between informer events and GET call(s) to observe the deletion of the object. In the edge case that the 'deleted' watch event is observed before the GET call completes, the system may become stuck because the getter overwrites the watcher's observation (as stored in the `cond.deleted` field).

In other words the `deleted` flag should be idempotent, and never transition from true to false.

Also, I notice that the informer could be more reliably started by the factory, since factory.Start is idempotent.  This will ensure that the informer is considered during shutdown, and that WaitForCacheSync would work as expected.

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->

closes #3317 