### PR TITLE
Fix a race condition during deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@
   credentials. For backward-compatibility `registry.json` is preferred if
   it exists. (https://github.com/pulumi/pulumi-kubernetes/issues/3606)
 
+- Fixed an issue where deletions could take longer than necessary. (https://github.com/pulumi/pulumi-kubernetes/issues/3317)
+
 ## 4.23.0 (May 1, 2025)
 
 ### Changed

--- a/provider/pkg/await/await.go
+++ b/provider/pkg/await/await.go
@@ -848,7 +848,10 @@ func Deletion(c DeleteConfig) error {
 	defer cancel()
 
 	// Setup our Informer factory.
-	source := condition.NewDynamicSource(ctx, c.ClientSet, c.Outputs.GetNamespace())
+	source, err := condition.NewDeletionSource(ctx, c.ClientSet, c.Outputs)
+	if err != nil {
+		return err
+	}
 
 	// Determine the condition to wait for.
 	deleted, err := metadata.DeletedCondition(ctx, source, c.ClientSet, c.DedupLogger, c.Inputs, c.Outputs)

--- a/provider/pkg/await/condition/deleted.go
+++ b/provider/pkg/await/condition/deleted.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"sync"
 	"sync/atomic"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
@@ -63,27 +62,11 @@ func NewDeleted(
 // exhausted, we attempt a final lookup on the cluster to be absolutely sure it
 // still exists.
 func (dc *Deleted) Range(yield func(watch.Event) bool) {
-	// Start listening to events before we check if the resource has already
-	// been deleted. This avoids races where the object is deleted in-between
-	// the 404 check and this watch.
-	wg := sync.WaitGroup{}
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		dc.observer.Range(yield)
-	}()
+	dc.observer.Range(yield)
 
-	dc.refreshClusterState()
 	if dc.deleted.Load() {
 		// Already deleted, nothing more to do. Our informer will get cleaned up
 		// when its context is canceled.
-		return
-	}
-
-	wg.Wait()
-
-	if dc.deleted.Load() {
-		// Nothing more to do.
 		return
 	}
 

--- a/provider/pkg/await/condition/deleted_test.go
+++ b/provider/pkg/await/condition/deleted_test.go
@@ -94,14 +94,11 @@ func TestDeleted(t *testing.T) {
 		getter := get404{}
 
 		source := &DeletionSource{obj: pod, getter: getter, source: Static(nil)}
-
 		cond, err := NewDeleted(ctx, source, getter, stdout, pod)
 		assert.NoError(t, err)
 
-		cond.Range(func(e watch.Event) bool {
-			err := cond.Observe(e)
-			assert.NoError(t, err)
-			return true
+		cond.Range(func(_ watch.Event) bool {
+			return true // A DELETED event is expected.
 		})
 
 		done, err := cond.Satisfied()
@@ -220,10 +217,8 @@ func TestDeleted(t *testing.T) {
 	t.Run("times out with recovery", func(t *testing.T) {
 		getter := &getsequence{[]objectGetter{&get200{pod}, get404{}}, 0}
 
-		source := &DeletionSource{obj: pod, getter: getter, source: Static(nil)}
-
 		ctx, cancel := context.WithCancel(context.Background())
-		cond, err := NewDeleted(ctx, source, getter, stdout, pod)
+		cond, err := NewDeleted(ctx, Static(nil), getter, stdout, pod)
 		assert.NoError(t, err)
 
 		cancel()

--- a/provider/pkg/await/condition/source.go
+++ b/provider/pkg/await/condition/source.go
@@ -158,8 +158,6 @@ func (ds *DeletionSource) Start(ctx context.Context, gvk schema.GroupVersionKind
 		// If the object was already deleted, return a synthetic DELETED event.
 		e := make(chan watch.Event, 1)
 		e <- watch.Event{Type: watch.Deleted, Object: ds.obj}
-		close(e)
-
 		return e, nil
 	}
 

--- a/provider/pkg/await/condition/source.go
+++ b/provider/pkg/await/condition/source.go
@@ -125,7 +125,7 @@ func (s Static) Start(context.Context, schema.GroupVersionKind) (<-chan watch.Ev
 type DeletionSource struct {
 	obj    *unstructured.Unstructured
 	getter objectGetter
-	source *DynamicSource
+	source Source
 }
 
 // NewDeletionSource creates a new DeletionSource.
@@ -158,6 +158,8 @@ func (ds *DeletionSource) Start(ctx context.Context, gvk schema.GroupVersionKind
 		// If the object was already deleted, return a synthetic DELETED event.
 		e := make(chan watch.Event, 1)
 		e <- watch.Event{Type: watch.Deleted, Object: ds.obj}
+		close(e)
+
 		return e, nil
 	}
 


### PR DESCRIPTION
If an informer is started after an object has been deleted we won't see any events for it. This creates a race condition here:

https://github.com/pulumi/pulumi-kubernetes/blob/18a34579dec0083b7412f84e0f2dc2b0821756bd/provider/pkg/await/condition/deleted.go#L69-L80

This is a race because either (a) the goroutine observing events might execute after `refreshClusterState` has run, or, more likely, (b) the goroutine's informer can take a little while to get established due to throttling/backoff/etc.

In both cases we have (1) a GET succeed with 200, (2) the object is deleted on the cluster, (3) our informer finally starts watching for events and never sees anything.

The repro in #3317 mentions it only happens on faster hardware, but I suspect it's actually a side effect of that faster hardware running a cluster under more load, making throttling more likely. That's my guess, at least -- @aureq could weigh in.

To fix the issue I'm adding a new `DeletionSource` which resolves the race by guaranteeing we always perform a quorum read after the informer has synced. If we find the object has already been deleted we generate a synthetic DELETED event.

I intentionally opted _not_ to touch the existing deleted condition's logic because I want to make this fix as small as possible and I don't want to risk inadvertently introducing other race conditions elsewhere.

Additionally I've only been able to occasionally reproduce the slowness so this is missing a unit/regression test. I don't think it would be a good use of time to try to create such a test. I've run the repro in #3317 several hundred times with this fix and haven't observed the slowness.

Fixes https://github.com/pulumi/pulumi-kubernetes/issues/3317