### PR TITLE
Fix race condition in istio test

### DIFF
--- a/tests/sdk/nodejs/istio/step1/istio.ts
+++ b/tests/sdk/nodejs/istio/step1/istio.ts
@@ -18,11 +18,9 @@ import { k8sProvider } from "./cluster";
 import * as config from "./config";
 
 const appName = "istio";
-const namespace = new k8s.core.v1.Namespace(
-    `${appName}-system`,
-    { metadata: { name: `${appName}-system` } },
-    { provider: k8sProvider }
-);
+
+// The istio-system Namespace is declared by yaml/istio.yaml; declaring it here
+// as well races with the ConfigFile and fails under client-side create.
 
 const adminBinding = new k8s.rbac.v1.ClusterRoleBinding(
     "cluster-admin-binding",


### PR DESCRIPTION
Do not recreate Namespace within the same test stack. Otherwise we'll hit "resource already exists" error.
