### PR TITLE
Update Go toolchain to 1.24.6

### DIFF
--- a/provider/go.mod
+++ b/provider/go.mod
@@ -2,7 +2,7 @@ module github.com/pulumi/pulumi-kubernetes/provider/v4
 
 go 1.24.0
 
-toolchain go1.24.1
+toolchain go1.24.6
 
 replace github.com/pulumi/pulumi-kubernetes/sdk/v4 => ../sdk
 


### PR DESCRIPTION
Security fix for:

https://pkg.go.dev/vuln/GO-2025-3956
https://pkg.go.dev/vuln/GO-2025-3849
https://pkg.go.dev/vuln/GO-2025-3751
https://pkg.go.dev/vuln/GO-2025-3749

Part of https://github.com/pulumi/home/issues/4362.
