### PR TITLE
Use modern Helm registry config path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
 
 - Added a `plainHttp` option to the `v4.Chart` resource. (https://github.com/pulumi/pulumi-kubernetes/issues/3250)
 
+### Fixed
+
+- Helm resources all now use the correct `registry/config.json` file for
+  credentials. For backward-compatibility `registry.json` is preferred if
+  it exists. (https://github.com/pulumi/pulumi-kubernetes/issues/3606)
+
 ## 4.23.0 (May 1, 2025)
 
 ### Changed

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -700,7 +700,11 @@ func (k *kubeProvider) Configure(_ context.Context, req *pulumirpc.ConfigureRequ
 		if registryPath, exists := os.LookupEnv("PULUMI_K8S_HELM_REGISTRY_CONFIG_PATH"); exists {
 			return registryPath
 		}
-		return helmpath.ConfigPath("registry.json")
+		legacyPath := helmpath.ConfigPath("registry.json")
+		if _, err := os.Stat(legacyPath); err == nil {
+			return legacyPath
+		}
+		return helmpath.ConfigPath("registry/config.json")
 	}
 	k.helmRegistryConfigPath = helmRegistryConfigPath()
 	if helmReleaseSettings.RegistryConfigPath != nil {


### PR DESCRIPTION
This makes `PULUMI_K8S_HELM_REGISTRY_CONFIG_PATH` aware of the new "registry/config.json" location.

For backward-compatibility we need to continue supporting the legacy "registry.json" path in case people are explicitly populating it. However if that legacy file doesn't exist we will prefer to use the modern config location.

Note that #3606 doesn't affect v3 or v4 Chart resources, only v3 Release. This is because the release provider overrides the default registry config with our own (incorrect) default.

https://github.com/pulumi/pulumi-kubernetes/blob/cf3748635c11721ddc7931815affccc9684ca986/provider/pkg/provider/helm_release.go#L207-L212

My gut says we should get rid of these Pulumi-specific overrides and just let the user use the normal Helm env vars (e.g. `HELM_REGISTRY_CONFIG`), but I don't have the background behind why these were originally added so I don't want to change them. It would be a reasonable thing to rip out in v5. https://github.com/pulumi/pulumi-kubernetes/issues/3652

Fixes https://github.com/pulumi/pulumi-kubernetes/issues/3606.