### PR TITLE
Update TestHelmRelease's metrics image and update test assertion

### DIFF
--- a/tests/sdk/nodejs/examples/examples_test.go
+++ b/tests/sdk/nodejs/examples/examples_test.go
@@ -388,6 +388,10 @@ func TestHelmRelease(t *testing.T) {
 				assert.Contains(t, values, "metrics")
 				assert.Equal(t, valMap["metrics"], map[string]any{
 					"enabled": true,
+					"image": map[string]any{
+						"repository": "bitnamilegacy/redis-exporter",
+						"tag":        "1.76.0",
+					},
 					"service": map[string]any{
 						"annotations": map[string]any{
 							"prometheus.io/port": "9127",

--- a/tests/sdk/nodejs/examples/helm-release/step1/metrics.yml
+++ b/tests/sdk/nodejs/examples/helm-release/step1/metrics.yml
@@ -1,5 +1,8 @@
 metrics:
   enabled: true
+  image:
+    repository: bitnamilegacy/redis-exporter
+    tag: 1.76.0
   service:
     annotations:
       "prometheus.io/port": "9127"


### PR DESCRIPTION
This pull request updates another helm release test's metrics container to use a legacy bitnami image registry location explicitly.
Also updates the test assertion to now include this image in the config.

Hopeful fix for https://github.com/pulumi/pulumi-kubernetes/issues/3918
