### PR TITLE
fix(helm): preserve empty-list overrides in valueYamlFiles when allowNullValues=false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fixed `valueYamlFiles` entries containing an empty list (`[]`) being silently dropped when `allowNullValues` is false (the default), causing Helm to fall back to chart defaults instead of honouring the override.
+
 ### Added
 
 - [#2280](https://github.com/pulumi/pulumi-kubernetes/issues/2280) Add `enablePatchForce` provider config option to force SSA patch conflicts on a per-stack basis.

--- a/provider/pkg/provider/helm_release.go
+++ b/provider/pkg/provider/helm_release.go
@@ -1418,7 +1418,7 @@ func excludeNulls(in any) any {
 		}
 		return out
 	case reflect.Slice, reflect.Array:
-		var out []any
+		out := make([]any, 0)
 		s := in.([]any)
 		for _, i := range s {
 			if i != nil {

--- a/provider/pkg/provider/helm_release_test.go
+++ b/provider/pkg/provider/helm_release_test.go
@@ -160,6 +160,21 @@ func Test_MergeMaps(t *testing.T) {
 			},
 		},
 		{
+			// Bug: excludeNulls returns nil (not []any{}) for an empty slice, causing the
+			// empty-list override to be indistinguishable from a missing key.
+			name:     "empty list overrides non-empty list with allowNil=false",
+			allowNil: false,
+			dest: map[string]any{
+				"list": []any{1, 2, 3},
+			},
+			src: map[string]any{
+				"list": []any{},
+			},
+			expected: map[string]any{
+				"list": []any{},
+			},
+		},
+		{
 			name:     "allow nil doesn't clear objects",
 			allowNil: true,
 			dest: map[string]any{
@@ -330,6 +345,21 @@ images: ["bitnami/nginx"]
 						"repository": "bitnami/nginx",
 						"tag":        "latest", // Not removed.
 					},
+				},
+			},
+		},
+		{
+			// Bug: valueYamlFiles containing an empty list should override the chart default,
+			// but excludeNulls collapses []any{} to nil, making it disappear as if unset.
+			name: "valueYamlFiles with empty list is preserved (allowNullValues=false)",
+			given: resource.PropertyMap{
+				"valueYamlFiles": resource.NewArrayProperty([]resource.PropertyValue{
+					resource.NewAssetProperty(&asset.Asset{Text: "items: []\n"}),
+				}),
+			},
+			want: &Release{
+				Values: map[string]any{
+					"items": []any{},
 				},
 			},
 		},

--- a/provider/pkg/provider/helm_release_test.go
+++ b/provider/pkg/provider/helm_release_test.go
@@ -160,6 +160,19 @@ func Test_MergeMaps(t *testing.T) {
 			},
 		},
 		{
+			// Confirm that a key absent from src leaves the dest value intact (i.e. our
+			// fix to excludeNulls does not accidentally introduce spurious empty-list keys).
+			name:     "key absent from src leaves dest list intact with allowNil=false",
+			allowNil: false,
+			dest: map[string]any{
+				"list": []any{"default"},
+			},
+			src:      map[string]any{},
+			expected: map[string]any{
+				"list": []any{"default"},
+			},
+		},
+		{
 			// Bug: excludeNulls returns nil (not []any{}) for an empty slice, causing the
 			// empty-list override to be indistinguishable from a missing key.
 			name:     "empty list overrides non-empty list with allowNil=false",


### PR DESCRIPTION
### Issue
Chart rendering is different through pulumi-kubernetes than helm when a values file overrides a list to be empty.

### Proposed changes

`excludeNulls` recurses into slice values using `var out []any`. When the input slice is empty, the loop never runs, so `out` remains nil and is returned that way. That nil slice is written back into the filtered values map, and later Helm value coalescing distinguishes nil `[]any` from a non-nil empty `[]any{}`: the nil form does not preserve the user’s explicit empty-list override, so the chart default is applied instead. Changing this to `out := make([]any, 0)` ensures an empty input slice round-trips as a non-nil empty slice and survives the merge as an explicit override.


### Notes on discovery and repro
I discovered this when I refactored a project from manual helm deployments to using this provider in Pulumi and started seeing issues in my workload, because the chart I was using had some default `podSecurityContext.sysctls` that I needed to remove in my environment. My local values file set the list to the empty list:
```yaml
# in the upstream chart's values:
podSecurityContext:
  sysctls:
    - name: net.ipv4.tcp_keepalive_time
      value: "300"

# in my local values file
podSecurityContext:
  sysctls: []
```

This worked great via helm. But using the pulumi-kubernetes provider did not behave the same way and was shipping the chart-defaults to my cluster instead. I reproduced this with a minimal setup that deployed the same chart with same values overrides via helm and via pulumi and observe different resultant configuration in the live cluster (let me know if you want to see the minimal repro and I can push a quick public repo or gist).

Disclosure: I used a combination of Codex (where I was doing the main project work when I discovered this, had it do the initial reproduction and initial hypothesis) and Claude Code with Opus 4.6 (where I honed in on this specific issue and worked up the minimal tests and fix). However, I'm generally a skeptic of agentic coding, so I've been careful to read through everything here (small as it is lol) and while I'm not a go programmer, this seems succinct and reasonable to me. I'm happy to followup with any additional contribution steps.