### PR TITLE
Map helm_release to kubernetes:helm.sh/v3:Release for terraform conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 
 ## Unreleased
 
-## 4.30.0 (April 24, 2026)
+### Added
+
+- [#2744](https://github.com/pulumi/pulumi-kubernetes/issues/2744) Advertise a `helm` mapping for `terraform` conversion so `pulumi import --from terraform` and `pulumi convert --from terraform` recognize `helm_release` and emit `kubernetes:helm.sh/v3:Release`.
 
 ### Fixed
 

--- a/provider/cmd/pulumi-resource-kubernetes/helm-mapping.json
+++ b/provider/cmd/pulumi-resource-kubernetes/helm-mapping.json
@@ -1,0 +1,15 @@
+{
+    "dataSources": {},
+    "name": "helm",
+    "provider": {},
+    "resources": {
+        "helm_release": {
+            "fields": {
+                "disable_crd_hooks": {
+                    "name": "disableCRDHooks"
+                }
+            },
+            "tok": "kubernetes:helm.sh/v3:Release"
+        }
+    }
+}

--- a/provider/cmd/pulumi-resource-kubernetes/main.go
+++ b/provider/cmd/pulumi-resource-kubernetes/main.go
@@ -31,6 +31,9 @@ var pulumiSchema []byte
 //go:embed terraform-mapping-embed.json
 var terraformMapping []byte
 
+//go:embed helm-mapping.json
+var helmMapping []byte
+
 func main() {
-	provider.Serve(providerName, version.Version, pulumiSchema, terraformMapping)
+	provider.Serve(providerName, version.Version, pulumiSchema, terraformMapping, helmMapping)
 }

--- a/provider/pkg/provider/mapping_test.go
+++ b/provider/pkg/provider/mapping_test.go
@@ -1,0 +1,134 @@
+// Copyright 2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+)
+
+func newMappingTestProvider(t *testing.T) *kubeProvider {
+	t.Helper()
+	k, err := makeKubeProvider(
+		newMockHost(nil),
+		"kubernetes",
+		testPluginVersion,
+		[]byte(testPulumiSchema),
+		[]byte(testTerraformMapping),
+		[]byte(testHelmMapping),
+	)
+	require.NoError(t, err)
+	return k
+}
+
+func TestGetMapping(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		key              string
+		provider         string
+		expectedProvider string
+		expectedData     []byte
+	}{
+		{
+			name:             "terraform key, no provider (legacy) returns kubernetes mapping",
+			key:              "terraform",
+			provider:         "",
+			expectedProvider: "kubernetes",
+			expectedData:     []byte(testTerraformMapping),
+		},
+		{
+			name:             "terraform key, kubernetes provider returns kubernetes mapping",
+			key:              "terraform",
+			provider:         "kubernetes",
+			expectedProvider: "kubernetes",
+			expectedData:     []byte(testTerraformMapping),
+		},
+		{
+			name:             "terraform key, helm provider returns helm mapping",
+			key:              "terraform",
+			provider:         "helm",
+			expectedProvider: "helm",
+			expectedData:     []byte(testHelmMapping),
+		},
+		{
+			name:             "terraform key, unknown provider returns empty",
+			key:              "terraform",
+			provider:         "unknown",
+			expectedProvider: "",
+			expectedData:     nil,
+		},
+		{
+			name:             "non-terraform key returns empty",
+			key:              "foo",
+			provider:         "",
+			expectedProvider: "",
+			expectedData:     nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			k := newMappingTestProvider(t)
+			resp, err := k.GetMapping(context.Background(), &pulumirpc.GetMappingRequest{
+				Key:      tt.key,
+				Provider: tt.provider,
+			})
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedProvider, resp.Provider)
+			assert.Equal(t, tt.expectedData, resp.Data)
+		})
+	}
+}
+
+func TestGetMappings(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		key               string
+		expectedProviders []string
+	}{
+		{
+			name:              "terraform key advertises kubernetes and helm",
+			key:               "terraform",
+			expectedProviders: []string{"kubernetes", "helm"},
+		},
+		{
+			name:              "non-terraform key returns empty",
+			key:               "foo",
+			expectedProviders: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			k := newMappingTestProvider(t)
+			resp, err := k.GetMappings(context.Background(), &pulumirpc.GetMappingsRequest{
+				Key: tt.key,
+			})
+			require.NoError(t, err)
+			assert.ElementsMatch(t, tt.expectedProviders, resp.Providers)
+		})
+	}
+}

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -126,6 +126,7 @@ type kubeProvider struct {
 	version          string
 	pulumiSchema     []byte
 	terraformMapping []byte
+	helmMapping      []byte
 	providerPackage  string
 	opts             kubeOpts
 	defaultNamespace string
@@ -174,7 +175,7 @@ type kubeProvider struct {
 var _ pulumirpc.ResourceProviderServer = (*kubeProvider)(nil)
 
 func makeKubeProvider(
-	host host.HostClient, name, version string, pulumiSchema, terraformMapping []byte,
+	host host.HostClient, name, version string, pulumiSchema, terraformMapping, helmMapping []byte,
 ) (*kubeProvider, error) {
 	cancelCtx := makeCancellationContext()
 	return &kubeProvider{
@@ -184,6 +185,7 @@ func makeKubeProvider(
 		version:                     version,
 		pulumiSchema:                pulumiSchema,
 		terraformMapping:            terraformMapping,
+		helmMapping:                 helmMapping,
 		providerPackage:             name,
 		enableSecrets:               false,
 		suppressDeprecationWarnings: false,
@@ -243,6 +245,20 @@ func (k *kubeProvider) Call(
 	return nil, status.Error(codes.Unimplemented, "Call is not yet implemented")
 }
 
+// GetMappings advertises the source TF providers this Pulumi provider can supply mappings for.
+// pulumi-kubernetes maps both `kubernetes` (kubernetes_* resources) and `helm` (helm_release).
+func (k *kubeProvider) GetMappings(
+	_ /* ctx */ context.Context,
+	request *pulumirpc.GetMappingsRequest,
+) (*pulumirpc.GetMappingsResponse, error) {
+	if request.Key != "terraform" {
+		return &pulumirpc.GetMappingsResponse{}, nil
+	}
+	return &pulumirpc.GetMappingsResponse{
+		Providers: []string{"kubernetes", "helm"},
+	}, nil
+}
+
 // GetMapping fetches the mapping for this resource provider, if any. A provider should return an empty
 // response (not an error) if it doesn't have a mapping for the given key.
 func (k *kubeProvider) GetMapping(
@@ -255,10 +271,20 @@ func (k *kubeProvider) GetMapping(
 		return &pulumirpc.GetMappingResponse{}, nil
 	}
 
-	return &pulumirpc.GetMappingResponse{
-		Provider: "kubernetes",
-		Data:     k.terraformMapping,
-	}, nil
+	switch request.Provider {
+	case "", "kubernetes":
+		return &pulumirpc.GetMappingResponse{
+			Provider: "kubernetes",
+			Data:     k.terraformMapping,
+		}, nil
+	case "helm":
+		return &pulumirpc.GetMappingResponse{
+			Provider: "helm",
+			Data:     k.helmMapping,
+		}, nil
+	default:
+		return &pulumirpc.GetMappingResponse{}, nil
+	}
 }
 
 // GetSchema returns the JSON-encoded schema for this provider's package.

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -245,13 +245,16 @@ func (k *kubeProvider) Call(
 	return nil, status.Error(codes.Unimplemented, "Call is not yet implemented")
 }
 
+// terraformMappingKey is the key used to identify terraform conversion mapping requests.
+const terraformMappingKey = "terraform"
+
 // GetMappings advertises the source TF providers this Pulumi provider can supply mappings for.
 // pulumi-kubernetes maps both `kubernetes` (kubernetes_* resources) and `helm` (helm_release).
 func (k *kubeProvider) GetMappings(
 	_ /* ctx */ context.Context,
 	request *pulumirpc.GetMappingsRequest,
 ) (*pulumirpc.GetMappingsResponse, error) {
-	if request.Key != "terraform" {
+	if request.Key != terraformMappingKey {
 		return &pulumirpc.GetMappingsResponse{}, nil
 	}
 	return &pulumirpc.GetMappingsResponse{
@@ -266,7 +269,7 @@ func (k *kubeProvider) GetMapping(
 	request *pulumirpc.GetMappingRequest,
 ) (*pulumirpc.GetMappingResponse, error) {
 	// We only return a mapping for terraform
-	if request.Key != "terraform" {
+	if request.Key != terraformMappingKey {
 		// an empty response means no mapping, by design we don't return an error here
 		return &pulumirpc.GetMappingResponse{}, nil
 	}

--- a/provider/pkg/provider/serve.go
+++ b/provider/pkg/provider/serve.go
@@ -24,11 +24,11 @@ import (
 )
 
 // Serve launches the gRPC server for the Pulumi Kubernetes resource provider.
-func Serve(providerName, version string, pulumiSchema, terraformMapping []byte) {
+func Serve(providerName, version string, pulumiSchema, terraformMapping, helmMapping []byte) {
 	// Start gRPC service.
 	err := provider.Main(
 		providerName, func(host *provider.HostClient) (lumirpc.ResourceProviderServer, error) {
-			return makeKubeProvider(host, providerName, version, pulumiSchema, terraformMapping)
+			return makeKubeProvider(host, providerName, version, pulumiSchema, terraformMapping, helmMapping)
 		})
 
 	if err != nil {

--- a/provider/pkg/provider/suite_test.go
+++ b/provider/pkg/provider/suite_test.go
@@ -43,6 +43,7 @@ const (
 	testPluginVersion    = "v0.0.0"
 	testPulumiSchema     = "{}"
 	testTerraformMapping = "{}"
+	testHelmMapping      = "{}"
 )
 
 // CheckFailure matches a CheckFailure by property and reason.
@@ -237,6 +238,7 @@ func (c *providerTestContext) NewProvider(opts ...NewProviderOption) *kubeProvid
 		testPluginVersion,
 		[]byte(testPulumiSchema),
 		[]byte(testTerraformMapping),
+		[]byte(testHelmMapping),
 	)
 	gm.Expect(err).ShouldNot(gm.HaveOccurred())
 


### PR DESCRIPTION
## Summary
- Adds `GetMappings` RPC and extends `GetMapping` to advertise the `helm` TF provider for terraform conversion
- Maps `helm_release` → `kubernetes:helm.sh/v3:Release` via a new `helm-mapping.json`

## What this fixes
Pairs with the 1-line `"helm": "kubernetes"` rename in pulumi-converter-terraform. Together:
- `pulumi import --from terraform <state>` now produces an `import.json` with the correct `kubernetes:helm.sh/v3:Release` type. `Read` against the live cluster generates idiomatic Pulumi-shape inputs, so the imported program is runnable for ongoing management.
- `pulumi convert --from terraform` now emits a `kubernetes.helm.v3.Release` with cleanly-mappable fields (instead of silently dropping the resource).

## What this does NOT fix yet
For `convert`, TF-shape inputs (`set` blocks, `repository_*` flat fields, `values = [yaml]`, etc.) come through as-is and do not compile against `ReleaseArgs`. The shape-transform problem is being addressed in a separate effort against `pulumi-converter-terraform`.

Originally proposed in #3092.

Part of #2744

## Test plan
- [ ] New unit tests in `provider/pkg/provider/mapping_test.go` cover both RPC handlers across all source-provider permutations
- [ ] Manually verified `pulumi import --from terraform` against a `helm_release` tfstate produces the correct type
- [ ] Manually verified `pulumi convert --from terraform` against a `helm_release` source emits a `kubernetes.helm.v3.Release` resource

🤖 Generated with [Claude Code](https://claude.com/claude-code)