### PR TITLE
Document valueYamlFiles null-as-delete pattern for clearing chart defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Previously, the resources field was incorrectly typed as a `string` in the schem
 ### Changed
 
 - Upgrade Kubernetes schema and libraries to v1.35.4.
+- Document `valueYamlFiles` as the cross-SDK path for clearing Helm chart default values via `key: null` in a yaml file. Added a "Delete a Chart Default Value" example to `helm.v3.Release` and `helm.v4.Chart`.
 
 ## 4.29.0 (April 15, 2026)
 

--- a/provider/pkg/gen/examples/overlays/chartV4.md
+++ b/provider/pkg/gen/examples/overlays/chartV4.md
@@ -512,6 +512,137 @@ resources:
 ```
 {{% /example %}}
 {{% example %}}
+### Delete a Chart Default Value
+
+Helm charts typically guard template fields with truthy checks such as `{{- if .Values.foo }}`. The standard way to suppress one of those defaults is `helm install --set foo=null`, which leaves the field out of the rendered chart. To express the same intent from Pulumi, set the key to `null` in a yaml file and reference it via `valueYamlFiles`. This pattern works in every Pulumi language SDK.
+
+```typescript
+import * as pulumi from "@pulumi/pulumi";
+import * as k8s from "@pulumi/kubernetes";
+
+const nginx = new k8s.helm.v4.Chart("nginx", {
+    chart: "nginx",
+    repositoryOpts: {
+        repo: "https://charts.bitnami.com/bitnami",
+    },
+    valueYamlFiles: [new pulumi.asset.FileAsset("./overrides.yaml")],
+});
+
+// -- Contents of overrides.yaml --
+// containerPorts:
+//   http: null
+```
+```python
+import pulumi
+from pulumi_kubernetes.helm.v4 import Chart, RepositoryOptsArgs
+
+nginx = Chart("nginx",
+    chart="nginx",
+    repository_opts=RepositoryOptsArgs(
+        repo="https://charts.bitnami.com/bitnami",
+    ),
+    value_yaml_files=[pulumi.FileAsset("./overrides.yaml")],
+)
+
+# -- Contents of overrides.yaml --
+# containerPorts:
+#   http: null
+```
+```csharp
+using Pulumi;
+using Pulumi.Kubernetes.Helm.V4;
+using Pulumi.Kubernetes.Types.Inputs.Helm.V4;
+
+return await Deployment.RunAsync(() =>
+{
+    new Chart("nginx", new ChartArgs
+    {
+        Chart = "nginx",
+        RepositoryOpts = new RepositoryOptsArgs
+        {
+            Repo = "https://charts.bitnami.com/bitnami",
+        },
+        ValueYamlFiles = { new FileAsset("./overrides.yaml") },
+    });
+});
+
+// -- Contents of overrides.yaml --
+// containerPorts:
+//   http: null
+```
+```go
+package main
+
+import (
+	helmv4 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/helm/v4"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		_, err := helmv4.NewChart(ctx, "nginx", &helmv4.ChartArgs{
+			Chart: pulumi.String("nginx"),
+			RepositoryOpts: &helmv4.RepositoryOptsArgs{
+				Repo: pulumi.String("https://charts.bitnami.com/bitnami"),
+			},
+			ValueYamlFiles: pulumi.AssetOrArchiveArray{
+				pulumi.NewFileAsset("./overrides.yaml"),
+			},
+		})
+		return err
+	})
+}
+
+// -- Contents of overrides.yaml --
+// containerPorts:
+//   http: null
+```
+```java
+package generated_program;
+
+import com.pulumi.Pulumi;
+import com.pulumi.asset.FileAsset;
+import com.pulumi.kubernetes.helm.v4.Chart;
+import com.pulumi.kubernetes.helm.v4.ChartArgs;
+import com.pulumi.kubernetes.helm.v4.inputs.RepositoryOptsArgs;
+
+public class App {
+    public static void main(String[] args) {
+        Pulumi.run(ctx -> {
+            new Chart("nginx", ChartArgs.builder()
+                    .chart("nginx")
+                    .repositoryOpts(RepositoryOptsArgs.builder()
+                            .repo("https://charts.bitnami.com/bitnami")
+                            .build())
+                    .valueYamlFiles(new FileAsset("./overrides.yaml"))
+                    .build());
+        });
+    }
+}
+
+// -- Contents of overrides.yaml --
+// containerPorts:
+//   http: null
+```
+```yaml
+name: example
+runtime: yaml
+resources:
+  nginx:
+    type: kubernetes:helm.sh/v4:Chart
+    properties:
+      chart: nginx
+      repositoryOpts:
+        repo: https://charts.bitnami.com/bitnami
+      valueYamlFiles:
+        - fn::fileAsset: overrides.yaml
+
+# -- Contents of overrides.yaml --
+# containerPorts:
+#   http: null
+```
+{{% /example %}}
+{{% example %}}
 ### Chart Namespace
 
 ```typescript

