### PR TITLE
Update autonaming to handle composite resource names (from helm charts)

### DIFF
--- a/provider/pkg/metadata/naming.go
+++ b/provider/pkg/metadata/naming.go
@@ -16,6 +16,7 @@ package metadata
 
 import (
 	"errors"
+	"strings"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -31,7 +32,9 @@ func AssignNameIfAutonamable(randomSeed []byte, engineAutonaming *pulumirpc.Chec
 	if IsNamed(obj, propMap) || IsGenerateName(obj, propMap) {
 		return nil
 	}
-	prefix := urn.Name() + "-"
+	// Composite resources (helm charts) have composite names
+	urnName := urn.Name()
+	prefix := urnName[strings.LastIndex(urnName, "/")+1:] + "-"
 	autoname, err := resource.NewUniqueName(randomSeed, prefix, 0, 0, nil)
 	contract.AssertNoErrorf(err, "unexpected error while creating NewUniqueName")
 	if engineAutonaming != nil {

--- a/provider/pkg/metadata/naming_test.go
+++ b/provider/pkg/metadata/naming_test.go
@@ -117,6 +117,17 @@ func TestAssignNameIfAutonamable(t *testing.T) {
 	assert.False(t, IsAutonamed(o7))
 	assert.Equal(t, "", o7.GetGenerateName())
 	assert.Equal(t, "", o7.GetName())
+
+	// o8 has no name, so autonaming succeeds, the short name is extracted from the composite resource name.
+	o8 := &unstructured.Unstructured{}
+	pm8 := resource.NewPropertyMap(struct{}{})
+	urn8 := resource.NewURN(tokens.QName("teststack"), tokens.PackageName("testproj"),
+		tokens.Type(""), tokens.Type("kubernetes:helm.sh/v4:Chart$kubernetes:apps/v1:StatefulSet"), "chartn:nsn/stsn")
+	err = AssignNameIfAutonamable(nil, nil, o8, pm8, urn8)
+	assert.NoError(t, err)
+	assert.True(t, IsAutonamed(o8))
+	assert.True(t, strings.HasPrefix(o8.GetName(), "stsn-"))
+	assert.Len(t, o8.GetName(), 13)
 }
 
 func TestAdoptName(t *testing.T) {


### PR DESCRIPTION
### Proposed changes

Update `AssignNameIfAutonamable` to strip `valkey:base/` out of the `valkey:base/valkey-node` resource name, so autonaming works on resources that are part of helm charts (`/` is invalid in a k8s resource name, `:` might be too, idk).

### Related issues (optional)

Relates to #3702

---

I hate Go's tooling, couldn't figure out how to `fmt` nor how to run the tests...