### PR TITLE
Adopt ci mgmt (again)

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -1,8 +1,8 @@
 template: native
 provider: kubernetes
 lint: true
-aws: true
-gcp: true
+aws: true # need AWS credentials to test in EKS
+gcp: true # need GCP credentials to test in GKE
 pulumiVersionFile: .pulumi.version
 major-version: 4
 parallel: 3

--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -1,0 +1,16 @@
+template: native
+provider: kubernetes
+lint: true
+aws: true
+gcp: true
+pulumiVersionFile: .pulumi.version
+major-version: 4
+parallel: 3
+envOverride:
+  AWS_REGION: us-west-2
+  PULUMI_TEST_OWNER: moolumi
+  GOLANGCI_LINT_VERSION: v1.61.0
+  GOOGLE_CI_SERVICE_ACCOUNT_EMAIL:  pulumi-ci@pulumi-k8s-provider.iam.gserviceaccount.com
+  GOOGLE_CI_WORKLOAD_IDENTITY_POOL: pulumi-ci
+  GOOGLE_CI_WORKLOAD_IDENTITY_PROVIDER: pulumi-ci
+  GOOGLE_PROJECT_NUMBER: 637339343727


### PR DESCRIPTION
Adds the .ci-mgmt.yaml I forgot the first time around. 

https://github.com/pulumi/pulumi-kubernetes/pull/3598 was missing the .ci-mgmt.yaml file so update jobs (eg. [Update GH workflows, ecosystem providers · pulumi/ci-mgmt@627bf35](https://github.com/pulumi/ci-mgmt/actions/runs/14700611890/job/41251076343)) are failing for this provider.

Fixes: https://github.com/pulumi/ci-mgmt/issues/1509