### PR TITLE
Fix make lint to run to completion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,18 +108,18 @@ only_build:: build
 
 lint::
 	git grep -l 'go:embed' -- provider | xargs perl -i -pe 's/go:embed/ goembed/g'
-	cd provider && golangci-lint run -c ../.golangci.yml --timeout 10m; PROVIDER_EXIT=$$?; \
+	(cd provider && golangci-lint run -c ../.golangci.yml --timeout 10m); PROVIDER_EXIT=$$?; \
 	git grep -l ' goembed' -- provider | xargs perl -i -pe 's/ goembed/go:embed/g'; \
-	cd tests && golangci-lint run -c ../.golangci.yml --timeout 10m; TESTS_EXIT=$$?; \
+	(cd tests && golangci-lint run -c ../.golangci.yml --timeout 10m); TESTS_EXIT=$$?; \
 	exit $$(( PROVIDER_EXIT + TESTS_EXIT ))
 
 # lint-fix is a utility target meant to be run manually
 # that will run the linter and fix errors when possible.
 lint.fix::
 	git grep -l 'go:embed' -- provider | xargs perl -i -pe 's/go:embed/ goembed/g'
-	cd provider && golangci-lint run -c ../.golangci.yml --fix --timeout 10m; PROVIDER_EXIT=$$?; \
+	(cd provider && golangci-lint run -c ../.golangci.yml --fix --timeout 10m); PROVIDER_EXIT=$$?; \
 	git grep -l ' goembed' -- provider | xargs perl -i -pe 's/ goembed/go:embed/g'; \
-	cd tests && golangci-lint run -c ../.golangci.yml --fix --timeout 10m; TESTS_EXIT=$$?; \
+	(cd tests && golangci-lint run -c ../.golangci.yml --fix --timeout 10m); TESTS_EXIT=$$?; \
 	exit $$(( PROVIDER_EXIT + TESTS_EXIT ))
 
 


### PR DESCRIPTION
## Summary

- Fix `make lint` and `make lint.fix` to always restore `go:embed` directives even on lint failure, preventing mutated working trees
- Run both `provider/` and `tests/` linting in a single invocation, reporting all errors at once instead of failing on the first directory

Previously, `&&` chaining meant a lint failure in `provider/` would skip the `go:embed` restore (leaving broken source files) and skip `tests/` linting entirely. This caused a frustrating cycle of fix-push-wait-find-more errors.

This feature already exists in native providers; this brings us on par with that.

Fixes https://github.com/pulumi/pulumi-kubernetes/issues/4214.

