### PR TITLE
Fix dotnet flakes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,9 +143,11 @@ test_all::
 generate_schema:: schema
 
 install_dotnet_sdk::
-	rm -rf $(WORKING_DIR)/nuget/$(NUGET_PKG_NAME).*.nupkg
-	mkdir -p $(WORKING_DIR)/nuget
-	find . -name '*.nupkg' -print -exec cp -p {} ${WORKING_DIR}/nuget \;
+	mkdir -p nuget
+	find sdk/dotnet/bin -name '*.nupkg' -print -exec cp -p "{}" ${WORKING_DIR}/nuget \;
+	if ! dotnet nuget list source | grep "${WORKING_DIR}/nuget"; then \
+		dotnet nuget add source "${WORKING_DIR}/nuget" --name "${WORKING_DIR}/nuget" \
+	; fi
 
 install_python_sdk::
 	#target intentionally blank


### PR DESCRIPTION
We've had some flakes ([example](https://github.com/pulumi/pulumi-kubernetes/actions/runs/19093062854/job/54549183911)) due to the dotnet SDK not getting installed correctly.

```
rm -rf /home/runner/work/pulumi-kubernetes/pulumi-kubernetes/nuget/Pulumi.Kubernetes.*.nupkg
mkdir -p /home/runner/work/pulumi-kubernetes/pulumi-kubernetes/nuget
find . -name '*.nupkg' -print -exec cp -p *** /home/runner/work/pulumi-kubernetes/pulumi-kubernetes/nuget \;
./sdk/dotnet/bin/Debug/Pulumi.Kubernetes.4.24.0-alpha.1762323179.nupkg
./nuget/Pulumi.Kubernetes.4.24.0-alpha.1762323179.nupkg
cp: './nuget/Pulumi.Kubernetes.4.24.0-alpha.1762323179.nupkg' and '/home/runner/work/pulumi-kubernetes/pulumi-kubernetes/nuget/Pulumi.Kubernetes.4.24.0-alpha.1762323179.nupkg' are the same file
```
(later)
```
copying test to temp dir : Failed to prepare /tmp/p-it-runnervmf2-yaml-unini-533b4712-2167156807: attempting to find a local NuGet package Pulumi.Kubernetes by searching /home/runner/.pulumi-dev/nuget/Pulumi.Kubernetes.?.*.nupkg yielded 0 results: []
```

This updates the dotnet install target to match what we use in bridged providers.