### PR TITLE
[chore] Cleanup golangci-lint var

### DIFF
--- a/.ci-mgmt.yaml
+++ b/.ci-mgmt.yaml
@@ -12,7 +12,6 @@ envOverride:
     PULUMI_API: https://api.pulumi-staging.io
     AWS_REGION: us-west-2
     PULUMI_TEST_OWNER: moolumi
-    GOLANGCI_LINT_VERSION: v1.64.8
     GOOGLE_CI_SERVICE_ACCOUNT_EMAIL: pulumi-ci@pulumi-k8s-provider.iam.gserviceaccount.com
     GOOGLE_CI_WORKLOAD_IDENTITY_POOL: pulumi-ci
     GOOGLE_CI_WORKLOAD_IDENTITY_PROVIDER: pulumi-ci

--- a/.github/actions/setup-tools/action.yml
+++ b/.github/actions/setup-tools/action.yml
@@ -14,7 +14,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup mise
-      uses: jdx/mise-action@db69447ab3fe3551c979c98174c303c5d9708e58
+      uses: jdx/mise-action@5ad13376e30bbca3721f7f33f25bc0baff52c02d
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,6 @@ env:
   DOTNETVERSION: "8.0.x"
   JAVAVERSION: "11"
   AWS_REGION: us-west-2
-  GOLANGCI_LINT_VERSION: v1.64.8
   GOOGLE_CI_SERVICE_ACCOUNT_EMAIL: pulumi-ci@pulumi-k8s-provider.iam.gserviceaccount.com
   GOOGLE_CI_WORKLOAD_IDENTITY_POOL: pulumi-ci
   GOOGLE_CI_WORKLOAD_IDENTITY_PROVIDER: pulumi-ci

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -56,7 +56,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
         run: gh pr checkout "$PR_NUMBER"
       - name: Setup mise
-        uses: jdx/mise-action@db69447ab3fe3551c979c98174c303c5d9708e58
+        uses: jdx/mise-action@5ad13376e30bbca3721f7f33f25bc0baff52c02d
         env:
           MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:

--- a/.github/workflows/command-dispatch.yml
+++ b/.github/workflows/command-dispatch.yml
@@ -2,7 +2,6 @@
 
 env:
   AWS_REGION: us-west-2
-  GOLANGCI_LINT_VERSION: v1.64.8
   GOOGLE_CI_SERVICE_ACCOUNT_EMAIL: pulumi-ci@pulumi-k8s-provider.iam.gserviceaccount.com
   GOOGLE_CI_WORKLOAD_IDENTITY_POOL: pulumi-ci
   GOOGLE_CI_WORKLOAD_IDENTITY_PROVIDER: pulumi-ci

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,6 @@ on:
 
 env:
   AWS_REGION: us-west-2
-  GOLANGCI_LINT_VERSION: v1.64.8
   GOOGLE_CI_SERVICE_ACCOUNT_EMAIL: pulumi-ci@pulumi-k8s-provider.iam.gserviceaccount.com
   GOOGLE_CI_WORKLOAD_IDENTITY_POOL: pulumi-ci
   GOOGLE_CI_WORKLOAD_IDENTITY_PROVIDER: pulumi-ci
@@ -49,7 +48,7 @@ jobs:
         private-key: ${{ steps.esc-secrets.outputs.PULUMI_PROVIDER_AUTOMATION_PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
     - name: Setup mise
-      uses: jdx/mise-action@db69447ab3fe3551c979c98174c303c5d9708e58
+      uses: jdx/mise-action@5ad13376e30bbca3721f7f33f25bc0baff52c02d
       env:
         MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
       with:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -14,7 +14,6 @@ env:
   DOTNETVERSION: "8.0.x"
   JAVAVERSION: "11"
   AWS_REGION: us-west-2
-  GOLANGCI_LINT_VERSION: v1.64.8
   GOOGLE_CI_SERVICE_ACCOUNT_EMAIL: pulumi-ci@pulumi-k8s-provider.iam.gserviceaccount.com
   GOOGLE_CI_WORKLOAD_IDENTITY_POOL: pulumi-ci
   GOOGLE_CI_WORKLOAD_IDENTITY_PROVIDER: pulumi-ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,6 @@ env:
   DOTNETVERSION: "8.0.x"
   JAVAVERSION: "11"
   AWS_REGION: us-west-2
-  GOLANGCI_LINT_VERSION: v1.64.8
   GOOGLE_CI_SERVICE_ACCOUNT_EMAIL: pulumi-ci@pulumi-k8s-provider.iam.gserviceaccount.com
   GOOGLE_CI_WORKLOAD_IDENTITY_POOL: pulumi-ci
   GOOGLE_CI_WORKLOAD_IDENTITY_PROVIDER: pulumi-ci

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -18,7 +18,6 @@ env:
   DOTNETVERSION: "8.0.x"
   JAVAVERSION: "11"
   AWS_REGION: us-west-2
-  GOLANGCI_LINT_VERSION: v1.64.8
   GOOGLE_CI_SERVICE_ACCOUNT_EMAIL: pulumi-ci@pulumi-k8s-provider.iam.gserviceaccount.com
   GOOGLE_CI_WORKLOAD_IDENTITY_POOL: pulumi-ci
   GOOGLE_CI_WORKLOAD_IDENTITY_PROVIDER: pulumi-ci

--- a/.github/workflows/weekly-pulumi-update.yml
+++ b/.github/workflows/weekly-pulumi-update.yml
@@ -15,7 +15,6 @@ env:
   DOTNETVERSION: "8.0.x"
   JAVAVERSION: "11"
   AWS_REGION: us-west-2
-  GOLANGCI_LINT_VERSION: v1.64.8
   GOOGLE_CI_SERVICE_ACCOUNT_EMAIL: pulumi-ci@pulumi-k8s-provider.iam.gserviceaccount.com
   GOOGLE_CI_WORKLOAD_IDENTITY_POOL: pulumi-ci
   GOOGLE_CI_WORKLOAD_IDENTITY_PROVIDER: pulumi-ci


### PR DESCRIPTION
What it says on the box. GOLANGCI_LINT_VERSION is unused and we should remove it.

Fixes https://github.com/pulumi/pulumi-kubernetes/issues/4309.