### PR TITLE
Re-generate workflows to use larger publish runner

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -17,3 +17,5 @@ envOverride:
     GOOGLE_CI_WORKLOAD_IDENTITY_POOL: pulumi-ci
     GOOGLE_CI_WORKLOAD_IDENTITY_PROVIDER: pulumi-ci
     GOOGLE_PROJECT_NUMBER: 637339343727
+runner:
+    publish: pulumi-ubuntu-8core

--- a/.config/mise.toml
+++ b/.config/mise.toml
@@ -12,7 +12,7 @@ PULUMI_HOME = "{{config_root}}/.pulumi"
 go = "{{ get_env(name='GO_VERSION_MISE', default='latest') }}"
 node = '20.19.5'
 python = '3.11.8'
-dotnet = '8.0.414'
+"vfox:version-fox/vfox-dotnet" = "8.0.20" # vfox backend doesn't work on Windows, gives "error converting Lua table to PreInstall (no version returned from vfox plugin)" https://github.com/jdx/mise/discussions/5876 https://github.com/jdx/mise/discussions/5550
 # Corretto version used as Java SE/OpenJDK version no longer offered
 java = 'corretto-11'
 

--- a/.github/actions/setup-tools/action.yml
+++ b/.github/actions/setup-tools/action.yml
@@ -18,7 +18,7 @@ runs:
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:
-        version: 2025.11.6
+        version: 2026.1.1
         cache_save: ${{ inputs.cache }}
         github_token: ${{ inputs.github_token }}
         plugin_install: https://github.com/pulumi/vfox-pulumi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -361,7 +361,7 @@ jobs:
       env:
         SLACK_WEBHOOK_URL: ${{ steps.esc-secrets.outputs.SLACK_WEBHOOK_URL }}
   publish:
-    runs-on: ubuntu-latest
+    runs-on: pulumi-ubuntu-8core
     needs: test
     name: publish
     permissions:


### PR DESCRIPTION
Publish has been failing for a week. Attempts to clear disk space were made in #4063 but to no effect.

This pull request uses larger runners to use on the publish job.

Related: https://github.com/pulumi/ci-mgmt/pull/1974

Fixes https://github.com/pulumi/pulumi-kubernetes/issues/4052.
