### PR TITLE
Remove unnecessary toolchain

### DIFF
--- a/provider/go.mod
+++ b/provider/go.mod
@@ -2,8 +2,6 @@ module github.com/pulumi/pulumi-kubernetes/provider/v4
 
 go 1.24.7
 
-toolchain go1.24.9
-
 replace github.com/pulumi/pulumi-kubernetes/sdk/v4 => ../sdk
 
 require (

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -2,8 +2,6 @@ module github.com/pulumi/pulumi-kubernetes/tests/v4
 
 go 1.24.7
 
-toolchain go1.24.9
-
 replace (
 	github.com/pulumi/pulumi-kubernetes/provider/v4 => ../provider
 	github.com/pulumi/pulumi-kubernetes/sdk/v4 => ../sdk


### PR DESCRIPTION
The toolchain entry causes us to re-download a Go toolchain instead of using the one mise has already cached for us. This is a flaky network dependency that we don't need.