--- a/provider/pkg/gen/examples/overlays/helmRelease.md
+++ b/provider/pkg/gen/examples/overlays/helmRelease.md
@@ -597,6 +597,140 @@ func main() {
 ```
 {{% /example %}}
 {{% example %}}
+### Delete a Chart Default Value
+
+Helm charts typically guard template fields with truthy checks such as `{{- if .Values.foo }}`. The standard way to suppress one of those defaults is `helm install --set foo=null`, which leaves the field out of the rendered chart. To express the same intent from Pulumi, set the key to `null` in a yaml file and reference it via `valueYamlFiles`. This pattern works in every Pulumi language SDK.
+
+```typescript
+import * as pulumi from "@pulumi/pulumi";
+import * as k8s from "@pulumi/kubernetes";
+
+const nginx = new k8s.helm.v3.Release("nginx", {
+    chart: "nginx",
+    repositoryOpts: {
+        repo: "https://charts.bitnami.com/bitnami",
+    },
+    valueYamlFiles: [new pulumi.asset.FileAsset("./overrides.yaml")],
+});
+
+// -- Contents of overrides.yaml --
+// containerPorts:
+//   http: null
+```
+```python
+import pulumi
+from pulumi_kubernetes.helm.v3 import Release, ReleaseArgs, RepositoryOptsArgs
+
+nginx = Release(
+    "nginx",
+    ReleaseArgs(
+        chart="nginx",
+        repository_opts=RepositoryOptsArgs(
+            repo="https://charts.bitnami.com/bitnami",
+        ),
+        value_yaml_files=[pulumi.FileAsset("./overrides.yaml")],
+    ),
+)
+
+# -- Contents of overrides.yaml --
+# containerPorts:
+#   http: null
+```
+```csharp
+using Pulumi;
+using Pulumi.Kubernetes.Helm.V3;
+using Pulumi.Kubernetes.Types.Inputs.Helm.V3;
+
+return await Deployment.RunAsync(() =>
+{
+    new Release("nginx", new ReleaseArgs
+    {
+        Chart = "nginx",
+        RepositoryOpts = new RepositoryOptsArgs
+        {
+            Repo = "https://charts.bitnami.com/bitnami",
+        },
+        ValueYamlFiles = { new FileAsset("./overrides.yaml") },
+    });
+});
+
+// -- Contents of overrides.yaml --
+// containerPorts:
+//   http: null
+```
+```go
+package main
+
+import (
+	helmv3 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/helm/v3"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		_, err := helmv3.NewRelease(ctx, "nginx", &helmv3.ReleaseArgs{
+			Chart: pulumi.String("nginx"),
+			RepositoryOpts: helmv3.RepositoryOptsArgs{
+				Repo: pulumi.String("https://charts.bitnami.com/bitnami"),
+			},
+			ValueYamlFiles: pulumi.AssetOrArchiveArray{
+				pulumi.NewFileAsset("./overrides.yaml"),
+			},
+		})
+		return err
+	})
+}
+
+// -- Contents of overrides.yaml --
+// containerPorts:
+//   http: null
+```
+```java
+package generated_program;
+
+import com.pulumi.Pulumi;
+import com.pulumi.asset.FileAsset;
+import com.pulumi.kubernetes.helm.v3.Release;
+import com.pulumi.kubernetes.helm.v3.ReleaseArgs;
+import com.pulumi.kubernetes.helm.v3.inputs.RepositoryOptsArgs;
+
+public class App {
+    public static void main(String[] args) {
+        Pulumi.run(ctx -> {
+            new Release("nginx", ReleaseArgs.builder()
+                    .chart("nginx")
+                    .repositoryOpts(RepositoryOptsArgs.builder()
+                            .repo("https://charts.bitnami.com/bitnami")
+                            .build())
+                    .valueYamlFiles(new FileAsset("./overrides.yaml"))
+                    .build());
+        });
+    }
+}
+
+// -- Contents of overrides.yaml --
+// containerPorts:
+//   http: null
+```
+```yaml
+name: example
+runtime: yaml
+resources:
+  nginx:
+    type: kubernetes:helm.sh/v3:Release
+    properties:
+      chart: nginx
+      repositoryOpts:
+        repo: https://charts.bitnami.com/bitnami
+      valueYamlFiles:
+        - fn::fileAsset: overrides.yaml
+
+# -- Contents of overrides.yaml --
+# containerPorts:
+#   http: null
+```
+{{% /example %}}
+{{% example %}}
 ### Query Kubernetes Resource Installed By Helm Chart
 
 ```typescript

--- a/provider/pkg/gen/overlays.go
+++ b/provider/pkg/gen/overlays.go
@@ -223,7 +223,11 @@ var helmV4ChartResource = pschema.ResourceSpec{
 					Ref: "pulumi.json#/Asset",
 				},
 			},
