### PR TITLE
Run build on patch upgrade PRs

### DIFF
--- a/.github/workflows/kubernetes-update-check.yml
+++ b/.github/workflows/kubernetes-update-check.yml
@@ -3,9 +3,6 @@ on:
   schedule:
     - cron: 35 12 * * 4 # Thursdays at 12:35
   workflow_dispatch: {}
-  push:
-    branches:
-      - 'guin/improve-upgrade-pr'
 env:
   GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
   PROVIDER: kubernetes


### PR DESCRIPTION
Previously, an upgrade PR would need manual intervention on all counts.

We've since moved cloud-ready-checks back to this repo. Additionally, patch releases of pulumi-kubernetes never have deprecations, so it is safe to generate the provider and SDKs on patch upgrades.

- **tweak text for PR instructions to remove cloud-ready-checks step**
- **add make k8sprovider build**
- **Update PR manual instructions and run build steps on PR**
