### PR TITLE
More bitnami fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@
 
 name: main # For consistency with bridged providers.
 on:
+  pull_request: {}
   push:
     branches:
     - master

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,6 @@
 
 name: main # For consistency with bridged providers.
 on:
-  pull_request: {}
   push:
     branches:
     - master

--- a/tests/sdk/go/helm/step1/main.go
+++ b/tests/sdk/go/helm/step1/main.go
@@ -17,13 +17,13 @@ func main() {
 			Values: pulumi.Map{
 				"service": pulumi.StringMap{"type": pulumi.String("ClusterIP")},
 				"image": pulumi.StringMap{
-					"repository": pulumi.String("bitnamisecure/nginx"),
-					"tag":        pulumi.String("latest"),
+					"repository": pulumi.String("bitnamilegacy/nginx"),
+					"tag":        pulumi.String("1.29.1"),
 				},
 				"mariadb": pulumi.Map{
 					"image": pulumi.StringMap{
-						"repository": pulumi.String("bitnamisecure/mariadb"),
-						"tag":        pulumi.String("latest"),
+						"repository": pulumi.String("bitnamilegacy/mariadb"),
+						"tag":        pulumi.String("12.0.2"),
 					},
 				},
 			},

--- a/tests/sdk/nodejs/examples/helm-no-default-provider/index.ts
+++ b/tests/sdk/nodejs/examples/helm-no-default-provider/index.ts
@@ -34,7 +34,7 @@ new k8s.helm.v3.Chart(
             },
             mariadb: {
                 image:{
-                    repository: "bitnamisecure/mariadb",
+                    repository: "bitnamilegacy/mariadb",
                     tag: "12.0.2",
                 },
             },

--- a/tests/sdk/nodejs/examples/helm-no-default-provider/index.ts
+++ b/tests/sdk/nodejs/examples/helm-no-default-provider/index.ts
@@ -29,13 +29,13 @@ new k8s.helm.v3.Chart(
         values: {
             "service": {"type": "ClusterIP"},
             image: {
-                repository: "bitnamisecure/wordpress",
-                tag: "latest",
+                repository: "bitnamilegacy/wordpress",
+                tag: "6.8.2-debian-12-r5",
             },
             mariadb: {
                 image:{
                     repository: "bitnamisecure/mariadb",
-                    tag: "latest",
+                    tag: "12.0.2",
                 },
             },
         },

--- a/tests/sdk/nodejs/examples/helm-release-redis/step1/index.ts
+++ b/tests/sdk/nodejs/examples/helm-release-redis/step1/index.ts
@@ -18,6 +18,10 @@ function values(password: pulumi.Output<string>): pulumi.Input<{ [key: string]: 
             enabled: true,
             slaveCount: 1,
         },
+        image: {
+            repository: "bitnamilegacy/redis",
+            tag: "8.2.1",
+        },
         global: {
             redis: {
                 password: password,

--- a/tests/sdk/nodejs/examples/helm-release-redis/step2/index.ts
+++ b/tests/sdk/nodejs/examples/helm-release-redis/step2/index.ts
@@ -18,6 +18,10 @@ function values(password: pulumi.Output<string>): pulumi.Input<{ [key: string]: 
             enabled: true,
             slaveCount: 1,
         },
+        image: {
+            repository: "bitnamilegacy/redis",
+            tag: "8.2.1",
+        },
         global: {
             redis: {
                 password: password,

--- a/tests/sdk/nodejs/examples/helm-release/step1/index.ts
+++ b/tests/sdk/nodejs/examples/helm-release/step1/index.ts
@@ -19,6 +19,10 @@ const release = new k8s.helm.v3.Release("release", {
             enabled: true,
             slaveCount: 2,
         },
+        image: {
+            repository: "bitnamilegacy/redis",
+            tag: "8.2.1",
+        },
         global: {
             redis: {
                 password: redisPassword,

--- a/tests/sdk/nodejs/examples/helm-release/step2/index.ts
+++ b/tests/sdk/nodejs/examples/helm-release/step2/index.ts
@@ -19,6 +19,10 @@ const release = new k8s.helm.v3.Release("release", {
             enabled: true,
             slaveCount: 2,
         },
+        image: {
+            repository: "bitnamilegacy/redis",
+            tag: "8.2.1",
+        },
         global: {
             redis: {
                 password: redisPassword,

--- a/tests/sdk/nodejs/examples/helm/step1/index.ts
+++ b/tests/sdk/nodejs/examples/helm/step1/index.ts
@@ -28,7 +28,11 @@ const nginx = new k8s.helm.v3.Chart("test", {
         repo: "https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami",
     },
     values: {
-        service: { type: "ClusterIP" }
+        service: { type: "ClusterIP" },
+        image: {
+            repository: "bitnamilegacy/nginx",
+            tag: "1.29.1",
+        }
     },
     transformations: [
         (obj: any, opts: pulumi.CustomResourceOptions) => {

--- a/tests/sdk/nodejs/examples/mariadb/config.ts
+++ b/tests/sdk/nodejs/examples/mariadb/config.ts
@@ -75,7 +75,7 @@ export const appConfig: AppConfig = {
         innodb_buffer_pool_size=2G`
     },
 
-    image: config.get("image") || "bitnamisecure/mariadb:latest",
+    image: config.get("image") || "bitnamilegacy/mariadb:12.0.2",
     imagePullPolicy: config.get("imagePullPolicy") || "IfNotPresent",
     serviceType: config.get("serviceType") || "ClusterIP",
     persistence: {

--- a/tests/sdk/nodejs/helm-release-unknowns/index.ts
+++ b/tests/sdk/nodejs/helm-release-unknowns/index.ts
@@ -26,6 +26,10 @@ const release = new k8s.helm.v3.Release("release", {
             enabled: true,
             slaveCount: 2,
         },
+        image: {
+            repository: "bitnamilegacy/redis",
+            tag: "8.2.1",
+        },
         global: {
             redis: {
                 password: password.result,


### PR DESCRIPTION
We still had some failures on master because our GH runners had some Docker images cached which weren't available on the GKE cluster we use for master builds.

This cleans up those images and fixes a few redis images as well while we're in here. I confirmed this fixes the master build by temporarily enable the CI cluster on this PR.

Fixes https://github.com/pulumi/pulumi-kubernetes/issues/3806.