### PR TITLE
Preventing `$GOPATH/bin` to be created as file.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ lint::
 	done
 
 install_provider:: k8sprovider
-	cp $(WORKING_DIR)/bin/${PROVIDER} ${GOPATH}/bin
+	cp $(WORKING_DIR)/bin/${PROVIDER} ${GOPATH}/bin/
 
 install:: install_nodejs_sdk install_dotnet_sdk install_provider
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-pulumi = '3.183.0'
+pulumi = 'latest'
 
 # See toolVersions at
 # https://github.com/pulumi/ci-mgmt/blob/master/provider-ci/internal/pkg/templates/defaults.config.yaml
@@ -17,6 +17,7 @@ go = '1.24'
 yarn = '1.22.22'
 golangci-lint = '2.2.2'
 "go:github.com/pulumi/pulumictl/cmd/pulumictl" = 'latest'
+
 
 [env]
 # Create a venv not to pollute the whole system with global Python dependencies


### PR DESCRIPTION
`pulumi-kubernetes` project Makefile targets depend on `$GOPATH` being set and having the right directory structure. Since I was setting up `mise`, I didn't have a global Golang installation present on my local dev environment. Hence, `$GOPATH` and the directories that are usually found on a Golang were not present.

When the following code was run as part of a Makefile target:

```sh
cp $(WORKING_DIR)/bin/${PROVIDER} ${GOPATH}/bin
```

It created a file called `bin` instead of a directory with the provider binaries as expected. This was causing the integration tests to fail locally as it was unable to find the required provider binaries.

This commit modifies the `cp` command to make explicit it expects bin to be a directory.

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
