### PR TITLE
Prepare for v4.22.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 
 ## Unreleased
 
+## 4.22.0 (March 13, 2025)
+
+### Changed
+
+- Update Pulumi dependency to v3.153.1 (<https://github.com/pulumi/pulumi-kubernetes/pull/3534>)
+- Update ESC dependency to v0.13.0 (<https://github.com/pulumi/pulumi-kubernetes/pull/3551>)
+
 ## 4.21.1 (January 27, 2025)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
 <!-- markdownlint-configure-file { "MD024": { "siblings_only": true } } -->
 # CHANGELOG
 
-## Unreleased
-
 ## 4.22.0 (March 13, 2025)
 
 ### Changed


### PR DESCRIPTION
### Changed

- Update Pulumi dependency to v3.153.1 (https://github.com/pulumi/pulumi-kubernetes/pull/3534)
- Update ESC dependency to v0.13.0 (https://github.com/pulumi/pulumi-kubernetes/pull/3551)
