### PR TITLE
Enable auto-merge for weekly pulumi update PRs

### DIFF
--- a/.github/workflows/weekly-pulumi-update.yml
+++ b/.github/workflows/weekly-pulumi-update.yml
@@ -112,4 +112,9 @@ jobs:
         gh pr create -t "$msg" -b "$msg"
       env:
         GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
+    - name: Enable auto-merge
+      if: steps.create-pr.outcome == 'success'
+      run: gh pr merge --auto --squash --delete-branch
+      env:
+        GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
     name: weekly-pulumi-update


### PR DESCRIPTION
## Summary
- Adds an auto-merge step to the `weekly-pulumi-update` workflow
- After the PR is created, `gh pr merge --auto --squash --delete-branch` is called so the PR merges automatically once all required checks pass
- Matches the pattern used by other Pulumi provider repos (e.g. pulumi-gcp) via `pulumi-upgrade-provider-action`

## Context
Currently, automated `pulumi/pulumi` upgrade PRs (like #4227) sit waiting for a manual merge even after all checks pass. This change eliminates that manual step.

## Test plan
- [ ] Verify the workflow YAML is valid
- [ ] Next weekly run (or manual `workflow_dispatch`) should create a PR with auto-merge enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)