### PR TITLE
CRD parameterization: implement Parameterize(Value) and array-of-objects flattening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [#4295](https://github.com/pulumi/pulumi-kubernetes/pull/4295)Fix kustomize.v2.Directory resource output type in the schema to properly support array outputs.
 Previously, the resources field was incorrectly typed as a `string` in the schema. This fix updates the type to an array of `Any`, aligning the schema with the provider's Go implementation (`pulumi.ArrayOutput`). This resolves a regression that caused the Kustomize v2 resource to fail in the Python SDK.
 - [#2997](https://github.com/pulumi/pulumi-kubernetes/issues/2997) Stop stripping null values when unmarshaling, fixing Helm chart default deletion and `valueYamlFiles` null handling. Deprecate `allowNullValues` (no longer needed).
+- [#4261](https://github.com/pulumi/pulumi-kubernetes/pull/4261) Fix CRD parameterization: implement `Parameterize(Value)` so subsequent runs can reconstruct the CRD schema from saved state, and flatten array-of-objects in OpenAPI specs so nested fields like `spec.listeners` generate typed args.
 
 ### Changed
 

--- a/provider/pkg/provider/provider_parameterize.go
+++ b/provider/pkg/provider/provider_parameterize.go
@@ -122,31 +122,23 @@ func parseCrdArgs(args []string) (*ParameterizedArgs, error) {
 	}, nil
 }
 
-// derivePackageName produces a package name from the CRD groups found in the
-// manifests. For example, a set of CRDs in "gateway.networking.k8s.io" yields
-// "gateway-networking". If multiple groups are present, they are joined with
-// a hyphen. Falls back to defaultPackageName if no groups can be extracted.
+// derivePackageName produces a package name from the first CRD group found in
+// the manifests. For example, CRDs in "gateway.networking.k8s.io" yield
+// "gateway-networking". Falls back to defaultPackageName if no groups can be
+// extracted. If CRDs span multiple groups, users should specify -n explicitly.
 func derivePackageName(crds []*extensionv1.CustomResourceDefinition) string {
-	seen := make(map[string]bool)
-	var parts []string
 	for _, crd := range crds {
 		group := crd.Spec.Group
-		if group == "" || seen[group] {
+		if group == "" {
 			continue
 		}
-		seen[group] = true
-
 		// Strip common k8s suffixes to get the meaningful prefix.
 		// "gateway.networking.k8s.io" → "gateway-networking"
 		// "cert-manager.io" → "cert-manager"
 		short := stripK8sSuffix(group)
-		short = strings.ReplaceAll(short, ".", "-")
-		parts = append(parts, short)
+		return strings.ReplaceAll(short, ".", "-")
 	}
-	if len(parts) == 0 {
-		return defaultPackageName
-	}
-	return strings.Join(parts, "-")
+	return defaultPackageName
 }
 
 // stripK8sSuffix removes common Kubernetes API group suffixes like ".k8s.io",

--- a/provider/pkg/provider/provider_parameterize.go
+++ b/provider/pkg/provider/provider_parameterize.go
@@ -203,8 +203,9 @@ func crdToOpenAPI(crd *extensionv1.CustomResourceDefinition) ([]*spec.Swagger, e
 	return openAPIManifests, nil
 }
 
-// flattenOpenAPI recursively finds all nested objects in the OpenAPI spec and flattens them into a single object as
-// definitions.
+// flattenOpenAPI recursively finds all nested objects in the OpenAPI spec and flattens them into
+// top-level definitions. This includes both direct object properties and objects nested inside
+// arrays (e.g., spec.listeners, spec.rules[].backendRefs).
 func flattenOpenAPI(sw *spec.Swagger) error {
 	// Create a stack of definition names to be processed.
 	definitionStack := make([]string, 0, len(sw.Definitions))
@@ -227,7 +228,41 @@ func flattenOpenAPI(sw *spec.Swagger) error {
 				continue
 			}
 
-			// If the property is not an object, we can skip it.
+			// Handle arrays whose items are objects — e.g., spec.listeners, spec.rules.
+			if propertySchema.Type.Contains("array") {
+				itemSchema := propertySchema.Items
+				if itemSchema == nil || itemSchema.Schema == nil {
+					continue
+				}
+				inner := itemSchema.Schema
+				if inner.Ref.GetURL() != nil {
+					continue
+				}
+				if !inner.Type.Contains("object") || inner.Properties == nil {
+					continue
+				}
+				if inner.AdditionalProperties != nil {
+					continue
+				}
+
+				nestedDefinitionName := definitionName + cgstrings.UppercaseFirst(propertyName)
+				sw.Definitions[nestedDefinitionName] = *inner
+				definitionStack = append(definitionStack, nestedDefinitionName)
+
+				ref, err := makeDefinitionRef(nestedDefinitionName)
+				if err != nil {
+					return err
+				}
+				propertySchema.Items = &spec.SchemaOrArray{
+					Schema: &spec.Schema{
+						SchemaProps: spec.SchemaProps{Ref: ref},
+					},
+				}
+				definition.Properties[propertyName] = propertySchema
+				continue
+			}
+
+			// Handle direct object properties.
 			if !propertySchema.Type.Contains("object") {
 				continue
 			}
@@ -250,23 +285,25 @@ func flattenOpenAPI(sw *spec.Swagger) error {
 			// Add nested object to the stack to be recursively flattened.
 			definitionStack = append(definitionStack, nestedDefinitionName)
 
-			// Reset the property to be a reference to the nested object.
-			refName := definitionPrefix + nestedDefinitionName
-			ref, err := jsonreference.New(refName)
+			ref, err := makeDefinitionRef(nestedDefinitionName)
 			if err != nil {
-				return fmt.Errorf("error creating OpenAPI json reference for nested object: %w", err)
+				return err
 			}
-
 			definition.Properties[propertyName] = spec.Schema{
-				SchemaProps: spec.SchemaProps{
-					Ref: spec.Ref{
-						Ref: ref,
-					},
-				},
+				SchemaProps: spec.SchemaProps{Ref: ref},
 			}
 		}
 	}
 	return nil
+}
+
+// makeDefinitionRef creates a spec.Ref pointing to #/definitions/<name>.
+func makeDefinitionRef(name string) (spec.Ref, error) {
+	ref, err := jsonreference.New(definitionPrefix + name)
+	if err != nil {
+		return spec.Ref{}, fmt.Errorf("error creating OpenAPI json reference for nested object: %w", err)
+	}
+	return spec.Ref{Ref: ref}, nil
 }
 
 // readCRDManifestFile reads the CRD manifest from the given file path.

--- a/provider/pkg/provider/provider_parameterize.go
+++ b/provider/pkg/provider/provider_parameterize.go
@@ -40,11 +40,9 @@ import (
 	"github.com/pulumi/pulumi-kubernetes/provider/v4/pkg/gen"
 )
 
-// TODO(rquitales): Remove the hardcoded package name once upstream extension
-// parameterization is implemented and can be passed. For now, we can only
-// "parameterize" with one package, but it is intended to not be a upper bound
-// on the number of packages that can be parameterized.
-const crdPackageName = "mycrd"
+// defaultPackageName is used when the user does not specify a package name
+// and one cannot be derived from the CRD groups.
+const defaultPackageName = "crds"
 
 const definitionPrefix = "#/definitions/"
 
@@ -83,21 +81,25 @@ func (c *parameterizedPackageMap) add(name, version string, schema *pulumischema
 // ParameterizedArgs is the struct that holds the arguments for the Kubernetes Provider parameterization.
 // Currently, this is only used for generating types from CRD manifests.
 type ParameterizedArgs struct {
+	PackageName      string
 	PackageVersion   string
 	CRDManifestPaths []string
 }
 
 // String returns a string representation of the ParameterizedArgs. This is used for logging purposes.
 func (p ParameterizedArgs) String() string {
-	return fmt.Sprintf("version: %s, crd-manifests: %v", p.PackageVersion, strings.Join(p.CRDManifestPaths, ", "))
+	return fmt.Sprintf("name: %s, version: %s, crd-manifests: %v",
+		p.PackageName, p.PackageVersion, strings.Join(p.CRDManifestPaths, ", "))
 }
 
 // parseCrdArgs parses the user provided arguments for provider parameterization.
 func parseCrdArgs(args []string) (*ParameterizedArgs, error) {
+	var crdPackageName string
 	var crdPackageVersion string
 	var yamlPaths []string
 
 	flags := pflag.NewFlagSet("crdargs", pflag.PanicOnError)
+	flags.StringVarP(&crdPackageName, "name", "n", "", "The name of the CRD package.")
 	flags.StringVarP(&crdPackageVersion, "version", "v", "", "The version of the CRD package.")
 	flags.StringArrayVarP(&yamlPaths, "crd-manifests", "c", nil, "The paths to the CRD manifests.")
 	err := flags.Parse(args)
@@ -114,9 +116,48 @@ func parseCrdArgs(args []string) (*ParameterizedArgs, error) {
 	}
 
 	return &ParameterizedArgs{
+		PackageName:      crdPackageName,
 		PackageVersion:   crdPackageVersion,
 		CRDManifestPaths: yamlPaths,
 	}, nil
+}
+
+// derivePackageName produces a package name from the CRD groups found in the
+// manifests. For example, a set of CRDs in "gateway.networking.k8s.io" yields
+// "gateway-networking". If multiple groups are present, they are joined with
+// a hyphen. Falls back to defaultPackageName if no groups can be extracted.
+func derivePackageName(crds []*extensionv1.CustomResourceDefinition) string {
+	seen := make(map[string]bool)
+	var parts []string
+	for _, crd := range crds {
+		group := crd.Spec.Group
+		if group == "" || seen[group] {
+			continue
+		}
+		seen[group] = true
+
+		// Strip common k8s suffixes to get the meaningful prefix.
+		// "gateway.networking.k8s.io" → "gateway-networking"
+		// "cert-manager.io" → "cert-manager"
+		short := stripK8sSuffix(group)
+		short = strings.ReplaceAll(short, ".", "-")
+		parts = append(parts, short)
+	}
+	if len(parts) == 0 {
+		return defaultPackageName
+	}
+	return strings.Join(parts, "-")
+}
+
+// stripK8sSuffix removes common Kubernetes API group suffixes like ".k8s.io",
+// ".io", and ".x-k8s.io" to produce a human-readable short name.
+func stripK8sSuffix(group string) string {
+	for _, suffix := range []string{".x-k8s.io", ".k8s.io", ".io"} {
+		if strings.HasSuffix(group, suffix) {
+			return strings.TrimSuffix(group, suffix)
+		}
+	}
+	return group
 }
 
 // fillDefaultNames sets the default names for the CRD if they are not specified.
@@ -340,6 +381,7 @@ func (k *kubeProvider) parameterizeRequestArgs(
 
 	logger.V(9).Infof("Parameterized Pulumi Kubernetes provider with user specified args: %s", args)
 
+	var allCRDs []*extensionv1.CustomResourceDefinition
 	var allCRDSpecs []*spec.Swagger
 
 	// We need to iterate through all filepaths provided by the user to generate the CRD schemas. Within each file, we
@@ -349,6 +391,8 @@ func (k *kubeProvider) parameterizeRequestArgs(
 		if err != nil {
 			return nil, fmt.Errorf("error reading CRD manifest: %w", err)
 		}
+
+		allCRDs = append(allCRDs, crds...)
 
 		for _, crd := range crds {
 			crdVersionSpecs, err := crdToOpenAPI(crd)
@@ -370,13 +414,19 @@ func (k *kubeProvider) parameterizeRequestArgs(
 		return nil, fmt.Errorf("error merging OpenAPI specs for all provided CRDs: %w", err)
 	}
 
+	// Determine the package name: user-specified > derived from CRD groups > default.
+	packageName := args.PackageName
+	if packageName == "" {
+		packageName = derivePackageName(allCRDs)
+	}
+
 	crdsPackageSpec := generateSchema(mergedSpecs, args.PackageVersion, k.name, k.version)
 
 	if crdsPackageSpec != nil {
-		k.crdSchemas.add(crdPackageName, args.PackageVersion, crdsPackageSpec)
+		k.crdSchemas.add(packageName, args.PackageVersion, crdsPackageSpec)
 	}
 
-	return &pulumirpc.ParameterizeResponse{Name: crdPackageName, Version: args.PackageVersion}, nil
+	return &pulumirpc.ParameterizeResponse{Name: packageName, Version: args.PackageVersion}, nil
 }
 
 // parameterizeRequestValue is a placeholder for the extension parameterization implementation. This allows the

--- a/provider/pkg/provider/provider_parameterize.go
+++ b/provider/pkg/provider/provider_parameterize.go
@@ -429,16 +429,48 @@ func (k *kubeProvider) parameterizeRequestArgs(
 	return &pulumirpc.ParameterizeResponse{Name: packageName, Version: args.PackageVersion}, nil
 }
 
-// parameterizeRequestValue is a placeholder for the extension parameterization implementation. This allows the
-// provider to reconstruct the necessary types for the CRD schemas generated from the CRD manifests. This is where we
-// handle field name denormalization and other necessary transformations to be able to translate the typed SDKs back to
-// the original
-// CR schema.
+// parameterizeRequestValue reconstructs the CRD schema from the saved
+// parameterization state. The engine calls this path on subsequent runs (e.g.,
+// `pulumi up` after the initial `pulumi package add`) by replaying the
+// parameters that were persisted in Pulumi.yaml.
+//
+// The Value.Value bytes contain the marshaled OpenAPI spec that was originally
+// stored as the Parameter field in the ParameterizationSpec during the Args
+// path. We unmarshal it, regenerate the Pulumi schema, and cache it.
 func (k *kubeProvider) parameterizeRequestValue(
-	_ *pulumirpc.ParameterizeRequest_Value,
+	p *pulumirpc.ParameterizeRequest_Value,
 ) (*pulumirpc.ParameterizeResponse, error) {
-	// TODO(rquitales): Implement the logic to generate the CRD schema from the CRD manifests once extension
-	// parameterization is implemented. We will need to handle the mapping of normalized field names (to conform to
-	// language requirements) to the original k8s field names.
-	return nil, nil
+	v := p.Value
+	if v == nil {
+		return nil, errors.New("parameterize value is nil")
+	}
+
+	packageName := v.GetName()
+	packageVersion := v.GetVersion()
+	paramBytes := v.GetValue()
+
+	if packageName == "" {
+		return nil, errors.New("parameterize value: package name must be provided")
+	}
+	if packageVersion == "" {
+		return nil, errors.New("parameterize value: package version must be provided")
+	}
+	if len(paramBytes) == 0 {
+		return nil, errors.New("parameterize value: parameter bytes must be provided")
+	}
+
+	logger.V(9).Infof("Reconstructing CRD schema for %s@%s from saved parameters", packageName, packageVersion)
+
+	// Deserialize the OpenAPI spec from the saved parameter bytes.
+	var swagger spec.Swagger
+	if err := json.Unmarshal(paramBytes, &swagger); err != nil {
+		return nil, fmt.Errorf("parameterize value: error unmarshalling saved OpenAPI spec: %w", err)
+	}
+
+	crdsPackageSpec := generateSchema(&swagger, packageVersion, k.name, k.version)
+	if crdsPackageSpec != nil {
+		k.crdSchemas.add(packageName, packageVersion, crdsPackageSpec)
+	}
+
+	return &pulumirpc.ParameterizeResponse{Name: packageName, Version: packageVersion}, nil
 }

--- a/provider/pkg/provider/provider_parameterize.go
+++ b/provider/pkg/provider/provider_parameterize.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -40,10 +41,14 @@ import (
 	"github.com/pulumi/pulumi-kubernetes/provider/v4/pkg/gen"
 )
 
-// defaultPackageName is used when the user does not specify a package name
-// and one cannot be derived from the CRD groups.
-const defaultPackageName = "crds"
+// defaultExtensionName is the final fallback when the user does not specify -n
+// and the manifest path's base name cannot be used.
+const defaultExtensionName = "crds"
 
+// definitionPrefix is the JSON Schema reference prefix used in OpenAPI specs to
+// point at shared type definitions in the same document (e.g.
+// "#/definitions/Foo" resolves to definitions.Foo). Used when flattenOpenAPI
+// hoists a nested object to a top-level definition and leaves a $ref behind.
 const definitionPrefix = "#/definitions/"
 
 // parameterizedPackageMap is a map of packages to their respective Pulumi PackageSpecs. This is used to store the
@@ -78,37 +83,38 @@ func (c *parameterizedPackageMap) add(name, version string, schema *pulumischema
 	c.crdSchemas[c.mapKey(name, version)] = schema
 }
 
-// ParameterizedArgs is the struct that holds the arguments for the Kubernetes Provider parameterization.
-// Currently, this is only used for generating types from CRD manifests.
+// ParameterizedArgs holds the arguments for the Kubernetes Provider
+// parameterization. Currently this is only used for generating types from CRD
+// manifests.
 type ParameterizedArgs struct {
-	PackageName      string
-	PackageVersion   string
+	ExtensionName    string
+	ExtensionVersion string
 	CRDManifestPaths []string
 }
 
 // String returns a string representation of the ParameterizedArgs. This is used for logging purposes.
 func (p ParameterizedArgs) String() string {
 	return fmt.Sprintf("name: %s, version: %s, crd-manifests: %v",
-		p.PackageName, p.PackageVersion, strings.Join(p.CRDManifestPaths, ", "))
+		p.ExtensionName, p.ExtensionVersion, strings.Join(p.CRDManifestPaths, ", "))
 }
 
 // parseCrdArgs parses the user provided arguments for provider parameterization.
 func parseCrdArgs(args []string) (*ParameterizedArgs, error) {
-	var crdPackageName string
-	var crdPackageVersion string
+	var extensionName string
+	var extensionVersion string
 	var yamlPaths []string
 
 	flags := pflag.NewFlagSet("crdargs", pflag.PanicOnError)
-	flags.StringVarP(&crdPackageName, "name", "n", "", "The name of the CRD package.")
-	flags.StringVarP(&crdPackageVersion, "version", "v", "", "The version of the CRD package.")
+	flags.StringVarP(&extensionName, "name", "n", "", "The name of the CRD extension.")
+	flags.StringVarP(&extensionVersion, "version", "v", "", "The version of the CRD extension.")
 	flags.StringArrayVarP(&yamlPaths, "crd-manifests", "c", nil, "The paths to the CRD manifests.")
 	err := flags.Parse(args)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing parameterization args: %w", err)
 	}
 
-	if crdPackageVersion == "" {
-		return nil, errors.New("package version must be provided")
+	if extensionVersion == "" {
+		return nil, errors.New("extension version must be provided")
 	}
 
 	if len(yamlPaths) == 0 {
@@ -116,40 +122,26 @@ func parseCrdArgs(args []string) (*ParameterizedArgs, error) {
 	}
 
 	return &ParameterizedArgs{
-		PackageName:      crdPackageName,
-		PackageVersion:   crdPackageVersion,
+		ExtensionName:    extensionName,
+		ExtensionVersion: extensionVersion,
 		CRDManifestPaths: yamlPaths,
 	}, nil
 }
 
-// derivePackageName produces a package name from the first CRD group found in
-// the manifests. For example, CRDs in "gateway.networking.k8s.io" yield
-// "gateway-networking". Falls back to defaultPackageName if no groups can be
-// extracted. If CRDs span multiple groups, users should specify -n explicitly.
-func derivePackageName(crds []*extensionv1.CustomResourceDefinition) string {
-	for _, crd := range crds {
-		group := crd.Spec.Group
-		if group == "" {
-			continue
-		}
-		// Strip common k8s suffixes to get the meaningful prefix.
-		// "gateway.networking.k8s.io" → "gateway-networking"
-		// "cert-manager.io" → "cert-manager"
-		short := stripK8sSuffix(group)
-		return strings.ReplaceAll(short, ".", "-")
-	}
-	return defaultPackageName
-}
-
-// stripK8sSuffix removes common Kubernetes API group suffixes like ".k8s.io",
-// ".io", and ".x-k8s.io" to produce a human-readable short name.
-func stripK8sSuffix(group string) string {
-	for _, suffix := range []string{".x-k8s.io", ".k8s.io", ".io"} {
-		if strings.HasSuffix(group, suffix) {
-			return strings.TrimSuffix(group, suffix)
+// deriveExtensionName produces an extension name from the first CRD manifest
+// file path. The file's base name (without extension) is used directly, e.g.
+// "gateway-api-crds.yaml" → "gateway-api-crds". Falls back to
+// defaultExtensionName if no usable path is provided.
+func deriveExtensionName(paths []string) string {
+	for _, p := range paths {
+		base := filepath.Base(p)
+		ext := filepath.Ext(base)
+		name := strings.TrimSuffix(base, ext)
+		if name != "" {
+			return name
 		}
 	}
-	return group
+	return defaultExtensionName
 }
 
 // fillDefaultNames sets the default names for the CRD if they are not specified.
@@ -289,7 +281,10 @@ func flattenOpenAPI(sw *spec.Swagger) error {
 	return nil
 }
 
-// makeDefinitionRef creates a spec.Ref pointing to #/definitions/<name>.
+// makeDefinitionRef builds the {$ref: "#/definitions/<name>"} pointer that
+// flattenOpenAPI leaves behind when it hoists a nested object to a top-level
+// definition. Helper because flattenOpenAPI does this in two places (direct
+// object properties and array-of-object properties).
 func makeDefinitionRef(name string) (spec.Ref, error) {
 	ref, err := jsonreference.New(definitionPrefix + name)
 	if err != nil {
@@ -410,7 +405,6 @@ func (k *kubeProvider) parameterizeRequestArgs(
 
 	logger.V(9).Infof("Parameterized Pulumi Kubernetes provider with user specified args: %s", args)
 
-	var allCRDs []*extensionv1.CustomResourceDefinition
 	var allCRDSpecs []*spec.Swagger
 
 	// We need to iterate through all filepaths provided by the user to generate the CRD schemas. Within each file, we
@@ -420,8 +414,6 @@ func (k *kubeProvider) parameterizeRequestArgs(
 		if err != nil {
 			return nil, fmt.Errorf("error reading CRD manifest: %w", err)
 		}
-
-		allCRDs = append(allCRDs, crds...)
 
 		for _, crd := range crds {
 			crdVersionSpecs, err := crdToOpenAPI(crd)
@@ -443,19 +435,19 @@ func (k *kubeProvider) parameterizeRequestArgs(
 		return nil, fmt.Errorf("error merging OpenAPI specs for all provided CRDs: %w", err)
 	}
 
-	// Determine the package name: user-specified > derived from CRD groups > default.
-	packageName := args.PackageName
-	if packageName == "" {
-		packageName = derivePackageName(allCRDs)
+	// Resolve the extension name: explicit -n > derived from manifest filename > default.
+	extensionName := args.ExtensionName
+	if extensionName == "" {
+		extensionName = deriveExtensionName(args.CRDManifestPaths)
 	}
 
-	crdsPackageSpec := generateSchema(mergedSpecs, args.PackageVersion, k.name, k.version)
+	crdsPackageSpec := generateSchema(mergedSpecs, args.ExtensionVersion, k.name, k.version)
 
 	if crdsPackageSpec != nil {
-		k.crdSchemas.add(packageName, args.PackageVersion, crdsPackageSpec)
+		k.crdSchemas.add(extensionName, args.ExtensionVersion, crdsPackageSpec)
 	}
 
-	return &pulumirpc.ParameterizeResponse{Name: packageName, Version: args.PackageVersion}, nil
+	return &pulumirpc.ParameterizeResponse{Name: extensionName, Version: args.ExtensionVersion}, nil
 }
 
 // parameterizeRequestValue reconstructs the CRD schema from the saved
@@ -474,21 +466,21 @@ func (k *kubeProvider) parameterizeRequestValue(
 		return nil, errors.New("parameterize value is nil")
 	}
 
-	packageName := v.GetName()
-	packageVersion := v.GetVersion()
+	extensionName := v.GetName()
+	extensionVersion := v.GetVersion()
 	paramBytes := v.GetValue()
 
-	if packageName == "" {
-		return nil, errors.New("parameterize value: package name must be provided")
+	if extensionName == "" {
+		return nil, errors.New("parameterize value: extension name must be provided")
 	}
-	if packageVersion == "" {
-		return nil, errors.New("parameterize value: package version must be provided")
+	if extensionVersion == "" {
+		return nil, errors.New("parameterize value: extension version must be provided")
 	}
 	if len(paramBytes) == 0 {
 		return nil, errors.New("parameterize value: parameter bytes must be provided")
 	}
 
-	logger.V(9).Infof("Reconstructing CRD schema for %s@%s from saved parameters", packageName, packageVersion)
+	logger.V(9).Infof("Reconstructing CRD schema for %s@%s from saved parameters", extensionName, extensionVersion)
 
 	// Deserialize the OpenAPI spec from the saved parameter bytes.
 	var swagger spec.Swagger
@@ -496,10 +488,10 @@ func (k *kubeProvider) parameterizeRequestValue(
 		return nil, fmt.Errorf("parameterize value: error unmarshalling saved OpenAPI spec: %w", err)
 	}
 
-	crdsPackageSpec := generateSchema(&swagger, packageVersion, k.name, k.version)
+	crdsPackageSpec := generateSchema(&swagger, extensionVersion, k.name, k.version)
 	if crdsPackageSpec != nil {
-		k.crdSchemas.add(packageName, packageVersion, crdsPackageSpec)
+		k.crdSchemas.add(extensionName, extensionVersion, crdsPackageSpec)
 	}
 
-	return &pulumirpc.ParameterizeResponse{Name: packageName, Version: packageVersion}, nil
+	return &pulumirpc.ParameterizeResponse{Name: extensionName, Version: extensionVersion}, nil
 }

--- a/provider/pkg/provider/provider_parameterize_test.go
+++ b/provider/pkg/provider/provider_parameterize_test.go
@@ -21,6 +21,118 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 )
 
+func TestParseCrdArgsWithName(t *testing.T) {
+	args, err := parseCrdArgs([]string{"-n", "gateway-api", "-v", "1.2.1", "-c", "crds.yaml"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if args.PackageName != "gateway-api" {
+		t.Errorf("expected package name %q, got %q", "gateway-api", args.PackageName)
+	}
+	if args.PackageVersion != "1.2.1" {
+		t.Errorf("expected version %q, got %q", "1.2.1", args.PackageVersion)
+	}
+}
+
+func TestParseCrdArgsWithoutName(t *testing.T) {
+	args, err := parseCrdArgs([]string{"-v", "1.0.0", "-c", "crds.yaml"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if args.PackageName != "" {
+		t.Errorf("expected empty package name, got %q", args.PackageName)
+	}
+}
+
+func TestDerivePackageName(t *testing.T) {
+	tests := []struct {
+		name     string
+		crds     []*extensionv1.CustomResourceDefinition
+		expected string
+	}{
+		{
+			"gateway API group",
+			[]*extensionv1.CustomResourceDefinition{
+				{Spec: extensionv1.CustomResourceDefinitionSpec{Group: "gateway.networking.k8s.io"}},
+			},
+			"gateway-networking",
+		},
+		{
+			"cert-manager group",
+			[]*extensionv1.CustomResourceDefinition{
+				{Spec: extensionv1.CustomResourceDefinitionSpec{Group: "cert-manager.io"}},
+			},
+			"cert-manager",
+		},
+		{
+			"multiple groups",
+			[]*extensionv1.CustomResourceDefinition{
+				{Spec: extensionv1.CustomResourceDefinitionSpec{Group: "gateway.networking.k8s.io"}},
+				{Spec: extensionv1.CustomResourceDefinitionSpec{Group: "cert-manager.io"}},
+			},
+			"gateway-networking-cert-manager",
+		},
+		{
+			"deduplicates same group",
+			[]*extensionv1.CustomResourceDefinition{
+				{Spec: extensionv1.CustomResourceDefinitionSpec{Group: "gateway.networking.k8s.io"}},
+				{Spec: extensionv1.CustomResourceDefinitionSpec{Group: "gateway.networking.k8s.io"}},
+			},
+			"gateway-networking",
+		},
+		{
+			"no groups falls back to default",
+			[]*extensionv1.CustomResourceDefinition{
+				{Spec: extensionv1.CustomResourceDefinitionSpec{Group: ""}},
+			},
+			defaultPackageName,
+		},
+		{
+			"x-k8s.io suffix",
+			[]*extensionv1.CustomResourceDefinition{
+				{Spec: extensionv1.CustomResourceDefinitionSpec{Group: "multicluster.x-k8s.io"}},
+			},
+			"multicluster",
+		},
+		{
+			"plain group without known suffix",
+			[]*extensionv1.CustomResourceDefinition{
+				{Spec: extensionv1.CustomResourceDefinitionSpec{Group: "example.com"}},
+			},
+			"example-com",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := derivePackageName(tt.crds)
+			if got != tt.expected {
+				t.Errorf("derivePackageName() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestStripK8sSuffix(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"gateway.networking.k8s.io", "gateway.networking"},
+		{"cert-manager.io", "cert-manager"},
+		{"multicluster.x-k8s.io", "multicluster"},
+		{"example.com", "example.com"},
+		{"storage", "storage"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := stripK8sSuffix(tt.input)
+			if got != tt.expected {
+				t.Errorf("stripK8sSuffix(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
 func TestSetCRDDefaults(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/provider/pkg/provider/provider_parameterize_test.go
+++ b/provider/pkg/provider/provider_parameterize_test.go
@@ -19,6 +19,7 @@ import (
 
 	extensionv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/kube-openapi/pkg/validation/spec"
 )
 
 func TestParseCrdArgsWithName(t *testing.T) {
@@ -212,4 +213,160 @@ func TestSetCRDDefaults(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFlattenOpenAPIArrayOfObjects(t *testing.T) {
+	// Simulate a CRD with an array-of-objects property (like spec.listeners).
+	sw := &spec.Swagger{
+		SwaggerProps: spec.SwaggerProps{
+			Definitions: spec.Definitions{
+				"io.k8s.networking.gateway.v1.GatewaySpec": spec.Schema{
+					SchemaProps: spec.SchemaProps{
+						Type: spec.StringOrArray{"object"},
+						Properties: map[string]spec.Schema{
+							"listeners": {
+								SchemaProps: spec.SchemaProps{
+									Type: spec.StringOrArray{"array"},
+									Items: &spec.SchemaOrArray{
+										Schema: &spec.Schema{
+											SchemaProps: spec.SchemaProps{
+												Type: spec.StringOrArray{"object"},
+												Properties: map[string]spec.Schema{
+													"name":     {SchemaProps: spec.SchemaProps{Type: spec.StringOrArray{"string"}}},
+													"port":     {SchemaProps: spec.SchemaProps{Type: spec.StringOrArray{"integer"}}},
+													"protocol": {SchemaProps: spec.SchemaProps{Type: spec.StringOrArray{"string"}}},
+												},
+											},
+										},
+									},
+								},
+							},
+							"gatewayClassName": {
+								SchemaProps: spec.SchemaProps{Type: spec.StringOrArray{"string"}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err := flattenOpenAPI(sw)
+	if err != nil {
+		t.Fatalf("flattenOpenAPI returned error: %v", err)
+	}
+
+	// The inner object should be hoisted to a top-level definition.
+	hoistedName := "io.k8s.networking.gateway.v1.GatewaySpecListeners"
+	hoisted, ok := sw.Definitions[hoistedName]
+	if !ok {
+		t.Fatalf("expected hoisted definition %q not found; have: %v", hoistedName, definitionNames(sw))
+	}
+
+	if _, ok := hoisted.Properties["name"]; !ok {
+		t.Error("hoisted definition missing 'name' property")
+	}
+	if _, ok := hoisted.Properties["port"]; !ok {
+		t.Error("hoisted definition missing 'port' property")
+	}
+	if _, ok := hoisted.Properties["protocol"]; !ok {
+		t.Error("hoisted definition missing 'protocol' property")
+	}
+
+	// The original array property's items should now be a $ref.
+	parentDef := sw.Definitions["io.k8s.networking.gateway.v1.GatewaySpec"]
+	listeners := parentDef.Properties["listeners"]
+	if listeners.Items == nil || listeners.Items.Schema == nil {
+		t.Fatal("listeners.Items.Schema is nil after flattening")
+	}
+	refURL := listeners.Items.Schema.Ref.GetURL()
+	if refURL == nil {
+		t.Fatal("listeners items should be a $ref after flattening")
+	}
+	expectedRef := "#/definitions/" + hoistedName
+	if refURL.String() != expectedRef {
+		t.Errorf("listeners items ref = %q, want %q", refURL.String(), expectedRef)
+	}
+
+	// Simple string property should be unchanged.
+	className := parentDef.Properties["gatewayClassName"]
+	if !className.Type.Contains("string") {
+		t.Error("gatewayClassName should still be a string")
+	}
+}
+
+func TestFlattenOpenAPINestedArrayOfObjects(t *testing.T) {
+	// Simulate rules[].backendRefs[] — nested array-of-objects inside array-of-objects.
+	sw := &spec.Swagger{
+		SwaggerProps: spec.SwaggerProps{
+			Definitions: spec.Definitions{
+				"io.k8s.networking.gateway.v1.HTTPRouteSpec": spec.Schema{
+					SchemaProps: spec.SchemaProps{
+						Type: spec.StringOrArray{"object"},
+						Properties: map[string]spec.Schema{
+							"rules": {
+								SchemaProps: spec.SchemaProps{
+									Type: spec.StringOrArray{"array"},
+									Items: &spec.SchemaOrArray{
+										Schema: &spec.Schema{
+											SchemaProps: spec.SchemaProps{
+												Type: spec.StringOrArray{"object"},
+												Properties: map[string]spec.Schema{
+													"backendRefs": {
+														SchemaProps: spec.SchemaProps{
+															Type: spec.StringOrArray{"array"},
+															Items: &spec.SchemaOrArray{
+																Schema: &spec.Schema{
+																	SchemaProps: spec.SchemaProps{
+																		Type: spec.StringOrArray{"object"},
+																		Properties: map[string]spec.Schema{
+																			"name": {SchemaProps: spec.SchemaProps{Type: spec.StringOrArray{"string"}}},
+																			"port": {SchemaProps: spec.SchemaProps{Type: spec.StringOrArray{"integer"}}},
+																		},
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err := flattenOpenAPI(sw)
+	if err != nil {
+		t.Fatalf("flattenOpenAPI returned error: %v", err)
+	}
+
+	if _, ok := sw.Definitions["io.k8s.networking.gateway.v1.HTTPRouteSpecRules"]; !ok {
+		t.Fatalf("expected Rules definition; have: %v", definitionNames(sw))
+	}
+
+	if _, ok := sw.Definitions["io.k8s.networking.gateway.v1.HTTPRouteSpecRulesBackendRefs"]; !ok {
+		t.Fatalf("expected BackendRefs definition; have: %v", definitionNames(sw))
+	}
+
+	backendRefs := sw.Definitions["io.k8s.networking.gateway.v1.HTTPRouteSpecRulesBackendRefs"]
+	if _, ok := backendRefs.Properties["name"]; !ok {
+		t.Error("backendRefs missing 'name' property")
+	}
+	if _, ok := backendRefs.Properties["port"]; !ok {
+		t.Error("backendRefs missing 'port' property")
+	}
+}
+
+func definitionNames(sw *spec.Swagger) []string {
+	var names []string
+	for k := range sw.Definitions {
+		names = append(names, k)
+	}
+	return names
 }

--- a/provider/pkg/provider/provider_parameterize_test.go
+++ b/provider/pkg/provider/provider_parameterize_test.go
@@ -66,18 +66,10 @@ func TestDerivePackageName(t *testing.T) {
 			"cert-manager",
 		},
 		{
-			"multiple groups",
+			"multiple groups uses first group",
 			[]*extensionv1.CustomResourceDefinition{
 				{Spec: extensionv1.CustomResourceDefinitionSpec{Group: "gateway.networking.k8s.io"}},
 				{Spec: extensionv1.CustomResourceDefinitionSpec{Group: "cert-manager.io"}},
-			},
-			"gateway-networking-cert-manager",
-		},
-		{
-			"deduplicates same group",
-			[]*extensionv1.CustomResourceDefinition{
-				{Spec: extensionv1.CustomResourceDefinitionSpec{Group: "gateway.networking.k8s.io"}},
-				{Spec: extensionv1.CustomResourceDefinitionSpec{Group: "gateway.networking.k8s.io"}},
 			},
 			"gateway-networking",
 		},

--- a/provider/pkg/provider/provider_parameterize_test.go
+++ b/provider/pkg/provider/provider_parameterize_test.go
@@ -209,6 +209,16 @@ func TestSetCRDDefaults(t *testing.T) {
 
 func TestFlattenOpenAPIArrayOfObjects(t *testing.T) {
 	// Simulate a CRD with an array-of-objects property (like spec.listeners).
+	listenerSchema := spec.Schema{
+		SchemaProps: spec.SchemaProps{
+			Type: spec.StringOrArray{"object"},
+			Properties: map[string]spec.Schema{
+				"name":     {SchemaProps: spec.SchemaProps{Type: spec.StringOrArray{"string"}}},
+				"port":     {SchemaProps: spec.SchemaProps{Type: spec.StringOrArray{"integer"}}},
+				"protocol": {SchemaProps: spec.SchemaProps{Type: spec.StringOrArray{"string"}}},
+			},
+		},
+	}
 	sw := &spec.Swagger{
 		SwaggerProps: spec.SwaggerProps{
 			Definitions: spec.Definitions{
@@ -218,19 +228,8 @@ func TestFlattenOpenAPIArrayOfObjects(t *testing.T) {
 						Properties: map[string]spec.Schema{
 							"listeners": {
 								SchemaProps: spec.SchemaProps{
-									Type: spec.StringOrArray{"array"},
-									Items: &spec.SchemaOrArray{
-										Schema: &spec.Schema{
-											SchemaProps: spec.SchemaProps{
-												Type: spec.StringOrArray{"object"},
-												Properties: map[string]spec.Schema{
-													"name":     {SchemaProps: spec.SchemaProps{Type: spec.StringOrArray{"string"}}},
-													"port":     {SchemaProps: spec.SchemaProps{Type: spec.StringOrArray{"integer"}}},
-													"protocol": {SchemaProps: spec.SchemaProps{Type: spec.StringOrArray{"string"}}},
-												},
-											},
-										},
-									},
+									Type:  spec.StringOrArray{"array"},
+									Items: &spec.SchemaOrArray{Schema: &listenerSchema},
 								},
 							},
 							"gatewayClassName": {
@@ -289,6 +288,28 @@ func TestFlattenOpenAPIArrayOfObjects(t *testing.T) {
 
 func TestFlattenOpenAPINestedArrayOfObjects(t *testing.T) {
 	// Simulate rules[].backendRefs[] — nested array-of-objects inside array-of-objects.
+	backendRefSchema := spec.Schema{
+		SchemaProps: spec.SchemaProps{
+			Type: spec.StringOrArray{"object"},
+			Properties: map[string]spec.Schema{
+				"name": {SchemaProps: spec.SchemaProps{Type: spec.StringOrArray{"string"}}},
+				"port": {SchemaProps: spec.SchemaProps{Type: spec.StringOrArray{"integer"}}},
+			},
+		},
+	}
+	ruleSchema := spec.Schema{
+		SchemaProps: spec.SchemaProps{
+			Type: spec.StringOrArray{"object"},
+			Properties: map[string]spec.Schema{
+				"backendRefs": {
+					SchemaProps: spec.SchemaProps{
+						Type:  spec.StringOrArray{"array"},
+						Items: &spec.SchemaOrArray{Schema: &backendRefSchema},
+					},
+				},
+			},
+		},
+	}
 	sw := &spec.Swagger{
 		SwaggerProps: spec.SwaggerProps{
 			Definitions: spec.Definitions{
@@ -298,32 +319,8 @@ func TestFlattenOpenAPINestedArrayOfObjects(t *testing.T) {
 						Properties: map[string]spec.Schema{
 							"rules": {
 								SchemaProps: spec.SchemaProps{
-									Type: spec.StringOrArray{"array"},
-									Items: &spec.SchemaOrArray{
-										Schema: &spec.Schema{
-											SchemaProps: spec.SchemaProps{
-												Type: spec.StringOrArray{"object"},
-												Properties: map[string]spec.Schema{
-													"backendRefs": {
-														SchemaProps: spec.SchemaProps{
-															Type: spec.StringOrArray{"array"},
-															Items: &spec.SchemaOrArray{
-																Schema: &spec.Schema{
-																	SchemaProps: spec.SchemaProps{
-																		Type: spec.StringOrArray{"object"},
-																		Properties: map[string]spec.Schema{
-																			"name": {SchemaProps: spec.SchemaProps{Type: spec.StringOrArray{"string"}}},
-																			"port": {SchemaProps: spec.SchemaProps{Type: spec.StringOrArray{"integer"}}},
-																		},
-																	},
-																},
-															},
-														},
-													},
-												},
-											},
-										},
-									},
+									Type:  spec.StringOrArray{"array"},
+									Items: &spec.SchemaOrArray{Schema: &ruleSchema},
 								},
 							},
 						},

--- a/provider/pkg/provider/provider_parameterize_test.go
+++ b/provider/pkg/provider/provider_parameterize_test.go
@@ -27,11 +27,11 @@ func TestParseCrdArgsWithName(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if args.PackageName != "gateway-api" {
-		t.Errorf("expected package name %q, got %q", "gateway-api", args.PackageName)
+	if args.ExtensionName != "gateway-api" {
+		t.Errorf("expected extension name %q, got %q", "gateway-api", args.ExtensionName)
 	}
-	if args.PackageVersion != "1.2.1" {
-		t.Errorf("expected version %q, got %q", "1.2.1", args.PackageVersion)
+	if args.ExtensionVersion != "1.2.1" {
+		t.Errorf("expected version %q, got %q", "1.2.1", args.ExtensionVersion)
 	}
 }
 
@@ -40,87 +40,29 @@ func TestParseCrdArgsWithoutName(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if args.PackageName != "" {
-		t.Errorf("expected empty package name, got %q", args.PackageName)
+	if args.ExtensionName != "" {
+		t.Errorf("expected empty extension name, got %q", args.ExtensionName)
 	}
 }
 
-func TestDerivePackageName(t *testing.T) {
+func TestDeriveExtensionName(t *testing.T) {
 	tests := []struct {
 		name     string
-		crds     []*extensionv1.CustomResourceDefinition
+		paths    []string
 		expected string
 	}{
-		{
-			"gateway API group",
-			[]*extensionv1.CustomResourceDefinition{
-				{Spec: extensionv1.CustomResourceDefinitionSpec{Group: "gateway.networking.k8s.io"}},
-			},
-			"gateway-networking",
-		},
-		{
-			"cert-manager group",
-			[]*extensionv1.CustomResourceDefinition{
-				{Spec: extensionv1.CustomResourceDefinitionSpec{Group: "cert-manager.io"}},
-			},
-			"cert-manager",
-		},
-		{
-			"multiple groups uses first group",
-			[]*extensionv1.CustomResourceDefinition{
-				{Spec: extensionv1.CustomResourceDefinitionSpec{Group: "gateway.networking.k8s.io"}},
-				{Spec: extensionv1.CustomResourceDefinitionSpec{Group: "cert-manager.io"}},
-			},
-			"gateway-networking",
-		},
-		{
-			"no groups falls back to default",
-			[]*extensionv1.CustomResourceDefinition{
-				{Spec: extensionv1.CustomResourceDefinitionSpec{Group: ""}},
-			},
-			defaultPackageName,
-		},
-		{
-			"x-k8s.io suffix",
-			[]*extensionv1.CustomResourceDefinition{
-				{Spec: extensionv1.CustomResourceDefinitionSpec{Group: "multicluster.x-k8s.io"}},
-			},
-			"multicluster",
-		},
-		{
-			"plain group without known suffix",
-			[]*extensionv1.CustomResourceDefinition{
-				{Spec: extensionv1.CustomResourceDefinitionSpec{Group: "example.com"}},
-			},
-			"example-com",
-		},
+		{"single yaml file", []string{"gateway-api-crds.yaml"}, "gateway-api-crds"},
+		{"yml extension", []string{"cert-manager.yml"}, "cert-manager"},
+		{"path with directory", []string{"manifests/gateway.yaml"}, "gateway"},
+		{"first path wins", []string{"gateway-api.yaml", "cert-manager.yaml"}, "gateway-api"},
+		{"empty list falls back to default", nil, defaultExtensionName},
+		{"empty path falls back to default", []string{""}, defaultExtensionName},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := derivePackageName(tt.crds)
+			got := deriveExtensionName(tt.paths)
 			if got != tt.expected {
-				t.Errorf("derivePackageName() = %q, want %q", got, tt.expected)
-			}
-		})
-	}
-}
-
-func TestStripK8sSuffix(t *testing.T) {
-	tests := []struct {
-		input    string
-		expected string
-	}{
-		{"gateway.networking.k8s.io", "gateway.networking"},
-		{"cert-manager.io", "cert-manager"},
-		{"multicluster.x-k8s.io", "multicluster"},
-		{"example.com", "example.com"},
-		{"storage", "storage"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.input, func(t *testing.T) {
-			got := stripK8sSuffix(tt.input)
-			if got != tt.expected {
-				t.Errorf("stripK8sSuffix(%q) = %q, want %q", tt.input, got, tt.expected)
+				t.Errorf("deriveExtensionName() = %q, want %q", got, tt.expected)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Preparatory fixes for CRD parameterization targeting extension parameterization. This will not be usable until engine capabilities ship, but can be merged with no downsides.

- **Implement `Parameterize(Value)`** so subsequent `pulumi up` runs can reconstruct the CRD schema from the saved blob in `Pulumi.yaml`. Previously this was a stub returning `nil` — the program worked once and failed on every subsequent run.
- **Flatten array-of-objects in OpenAPI specs**. `flattenOpenAPI` only handled direct object properties, missing objects nested inside arrays (e.g., `spec.listeners`, `spec.rules[].backendRefs`). These came out as untyped `StringMapArrayInput` instead of typed structs like `GatewaySpecListenersArgs`.
- **Derive extension name from manifest filename** (e.g., `gateway-api-crds.yaml` → `gateway-api-crds`). `-n`/`--name` overrides; `"crds"` is the final fallback.
- **Rename `PackageName`/`PackageVersion` → `ExtensionName`/`ExtensionVersion`** in `ParameterizedArgs`. The value identifies the extension (consumed by `Pulumi.yaml` and the generated SDK), not the base provider's package.

## Test plan

- [x] `TestParseCrdArgsWithName` / `TestParseCrdArgsWithoutName`
- [x] `TestDeriveExtensionName` — filename → name derivation with edge cases
- [x] `TestSetCRDDefaults`
- [x] `TestFlattenOpenAPIArrayOfObjects` — typed args for `spec.listeners`-style schemas
- [x] `TestFlattenOpenAPINestedArrayOfObjects` — nested case (`rules[].backendRefs[]`)

e2e tests deferred until pulumi/pulumi has extension capabilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)