### PR TITLE
Enable automated builds for minor upstream Kubernetes releases

### DIFF
--- a/.github/workflows/kubernetes-update-check.yml
+++ b/.github/workflows/kubernetes-update-check.yml
@@ -37,11 +37,6 @@ jobs:
             echo "Updating to Kubernetes version $KUBE_VERSION"
             echo "needs_update=1" >> "$GITHUB_OUTPUT"
 
-            CURRENT_PATCH=$(echo "$CURRENT_VERSION" | cut -d. -f3)
-            NEW_PATCH=$(echo "$KUBE_VERSION" | cut -d. -f3)
-            if [ "$CURRENT_PATCH" != "$NEW_PATCH" ]; then
-              echo "is_patch_update=1" >> "$GITHUB_OUTPUT"
-            fi
           fi
       - name: Fetch secrets from ESC
         if: steps.get-kubernetes-version.outputs.needs_update != 0
@@ -100,10 +95,8 @@ jobs:
           cd ..
           find . -name go.mod -execdir go mod tidy \;
 
-          # Build provider and SDKs (only for patch upgrades; minor upgrades need manual review)
-          if [ "${{ steps.get-kubernetes-version.outputs.is_patch_update }}" = "1" ]; then
-            make k8sprovider build
-          fi
+          # Build provider and SDKs
+          make k8sprovider build
 
           # Add CHANGELOG entry at end of ## Unreleased section (before next ## heading)
           sed -i '/^## Unreleased$/,/^## [0-9]/{/^## [0-9]/i\\### Changed\n\n- Upgrade Kubernetes schema and libraries to v'"${KUBE_VERSION}"'.\n
@@ -120,16 +113,11 @@ jobs:
           version="${{ steps.get-kubernetes-version.outputs.kube_version }}"
           title="Automated upgrade: bump Kubernetes to v${version}"
           body="## Automated Changes
-          
+
           - Updated KUBE_VERSION in Makefile to ${version}
           - Ran \`make openapi_file\` and \`make schema\`
           - Updated k8s.io/* client libraries to ${{ steps.update-files.outputs.client_version }}
-          
-          ## Manual Steps Required
-          
-          If this is a **minor** upgrade, please complete the following before merging:
-          1. Update \`deprecations.go\` with additions, deprecations, and removals based on the [Deprecated API Migration Guide](https://kubernetes.io/docs/reference/using-api/deprecation-guide/)
-          2. Build provider and SDKs with \`make k8sprovider build\`
+          - Built provider and SDKs with \`make k8sprovider build\`
 
           Closes #${{ steps.create-issue.outputs.issue_number }}."
                     


### PR DESCRIPTION
## Summary

- Remove the `is_patch_update` condition that gated `make k8sprovider build` on patch-only releases
- Now that `deprecated.go` is automated via upstream lifecycle data (#4228), minor releases no longer need manual intervention before building
- Update the PR body template to reflect that all steps are now automated

## Test plan

- [ ] Verify workflow YAML is valid
- [ ] Confirm no other references to `is_patch_update` exist in the repo

Closes #4232
Also closes https://github.com/pulumi/pulumi-kubernetes/issues/4210.

🤖 Generated with [Claude Code](https://claude.com/claude-code)