### PR TITLE
Pin provider dependency in await test

### DIFF
--- a/tests/sdk/nodejs/await_test.go
+++ b/tests/sdk/nodejs/await_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/pulumi/providertest/pulumitest"
+	"github.com/pulumi/providertest/pulumitest/opttest"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/events"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optdestroy"
@@ -174,8 +175,13 @@ func TestAwaitGeneric(t *testing.T) {
 	t.Run("enabled", func(t *testing.T) {
 		t.Setenv("PULUMI_K8S_AWAIT_ALL", "true")
 
+		cwd, err := os.Getwd()
+		require.NoError(t, err)
+
 		test := pulumitest.NewPulumiTest(t,
 			"testdata/await/generic",
+			opttest.YarnLink("@pulumi/kubernetes"),
+			opttest.LocalProviderPath("kubernetes", filepath.Join(cwd, "../../../bin")),
 		)
 		dir := test.WorkingDir()
 		t.Cleanup(func() {


### PR DESCRIPTION
I'm seeing an issue where this test can sometimes fail because it ends up installing p-k v4.15 (a version that predates the await logic under test). I was able to reproduce the issue locally. I suspect other jobs are passing perhaps because they have a more recent provider cached?

In any case, we want this test to run against the checked out provider and not something that's been released. 

Update the test to point at the local binary.