### PR TITLE
gen: rename properties named 'pulumi'

### DIFF
--- a/provider/pkg/gen/typegen.go
+++ b/provider/pkg/gen/typegen.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 
@@ -629,6 +630,14 @@ func createKinds(definitions []definition, canonicalGroups map[string]string, al
 				propName = "x_kubernetes_preserve_unknown_fields"
 			case "x-kubernetes-validations":
 				propName = "x_kubernetes_validations" //nolint:gosec
+			}
+
+			// 'pulumi' is treated as a reserved work by the schema binder, so replace it with 'pulumi_' until it's unique.
+			if propName == "pulumi" {
+				propName = "pulumi_"
+				for slices.Contains(propNames, propName) {
+					propName += "_"
+				}
 			}
 
 			if !allowHyphens {


### PR DESCRIPTION
Attempt to rename these properties to 'pulumi_', and keep adding
underscores if the name already exists. This absorbs a breaking change
from the fix to https://github.com/pulumi/pulumi/issues/18994, which
made 'pulumi' a reserved property name.

Motivated by https://github.com/pulumi/crd2pulumi/issues/253, as
`crd2pulumi` uses this infra for its own schema generation.
