### PR TITLE
Enable more node tests to run on run-acceptance-tests

### DIFF
--- a/tests/sdk/nodejs/examples/examples_test.go
+++ b/tests/sdk/nodejs/examples/examples_test.go
@@ -43,7 +43,6 @@ func TestAccMinimal(t *testing.T) {
 }
 
 func TestAccGuestbook(t *testing.T) {
-	tests.SkipIfShort(t, "test provisions a load balancer and requires a cloud provider cluster to run")
 	test := getBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			Dir:                  filepath.Join(getCwd(t), "guestbook"),
@@ -164,7 +163,6 @@ func TestAccIngress(t *testing.T) {
 }
 
 func TestAccHelm(t *testing.T) {
-	tests.SkipIfShort(t, "test provisions a load balancer and requires a cloud provider cluster to run")
 	test := getBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			Dir:         filepath.Join(getCwd(t), "helm", "step1"),
@@ -260,7 +258,6 @@ func TestAccHelmAllowCRDRendering(t *testing.T) {
 }
 
 func TestAccHelmLocal(t *testing.T) {
-	tests.SkipIfShort(t, "test provisions a load balancer and requires a cloud provider cluster to run")
 	test := getBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			Dir:                  filepath.Join(getCwd(t), "helm-local", "step1"),
@@ -304,7 +301,6 @@ func TestAccHelmLocal(t *testing.T) {
 }
 
 func TestAccPrometheusOperator(t *testing.T) {
-	tests.SkipIfShort(t, "test provisions a load balancer and requires a cloud provider cluster to run")
 	test := getBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			Dir:         filepath.Join(getCwd(t), "prometheus-operator"),
@@ -360,7 +356,6 @@ func TestAccProvider(t *testing.T) {
 }
 
 func TestHelmRelease(t *testing.T) {
-	tests.SkipIfShort(t, "test provisions a load balancer and requires a cloud provider cluster to run")
 	validationFunc := func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
 		assert.NotEmpty(t, stackInfo.Outputs["redisMasterClusterIP"].(string))
 		assert.Equal(t, stackInfo.Outputs["status"], "deployed")
@@ -446,7 +441,6 @@ func TestHelmReleaseCRD(t *testing.T) {
 
 func TestHelmReleaseNamespace(t *testing.T) {
 	// Validate fix for https://github.com/pulumi/pulumi-kubernetes/issues/1710
-	tests.SkipIfShort(t, "test provisions a load balancer and requires a cloud provider cluster to run")
 	test := getBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			Dir:                  filepath.Join(getCwd(t), "helm-release-namespace", "step1"),
@@ -516,7 +510,6 @@ func TestHelmReleaseRedis(t *testing.T) {
 	}
 
 	// Validate fix for https://github.com/pulumi/pulumi-kubernetes/issues/1933
-	tests.SkipIfShort(t, "test provisions a load balancer and requires a cloud provider cluster to run")
 	test := getBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			Dir:                  filepath.Join(getCwd(t), "helm-release-redis", "step1"),


### PR DESCRIPTION
These tests were not running on pull requests because `run-acceptance-tests` runs all tests in short mode by default. The assertion that these tests provision node balancers and thus need more than a KinD cluster seem incorrect at first glance; we should be able to run them on a KinD cluster.
This pull request removes the `tests.SkipIfShort` condition on these tests.

Tests now enabled are:

- TestAccGuestbook
- TestAccHelm
- TestAccHelmLocal
- TestAccPrometheusOperator
- TestHelmRelease
- TestHelmReleaseNamespace
