### PR TITLE
fix: Handle nil annotations field when setting manifest annotations

### DIFF
--- a/provider/pkg/provider/yaml/v2/yaml_test.go
+++ b/provider/pkg/provider/yaml/v2/yaml_test.go
@@ -42,6 +42,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: crontabs.stable.example.com
+  # Purposefully set annotations here to be null: pulumi/pulumi-kubernetes#3585
+  annotations: 
 spec:
   group: stable.example.com
   versions:


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

This PR updates the logic for setting the annotations field when working with unstructured objects in the YAML and Helm providers.

Previously, when decoding manifests, fields with `null` values were unmarshaled into untyped `nil` values. This caused `unstructured.SetNestedValue()` to fail, as it expects a `map[string]any` type for nested fields, not an untyped `nil`.

To address this, we now check if the existing value is a non-map `nil` and initialize it as a `map[string]any` before setting annotations. This prevents runtime errors and ensures annotations are applied correctly.

This PR modifies an existing test manifest to include a `nul`l annotations field, ensuring the fix is properly exercised. The test fails without the changes introduced in this PR.

### Related issues (optional)

Closes: #3585