### PR TITLE
tests: upgrade GKE test cluster to v1.33

### DIFF
--- a/tests/ci-cluster/gke.ts
+++ b/tests/ci-cluster/gke.ts
@@ -26,8 +26,8 @@ export class GkeCluster extends pulumi.ComponentResource {
                 opts: pulumi.ComponentResourceOptions = {}) {
         super("pulumi-kubernetes:ci:GkeCluster", name, {}, opts);
 
-        // Use the latest 1.32.x engine version.
-        const engineVersion = "1.32";
+        // Use the latest 1.33.x engine version.
+        const engineVersion = "1.33";
 
         // Create the GKE cluster.
         const k8sCluster = new gcp.container.Cluster("ephemeral-ci-cluster", {


### PR DESCRIPTION
## Summary

GKE has dropped support for v1.32 clusters, causing the `build-test-cluster` workflow on `main` to fail when creating the ephemeral test cluster:

```
gcp:container:Cluster (ephemeral-ci-cluster):
  error: sdk-v2/provider2.go:572: sdk.helper_schema: googleapi: Error 400: No valid versions with the prefix "1.32" found.
```

Bump the pinned engine version in `tests/ci-cluster/gke.ts` from `1.32` to `1.33` to unblock the workflow. Mirrors the prior fix in #3504 (1.28 → 1.32) the last time GKE retired our pinned minor.

Part of #4325

## Test plan

- [x] `build-test-cluster` workflow succeeds at creating `ephemeral-ci-cluster` on this branch. Triggered via `workflow_dispatch`: https://github.com/pulumi/pulumi-kubernetes/actions/runs/25661914866

🤖 Generated with [Claude Code](https://claude.com/claude-code)
