### PR TITLE
Use current Pulumi versions in test cluster

### DIFF
--- a/tests/ci-cluster/package.json
+++ b/tests/ci-cluster/package.json
@@ -5,7 +5,7 @@
     },
     "dependencies": {
         "@pulumi/gcp": "8.41.1",
-        "@pulumi/kubernetes": "4.23.0",
-        "@pulumi/pulumi": "3.196.0"
+        "@pulumi/kubernetes": "4.24.0",
+        "@pulumi/pulumi": "3.204.0"
     }
 }


### PR DESCRIPTION
Currently master build is failing: https://github.com/pulumi/pulumi-kubernetes/actions/runs/18794729743/job/53632836101

This pull request updates the versions of Pulumi and p-k8s used to create the test cluster.
