### PR TITLE
Prepare for v4.28.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ## Unreleased
 
+## 4.28.0 (March 12, 2026)
+
 ### Changed
 
 - Upgrade Kubernetes schema and libraries to v1.35.2.


### PR DESCRIPTION
## Summary

- Add v4.28.0 release heading to CHANGELOG

## Changes in this release

- Upgrade Kubernetes schema and libraries to v1.35.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)