### PR TITLE
fix: correct `kustomize.v2.Directory` schema types to fix Python SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 
 ## Unreleased
 
+### Fixed
+
+- [#4295](https://github.com/pulumi/pulumi-kubernetes/pull/4295)Fix kustomize.v2.Directory resource output type in the schema to properly support array outputs.
+Previously, the resources field was incorrectly typed as a `string` in the schema. This fix updates the type to an array of `Any`, aligning the schema with the provider's Go implementation (`pulumi.ArrayOutput`). This resolves a regression that caused the Kustomize v2 resource to fail in the Python SDK.
+
 ### Changed
 
 - Upgrade Kubernetes schema and libraries to v1.35.4.

--- a/provider/pkg/gen/overlays.go
+++ b/provider/pkg/gen/overlays.go
@@ -1287,7 +1287,10 @@ var kustomizeDirectoryV2Resource = pschema.ResourceSpec{
 		Properties: map[string]pschema.PropertySpec{
 			"resources": {
 				TypeSpec: pschema.TypeSpec{
-					Type: "string",
+					Type: "array",
+					Items: &pschema.TypeSpec{
+						Ref: "pulumi.json#/Any",
+					},
 				},
 				Description: "Resources created by the Directory resource.",
 			},

--- a/sdk/dotnet/Kustomize/V2/Directory.cs
+++ b/sdk/dotnet/Kustomize/V2/Directory.cs
@@ -55,7 +55,7 @@ namespace Pulumi.Kubernetes.Kustomize.V2
         /// Resources created by the Directory resource.
         /// </summary>
         [Output("resources")]
-        public Output<string> Resources { get; private set; } = null!;
+        public Output<ImmutableArray<object>> Resources { get; private set; } = null!;
 
 
         /// <summary>

--- a/sdk/go/kubernetes/kustomize/v2/directory.go
+++ b/sdk/go/kubernetes/kustomize/v2/directory.go
@@ -73,7 +73,7 @@ type Directory struct {
 	pulumi.ResourceState
 
 	// Resources created by the Directory resource.
-	Resources pulumi.StringPtrOutput `pulumi:"resources"`
+	Resources pulumi.ArrayOutput `pulumi:"resources"`
 }
 
 // NewDirectory registers a new resource with the given unique name, arguments, and options.
@@ -212,8 +212,8 @@ func (o DirectoryOutput) ToDirectoryOutputWithContext(ctx context.Context) Direc
 }
 
 // Resources created by the Directory resource.
-func (o DirectoryOutput) Resources() pulumi.StringPtrOutput {
-	return o.ApplyT(func(v *Directory) pulumi.StringPtrOutput { return v.Resources }).(pulumi.StringPtrOutput)
+func (o DirectoryOutput) Resources() pulumi.ArrayOutput {
+	return o.ApplyT(func(v *Directory) pulumi.ArrayOutput { return v.Resources }).(pulumi.ArrayOutput)
 }
 
 type DirectoryArrayOutput struct{ *pulumi.OutputState }

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/kustomize/v2/Directory.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/kustomize/v2/Directory.java
@@ -9,7 +9,8 @@ import com.pulumi.core.annotations.ResourceType;
 import com.pulumi.core.internal.Codegen;
 import com.pulumi.kubernetes.Utilities;
 import com.pulumi.kubernetes.kustomize.v2.DirectoryArgs;
-import java.lang.String;
+import java.lang.Object;
+import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nullable;
 
@@ -65,14 +66,14 @@ public class Directory extends com.pulumi.resources.ComponentResource {
      * Resources created by the Directory resource.
      * 
      */
-    @Export(name="resources", refs={String.class}, tree="[0]")
-    private Output</* @Nullable */ String> resources;
+    @Export(name="resources", refs={List.class,Object.class}, tree="[0,1]")
+    private Output</* @Nullable */ List<Object>> resources;
 
     /**
      * @return Resources created by the Directory resource.
      * 
      */
-    public Output<Optional<String>> resources() {
+    public Output<Optional<List<Object>>> resources() {
         return Codegen.optional(this.resources);
     }
 

--- a/sdk/nodejs/kustomize/v2/directory.ts
+++ b/sdk/nodejs/kustomize/v2/directory.ts
@@ -43,7 +43,7 @@ export class Directory extends pulumi.ComponentResource {
     /**
      * Resources created by the Directory resource.
      */
-    declare public /*out*/ readonly resources: pulumi.Output<string>;
+    declare public /*out*/ readonly resources: pulumi.Output<any[]>;
 
     /**
      * Create a Directory resource with the given unique name, arguments, and options.

--- a/sdk/python/pulumi_kubernetes/kustomize/v2/Directory.py
+++ b/sdk/python/pulumi_kubernetes/kustomize/v2/Directory.py
@@ -215,7 +215,7 @@ class Directory(pulumi.ComponentResource):
 
     @_builtins.property
     @pulumi.getter
-    def resources(self) -> pulumi.Output[Optional[_builtins.str]]:
+    def resources(self) -> pulumi.Output[Optional[Sequence[Any]]]:
         """
         Resources created by the Directory resource.
         """

--- a/tests/sdk/python/kustomize/__main__.py
+++ b/tests/sdk/python/kustomize/__main__.py
@@ -17,7 +17,7 @@ from pulumi import ResourceOptions
 
 from typing import Any
 
-
+# 1. Ensure we can create Kustomize v1 resources.
 def set_namespace(namespace):
     def f(obj: Any):
         if "metadata" in obj:
@@ -37,4 +37,14 @@ k8s.kustomize.Directory(
     "helloWorld",
     transformations=[set_namespace(ns)],
     opts=ResourceOptions(provider=provider),
+)
+
+# 2. Ensure that we can create Kustomize v2 resources.
+v2_ns = k8s.core.v1.Namespace("v2ns", opts=ResourceOptions(provider=provider))
+
+k8s.kustomize.v2.Directory(
+    "kustomizev2",
+    directory="helloWorld",
+    namespace=v2_ns.metadata["name"],
+    opts=ResourceOptions(provider=provider)
 )


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
This PR fixes a schema mismatch for the `kustomize.v2.Directory` resource.

The `resources` property was incorrectly defined as a `string` in the schema overlay: https://github.com/pulumi/pulumi-kubernetes/blob/ec3b5cbc2087e6eaa5cc199a2c961a80ff8f6e8e/provider/pkg/gen/overlays.go#L1282-L1296

However, the underlying provider implementation in Go defines this field as a `pulumi.ArrayOutput`: https://github.com/pulumi/pulumi-kubernetes/blob/ec3b5cbc2087e6eaa5cc199a2c961a80ff8f6e8e/provider/pkg/provider/kustomize/v2/directory.go#L83-L86

This discrepancy caused the schema-driven SDK generation to produce incorrect type hints and serialization logic, specifically breaking the resource for Python users.

This fix updates the schema type to `pulumi.json#/Any`, bringing it into parity with how similar collection-based resources (like `helm.v4.Chart`) are handled.

### Checklist
- [x] dd test to verify fix for `kustomize.v2.Directory` Python SDK
- [x] Updated schema overlay for kustomize.v2.Directory
- [x] Regenerated SDKs and verified Python compatibility
- [x] Updated CHANGELOG.md

---

> [!IMPORTANT]
> **Note for Maintainers:**
> Could you please regenerate the **Java** and **.NET** SDKs and commit them to this PR? I do not have those environments configured locally to perform the full generation.

---

### Related issues (optional)

Closes: https://github.com/pulumi/pulumi-kubernetes/issues/3389#issuecomment-4272013738