-			Description: "List of assets (raw yaml files). Content is read and merged with values.",
+			Description: "List of assets (raw yaml files). Content is read and merged with values. " +
+				"Set a key to `null` in a yaml file to delete the corresponding chart default — the standard " +
+				"`helm install --set key=null` pattern. This is the recommended path for clearing chart " +
+				"defaults from Pulumi, since some language SDKs cannot represent explicit `null` in the " +
+				"inline `values` map.",
 		},
 		"values": {
 			TypeSpec: pschema.TypeSpec{
@@ -727,7 +731,10 @@ var helmV3ReleaseResource = pschema.ResourceSpec{
 					},
 				},
 				Description: "List of assets (raw yaml files). Content is read and merged with values " +
-					"(with values taking precedence).",
+					"(with values taking precedence). Set a key to `null` in a yaml file to delete the " +
+					"corresponding chart default — the standard `helm install --set key=null` pattern. This " +
+					"is the recommended path for clearing chart defaults from Pulumi, since some language " +
+					"SDKs cannot represent explicit `null` in the inline `values` map.",
 			},
 			"values": {
 				TypeSpec: pschema.TypeSpec{
@@ -1006,7 +1013,11 @@ var helmV3ReleaseResource = pschema.ResourceSpec{
 					Ref: "pulumi.json#/Asset",
 				},
 			},
-			Description: "List of assets (raw yaml files). Content is read and merged with values.",
+			Description: "List of assets (raw yaml files). Content is read and merged with values. " +
+				"Set a key to `null` in a yaml file to delete the corresponding chart default — the standard " +
+				"`helm install --set key=null` pattern. This is the recommended path for clearing chart " +
+				"defaults from Pulumi, since some language SDKs cannot represent explicit `null` in the " +
+				"inline `values` map.",
 		},
 		"values": {
 			TypeSpec: pschema.TypeSpec{

--- a/sdk/dotnet/Helm/V3/Release.cs
+++ b/sdk/dotnet/Helm/V3/Release.cs
@@ -201,6 +201,31 @@ namespace Pulumi.Kubernetes.Helm.V3
     /// // metrics:
     /// //     enabled: true
     /// ```
+    /// ### Delete a Chart Default Value
+    /// 
+    /// Helm charts typically guard template fields with truthy checks such as `{{- if .Values.foo }}`. The standard way to suppress one of those defaults is `helm install --set foo=null`, which leaves the field out of the rendered chart. To express the same intent from Pulumi, set the key to `null` in a yaml file and reference it via `valueYamlFiles`. This pattern works in every Pulumi language SDK.
+    /// ```csharp
+    /// using Pulumi;
+    /// using Pulumi.Kubernetes.Helm.V3;
+    /// using Pulumi.Kubernetes.Types.Inputs.Helm.V3;
+    /// 
+    /// return await Deployment.RunAsync(() =&gt;
+    /// {
+    ///     new Release("nginx", new ReleaseArgs
+    ///     {
+    ///         Chart = "nginx",
+    ///         RepositoryOpts = new RepositoryOptsArgs
+    ///         {
+    ///             Repo = "https://charts.bitnami.com/bitnami",
+    ///         },
+    ///         ValueYamlFiles = { new FileAsset("./overrides.yaml") },
+    ///     });
+    /// });
+    /// 
+    /// // -- Contents of overrides.yaml --
+    /// // containerPorts:
+    /// //   http: null
+    /// ```
     /// ### Query Kubernetes Resource Installed By Helm Chart
     /// ```csharp
     /// using System.Collections.Generic;
@@ -436,7 +461,7 @@ namespace Pulumi.Kubernetes.Helm.V3
         public Output<int> Timeout { get; private set; } = null!;
 
         /// <summary>
-        /// List of assets (raw yaml files). Content is read and merged with values (with values taking precedence).
+        /// List of assets (raw yaml files). Content is read and merged with values (with values taking precedence). Set a key to `null` in a yaml file to delete the corresponding chart default — the standard `helm install --set key=null` pattern. This is the recommended path for clearing chart defaults from Pulumi, since some language SDKs cannot represent explicit `null` in the inline `values` map.
         /// </summary>
         [Output("valueYamlFiles")]
         public Output<ImmutableArray<AssetOrArchive>> ValueYamlFiles { get; private set; } = null!;
@@ -717,7 +742,7 @@ namespace Pulumi.Kubernetes.Types.Inputs.Helm.V3
         private InputList<AssetOrArchive>? _valueYamlFiles;
 
         /// <summary>
-        /// List of assets (raw yaml files). Content is read and merged with values.
+        /// List of assets (raw yaml files). Content is read and merged with values. Set a key to `null` in a yaml file to delete the corresponding chart default — the standard `helm install --set key=null` pattern. This is the recommended path for clearing chart defaults from Pulumi, since some language SDKs cannot represent explicit `null` in the inline `values` map.
         /// </summary>
         public InputList<AssetOrArchive> ValueYamlFiles
         {

--- a/sdk/dotnet/Helm/V4/Chart.cs
+++ b/sdk/dotnet/Helm/V4/Chart.cs
@@ -186,6 +186,31 @@ namespace Pulumi.Kubernetes.Helm.V4
     ///     return new Dictionary&lt;string, object?&gt;{};
     /// });
     /// ```
+    /// ### Delete a Chart Default Value
+    /// 
+    /// Helm charts typically guard template fields with truthy checks such as `{{- if .Values.foo }}`. The standard way to suppress one of those defaults is `helm install --set foo=null`, which leaves the field out of the rendered chart. To express the same intent from Pulumi, set the key to `null` in a yaml file and reference it via `valueYamlFiles`. This pattern works in every Pulumi language SDK.
+    /// ```csharp
+    /// using Pulumi;
+    /// using Pulumi.Kubernetes.Helm.V4;
+    /// using Pulumi.Kubernetes.Types.Inputs.Helm.V4;
+    /// 
+    /// return await Deployment.RunAsync(() =&gt;
+    /// {
+    ///     new Chart("nginx", new ChartArgs
+    ///     {
+    ///         Chart = "nginx",
+    ///         RepositoryOpts = new RepositoryOptsArgs
+    ///         {
+    ///             Repo = "https://charts.bitnami.com/bitnami",
+    ///         },
+    ///         ValueYamlFiles = { new FileAsset("./overrides.yaml") },
+    ///     });
+    /// });
+    /// 
+    /// // -- Contents of overrides.yaml --
+    /// // containerPorts:
+    /// //   http: null
+    /// ```
     /// ### Chart Namespace
     /// ```csharp
     /// using Pulumi;
@@ -330,7 +355,7 @@ namespace Pulumi.Kubernetes.Types.Inputs.Helm.V4
         private InputList<AssetOrArchive>? _valueYamlFiles;
 
         /// <summary>
-        /// List of assets (raw yaml files). Content is read and merged with values.
+        /// List of assets (raw yaml files). Content is read and merged with values. Set a key to `null` in a yaml file to delete the corresponding chart default — the standard `helm install --set key=null` pattern. This is the recommended path for clearing chart defaults from Pulumi, since some language SDKs cannot represent explicit `null` in the inline `values` map.
         /// </summary>
         public InputList<AssetOrArchive> ValueYamlFiles
         {

--- a/sdk/go/kubernetes/helm/v3/release.go
+++ b/sdk/go/kubernetes/helm/v3/release.go
@@ -230,6 +230,38 @@ import (
 // // metrics:
 // //     enabled: true
 // ```
+// ### Delete a Chart Default Value
+//
+// Helm charts typically guard template fields with truthy checks such as `{{- if .Values.foo }}`. The standard way to suppress one of those defaults is `helm install --set foo=null`, which leaves the field out of the rendered chart. To express the same intent from Pulumi, set the key to `null` in a yaml file and reference it via `valueYamlFiles`. This pattern works in every Pulumi language SDK.
+// ```go
+// package main
+//
+// import (
+//
+//	helmv3 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/helm/v3"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+// )
+//
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			_, err := helmv3.NewRelease(ctx, "nginx", &helmv3.ReleaseArgs{
+//				Chart: pulumi.String("nginx"),
+//				RepositoryOpts: helmv3.RepositoryOptsArgs{
+//					Repo: pulumi.String("https://charts.bitnami.com/bitnami"),
+//				},
+//				ValueYamlFiles: pulumi.AssetOrArchiveArray{
+//					pulumi.NewFileAsset("./overrides.yaml"),
+//				},
+//			})
+//			return err
+//		})
+//	}
+//
+// // -- Contents of overrides.yaml --
+// // containerPorts:
+// //   http: null
+// ```
 // ### Query Kubernetes Resource Installed By Helm Chart
 // ```go
 // package main
@@ -359,7 +391,7 @@ type Release struct {
 	Status ReleaseStatusOutput `pulumi:"status"`
 	// Time in seconds to wait for any individual kubernetes operation.
 	Timeout pulumi.IntPtrOutput `pulumi:"timeout"`
-	// List of assets (raw yaml files). Content is read and merged with values (with values taking precedence).
+	// List of assets (raw yaml files). Content is read and merged with values (with values taking precedence). Set a key to `null` in a yaml file to delete the corresponding chart default — the standard `helm install --set key=null` pattern. This is the recommended path for clearing chart defaults from Pulumi, since some language SDKs cannot represent explicit `null` in the inline `values` map.
 	ValueYamlFiles pulumi.AssetOrArchiveArrayOutput `pulumi:"valueYamlFiles"`
 	// Custom values set for the release.
 	Values pulumi.MapOutput `pulumi:"values"`
@@ -474,7 +506,7 @@ type releaseArgs struct {
 	SkipCrds *bool `pulumi:"skipCrds"`
 	// Time in seconds to wait for any individual kubernetes operation.
 	Timeout *int `pulumi:"timeout"`
-	// List of assets (raw yaml files). Content is read and merged with values.
+	// List of assets (raw yaml files). Content is read and merged with values. Set a key to `null` in a yaml file to delete the corresponding chart default — the standard `helm install --set key=null` pattern. This is the recommended path for clearing chart defaults from Pulumi, since some language SDKs cannot represent explicit `null` in the inline `values` map.
 	ValueYamlFiles []pulumi.AssetOrArchive `pulumi:"valueYamlFiles"`
 	// Custom values set for the release.
 	Values map[string]interface{} `pulumi:"values"`
@@ -547,7 +579,7 @@ type ReleaseArgs struct {
 	SkipCrds pulumi.BoolPtrInput
 	// Time in seconds to wait for any individual kubernetes operation.
 	Timeout pulumi.IntPtrInput
-	// List of assets (raw yaml files). Content is read and merged with values.
+	// List of assets (raw yaml files). Content is read and merged with values. Set a key to `null` in a yaml file to delete the corresponding chart default — the standard `helm install --set key=null` pattern. This is the recommended path for clearing chart defaults from Pulumi, since some language SDKs cannot represent explicit `null` in the inline `values` map.
 	ValueYamlFiles pulumi.AssetOrArchiveArrayInput
 	// Custom values set for the release.
 	Values pulumi.MapInput
@@ -796,7 +828,7 @@ func (o ReleaseOutput) Timeout() pulumi.IntPtrOutput {
 	return o.ApplyT(func(v *Release) pulumi.IntPtrOutput { return v.Timeout }).(pulumi.IntPtrOutput)
 }
 
-// List of assets (raw yaml files). Content is read and merged with values (with values taking precedence).
+// List of assets (raw yaml files). Content is read and merged with values (with values taking precedence). Set a key to `null` in a yaml file to delete the corresponding chart default — the standard `helm install --set key=null` pattern. This is the recommended path for clearing chart defaults from Pulumi, since some language SDKs cannot represent explicit `null` in the inline `values` map.
 func (o ReleaseOutput) ValueYamlFiles() pulumi.AssetOrArchiveArrayOutput {
 	return o.ApplyT(func(v *Release) pulumi.AssetOrArchiveArrayOutput { return v.ValueYamlFiles }).(pulumi.AssetOrArchiveArrayOutput)
 }

--- a/sdk/go/kubernetes/helm/v4/chart.go
+++ b/sdk/go/kubernetes/helm/v4/chart.go
@@ -216,6 +216,38 @@ import (
 //	}
 //
 // ```
+// ### Delete a Chart Default Value
+//
+// Helm charts typically guard template fields with truthy checks such as `{{- if .Values.foo }}`. The standard way to suppress one of those defaults is `helm install --set foo=null`, which leaves the field out of the rendered chart. To express the same intent from Pulumi, set the key to `null` in a yaml file and reference it via `valueYamlFiles`. This pattern works in every Pulumi language SDK.
+// ```go
+// package main
+//
+// import (
+//
+//	helmv4 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/helm/v4"
+//	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+//
+// )
+//
+//	func main() {
+//		pulumi.Run(func(ctx *pulumi.Context) error {
+//			_, err := helmv4.NewChart(ctx, "nginx", &helmv4.ChartArgs{
+//				Chart: pulumi.String("nginx"),
+//				RepositoryOpts: &helmv4.RepositoryOptsArgs{
+//					Repo: pulumi.String("https://charts.bitnami.com/bitnami"),
+//				},
+//				ValueYamlFiles: pulumi.AssetOrArchiveArray{
+//					pulumi.NewFileAsset("./overrides.yaml"),
+//				},
+//			})
+//			return err
+//		})
+//	}
+//
+// // -- Contents of overrides.yaml --
+// // containerPorts:
+// //   http: null
+// ```
 // ### Chart Namespace
 // ```go
 // package main
@@ -303,7 +335,7 @@ type chartArgs struct {
 	SkipAwait *bool `pulumi:"skipAwait"`
 	// If set, no CRDs will be installed. By default, CRDs are installed if not already present.
 	SkipCrds *bool `pulumi:"skipCrds"`
-	// List of assets (raw yaml files). Content is read and merged with values.
+	// List of assets (raw yaml files). Content is read and merged with values. Set a key to `null` in a yaml file to delete the corresponding chart default — the standard `helm install --set key=null` pattern. This is the recommended path for clearing chart defaults from Pulumi, since some language SDKs cannot represent explicit `null` in the inline `values` map.
 	ValueYamlFiles []pulumi.AssetOrArchive `pulumi:"valueYamlFiles"`
 	// Custom values set for the release.
 	Values map[string]interface{} `pulumi:"values"`
@@ -339,7 +371,7 @@ type ChartArgs struct {
 	SkipAwait pulumi.BoolPtrInput
 	// If set, no CRDs will be installed. By default, CRDs are installed if not already present.
 	SkipCrds pulumi.BoolPtrInput
-	// List of assets (raw yaml files). Content is read and merged with values.
+	// List of assets (raw yaml files). Content is read and merged with values. Set a key to `null` in a yaml file to delete the corresponding chart default — the standard `helm install --set key=null` pattern. This is the recommended path for clearing chart defaults from Pulumi, since some language SDKs cannot represent explicit `null` in the inline `values` map.
 	ValueYamlFiles pulumi.AssetOrArchiveArrayInput
 	// Custom values set for the release.
 	Values pulumi.MapInput

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/helm/v3/Release.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/helm/v3/Release.java
@@ -32,6 +32,38 @@ import javax.annotation.Nullable;
  * You may also want to consider the `Chart` resource as an alternative method for managing helm charts. For more information about the trade-offs between these options see: [Choosing the right Helm resource for your use case](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/choosing-the-right-helm-resource-for-your-use-case)
  * 
  * ## Example Usage
+ * ### Delete a Chart Default Value
+ * 
+ * Helm charts typically guard template fields with truthy checks such as `{{- if .Values.foo }}`. The standard way to suppress one of those defaults is `helm install --set foo=null`, which leaves the field out of the rendered chart. To express the same intent from Pulumi, set the key to `null` in a yaml file and reference it via `valueYamlFiles`. This pattern works in every Pulumi language SDK.
+ * <pre>
+ * {@code
+ * package generated_program;
+ * 
+ * import com.pulumi.Pulumi;
+ * import com.pulumi.asset.FileAsset;
+ * import com.pulumi.kubernetes.helm.v3.Release;
+ * import com.pulumi.kubernetes.helm.v3.ReleaseArgs;
+ * import com.pulumi.kubernetes.helm.v3.inputs.RepositoryOptsArgs;
+ * 
+ * public class App {
+ *     public static void main(String[] args) {
+ *         Pulumi.run(ctx -> {
+ *             new Release("nginx", ReleaseArgs.builder()
+ *                     .chart("nginx")
+ *                     .repositoryOpts(RepositoryOptsArgs.builder()
+ *                             .repo("https://charts.bitnami.com/bitnami")
+ *                             .build())
+ *                     .valueYamlFiles(new FileAsset("./overrides.yaml"))
+ *                     .build());
+ *         });
+ *     }
+ * }
+ * 
+ * // -- Contents of overrides.yaml --
+ * // containerPorts:
+ * //   http: null
+ * }
+ * </pre>
  * 
  * ## Import
  * 
@@ -465,14 +497,14 @@ public class Release extends com.pulumi.resources.CustomResource {
         return Codegen.optional(this.timeout);
     }
     /**
-     * List of assets (raw yaml files). Content is read and merged with values (with values taking precedence).
+     * List of assets (raw yaml files). Content is read and merged with values (with values taking precedence). Set a key to `null` in a yaml file to delete the corresponding chart default — the standard `helm install --set key=null` pattern. This is the recommended path for clearing chart defaults from Pulumi, since some language SDKs cannot represent explicit `null` in the inline `values` map.
      * 
      */
     @Export(name="valueYamlFiles", refs={List.class,AssetOrArchive.class}, tree="[0,1]")
     private Output</* @Nullable */ List<AssetOrArchive>> valueYamlFiles;
 
     /**
-     * @return List of assets (raw yaml files). Content is read and merged with values (with values taking precedence).
+     * @return List of assets (raw yaml files). Content is read and merged with values (with values taking precedence). Set a key to `null` in a yaml file to delete the corresponding chart default — the standard `helm install --set key=null` pattern. This is the recommended path for clearing chart defaults from Pulumi, since some language SDKs cannot represent explicit `null` in the inline `values` map.
      * 
      */
     public Output<Optional<List<AssetOrArchive>>> valueYamlFiles() {

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/helm/v3/ReleaseArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/helm/v3/ReleaseArgs.java
@@ -467,14 +467,14 @@ public final class ReleaseArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * List of assets (raw yaml files). Content is read and merged with values.
+     * List of assets (raw yaml files). Content is read and merged with values. Set a key to `null` in a yaml file to delete the corresponding chart default — the standard `helm install --set key=null` pattern. This is the recommended path for clearing chart defaults from Pulumi, since some language SDKs cannot represent explicit `null` in the inline `values` map.
      * 
      */
     @Import(name="valueYamlFiles")
     private @Nullable Output<List<AssetOrArchive>> valueYamlFiles;
 
     /**
-     * @return List of assets (raw yaml files). Content is read and merged with values.
+     * @return List of assets (raw yaml files). Content is read and merged with values. Set a key to `null` in a yaml file to delete the corresponding chart default — the standard `helm install --set key=null` pattern. This is the recommended path for clearing chart defaults from Pulumi, since some language SDKs cannot represent explicit `null` in the inline `values` map.
      * 
      */
     public Optional<Output<List<AssetOrArchive>>> valueYamlFiles() {
@@ -1218,7 +1218,7 @@ public final class ReleaseArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param valueYamlFiles List of assets (raw yaml files). Content is read and merged with values.
+         * @param valueYamlFiles List of assets (raw yaml files). Content is read and merged with values. Set a key to `null` in a yaml file to delete the corresponding chart default — the standard `helm install --set key=null` pattern. This is the recommended path for clearing chart defaults from Pulumi, since some language SDKs cannot represent explicit `null` in the inline `values` map.
          * 
          * @return builder
          * 
@@ -1229,7 +1229,7 @@ public final class ReleaseArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param valueYamlFiles List of assets (raw yaml files). Content is read and merged with values.
+         * @param valueYamlFiles List of assets (raw yaml files). Content is read and merged with values. Set a key to `null` in a yaml file to delete the corresponding chart default — the standard `helm install --set key=null` pattern. This is the recommended path for clearing chart defaults from Pulumi, since some language SDKs cannot represent explicit `null` in the inline `values` map.
          * 
          * @return builder
          * 
@@ -1239,7 +1239,7 @@ public final class ReleaseArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param valueYamlFiles List of assets (raw yaml files). Content is read and merged with values.
+         * @param valueYamlFiles List of assets (raw yaml files). Content is read and merged with values. Set a key to `null` in a yaml file to delete the corresponding chart default — the standard `helm install --set key=null` pattern. This is the recommended path for clearing chart defaults from Pulumi, since some language SDKs cannot represent explicit `null` in the inline `values` map.
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/helm/v4/Chart.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/helm/v4/Chart.java
@@ -204,6 +204,38 @@ import javax.annotation.Nullable;
  * }
  * }
  * </pre>
+ * ### Delete a Chart Default Value
+ * 
+ * Helm charts typically guard template fields with truthy checks such as `{{- if .Values.foo }}`. The standard way to suppress one of those defaults is `helm install --set foo=null`, which leaves the field out of the rendered chart. To express the same intent from Pulumi, set the key to `null` in a yaml file and reference it via `valueYamlFiles`. This pattern works in every Pulumi language SDK.
+ * <pre>
+ * {@code
+ * package generated_program;
+ * 
+ * import com.pulumi.Pulumi;
+ * import com.pulumi.asset.FileAsset;
+ * import com.pulumi.kubernetes.helm.v4.Chart;
+ * import com.pulumi.kubernetes.helm.v4.ChartArgs;
+ * import com.pulumi.kubernetes.helm.v4.inputs.RepositoryOptsArgs;
+ * 
+ * public class App {
+ *     public static void main(String[] args) {
+ *         Pulumi.run(ctx -> {
+ *             new Chart("nginx", ChartArgs.builder()
+ *                     .chart("nginx")
+ *                     .repositoryOpts(RepositoryOptsArgs.builder()
+ *                             .repo("https://charts.bitnami.com/bitnami")
+ *                             .build())
+ *                     .valueYamlFiles(new FileAsset("./overrides.yaml"))
+ *                     .build());
+ *         });
+ *     }
+ * }
+ * 
+ * // -- Contents of overrides.yaml --
+ * // containerPorts:
+ * //   http: null
+ * }
+ * </pre>
  * ### Chart Namespace
  * <pre>
  * {@code

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/helm/v4/ChartArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/helm/v4/ChartArgs.java
@@ -204,14 +204,14 @@ public final class ChartArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * List of assets (raw yaml files). Content is read and merged with values.
+     * List of assets (raw yaml files). Content is read and merged with values. Set a key to `null` in a yaml file to delete the corresponding chart default — the standard `helm install --set key=null` pattern. This is the recommended path for clearing chart defaults from Pulumi, since some language SDKs cannot represent explicit `null` in the inline `values` map.
      * 
      */
     @Import(name="valueYamlFiles")
     private @Nullable Output<List<AssetOrArchive>> valueYamlFiles;
 
     /**
-     * @return List of assets (raw yaml files). Content is read and merged with values.
+     * @return List of assets (raw yaml files). Content is read and merged with values. Set a key to `null` in a yaml file to delete the corresponding chart default — the standard `helm install --set key=null` pattern. This is the recommended path for clearing chart defaults from Pulumi, since some language SDKs cannot represent explicit `null` in the inline `values` map.
      * 
      */
     public Optional<Output<List<AssetOrArchive>>> valueYamlFiles() {
@@ -555,7 +555,7 @@ public final class ChartArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param valueYamlFiles List of assets (raw yaml files). Content is read and merged with values.
+         * @param valueYamlFiles List of assets (raw yaml files). Content is read and merged with values. Set a key to `null` in a yaml file to delete the corresponding chart default — the standard `helm install --set key=null` pattern. This is the recommended path for clearing chart defaults from Pulumi, since some language SDKs cannot represent explicit `null` in the inline `values` map.
          * 
          * @return builder
          * 
@@ -566,7 +566,7 @@ public final class ChartArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param valueYamlFiles List of assets (raw yaml files). Content is read and merged with values.
+         * @param valueYamlFiles List of assets (raw yaml files). Content is read and merged with values. Set a key to `null` in a yaml file to delete the corresponding chart default — the standard `helm install --set key=null` pattern. This is the recommended path for clearing chart defaults from Pulumi, since some language SDKs cannot represent explicit `null` in the inline `values` map.
          * 
          * @return builder
          * 
@@ -576,7 +576,7 @@ public final class ChartArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param valueYamlFiles List of assets (raw yaml files). Content is read and merged with values.
+         * @param valueYamlFiles List of assets (raw yaml files). Content is read and merged with values. Set a key to `null` in a yaml file to delete the corresponding chart default — the standard `helm install --set key=null` pattern. This is the recommended path for clearing chart defaults from Pulumi, since some language SDKs cannot represent explicit `null` in the inline `values` map.
          * 
          * @return builder
          * 

--- a/sdk/nodejs/helm/v3/release.ts
+++ b/sdk/nodejs/helm/v3/release.ts
@@ -125,6 +125,26 @@ import * as utilities from "../../utilities";
  * // metrics:
  * //     enabled: true
  * ```
+ * ### Delete a Chart Default Value
+ *
+ * Helm charts typically guard template fields with truthy checks such as `{{- if .Values.foo }}`. The standard way to suppress one of those defaults is `helm install --set foo=null`, which leaves the field out of the rendered chart. To express the same intent from Pulumi, set the key to `null` in a yaml file and reference it via `valueYamlFiles`. This pattern works in every Pulumi language SDK.
+ *
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as k8s from "@pulumi/kubernetes";
+ *
+ * const nginx = new k8s.helm.v3.Release("nginx", {
+ *     chart: "nginx",
+ *     repositoryOpts: {
+ *         repo: "https://charts.bitnami.com/bitnami",
+ *     },
+ *     valueYamlFiles: [new pulumi.asset.FileAsset("./overrides.yaml")],
+ * });
+ *
+ * // -- Contents of overrides.yaml --
+ * // containerPorts:
+ * //   http: null
+ * ```
  * ### Query Kubernetes Resource Installed By Helm Chart
  *
  * ```typescript
@@ -308,7 +328,7 @@ export class Release extends pulumi.CustomResource {
      */
     declare public readonly timeout: pulumi.Output<number>;
     /**
-     * List of assets (raw yaml files). Content is read and merged with values (with values taking precedence).
+     * List of assets (raw yaml files). Content is read and merged with values (with values taking precedence). Set a key to `null` in a yaml file to delete the corresponding chart default — the standard `helm install --set key=null` pattern. This is the recommended path for clearing chart defaults from Pulumi, since some language SDKs cannot represent explicit `null` in the inline `values` map.
      */
     declare public readonly valueYamlFiles: pulumi.Output<(pulumi.asset.Asset | pulumi.asset.Archive)[]>;
     /**
@@ -542,7 +562,7 @@ export interface ReleaseArgs {
      */
     timeout?: pulumi.Input<number>;
     /**
-     * List of assets (raw yaml files). Content is read and merged with values.
+     * List of assets (raw yaml files). Content is read and merged with values. Set a key to `null` in a yaml file to delete the corresponding chart default — the standard `helm install --set key=null` pattern. This is the recommended path for clearing chart defaults from Pulumi, since some language SDKs cannot represent explicit `null` in the inline `values` map.
      */
     valueYamlFiles?: pulumi.Input<pulumi.Input<pulumi.asset.Asset | pulumi.asset.Archive>[]>;
     /**

--- a/sdk/nodejs/helm/v4/chart.ts
+++ b/sdk/nodejs/helm/v4/chart.ts
@@ -153,6 +153,26 @@ import * as utilities from "../../utilities";
  *     },
  * });
  * ```
+ * ### Delete a Chart Default Value
+ *
+ * Helm charts typically guard template fields with truthy checks such as `{{- if .Values.foo }}`. The standard way to suppress one of those defaults is `helm install --set foo=null`, which leaves the field out of the rendered chart. To express the same intent from Pulumi, set the key to `null` in a yaml file and reference it via `valueYamlFiles`. This pattern works in every Pulumi language SDK.
+ *
+ * ```typescript
+ * import * as pulumi from "@pulumi/pulumi";
+ * import * as k8s from "@pulumi/kubernetes";
+ *
+ * const nginx = new k8s.helm.v4.Chart("nginx", {
+ *     chart: "nginx",
+ *     repositoryOpts: {
+ *         repo: "https://charts.bitnami.com/bitnami",
+ *     },
+ *     valueYamlFiles: [new pulumi.asset.FileAsset("./overrides.yaml")],
+ * });
+ *
+ * // -- Contents of overrides.yaml --
+ * // containerPorts:
+ * //   http: null
+ * ```
  * ### Chart Namespace
  *
  * ```typescript
@@ -283,7 +303,7 @@ export interface ChartArgs {
      */
     skipCrds?: pulumi.Input<boolean>;
     /**
-     * List of assets (raw yaml files). Content is read and merged with values.
+     * List of assets (raw yaml files). Content is read and merged with values. Set a key to `null` in a yaml file to delete the corresponding chart default — the standard `helm install --set key=null` pattern. This is the recommended path for clearing chart defaults from Pulumi, since some language SDKs cannot represent explicit `null` in the inline `values` map.
      */
     valueYamlFiles?: pulumi.Input<pulumi.Input<pulumi.asset.Asset | pulumi.asset.Archive>[]>;
     /**

--- a/sdk/python/pulumi_kubernetes/helm/v3/Release.py
+++ b/sdk/python/pulumi_kubernetes/helm/v3/Release.py
@@ -88,7 +88,7 @@ class ReleaseArgs:
         :param pulumi.Input[_builtins.bool] skip_await: By default, the provider waits until all resources are in a ready state before marking the release as successful. Setting this to true will skip such await logic.
         :param pulumi.Input[_builtins.bool] skip_crds: If set, no CRDs will be installed. By default, CRDs are installed if not already present.
         :param pulumi.Input[_builtins.int] timeout: Time in seconds to wait for any individual kubernetes operation.
-        :param pulumi.Input[Sequence[pulumi.Input[Union[pulumi.Asset, pulumi.Archive]]]] value_yaml_files: List of assets (raw yaml files). Content is read and merged with values.
+        :param pulumi.Input[Sequence[pulumi.Input[Union[pulumi.Asset, pulumi.Archive]]]] value_yaml_files: List of assets (raw yaml files). Content is read and merged with values. Set a key to `null` in a yaml file to delete the corresponding chart default — the standard `helm install --set key=null` pattern. This is the recommended path for clearing chart defaults from Pulumi, since some language SDKs cannot represent explicit `null` in the inline `values` map.
         :param pulumi.Input[Mapping[str, Any]] values: Custom values set for the release.
         :param pulumi.Input[_builtins.bool] verify: Verify the package before installing it.
         :param pulumi.Input[_builtins.str] version: Specify the exact chart version to install. If this is not specified, the latest version is installed.
@@ -525,7 +525,7 @@ class ReleaseArgs:
     @pulumi.getter(name="valueYamlFiles")
     def value_yaml_files(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[Union[pulumi.Asset, pulumi.Archive]]]]]:
         """
-        List of assets (raw yaml files). Content is read and merged with values.
+        List of assets (raw yaml files). Content is read and merged with values. Set a key to `null` in a yaml file to delete the corresponding chart default — the standard `helm install --set key=null` pattern. This is the recommended path for clearing chart defaults from Pulumi, since some language SDKs cannot represent explicit `null` in the inline `values` map.
         """
         return pulumi.get(self, "value_yaml_files")
 
@@ -752,6 +752,28 @@ class Release(pulumi.CustomResource):
         # metrics:
         #     enabled: true
         ```
+        ### Delete a Chart Default Value
+
+        Helm charts typically guard template fields with truthy checks such as `{{- if .Values.foo }}`. The standard way to suppress one of those defaults is `helm install --set foo=null`, which leaves the field out of the rendered chart. To express the same intent from Pulumi, set the key to `null` in a yaml file and reference it via `valueYamlFiles`. This pattern works in every Pulumi language SDK.
+        ```python
+        import pulumi
+        from pulumi_kubernetes.helm.v3 import Release, ReleaseArgs, RepositoryOptsArgs
+
+        nginx = Release(
+            "nginx",
+            ReleaseArgs(
+                chart="nginx",
+                repository_opts=RepositoryOptsArgs(
+                    repo="https://charts.bitnami.com/bitnami",
+                ),
+                value_yaml_files=[pulumi.FileAsset("./overrides.yaml")],
+            ),
+        )
+
+        # -- Contents of overrides.yaml --
+        # containerPorts:
+        #   http: null
+        ```
         ### Query Kubernetes Resource Installed By Helm Chart
         ```python
         from pulumi import Output
@@ -821,7 +843,7 @@ class Release(pulumi.CustomResource):
         :param pulumi.Input[_builtins.bool] skip_await: By default, the provider waits until all resources are in a ready state before marking the release as successful. Setting this to true will skip such await logic.
         :param pulumi.Input[_builtins.bool] skip_crds: If set, no CRDs will be installed. By default, CRDs are installed if not already present.
         :param pulumi.Input[_builtins.int] timeout: Time in seconds to wait for any individual kubernetes operation.
-        :param pulumi.Input[Sequence[pulumi.Input[Union[pulumi.Asset, pulumi.Archive]]]] value_yaml_files: List of assets (raw yaml files). Content is read and merged with values.
+        :param pulumi.Input[Sequence[pulumi.Input[Union[pulumi.Asset, pulumi.Archive]]]] value_yaml_files: List of assets (raw yaml files). Content is read and merged with values. Set a key to `null` in a yaml file to delete the corresponding chart default — the standard `helm install --set key=null` pattern. This is the recommended path for clearing chart defaults from Pulumi, since some language SDKs cannot represent explicit `null` in the inline `values` map.
         :param pulumi.Input[Mapping[str, Any]] values: Custom values set for the release.
         :param pulumi.Input[_builtins.bool] verify: Verify the package before installing it.
         :param pulumi.Input[_builtins.str] version: Specify the exact chart version to install. If this is not specified, the latest version is installed.
@@ -960,6 +982,28 @@ class Release(pulumi.CustomResource):
         # -- Contents of metrics.yml --
         # metrics:
         #     enabled: true
+        ```
+        ### Delete a Chart Default Value
+
+        Helm charts typically guard template fields with truthy checks such as `{{- if .Values.foo }}`. The standard way to suppress one of those defaults is `helm install --set foo=null`, which leaves the field out of the rendered chart. To express the same intent from Pulumi, set the key to `null` in a yaml file and reference it via `valueYamlFiles`. This pattern works in every Pulumi language SDK.
+        ```python
+        import pulumi
+        from pulumi_kubernetes.helm.v3 import Release, ReleaseArgs, RepositoryOptsArgs
+
+        nginx = Release(
+            "nginx",
+            ReleaseArgs(
+                chart="nginx",
+                repository_opts=RepositoryOptsArgs(
+                    repo="https://charts.bitnami.com/bitnami",
+                ),
+                value_yaml_files=[pulumi.FileAsset("./overrides.yaml")],
+            ),
+        )
+
+        # -- Contents of overrides.yaml --
+        # containerPorts:
+        #   http: null
         ```
         ### Query Kubernetes Resource Installed By Helm Chart
         ```python
@@ -1399,7 +1443,7 @@ class Release(pulumi.CustomResource):
     @pulumi.getter(name="valueYamlFiles")
     def value_yaml_files(self) -> pulumi.Output[Optional[Sequence[Union[pulumi.Asset, pulumi.Archive]]]]:
         """
-        List of assets (raw yaml files). Content is read and merged with values (with values taking precedence).
+        List of assets (raw yaml files). Content is read and merged with values (with values taking precedence). Set a key to `null` in a yaml file to delete the corresponding chart default — the standard `helm install --set key=null` pattern. This is the recommended path for clearing chart defaults from Pulumi, since some language SDKs cannot represent explicit `null` in the inline `values` map.
         """
         return pulumi.get(self, "value_yaml_files")
 

--- a/sdk/python/pulumi_kubernetes/helm/v4/Chart.py
+++ b/sdk/python/pulumi_kubernetes/helm/v4/Chart.py
@@ -51,7 +51,7 @@ class ChartArgs:
         :param pulumi.Input[_builtins.str] resource_prefix: An optional prefix for the auto-generated resource names. Example: A resource created with resourcePrefix="foo" would produce a resource named "foo:resourceName".
         :param pulumi.Input[_builtins.bool] skip_await: By default, the provider waits until all resources are in a ready state before marking the release as successful. Setting this to true will skip such await logic.
         :param pulumi.Input[_builtins.bool] skip_crds: If set, no CRDs will be installed. By default, CRDs are installed if not already present.
-        :param pulumi.Input[Sequence[pulumi.Input[Union[pulumi.Asset, pulumi.Archive]]]] value_yaml_files: List of assets (raw yaml files). Content is read and merged with values.
+        :param pulumi.Input[Sequence[pulumi.Input[Union[pulumi.Asset, pulumi.Archive]]]] value_yaml_files: List of assets (raw yaml files). Content is read and merged with values. Set a key to `null` in a yaml file to delete the corresponding chart default — the standard `helm install --set key=null` pattern. This is the recommended path for clearing chart defaults from Pulumi, since some language SDKs cannot represent explicit `null` in the inline `values` map.
         :param pulumi.Input[Mapping[str, Any]] values: Custom values set for the release.
         :param pulumi.Input[_builtins.bool] verify: Verify the chart's integrity.
         :param pulumi.Input[_builtins.str] version: Specify the chart version to install. If this is not specified, the latest version is installed.
@@ -236,7 +236,7 @@ class ChartArgs:
     @pulumi.getter(name="valueYamlFiles")
     def value_yaml_files(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[Union[pulumi.Asset, pulumi.Archive]]]]]:
         """
-        List of assets (raw yaml files). Content is read and merged with values.
+        List of assets (raw yaml files). Content is read and merged with values. Set a key to `null` in a yaml file to delete the corresponding chart default — the standard `helm install --set key=null` pattern. This is the recommended path for clearing chart defaults from Pulumi, since some language SDKs cannot represent explicit `null` in the inline `values` map.
         """
         return pulumi.get(self, "value_yaml_files")
 
@@ -451,6 +451,25 @@ class Chart(pulumi.ComponentResource):
             }
         )
         ```
+        ### Delete a Chart Default Value
+
+        Helm charts typically guard template fields with truthy checks such as `{{- if .Values.foo }}`. The standard way to suppress one of those defaults is `helm install --set foo=null`, which leaves the field out of the rendered chart. To express the same intent from Pulumi, set the key to `null` in a yaml file and reference it via `valueYamlFiles`. This pattern works in every Pulumi language SDK.
+        ```python
+        import pulumi
+        from pulumi_kubernetes.helm.v4 import Chart, RepositoryOptsArgs
+
+        nginx = Chart("nginx",
+            chart="nginx",
+            repository_opts=RepositoryOptsArgs(
+                repo="https://charts.bitnami.com/bitnami",
+            ),
+            value_yaml_files=[pulumi.FileAsset("./overrides.yaml")],
+        )
+
+        # -- Contents of overrides.yaml --
+        # containerPorts:
+        #   http: null
+        ```
         ### Chart Namespace
         ```python
         import pulumi
@@ -487,7 +506,7 @@ class Chart(pulumi.ComponentResource):
         :param pulumi.Input[_builtins.str] resource_prefix: An optional prefix for the auto-generated resource names. Example: A resource created with resourcePrefix="foo" would produce a resource named "foo:resourceName".
         :param pulumi.Input[_builtins.bool] skip_await: By default, the provider waits until all resources are in a ready state before marking the release as successful. Setting this to true will skip such await logic.
         :param pulumi.Input[_builtins.bool] skip_crds: If set, no CRDs will be installed. By default, CRDs are installed if not already present.
-        :param pulumi.Input[Sequence[pulumi.Input[Union[pulumi.Asset, pulumi.Archive]]]] value_yaml_files: List of assets (raw yaml files). Content is read and merged with values.
+        :param pulumi.Input[Sequence[pulumi.Input[Union[pulumi.Asset, pulumi.Archive]]]] value_yaml_files: List of assets (raw yaml files). Content is read and merged with values. Set a key to `null` in a yaml file to delete the corresponding chart default — the standard `helm install --set key=null` pattern. This is the recommended path for clearing chart defaults from Pulumi, since some language SDKs cannot represent explicit `null` in the inline `values` map.
         :param pulumi.Input[Mapping[str, Any]] values: Custom values set for the release.
         :param pulumi.Input[_builtins.bool] verify: Verify the chart's integrity.
         :param pulumi.Input[_builtins.str] version: Specify the chart version to install. If this is not specified, the latest version is installed.
@@ -644,6 +663,25 @@ class Chart(pulumi.ComponentResource):
                 "notes": pulumi.FileAsset("./notes.txt")
             }
         )
+        ```
+        ### Delete a Chart Default Value
+
+        Helm charts typically guard template fields with truthy checks such as `{{- if .Values.foo }}`. The standard way to suppress one of those defaults is `helm install --set foo=null`, which leaves the field out of the rendered chart. To express the same intent from Pulumi, set the key to `null` in a yaml file and reference it via `valueYamlFiles`. This pattern works in every Pulumi language SDK.
+        ```python
+        import pulumi
+        from pulumi_kubernetes.helm.v4 import Chart, RepositoryOptsArgs
+
+        nginx = Chart("nginx",
+            chart="nginx",
+            repository_opts=RepositoryOptsArgs(
+                repo="https://charts.bitnami.com/bitnami",
+            ),
+            value_yaml_files=[pulumi.FileAsset("./overrides.yaml")],
+        )
+
+        # -- Contents of overrides.yaml --
+        # containerPorts:
+        #   http: null
         ```
         ### Chart Namespace
         ```python


### PR DESCRIPTION
## Summary

- Expand the `valueYamlFiles` property description on `helm.v3.Release` and `helm.v4.Chart` to explain how a `key: null` entry in a referenced yaml file clears a chart default.
- Add a new **Delete a Chart Default Value** example block to the overlay docs for both resources, with code in TypeScript, Python, Go, C#, Java, and YAML.
- Regenerated schema + all language SDKs.

## Why

After #4293 the Kubernetes provider honors explicit `null` values end-to-end. In TypeScript, users can now pass inline `null` in the `values` map. But the other Pulumi SDKs strip null map values before they reach the engine (tracked in pulumi/pulumi#22713 Go, #22714 .NET, #22715 Java, #12178 Python), so for those languages `valueYamlFiles` is the only way to express `key: null` on the wire — the yaml file is opaque to the SDK marshaler.

This PR surfaces that workaround in the user-facing docs so anyone hitting the "can't delete a chart default" case finds the recommended pattern directly on the Registry page.

No behavior change. Docs + regenerated SDK doc comments only.

## Test plan

- [ ] CI builds and tidy checks pass
- [ ] Spot-check the rendered Registry preview for `helm.v3.Release` and `helm.v4.Chart` after merge