### PR TITLE
Implement List for Kubernetes resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Added
 
 - [#2744](https://github.com/pulumi/pulumi-kubernetes/issues/2744) Advertise a `helm` mapping for `terraform` conversion so `pulumi import --from terraform` and `pulumi convert --from terraform` recognize `helm_release` and emit `kubernetes:helm.sh/v3:Release`.
+- [#4332](https://github.com/pulumi/pulumi-kubernetes/issues/4332) Implement the `List` provider RPC and advertise `listInputs` (`namespace`, `name`, `labelSelector`, `fieldSelector`) on every non-nested resource. `namespace` is omitted from `listInputs` on cluster-scoped kinds.
 
 ### Fixed
 

--- a/provider/pkg/gen/schema.go
+++ b/provider/pkg/gen/schema.go
@@ -516,7 +516,11 @@ func PulumiSchema(swagger map[string]any, opts ...schemaGeneratorOption) pschema
 					ObjectTypeSpec:     objectSpec,
 					DeprecationMessage: kind.DeprecationComment(),
 					InputProperties:    map[string]pschema.PropertySpec{},
-					ListInputs:         listInputsSpec(kind.kind),
+				}
+				// *List envelope kinds (PodList, DeploymentList, ...) are not addressable REST
+				// resources; only their base kind can be listed.
+				if !kind.isList {
+					resourceSpec.ListInputs = listInputsSpec(kind.kind)
 				}
 
 				for _, p := range kind.RequiredInputProperties() {

--- a/provider/pkg/gen/schema.go
+++ b/provider/pkg/gen/schema.go
@@ -23,9 +23,24 @@ import (
 	"strings"
 
 	"github.com/pulumi/pulumi-kubernetes/provider/v4/pkg/gen/examples"
+	"github.com/pulumi/pulumi-kubernetes/provider/v4/pkg/kinds"
 	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
+
+// listInputsSpec builds the ObjectTypeSpec advertising List support for a Kubernetes
+// resource kind. The namespace property is omitted for known cluster-scoped kinds.
+func listInputsSpec(kind string) *pschema.ObjectTypeSpec {
+	props := map[string]pschema.PropertySpec{
+		"name":          {TypeSpec: pschema.TypeSpec{Type: "string"}},
+		"labelSelector": {TypeSpec: pschema.TypeSpec{Type: "string"}},
+		"fieldSelector": {TypeSpec: pschema.TypeSpec{Type: "string"}},
+	}
+	if known, namespaced := kinds.Kind(kind).Namespaced(); !known || namespaced {
+		props["namespace"] = pschema.PropertySpec{TypeSpec: pschema.TypeSpec{Type: "string"}}
+	}
+	return &pschema.ObjectTypeSpec{Type: "object", Properties: props}
+}
 
 type schemaGenerator struct {
 	// typeOverlays augment the types defined by the kubernetes schema.
@@ -501,6 +516,7 @@ func PulumiSchema(swagger map[string]any, opts ...schemaGeneratorOption) pschema
 					ObjectTypeSpec:     objectSpec,
 					DeprecationMessage: kind.DeprecationComment(),
 					InputProperties:    map[string]pschema.PropertySpec{},
+					ListInputs:         listInputsSpec(kind.kind),
 				}
 
 				for _, p := range kind.RequiredInputProperties() {

--- a/provider/pkg/gen/schema_test.go
+++ b/provider/pkg/gen/schema_test.go
@@ -1,0 +1,52 @@
+// Copyright 2016-2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gen
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListInputsSpec(t *testing.T) {
+	cases := []struct {
+		name             string
+		kind             string
+		expectNamespace  bool
+	}{
+		{"namespaced kind includes namespace", "ConfigMap", true},
+		{"namespaced kind (apps/v1) includes namespace", "Deployment", true},
+		{"cluster-scoped kind omits namespace", "Namespace", false},
+		{"cluster-scoped Node omits namespace", "Node", false},
+		{"cluster-scoped ClusterRole omits namespace", "ClusterRole", false},
+		{"unknown kind keeps namespace conservatively", "SomeCustomResource", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			spec := listInputsSpec(tc.kind)
+			require.NotNil(t, spec)
+			assert.Equal(t, "object", spec.Type)
+			assert.Contains(t, spec.Properties, "name")
+			assert.Contains(t, spec.Properties, "labelSelector")
+			assert.Contains(t, spec.Properties, "fieldSelector")
+			if tc.expectNamespace {
+				assert.Contains(t, spec.Properties, "namespace", "namespaced kinds must advertise the namespace filter")
+			} else {
+				assert.NotContains(t, spec.Properties, "namespace", "cluster-scoped kinds must omit the namespace filter")
+			}
+		})
+	}
+}

--- a/provider/pkg/gen/schema_test.go
+++ b/provider/pkg/gen/schema_test.go
@@ -23,9 +23,9 @@ import (
 
 func TestListInputsSpec(t *testing.T) {
 	cases := []struct {
-		name             string
-		kind             string
-		expectNamespace  bool
+		name            string
+		kind            string
+		expectNamespace bool
 	}{
 		{"namespaced kind includes namespace", "ConfigMap", true},
 		{"namespaced kind (apps/v1) includes namespace", "Deployment", true},

--- a/provider/pkg/gen/typegen.go
+++ b/provider/pkg/gen/typegen.go
@@ -341,7 +341,7 @@ const (
 func makeSchemaTypeSpec(prop map[string]any, canonicalGroups map[string]string) pschema.TypeSpec {
 	if t, exists := prop["type"]; exists {
 		switch t := t.(string); t {
-		case "array":
+		case "array": //nolint:goconst // OpenAPI type keyword, not a free-form string constant
 			elemSpec := makeSchemaTypeSpec(prop["items"].(map[string]any), canonicalGroups)
 			return pschema.TypeSpec{
 				Type:  "array",

--- a/provider/pkg/provider/list_pagination.go
+++ b/provider/pkg/provider/list_pagination.go
@@ -1,0 +1,94 @@
+// Copyright 2016-2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+)
+
+// continuationState carries provider-side pagination state across paginated List calls.
+type continuationState struct {
+	K8sContinue string `json:"k8sContinue,omitempty"` // K8s's own pagination cursor
+	Remaining   *int64 `json:"remaining,omitempty"`   // items still allowed under the request's limit; nil = no cap, *0 = cap exhausted
+}
+
+// isZero reports whether the pagination state carries nothing worth emitting.
+func (c continuationState) isZero() bool {
+	if c.K8sContinue == "" {
+		return true
+	}
+	if c.Remaining != nil && *c.Remaining == 0 {
+		return true
+	}
+	return false
+}
+
+// effectiveLimit returns the value to set on metav1.ListOptions.Limit for a single
+// paginated K8s call, given the request's page_size and the remaining items allowed
+// under the session cap. A return of 0 means "no cap" — K8s returns all matching items.
+//
+// Programming errors panic: pageSize must be non-negative (caller validates the
+// request), and *remaining must not be zero or negative (caller must stop before
+// invoking this when the cap is exhausted).
+func effectiveLimit(pageSize int64, remaining *int64) int64 {
+	if pageSize < 0 {
+		panic("effectiveLimit: pageSize is negative — caller should have validated the request")
+	}
+	if remaining != nil && *remaining <= 0 {
+		panic("effectiveLimit: remaining points to a non-positive value — caller should have stopped before invoking this")
+	}
+	if remaining == nil {
+		return pageSize
+	}
+	if pageSize == 0 {
+		return *remaining
+	}
+	return min(pageSize, *remaining)
+}
+
+// encodeContinuation serializes the pagination state to an opaque token suitable for
+// emission as a ListResponse continuation_token. Zero state encodes to an empty string
+// so callers can use the empty value to mean "do not emit a continuation message."
+func encodeContinuation(c continuationState) (string, error) {
+	if c.isZero() {
+		return "", nil
+	}
+	b, err := json.Marshal(c)
+	if err != nil {
+		return "", fmt.Errorf("encode continuation: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+// decodeContinuation parses a token produced by encodeContinuation back into pagination state.
+// An empty token yields zero state with no error (first call in a session). A malformed
+// token returns an error so the caller can surface InvalidArgument rather than silently
+// recovering, since stale or hand-rolled tokens indicate protocol misuse.
+func decodeContinuation(token string) (continuationState, error) {
+	if token == "" {
+		return continuationState{}, nil
+	}
+	b, err := base64.RawURLEncoding.DecodeString(token)
+	if err != nil {
+		return continuationState{}, fmt.Errorf("decode continuation: %w", err)
+	}
+	var decoded continuationState
+	if err := json.Unmarshal(b, &decoded); err != nil {
+		return continuationState{}, fmt.Errorf("decode continuation: %w", err)
+	}
+	return decoded, nil
+}

--- a/provider/pkg/provider/list_pagination.go
+++ b/provider/pkg/provider/list_pagination.go
@@ -22,8 +22,11 @@ import (
 
 // continuationState carries provider-side pagination state across paginated List calls.
 type continuationState struct {
-	K8sContinue string `json:"k8sContinue,omitempty"` // K8s's own pagination cursor
-	Remaining   *int64 `json:"remaining,omitempty"`   // items still allowed under the request's limit; nil = no cap, *0 = cap exhausted
+	// K8sContinue is K8s's own pagination cursor.
+	K8sContinue string `json:"k8sContinue,omitempty"`
+	// Remaining tracks items still allowed under the request's limit.
+	// nil = no cap; *0 = cap exhausted; *N>0 = N items allowed.
+	Remaining *int64 `json:"remaining,omitempty"`
 }
 
 // isZero reports whether the pagination state carries nothing worth emitting.

--- a/provider/pkg/provider/list_pagination_test.go
+++ b/provider/pkg/provider/list_pagination_test.go
@@ -80,11 +80,26 @@ func TestIsZero(t *testing.T) {
 		want bool
 	}{
 		{"empty struct", continuationState{}, true},
-		{"more K8s pages available, no session cap", continuationState{K8sContinue: "abc"}, false},
-		{"more K8s pages, session budget unspent", continuationState{K8sContinue: "abc", Remaining: ptr.To(int64(25))}, false},
-		{"session cap exhausted", continuationState{K8sContinue: "abc", Remaining: ptr.To(int64(0))}, true},
-		{"no more K8s pages, session budget unspent", continuationState{Remaining: ptr.To(int64(5))}, true},
-		{"no more K8s pages and cap exhausted", continuationState{Remaining: ptr.To(int64(0))}, true},
+		{
+			"more K8s pages available, no session cap",
+			continuationState{K8sContinue: "abc"}, false,
+		},
+		{
+			"more K8s pages, session budget unspent",
+			continuationState{K8sContinue: "abc", Remaining: ptr.To(int64(25))}, false,
+		},
+		{
+			"session cap exhausted",
+			continuationState{K8sContinue: "abc", Remaining: ptr.To(int64(0))}, true,
+		},
+		{
+			"no more K8s pages, session budget unspent",
+			continuationState{Remaining: ptr.To(int64(5))}, true,
+		},
+		{
+			"no more K8s pages and cap exhausted",
+			continuationState{Remaining: ptr.To(int64(0))}, true,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -100,7 +115,10 @@ func TestContinuationRoundTrip(t *testing.T) {
 	}{
 		{"k8s cursor only — no cap", continuationState{K8sContinue: "abc-cursor"}},
 		{"k8s cursor + remaining set", continuationState{K8sContinue: "cursor-xyz", Remaining: ptr.To(int64(100))}},
-		{"k8s cursor with chars outside url-safe base64", continuationState{K8sContinue: "abc/def+xyz=", Remaining: ptr.To(int64(5))}},
+		{
+			"k8s cursor with chars outside url-safe base64",
+			continuationState{K8sContinue: "abc/def+xyz=", Remaining: ptr.To(int64(5))},
+		},
 		{"large remaining", continuationState{K8sContinue: "x", Remaining: ptr.To(int64(1_000_000))}},
 	}
 	for _, tc := range cases {

--- a/provider/pkg/provider/list_pagination_test.go
+++ b/provider/pkg/provider/list_pagination_test.go
@@ -1,0 +1,177 @@
+// Copyright 2016-2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/utils/ptr"
+)
+
+func TestEffectiveLimit(t *testing.T) {
+	cases := []struct {
+		name      string
+		pageSize  int64
+		remaining *int64
+		want      int64
+	}{
+		{"no caps anywhere — K8s returns everything", 0, nil, 0},
+		{"only page size — no session cap", 25, nil, 25},
+		{"only remaining — caller did not set page size", 0, ptr.To(int64(50)), 50},
+		{"page smaller than remaining — page caps the call", 25, ptr.To(int64(50)), 25},
+		{"remaining smaller than page — final partial page", 25, ptr.To(int64(10)), 10},
+		{"equal", 25, ptr.To(int64(25)), 25},
+		{"remaining = 1, about to finish", 25, ptr.To(int64(1)), 1},
+		{"page = 1, remaining = 100", 1, ptr.To(int64(100)), 1},
+		{"both 1", 1, ptr.To(int64(1)), 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := effectiveLimit(tc.pageSize, tc.remaining)
+			assert.Equal(t, tc.want, got)
+			assert.GreaterOrEqual(t, got, int64(0), "result must never be negative")
+			if tc.pageSize > 0 {
+				assert.LessOrEqual(t, got, tc.pageSize, "result must not exceed page_size when set")
+			}
+			if tc.remaining != nil {
+				assert.LessOrEqual(t, got, *tc.remaining, "result must not exceed remaining when set")
+			}
+		})
+	}
+}
+
+func TestEffectiveLimit_PanicsOnExhaustedRemaining(t *testing.T) {
+	assert.Panics(t, func() {
+		effectiveLimit(10, ptr.To(int64(0)))
+	}, "remaining=*0 (cap exhausted) is a programming error; caller should have stopped")
+}
+
+func TestEffectiveLimit_PanicsOnNegativeRemaining(t *testing.T) {
+	assert.Panics(t, func() {
+		effectiveLimit(10, ptr.To(int64(-1)))
+	}, "negative remaining is invalid")
+}
+
+func TestEffectiveLimit_PanicsOnNegativePageSize(t *testing.T) {
+	assert.Panics(t, func() {
+		effectiveLimit(-1, nil)
+	}, "negative pageSize is invalid — caller should have rejected the request upstream")
+}
+
+func TestIsZero(t *testing.T) {
+	cases := []struct {
+		name string
+		cont continuationState
+		want bool
+	}{
+		{"empty struct", continuationState{}, true},
+		{"more K8s pages available, no session cap", continuationState{K8sContinue: "abc"}, false},
+		{"more K8s pages, session budget unspent", continuationState{K8sContinue: "abc", Remaining: ptr.To(int64(25))}, false},
+		{"session cap exhausted", continuationState{K8sContinue: "abc", Remaining: ptr.To(int64(0))}, true},
+		{"no more K8s pages, session budget unspent", continuationState{Remaining: ptr.To(int64(5))}, true},
+		{"no more K8s pages and cap exhausted", continuationState{Remaining: ptr.To(int64(0))}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.cont.isZero())
+		})
+	}
+}
+
+func TestContinuationRoundTrip(t *testing.T) {
+	cases := []struct {
+		name string
+		in   continuationState
+	}{
+		{"k8s cursor only — no cap", continuationState{K8sContinue: "abc-cursor"}},
+		{"k8s cursor + remaining set", continuationState{K8sContinue: "cursor-xyz", Remaining: ptr.To(int64(100))}},
+		{"k8s cursor with chars outside url-safe base64", continuationState{K8sContinue: "abc/def+xyz=", Remaining: ptr.To(int64(5))}},
+		{"large remaining", continuationState{K8sContinue: "x", Remaining: ptr.To(int64(1_000_000))}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tok, err := encodeContinuation(tc.in)
+			require.NoError(t, err)
+			require.NotEmpty(t, tok, "non-zero state must produce a non-empty token")
+			out, err := decodeContinuation(tok)
+			require.NoError(t, err)
+			assert.Equal(t, tc.in.K8sContinue, out.K8sContinue)
+			if tc.in.Remaining == nil {
+				assert.Nil(t, out.Remaining, "nil remaining must round-trip as nil (no cap)")
+			} else {
+				require.NotNil(t, out.Remaining)
+				assert.Equal(t, *tc.in.Remaining, *out.Remaining)
+			}
+		})
+	}
+}
+
+func TestEncodeContinuation_ZeroStateIsEmpty(t *testing.T) {
+	tok, err := encodeContinuation(continuationState{})
+	require.NoError(t, err)
+	assert.Empty(t, tok, "zero state must encode to empty string so no continuation message is emitted")
+}
+
+func TestEncodeContinuation_CapExhaustedIsEmpty(t *testing.T) {
+	tok, err := encodeContinuation(continuationState{K8sContinue: "abc", Remaining: ptr.To(int64(0))})
+	require.NoError(t, err)
+	assert.Empty(t, tok, "cap-exhausted state must encode to empty string even when K8s has more pages")
+}
+
+func TestEncodeContinuation_K8sDoneIsEmpty(t *testing.T) {
+	tok, err := encodeContinuation(continuationState{Remaining: ptr.To(int64(50))})
+	require.NoError(t, err)
+	assert.Empty(t, tok, "no K8s cursor means K8s is done — nothing to resume")
+}
+
+func TestDecodeContinuation_EmptyIsZero(t *testing.T) {
+	state, err := decodeContinuation("")
+	require.NoError(t, err)
+	assert.Equal(t, continuationState{}, state, "empty token must decode to zero state — used on first call")
+}
+
+func TestDecodeContinuation_RemainingZeroRoundtrips(t *testing.T) {
+	// A continuation token carrying Remaining=0 should not normally be emitted, but if
+	// callers ever decode such a token (e.g. hand-rolled in a test), the pointer must
+	// not be confused with nil.
+	encoded := base64.RawURLEncoding.EncodeToString([]byte(`{"k8sContinue":"abc","remaining":0}`))
+	state, err := decodeContinuation(encoded)
+	require.NoError(t, err)
+	require.NotNil(t, state.Remaining)
+	assert.Equal(t, int64(0), *state.Remaining)
+}
+
+func TestDecodeContinuation_MalformedRejected(t *testing.T) {
+	notJSON := base64.RawURLEncoding.EncodeToString([]byte("not-json"))
+	wrongShape := base64.RawURLEncoding.EncodeToString([]byte(`["array","not","object"]`))
+
+	cases := []struct {
+		name  string
+		token string
+	}{
+		{"not base64", "not-base64-!@#$"},
+		{"valid base64, not JSON", notJSON},
+		{"valid base64, wrong JSON shape", wrongShape},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := decodeContinuation(tc.token)
+			assert.Error(t, err, "malformed token must surface an error so callers can return InvalidArgument")
+		})
+	}
+}

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -100,6 +100,7 @@ const (
 	secretKind           = "Secret"
 	clusterIdentifierKey = "clusterIdentifier"
 	trueStr              = "true"
+	coreGroup            = "core"
 )
 
 type cancellationContext struct {
@@ -2187,7 +2188,8 @@ func (k *kubeProvider) List(
 	if mapping.Scope.Name() == meta.RESTScopeNameNamespace {
 		resourceClient = k.clientSet.GenericClient.Resource(mapping.Resource).Namespace(query.namespace)
 	} else if query.namespace != "" {
-		return status.Errorf(codes.InvalidArgument, "query.namespace is invalid for cluster-scoped resource %q", req.GetToken())
+		return status.Errorf(codes.InvalidArgument,
+			"query.namespace is invalid for cluster-scoped resource %q", req.GetToken())
 	} else {
 		resourceClient = k.clientSet.GenericClient.Resource(mapping.Resource)
 	}
@@ -2652,7 +2654,7 @@ func (k *kubeProvider) gvkFromUnstructured(input *unstructured.Unstructured) sch
 	} else {
 		group, version = gv[0], gv[1]
 	}
-	if group == "core" {
+	if group == coreGroup {
 		group = ""
 	}
 
@@ -2677,7 +2679,7 @@ func (k *kubeProvider) gvkFromURN(urn resource.URN) (schema.GroupVersionKind, er
 			fmt.Errorf("apiVersion does not have both a group and a version: %q", urn.Type().Module().Name())
 	}
 	group, version := gv[0], gv[1]
-	if group == "core" {
+	if group == coreGroup {
 		group = ""
 	}
 
@@ -2706,7 +2708,7 @@ func (k *kubeProvider) gvkFromTypeToken(typeToken string) (schema.GroupVersionKi
 	}
 
 	group := gv[0]
-	if group == "core" {
+	if group == coreGroup {
 		group = ""
 	}
 

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -2167,6 +2167,28 @@ func (k *kubeProvider) List(
 		return status.Errorf(codes.InvalidArgument, "invalid query: %v", err)
 	}
 
+	// Decode the incoming continuation token. Empty token = first call.
+	contState, err := decodeContinuation(req.GetContinuationToken())
+	if err != nil {
+		return status.Errorf(codes.InvalidArgument, "invalid continuation_token: %v", err)
+	}
+	if contState.Remaining != nil && *contState.Remaining <= 0 {
+		return status.Errorf(codes.InvalidArgument,
+			"continuation_token carries invalid remaining: %d", *contState.Remaining)
+	}
+
+	// Determine the remaining budget for this call. A non-nil contState.Remaining means
+	// we are continuing a paginated session that is tracking a session-wide cap; use that
+	// value verbatim. Otherwise — first call, or no-cap continuation — initialize from the
+	// request's limit if positive; leave nil to mean "no cap."
+	var remaining *int64
+	if contState.Remaining != nil {
+		remaining = contState.Remaining
+	} else if req.GetLimit() > 0 {
+		sessionLimit := req.GetLimit()
+		remaining = &sessionLimit
+	}
+
 	gvk, err := k.gvkFromTypeToken(req.GetToken())
 	if err != nil {
 		return status.Errorf(codes.InvalidArgument, "invalid token %q: %v", req.GetToken(), err)
@@ -2197,7 +2219,8 @@ func (k *kubeProvider) List(
 	listOpts := metav1.ListOptions{
 		LabelSelector: query.labelSelector,
 		FieldSelector: query.fieldSelector,
-		Continue:      req.GetContinuationToken(),
+		Continue:      contState.K8sContinue,
+		Limit:         effectiveLimit(req.GetPageSize(), remaining),
 	}
 	if query.name != "" {
 		nameSelector := "metadata.name=" + query.name
@@ -2208,19 +2231,12 @@ func (k *kubeProvider) List(
 		}
 	}
 
-	limit := req.GetPageSize()
-	if req.GetLimit() > 0 && (limit == 0 || req.GetLimit() < limit) {
-		limit = req.GetLimit()
-	}
-	if limit > 0 {
-		listOpts.Limit = limit
-	}
-
 	resources, err := resourceClient.List(stream.Context(), listOpts)
 	if err != nil {
 		return err
 	}
 
+	var sent int64
 	for i := range resources.Items {
 		item := resources.Items[i]
 		if err := stream.Send(&pulumirpc.ListResponse{
@@ -2233,13 +2249,27 @@ func (k *kubeProvider) List(
 		}); err != nil {
 			return err
 		}
+		sent++
 	}
 
-	if resources.GetContinue() != "" {
+	// Build the outgoing continuation state and decide whether to emit a token.
+	nextState := continuationState{K8sContinue: resources.GetContinue()}
+	if remaining != nil {
+		newRem := *remaining - sent
+		if newRem < 0 {
+			newRem = 0
+		}
+		nextState.Remaining = &newRem
+	}
+	token, err := encodeContinuation(nextState)
+	if err != nil {
+		return fmt.Errorf("encode continuation: %w", err)
+	}
+	if token != "" {
 		if err := stream.Send(&pulumirpc.ListResponse{
 			Response: &pulumirpc.ListResponse_Continuation_{
 				Continuation: &pulumirpc.ListResponse_Continuation{
-					ContinuationToken: resources.GetContinue(),
+					ContinuationToken: token,
 				},
 			},
 		}); err != nil {

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -34,6 +34,7 @@ import (
 	jsonpatch "github.com/evanphx/json-patch"
 	pbempty "github.com/golang/protobuf/ptypes/empty"
 	structpb "github.com/golang/protobuf/ptypes/struct"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	helmcli "helm.sh/helm/v3/pkg/cli"
@@ -44,6 +45,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientapi "k8s.io/client-go/tools/clientcmd/api"
@@ -115,6 +117,13 @@ func makeCancellationContext() *cancellationContext {
 
 type kubeOpts struct {
 	rejectUnknownResources bool
+}
+
+type listQuery struct {
+	namespace     string
+	name          string
+	labelSelector string
+	fieldSelector string
 }
 
 type kubeProvider struct {
@@ -2128,6 +2137,117 @@ func (k *kubeProvider) Read(ctx context.Context, req *pulumirpc.ReadRequest) (*p
 	return &pulumirpc.ReadResponse{Id: id, Properties: state, Inputs: inputs}, nil
 }
 
+// List lists resources of a given token and streams resource identifiers.
+func (k *kubeProvider) List(
+	req *pulumirpc.ListRequest,
+	stream grpc.ServerStreamingServer[pulumirpc.ListResponse],
+) error {
+	if req == nil {
+		return status.Error(codes.InvalidArgument, "list request must not be nil")
+	}
+	if req.GetToken() == "" {
+		return status.Error(codes.InvalidArgument, "token must not be empty")
+	}
+	if req.GetLimit() < 0 {
+		return status.Error(codes.InvalidArgument, "limit must be >= 0")
+	}
+	if req.GetPageSize() < 0 {
+		return status.Error(codes.InvalidArgument, "page_size must be >= 0")
+	}
+	if k.clusterUnreachable {
+		return fmt.Errorf("configured Kubernetes cluster is unreachable: %s", k.clusterUnreachableReason)
+	}
+	if k.clientSet == nil || k.clientSet.GenericClient == nil || k.clientSet.RESTMapper == nil {
+		return status.Error(codes.FailedPrecondition, "provider is not configured")
+	}
+
+	query, err := parseListQuery(req.GetQuery())
+	if err != nil {
+		return status.Errorf(codes.InvalidArgument, "invalid query: %v", err)
+	}
+
+	gvk, err := k.gvkFromTypeToken(req.GetToken())
+	if err != nil {
+		return status.Errorf(codes.InvalidArgument, "invalid token %q: %v", req.GetToken(), err)
+	}
+	// Patch resources map to the same API resource as their underlying type.
+	gvk.Kind = strings.TrimSuffix(gvk.Kind, "Patch")
+
+	mapping, err := k.clientSet.RESTMapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	if err != nil {
+		// Mapping can fail when discovery cache is stale (for example, after CRDs are added).
+		k.clientSet.RESTMapper.Reset()
+		mapping, err = k.clientSet.RESTMapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+		if err != nil {
+			return err
+		}
+	}
+
+	var resourceClient dynamic.ResourceInterface
+	if mapping.Scope.Name() == meta.RESTScopeNameNamespace {
+		resourceClient = k.clientSet.GenericClient.Resource(mapping.Resource).Namespace(query.namespace)
+	} else if query.namespace != "" {
+		return status.Errorf(codes.InvalidArgument, "query.namespace is invalid for cluster-scoped resource %q", req.GetToken())
+	} else {
+		resourceClient = k.clientSet.GenericClient.Resource(mapping.Resource)
+	}
+
+	listOpts := metav1.ListOptions{
+		LabelSelector: query.labelSelector,
+		FieldSelector: query.fieldSelector,
+		Continue:      req.GetContinuationToken(),
+	}
+	if query.name != "" {
+		nameSelector := "metadata.name=" + query.name
+		if listOpts.FieldSelector == "" {
+			listOpts.FieldSelector = nameSelector
+		} else {
+			listOpts.FieldSelector += "," + nameSelector
+		}
+	}
+
+	limit := req.GetPageSize()
+	if req.GetLimit() > 0 && (limit == 0 || req.GetLimit() < limit) {
+		limit = req.GetLimit()
+	}
+	if limit > 0 {
+		listOpts.Limit = limit
+	}
+
+	resources, err := resourceClient.List(stream.Context(), listOpts)
+	if err != nil {
+		return err
+	}
+
+	for i := range resources.Items {
+		item := resources.Items[i]
+		if err := stream.Send(&pulumirpc.ListResponse{
+			Response: &pulumirpc.ListResponse_Result_{
+				Result: &pulumirpc.ListResponse_Result{
+					Id:   fqObjName(&item),
+					Name: item.GetName(),
+				},
+			},
+		}); err != nil {
+			return err
+		}
+	}
+
+	if resources.GetContinue() != "" {
+		if err := stream.Send(&pulumirpc.ListResponse{
+			Response: &pulumirpc.ListResponse_Continuation_{
+				Continuation: &pulumirpc.ListResponse_Continuation{
+					ContinuationToken: resources.GetContinue(),
+				},
+			},
+		}); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // Update updates an existing resource with new values. This client uses a Server-side Apply (SSA) patch by default, but
 // also supports the older three-way JSON patch and the strategic merge patch as fallback options.
 // See references [1], [2], [3].
@@ -2565,6 +2685,108 @@ func (k *kubeProvider) gvkFromURN(urn resource.URN) (schema.GroupVersionKind, er
 		Group:   group,
 		Version: version,
 		Kind:    kind,
+	}, nil
+}
+
+func (k *kubeProvider) gvkFromTypeToken(typeToken string) (schema.GroupVersionKind, error) {
+	parts := strings.Split(typeToken, ":")
+	if len(parts) != 3 {
+		return schema.GroupVersionKind{}, fmt.Errorf("type token must be in the format <package>:<group/version>:<kind>")
+	}
+	if parts[0] != k.providerPackage {
+		return schema.GroupVersionKind{}, fmt.Errorf("unrecognized resource type: %q for this provider", typeToken)
+	}
+	if parts[2] == "" {
+		return schema.GroupVersionKind{}, fmt.Errorf("token kind is empty")
+	}
+
+	gv := strings.Split(parts[1], "/")
+	if len(gv) != 2 {
+		return schema.GroupVersionKind{}, fmt.Errorf("apiVersion does not have both a group and a version: %q", parts[1])
+	}
+
+	group := gv[0]
+	if group == "core" {
+		group = ""
+	}
+
+	return schema.GroupVersionKind{
+		Group:   group,
+		Version: gv[1],
+		Kind:    parts[2],
+	}, nil
+}
+
+func parseListQuery(query *structpb.Struct) (listQuery, error) {
+	if query == nil {
+		return listQuery{}, nil
+	}
+
+	fields := query.AsMap()
+	getString := func(key string) (string, error) {
+		value, ok := fields[key]
+		if !ok {
+			return "", nil
+		}
+		s, ok := value.(string)
+		if !ok {
+			return "", fmt.Errorf("query.%s must be a string", key)
+		}
+		return s, nil
+	}
+
+	metadataNamespace := ""
+	metadataName := ""
+	if metadataField, ok := fields["metadata"]; ok {
+		metadata, ok := metadataField.(map[string]any)
+		if !ok {
+			return listQuery{}, fmt.Errorf("query.metadata must be an object")
+		}
+		if value, ok := metadata["namespace"]; ok {
+			s, ok := value.(string)
+			if !ok {
+				return listQuery{}, fmt.Errorf("query.metadata.namespace must be a string")
+			}
+			metadataNamespace = s
+		}
+		if value, ok := metadata["name"]; ok {
+			s, ok := value.(string)
+			if !ok {
+				return listQuery{}, fmt.Errorf("query.metadata.name must be a string")
+			}
+			metadataName = s
+		}
+	}
+
+	namespace, err := getString("namespace")
+	if err != nil {
+		return listQuery{}, err
+	}
+	name, err := getString("name")
+	if err != nil {
+		return listQuery{}, err
+	}
+	labelSelector, err := getString("labelSelector")
+	if err != nil {
+		return listQuery{}, err
+	}
+	fieldSelector, err := getString("fieldSelector")
+	if err != nil {
+		return listQuery{}, err
+	}
+
+	if namespace == "" {
+		namespace = metadataNamespace
+	}
+	if name == "" {
+		name = metadataName
+	}
+
+	return listQuery{
+		namespace:     namespace,
+		name:          name,
+		labelSelector: labelSelector,
+		fieldSelector: fieldSelector,
 	}, nil
 }
 

--- a/provider/pkg/provider/provider_list_test.go
+++ b/provider/pkg/provider/provider_list_test.go
@@ -31,7 +31,10 @@ import (
 	structpb "google.golang.org/protobuf/types/known/structpb"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
@@ -394,4 +397,204 @@ func TestList_OverGRPC(t *testing.T) {
 	ids, contToken := drainList(t, stream)
 	assert.ElementsMatch(t, []string{"ns-1/cm-1", "ns-2/cm-2"}, ids)
 	assert.Empty(t, contToken, "two results fit in one page; no continuation token expected")
+}
+
+// paginatingFake wraps dynamic.Interface and intercepts List on a per-GVR item pool
+// to honor opts.Limit and opts.Continue. All other operations delegate to the embedded interface.
+type paginatingFake struct {
+	dynamic.Interface
+	pools map[schema.GroupVersionResource][]unstructured.Unstructured
+}
+
+func (f *paginatingFake) Resource(gvr schema.GroupVersionResource) dynamic.NamespaceableResourceInterface {
+	return &paginatingNamespaceable{
+		NamespaceableResourceInterface: f.Interface.Resource(gvr),
+		pool:                           f.pools[gvr],
+	}
+}
+
+type paginatingNamespaceable struct {
+	dynamic.NamespaceableResourceInterface
+	pool []unstructured.Unstructured
+}
+
+func (n *paginatingNamespaceable) Namespace(ns string) dynamic.ResourceInterface {
+	return &paginatingResource{
+		ResourceInterface: n.NamespaceableResourceInterface.Namespace(ns),
+		pool:              n.pool,
+	}
+}
+
+func (n *paginatingNamespaceable) List(_ context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	return paginatePool(n.pool, opts), nil
+}
+
+type paginatingResource struct {
+	dynamic.ResourceInterface
+	pool []unstructured.Unstructured
+}
+
+func (r *paginatingResource) List(_ context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	return paginatePool(r.pool, opts), nil
+}
+
+// paginatePool faithfully implements server-side pagination: slice the pool by
+// opts.Continue (encoded as "page-N", where N is the absolute starting offset),
+// cap to opts.Limit items per call, and emit a continue token when more remain.
+func paginatePool(pool []unstructured.Unstructured, opts metav1.ListOptions) *unstructured.UnstructuredList {
+	start := 0
+	if opts.Continue != "" {
+		_, _ = fmt.Sscanf(opts.Continue, "page-%d", &start)
+	}
+	end := len(pool)
+	if opts.Limit > 0 {
+		candidate := start + int(opts.Limit)
+		if candidate < end {
+			end = candidate
+		}
+	}
+	list := &unstructured.UnstructuredList{}
+	list.SetAPIVersion("v1")
+	list.SetKind("ConfigMapList")
+	if start < end {
+		list.Items = append([]unstructured.Unstructured{}, pool[start:end]...)
+	}
+	if end < len(pool) {
+		list.SetContinue(fmt.Sprintf("page-%d", end))
+	}
+	return list
+}
+
+// newSessionTestProvider returns a *kubeProvider whose ConfigMap REST calls are
+// served by the paginatingFake over the given pool of items.
+func newSessionTestProvider(t *testing.T, ns string, count int) *kubeProvider {
+	t.Helper()
+	k, err := makeKubeProvider(nil, "kubernetes", "v0.0.0", []byte("{}"), []byte("{}"), []byte("{}"))
+	require.NoError(t, err)
+	cs, _, _, _ := fakeclients.NewSimpleDynamicClient()
+	cs.GenericClient = &paginatingFake{
+		Interface: cs.GenericClient,
+		pools: map[schema.GroupVersionResource][]unstructured.Unstructured{
+			{Group: "", Version: "v1", Resource: "configmaps"}: makeNConfigMaps(ns, count),
+		},
+	}
+	k.clientSet = cs
+	return k
+}
+
+func makeNConfigMaps(ns string, count int) []unstructured.Unstructured {
+	items := make([]unstructured.Unstructured, count)
+	for i := range items {
+		items[i].SetAPIVersion("v1")
+		items[i].SetKind("ConfigMap")
+		items[i].SetNamespace(ns)
+		items[i].SetName(fmt.Sprintf("cm-%03d", i))
+	}
+	return items
+}
+
+// runListSession simulates the engine's pagination loop: call List repeatedly,
+// chaining continuation tokens, until the provider stops emitting them.
+// Returns all IDs received across calls and the total call count.
+func runListSession(t *testing.T, client pulumirpc.ResourceProviderClient, base *pulumirpc.ListRequest) ([]string, int) {
+	t.Helper()
+	var allIDs []string
+	var contToken string
+	callCount := 0
+	for {
+		callCount++
+		require.Less(t, callCount, 50, "infinite-loop guard — provider should signal stop by now")
+
+		req := *base
+		req.ContinuationToken = contToken
+		stream, err := client.List(context.Background(), &req)
+		require.NoError(t, err)
+		ids, nextToken := drainList(t, stream)
+		allIDs = append(allIDs, ids...)
+
+		if nextToken == "" {
+			break
+		}
+		contToken = nextToken
+	}
+	return allIDs, callCount
+}
+
+func assertAllUnique(t *testing.T, ids []string) {
+	t.Helper()
+	seen := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		if seen[id] {
+			t.Errorf("duplicate ID across paginated calls: %s", id)
+		}
+		seen[id] = true
+	}
+}
+
+func TestList_Session_PageEvenlyDividesLimit(t *testing.T) {
+	k := newSessionTestProvider(t, "ns-1", 100)
+	client := startKubeProviderServer(t, k)
+
+	ids, callCount := runListSession(t, client, &pulumirpc.ListRequest{
+		Token:    configMapType,
+		PageSize: 25,
+		Limit:    50,
+	})
+	assert.Equal(t, 2, callCount, "page_size=25 + limit=50 should complete in 2 calls")
+	assert.Len(t, ids, 50, "must respect session cap")
+	assertAllUnique(t, ids)
+}
+
+func TestList_Session_PageDoesNotEvenlyDivideLimit(t *testing.T) {
+	k := newSessionTestProvider(t, "ns-1", 100)
+	client := startKubeProviderServer(t, k)
+
+	ids, callCount := runListSession(t, client, &pulumirpc.ListRequest{
+		Token:    configMapType,
+		PageSize: 20,
+		Limit:    50,
+	})
+	assert.Equal(t, 3, callCount, "page_size=20 + limit=50 should complete in 3 calls (20+20+10)")
+	assert.Len(t, ids, 50, "must respect session cap exactly, not overshoot")
+	assertAllUnique(t, ids)
+}
+
+func TestList_Session_K8sRunsOutBeforeLimit(t *testing.T) {
+	k := newSessionTestProvider(t, "ns-1", 30)
+	client := startKubeProviderServer(t, k)
+
+	ids, callCount := runListSession(t, client, &pulumirpc.ListRequest{
+		Token:    configMapType,
+		PageSize: 10,
+		Limit:    50,
+	})
+	assert.Equal(t, 3, callCount)
+	assert.Len(t, ids, 30, "cluster only has 30 items; cap is unreachable")
+	assertAllUnique(t, ids)
+}
+
+func TestList_Session_NoLimit(t *testing.T) {
+	k := newSessionTestProvider(t, "ns-1", 50)
+	client := startKubeProviderServer(t, k)
+
+	ids, callCount := runListSession(t, client, &pulumirpc.ListRequest{
+		Token:    configMapType,
+		PageSize: 10,
+	})
+	assert.Equal(t, 5, callCount, "with no cap, paginate until K8s runs out")
+	assert.Len(t, ids, 50)
+	assertAllUnique(t, ids)
+}
+
+func TestList_Session_LimitOnly_OneCall(t *testing.T) {
+	k := newSessionTestProvider(t, "ns-1", 100)
+	client := startKubeProviderServer(t, k)
+
+	ids, callCount := runListSession(t, client, &pulumirpc.ListRequest{
+		Token: configMapType,
+		Limit: 50,
+	})
+	assert.Equal(t, 1, callCount, "no page_size means one call, sized to the limit")
+	assert.Len(t, ids, 50)
+	assertAllUnique(t, ids)
 }

--- a/provider/pkg/provider/provider_list_test.go
+++ b/provider/pkg/provider/provider_list_test.go
@@ -349,6 +349,34 @@ func TestGvkFromTypeToken(t *testing.T) {
 	}
 }
 
+// TestList_ClusterUnreachable verifies that List surfaces a descriptive error when the provider
+// recorded the cluster as unreachable during Configure.
+func TestList_ClusterUnreachable(t *testing.T) {
+	k := newListTestProvider(t)
+	k.clusterUnreachable = true
+	k.clusterUnreachableReason = "test-only: cluster down"
+
+	err := k.List(&pulumirpc.ListRequest{Token: configMapType}, &listResponseStream{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "test-only: cluster down")
+}
+
+// TestList_NameAndFieldSelectorCompose verifies that query.name and query.fieldSelector are
+// composed (the name filter is appended to any caller-supplied fieldSelector).
+func TestList_NameAndFieldSelectorCompose(t *testing.T) {
+	k := newListTestProvider(t, configMap("ns-1", "cm-target", nil))
+	q, err := structpb.NewStruct(map[string]any{
+		"namespace":     "ns-1",
+		"name":          "cm-target",
+		"fieldSelector": "status.phase=Active",
+	})
+	require.NoError(t, err)
+	stream := &listResponseStream{}
+	err = k.List(&pulumirpc.ListRequest{Token: configMapType, Query: q}, stream)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ns-1/cm-target"}, collectIDs(stream))
+}
+
 // TestList_OverGRPC exercises List end-to-end through a real gRPC server stream,
 // confirming the proto oneof wrappers and stream.Send/Recv work on the wire.
 func TestList_OverGRPC(t *testing.T) {

--- a/provider/pkg/provider/provider_list_test.go
+++ b/provider/pkg/provider/provider_list_test.go
@@ -33,10 +33,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	fakeclients "github.com/pulumi/pulumi-kubernetes/provider/v4/pkg/clients/fake"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+
+	fakeclients "github.com/pulumi/pulumi-kubernetes/provider/v4/pkg/clients/fake"
 )
+
+// configMapType is the Pulumi resource type token for core/v1 ConfigMap,
+// hoisted out to silence gosec G101 false positives on `Token: "..."` literals.
+const configMapType = "kubernetes:core/v1:ConfigMap"
 
 // listResponseStream is an in-memory ListResponse stream for testing.
 type listResponseStream struct {
@@ -154,8 +159,8 @@ func TestList_RejectsInvalidArgs(t *testing.T) {
 		req  *pulumirpc.ListRequest
 	}{
 		{"empty token", &pulumirpc.ListRequest{}},
-		{"negative limit", &pulumirpc.ListRequest{Token: "kubernetes:core/v1:ConfigMap", Limit: -1}},
-		{"negative page size", &pulumirpc.ListRequest{Token: "kubernetes:core/v1:ConfigMap", PageSize: -1}},
+		{"negative limit", &pulumirpc.ListRequest{Token: configMapType, Limit: -1}},
+		{"negative page size", &pulumirpc.ListRequest{Token: configMapType, PageSize: -1}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -169,7 +174,7 @@ func TestList_RejectsInvalidArgs(t *testing.T) {
 func TestList_NotConfigured(t *testing.T) {
 	k, err := makeKubeProvider(nil, "kubernetes", "v0.0.0", []byte("{}"), []byte("{}"), []byte("{}"))
 	require.NoError(t, err)
-	err = k.List(&pulumirpc.ListRequest{Token: "kubernetes:core/v1:ConfigMap"}, &listResponseStream{})
+	err = k.List(&pulumirpc.ListRequest{Token: configMapType}, &listResponseStream{})
 	require.Error(t, err)
 	assert.Equal(t, codes.FailedPrecondition, status.Code(err))
 }
@@ -187,7 +192,7 @@ func TestList_BasicReturnsAllResources(t *testing.T) {
 		configMap("ns-2", "cm-2", map[string]string{"env": "dev"}),
 	)
 	stream := &listResponseStream{}
-	err := k.List(&pulumirpc.ListRequest{Token: "kubernetes:core/v1:ConfigMap"}, stream)
+	err := k.List(&pulumirpc.ListRequest{Token: configMapType}, stream)
 	require.NoError(t, err)
 	assert.ElementsMatch(t, []string{"ns-1/cm-1", "ns-2/cm-2"}, collectIDs(stream))
 }
@@ -200,7 +205,7 @@ func TestList_NamespaceFilter(t *testing.T) {
 	q, err := structpb.NewStruct(map[string]any{"namespace": "ns-1"})
 	require.NoError(t, err)
 	stream := &listResponseStream{}
-	err = k.List(&pulumirpc.ListRequest{Token: "kubernetes:core/v1:ConfigMap", Query: q}, stream)
+	err = k.List(&pulumirpc.ListRequest{Token: configMapType, Query: q}, stream)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ns-1/cm-1"}, collectIDs(stream))
 }
@@ -213,7 +218,7 @@ func TestList_MetadataNamespaceFallback(t *testing.T) {
 	q, err := structpb.NewStruct(map[string]any{"metadata": map[string]any{"namespace": "ns-2"}})
 	require.NoError(t, err)
 	stream := &listResponseStream{}
-	err = k.List(&pulumirpc.ListRequest{Token: "kubernetes:core/v1:ConfigMap", Query: q}, stream)
+	err = k.List(&pulumirpc.ListRequest{Token: configMapType, Query: q}, stream)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ns-2/cm-2"}, collectIDs(stream))
 }
@@ -226,7 +231,7 @@ func TestList_LabelSelector(t *testing.T) {
 	q, err := structpb.NewStruct(map[string]any{"labelSelector": "env=prod"})
 	require.NoError(t, err)
 	stream := &listResponseStream{}
-	err = k.List(&pulumirpc.ListRequest{Token: "kubernetes:core/v1:ConfigMap", Query: q}, stream)
+	err = k.List(&pulumirpc.ListRequest{Token: configMapType, Query: q}, stream)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ns-1/cm-prod"}, collectIDs(stream))
 }
@@ -354,7 +359,7 @@ func TestList_OverGRPC(t *testing.T) {
 	client := startKubeProviderServer(t, k)
 
 	stream, err := client.List(context.Background(), &pulumirpc.ListRequest{
-		Token: "kubernetes:core/v1:ConfigMap",
+		Token: configMapType,
 	})
 	require.NoError(t, err)
 

--- a/provider/pkg/provider/provider_list_test.go
+++ b/provider/pkg/provider/provider_list_test.go
@@ -1,0 +1,287 @@
+// Copyright 2016-2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+	structpb "google.golang.org/protobuf/types/known/structpb"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	fakeclients "github.com/pulumi/pulumi-kubernetes/provider/v4/pkg/clients/fake"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+)
+
+// listResponseStream is an in-memory ListResponse stream for testing.
+type listResponseStream struct {
+	ctx       context.Context
+	responses []*pulumirpc.ListResponse
+}
+
+func (s *listResponseStream) Send(resp *pulumirpc.ListResponse) error {
+	s.responses = append(s.responses, resp)
+	return nil
+}
+
+func (s *listResponseStream) SetHeader(metadata.MD) error  { return nil }
+func (s *listResponseStream) SendHeader(metadata.MD) error { return nil }
+func (s *listResponseStream) SetTrailer(metadata.MD)       {}
+func (s *listResponseStream) Context() context.Context {
+	if s.ctx != nil {
+		return s.ctx
+	}
+	return context.Background()
+}
+func (s *listResponseStream) SendMsg(any) error { return nil }
+func (s *listResponseStream) RecvMsg(any) error { return nil }
+
+// newListTestProvider returns a *kubeProvider wired to a fake clientset pre-populated with objs.
+func newListTestProvider(t *testing.T, objs ...runtime.Object) *kubeProvider {
+	t.Helper()
+	k, err := makeKubeProvider(nil, "kubernetes", "v0.0.0", []byte("{}"), []byte("{}"), []byte("{}"))
+	require.NoError(t, err)
+	cs, _, _, _ := fakeclients.NewSimpleDynamicClient(fakeclients.WithObjects(objs...))
+	k.clientSet = cs
+	return k
+}
+
+func configMap(ns, name string, labels map[string]string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns, Labels: labels},
+	}
+}
+
+func collectIDs(stream *listResponseStream) []string {
+	var ids []string
+	for _, r := range stream.responses {
+		if res := r.GetResult(); res != nil {
+			ids = append(ids, res.GetId())
+		}
+	}
+	return ids
+}
+
+func TestList_NilRequest(t *testing.T) {
+	k := newListTestProvider(t)
+	err := k.List(nil, &listResponseStream{})
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+func TestList_RejectsInvalidArgs(t *testing.T) {
+	k := newListTestProvider(t)
+	cases := []struct {
+		name string
+		req  *pulumirpc.ListRequest
+	}{
+		{"empty token", &pulumirpc.ListRequest{}},
+		{"negative limit", &pulumirpc.ListRequest{Token: "kubernetes:core/v1:ConfigMap", Limit: -1}},
+		{"negative page size", &pulumirpc.ListRequest{Token: "kubernetes:core/v1:ConfigMap", PageSize: -1}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := k.List(tc.req, &listResponseStream{})
+			require.Error(t, err)
+			assert.Equal(t, codes.InvalidArgument, status.Code(err))
+		})
+	}
+}
+
+func TestList_NotConfigured(t *testing.T) {
+	k, err := makeKubeProvider(nil, "kubernetes", "v0.0.0", []byte("{}"), []byte("{}"), []byte("{}"))
+	require.NoError(t, err)
+	err = k.List(&pulumirpc.ListRequest{Token: "kubernetes:core/v1:ConfigMap"}, &listResponseStream{})
+	require.Error(t, err)
+	assert.Equal(t, codes.FailedPrecondition, status.Code(err))
+}
+
+func TestList_UnknownPackageRejected(t *testing.T) {
+	k := newListTestProvider(t)
+	err := k.List(&pulumirpc.ListRequest{Token: "aws:s3/bucket:Bucket"}, &listResponseStream{})
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+func TestList_BasicReturnsAllResources(t *testing.T) {
+	k := newListTestProvider(t,
+		configMap("ns-1", "cm-1", map[string]string{"env": "prod"}),
+		configMap("ns-2", "cm-2", map[string]string{"env": "dev"}),
+	)
+	stream := &listResponseStream{}
+	err := k.List(&pulumirpc.ListRequest{Token: "kubernetes:core/v1:ConfigMap"}, stream)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"ns-1/cm-1", "ns-2/cm-2"}, collectIDs(stream))
+}
+
+func TestList_NamespaceFilter(t *testing.T) {
+	k := newListTestProvider(t,
+		configMap("ns-1", "cm-1", nil),
+		configMap("ns-2", "cm-2", nil),
+	)
+	q, err := structpb.NewStruct(map[string]any{"namespace": "ns-1"})
+	require.NoError(t, err)
+	stream := &listResponseStream{}
+	err = k.List(&pulumirpc.ListRequest{Token: "kubernetes:core/v1:ConfigMap", Query: q}, stream)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ns-1/cm-1"}, collectIDs(stream))
+}
+
+func TestList_MetadataNamespaceFallback(t *testing.T) {
+	k := newListTestProvider(t,
+		configMap("ns-1", "cm-1", nil),
+		configMap("ns-2", "cm-2", nil),
+	)
+	q, err := structpb.NewStruct(map[string]any{"metadata": map[string]any{"namespace": "ns-2"}})
+	require.NoError(t, err)
+	stream := &listResponseStream{}
+	err = k.List(&pulumirpc.ListRequest{Token: "kubernetes:core/v1:ConfigMap", Query: q}, stream)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ns-2/cm-2"}, collectIDs(stream))
+}
+
+func TestList_LabelSelector(t *testing.T) {
+	k := newListTestProvider(t,
+		configMap("ns-1", "cm-prod", map[string]string{"env": "prod"}),
+		configMap("ns-1", "cm-dev", map[string]string{"env": "dev"}),
+	)
+	q, err := structpb.NewStruct(map[string]any{"labelSelector": "env=prod"})
+	require.NoError(t, err)
+	stream := &listResponseStream{}
+	err = k.List(&pulumirpc.ListRequest{Token: "kubernetes:core/v1:ConfigMap", Query: q}, stream)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ns-1/cm-prod"}, collectIDs(stream))
+}
+
+func TestList_PatchSuffixStripped(t *testing.T) {
+	k := newListTestProvider(t,
+		configMap("ns-1", "cm-1", nil),
+	)
+	stream := &listResponseStream{}
+	err := k.List(&pulumirpc.ListRequest{Token: "kubernetes:core/v1:ConfigMapPatch"}, stream)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ns-1/cm-1"}, collectIDs(stream))
+}
+
+func TestList_ClusterScopedRejectsNamespaceQuery(t *testing.T) {
+	k := newListTestProvider(t,
+		&corev1.Namespace{
+			TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Namespace"},
+			ObjectMeta: metav1.ObjectMeta{Name: "ns-1"},
+		},
+	)
+	q, err := structpb.NewStruct(map[string]any{"namespace": "x"})
+	require.NoError(t, err)
+	err = k.List(&pulumirpc.ListRequest{Token: "kubernetes:core/v1:Namespace", Query: q}, &listResponseStream{})
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+func TestList_ClusterScopedListsWithoutNamespace(t *testing.T) {
+	k := newListTestProvider(t,
+		&corev1.Namespace{
+			TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Namespace"},
+			ObjectMeta: metav1.ObjectMeta{Name: "ns-1"},
+		},
+		&corev1.Namespace{
+			TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Namespace"},
+			ObjectMeta: metav1.ObjectMeta{Name: "ns-2"},
+		},
+	)
+	stream := &listResponseStream{}
+	err := k.List(&pulumirpc.ListRequest{Token: "kubernetes:core/v1:Namespace"}, stream)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"ns-1", "ns-2"}, collectIDs(stream))
+}
+
+func TestParseListQuery_NilReturnsZero(t *testing.T) {
+	q, err := parseListQuery(nil)
+	require.NoError(t, err)
+	assert.Equal(t, listQuery{}, q)
+}
+
+func TestParseListQuery_TopLevelOverridesMetadata(t *testing.T) {
+	s, err := structpb.NewStruct(map[string]any{
+		"namespace": "top",
+		"metadata":  map[string]any{"namespace": "meta"},
+	})
+	require.NoError(t, err)
+	q, err := parseListQuery(s)
+	require.NoError(t, err)
+	assert.Equal(t, "top", q.namespace)
+}
+
+func TestParseListQuery_RejectsWrongTypes(t *testing.T) {
+	cases := []struct {
+		name string
+		in   map[string]any
+	}{
+		{"namespace non-string", map[string]any{"namespace": 1}},
+		{"name non-string", map[string]any{"name": true}},
+		{"labelSelector non-string", map[string]any{"labelSelector": []any{"x"}}},
+		{"fieldSelector non-string", map[string]any{"fieldSelector": 3.14}},
+		{"metadata non-object", map[string]any{"metadata": "x"}},
+		{"metadata.namespace non-string", map[string]any{"metadata": map[string]any{"namespace": 5}}},
+		{"metadata.name non-string", map[string]any{"metadata": map[string]any{"name": false}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s, err := structpb.NewStruct(tc.in)
+			require.NoError(t, err)
+			_, err = parseListQuery(s)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestGvkFromTypeToken(t *testing.T) {
+	k := &kubeProvider{providerPackage: "kubernetes"}
+	cases := []struct {
+		token    string
+		ok       bool
+		group    string
+		version  string
+		kind     string
+	}{
+		{"kubernetes:core/v1:ConfigMap", true, "", "v1", "ConfigMap"},
+		{"kubernetes:apps/v1:Deployment", true, "apps", "v1", "Deployment"},
+		{"kubernetes:core/v1:ConfigMapPatch", true, "", "v1", "ConfigMapPatch"},
+		{"aws:s3/bucket:Bucket", false, "", "", ""},
+		{"kubernetes:core:ConfigMap", false, "", "", ""},
+		{"kubernetes:core/v1:", false, "", "", ""},
+		{"kubernetes::ConfigMap", false, "", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.token, func(t *testing.T) {
+			gvk, err := k.gvkFromTypeToken(tc.token)
+			if !tc.ok {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.group, gvk.Group)
+			assert.Equal(t, tc.version, gvk.Version)
+			assert.Equal(t, tc.kind, gvk.Kind)
+		})
+	}
+}

--- a/provider/pkg/provider/provider_list_test.go
+++ b/provider/pkg/provider/provider_list_test.go
@@ -42,9 +42,15 @@ import (
 	fakeclients "github.com/pulumi/pulumi-kubernetes/provider/v4/pkg/clients/fake"
 )
 
-// configMapType is the Pulumi resource type token for core/v1 ConfigMap,
-// hoisted out to silence gosec G101 false positives on `Token: "..."` literals.
-const configMapType = "kubernetes:core/v1:ConfigMap"
+// Pulumi resource type tokens hoisted out to silence gosec G101 false
+// positives on `Token: "..."` literals (the proto field name "Token" matches
+// the linter's credential-name regex).
+const (
+	configMapType      = "kubernetes:core/v1:ConfigMap"
+	configMapPatchType = "kubernetes:core/v1:ConfigMapPatch"
+	namespaceType      = "kubernetes:core/v1:Namespace"
+	awsBucketType      = "aws:s3/bucket:Bucket"
+)
 
 // listResponseStream is an in-memory ListResponse stream for testing.
 type listResponseStream struct {
@@ -184,7 +190,7 @@ func TestList_NotConfigured(t *testing.T) {
 
 func TestList_UnknownPackageRejected(t *testing.T) {
 	k := newListTestProvider(t)
-	err := k.List(&pulumirpc.ListRequest{Token: "aws:s3/bucket:Bucket"}, &listResponseStream{})
+	err := k.List(&pulumirpc.ListRequest{Token: awsBucketType}, &listResponseStream{})
 	require.Error(t, err)
 	assert.Equal(t, codes.InvalidArgument, status.Code(err))
 }
@@ -244,7 +250,7 @@ func TestList_PatchSuffixStripped(t *testing.T) {
 		configMap("ns-1", "cm-1", nil),
 	)
 	stream := &listResponseStream{}
-	err := k.List(&pulumirpc.ListRequest{Token: "kubernetes:core/v1:ConfigMapPatch"}, stream)
+	err := k.List(&pulumirpc.ListRequest{Token: configMapPatchType}, stream)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"ns-1/cm-1"}, collectIDs(stream))
 }
@@ -258,7 +264,7 @@ func TestList_ClusterScopedRejectsNamespaceQuery(t *testing.T) {
 	)
 	q, err := structpb.NewStruct(map[string]any{"namespace": "x"})
 	require.NoError(t, err)
-	err = k.List(&pulumirpc.ListRequest{Token: "kubernetes:core/v1:Namespace", Query: q}, &listResponseStream{})
+	err = k.List(&pulumirpc.ListRequest{Token: namespaceType, Query: q}, &listResponseStream{})
 	require.Error(t, err)
 	assert.Equal(t, codes.InvalidArgument, status.Code(err))
 }
@@ -275,7 +281,7 @@ func TestList_ClusterScopedListsWithoutNamespace(t *testing.T) {
 		},
 	)
 	stream := &listResponseStream{}
-	err := k.List(&pulumirpc.ListRequest{Token: "kubernetes:core/v1:Namespace"}, stream)
+	err := k.List(&pulumirpc.ListRequest{Token: namespaceType}, stream)
 	require.NoError(t, err)
 	assert.ElementsMatch(t, []string{"ns-1", "ns-2"}, collectIDs(stream))
 }
@@ -323,11 +329,11 @@ func TestParseListQuery_RejectsWrongTypes(t *testing.T) {
 func TestGvkFromTypeToken(t *testing.T) {
 	k := &kubeProvider{providerPackage: "kubernetes"}
 	cases := []struct {
-		token    string
-		ok       bool
-		group    string
-		version  string
-		kind     string
+		token   string
+		ok      bool
+		group   string
+		version string
+		kind    string
 	}{
 		{"kubernetes:core/v1:ConfigMap", true, "", "v1", "ConfigMap"},
 		{"kubernetes:apps/v1:Deployment", true, "apps", "v1", "Deployment"},
@@ -425,7 +431,9 @@ func (n *paginatingNamespaceable) Namespace(ns string) dynamic.ResourceInterface
 	}
 }
 
-func (n *paginatingNamespaceable) List(_ context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+func (n *paginatingNamespaceable) List(
+	_ context.Context, opts metav1.ListOptions,
+) (*unstructured.UnstructuredList, error) {
 	return paginatePool(n.pool, opts), nil
 }
 
@@ -496,7 +504,9 @@ func makeNConfigMaps(ns string, count int) []unstructured.Unstructured {
 // runListSession simulates the engine's pagination loop: call List repeatedly,
 // chaining continuation tokens, until the provider stops emitting them.
 // Returns all IDs received across calls and the total call count.
-func runListSession(t *testing.T, client pulumirpc.ResourceProviderClient, base *pulumirpc.ListRequest) ([]string, int) {
+func runListSession(
+	t *testing.T, client pulumirpc.ResourceProviderClient, base *pulumirpc.ListRequest,
+) ([]string, int) {
 	t.Helper()
 	var allIDs []string
 	var contToken string
@@ -505,9 +515,15 @@ func runListSession(t *testing.T, client pulumirpc.ResourceProviderClient, base 
 		callCount++
 		require.Less(t, callCount, 50, "infinite-loop guard — provider should signal stop by now")
 
-		req := *base
-		req.ContinuationToken = contToken
-		stream, err := client.List(context.Background(), &req)
+		// Build a fresh ListRequest per call rather than copying *base (which contains
+		// a sync.Mutex inside its proto MessageState — copylocks flags struct copies).
+		stream, err := client.List(context.Background(), &pulumirpc.ListRequest{
+			Token:             base.GetToken(),
+			Query:             base.GetQuery(),
+			Limit:             base.GetLimit(),
+			PageSize:          base.GetPageSize(),
+			ContinuationToken: contToken,
+		})
 		require.NoError(t, err)
 		ids, nextToken := drainList(t, stream)
 		allIDs = append(allIDs, ids...)

--- a/provider/pkg/provider/provider_list_test.go
+++ b/provider/pkg/provider/provider_list_test.go
@@ -16,11 +16,16 @@ package provider
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	structpb "google.golang.org/protobuf/types/known/structpb"
@@ -29,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	fakeclients "github.com/pulumi/pulumi-kubernetes/provider/v4/pkg/clients/fake"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/rpcutil"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 )
 
@@ -63,6 +69,58 @@ func newListTestProvider(t *testing.T, objs ...runtime.Object) *kubeProvider {
 	cs, _, _, _ := fakeclients.NewSimpleDynamicClient(fakeclients.WithObjects(objs...))
 	k.clientSet = cs
 	return k
+}
+
+// startKubeProviderServer runs k as an in-process gRPC server and returns a connected client.
+func startKubeProviderServer(t *testing.T, k *kubeProvider) pulumirpc.ResourceProviderClient {
+	t.Helper()
+	cancel := make(chan bool)
+	t.Cleanup(func() { close(cancel) })
+
+	handle, err := rpcutil.ServeWithOptions(rpcutil.ServeOptions{
+		Cancel: cancel,
+		Init: func(srv *grpc.Server) error {
+			pulumirpc.RegisterResourceProviderServer(srv, k)
+			return nil
+		},
+	})
+	require.NoError(t, err)
+	go func() {
+		if err := <-handle.Done; err != nil {
+			t.Errorf("kube provider gRPC server: %v", err)
+		}
+	}()
+
+	conn, err := grpc.NewClient(
+		fmt.Sprintf("127.0.0.1:%d", handle.Port),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	return pulumirpc.NewResourceProviderClient(conn)
+}
+
+// drainList consumes a List response stream and returns the result IDs and the
+// final continuation token (empty if none was sent).
+func drainList(t *testing.T, stream grpc.ServerStreamingClient[pulumirpc.ListResponse]) ([]string, string) {
+	t.Helper()
+	var ids []string
+	var contToken string
+	for {
+		resp, err := stream.Recv()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		require.NoError(t, err)
+		if r := resp.GetResult(); r != nil {
+			ids = append(ids, r.GetId())
+		}
+		if c := resp.GetContinuation(); c != nil {
+			contToken = c.GetContinuationToken()
+		}
+	}
+	return ids, contToken
 }
 
 func configMap(ns, name string, labels map[string]string) *corev1.ConfigMap {
@@ -284,4 +342,23 @@ func TestGvkFromTypeToken(t *testing.T) {
 			assert.Equal(t, tc.kind, gvk.Kind)
 		})
 	}
+}
+
+// TestList_OverGRPC exercises List end-to-end through a real gRPC server stream,
+// confirming the proto oneof wrappers and stream.Send/Recv work on the wire.
+func TestList_OverGRPC(t *testing.T) {
+	k := newListTestProvider(t,
+		configMap("ns-1", "cm-1", nil),
+		configMap("ns-2", "cm-2", nil),
+	)
+	client := startKubeProviderServer(t, k)
+
+	stream, err := client.List(context.Background(), &pulumirpc.ListRequest{
+		Token: "kubernetes:core/v1:ConfigMap",
+	})
+	require.NoError(t, err)
+
+	ids, contToken := drainList(t, stream)
+	assert.ElementsMatch(t, []string{"ns-1/cm-1", "ns-2/cm-2"}, ids)
+	assert.Empty(t, contToken, "two results fit in one page; no continuation token expected")
 }


### PR DESCRIPTION
This pull request implements the [`List` provider RPC](https://github.com/pulumi/pulumi/pull/22693)
for Kubernetes resources.

- Adds `kubeProvider.List method that resolves the given token to a GVK, maps to a RESTMapping, and streams `Result` / `Continuation` from the K8s dynamic client.
- Defines `listInputs`:
  - `name`
  - `labelSelector`
  - `fieldSelector`
  - `namespace` (will error for cluster-scoped kinds)
ListInputs are set on any Kubernetes kind that is Listable, that is every non-nested resource that is not a Patch resource.
- Query supports top-level keys and a `metadata.{namespace,name}` fallback.
- Unit test coverage of validation, filters, Patch-suffix stripping, cluster-scoped guard, 
- Round-trip in-process gRPC test

## Test plan
- [x] `go test ./provider/pkg/provider/ -run "TestList_|TestParseListQuery|TestGvkFromTypeToken"` passes
- [x] Manually exercised against a real cluster via a direct gRPC client
- [x] `make schema` regenerates 341 `listInputs` blocks on non-Patch resources

## Known gaps
- Unit-level verification that `page_size` is forwarded to `ListOptions.Limit` is deferred because the fake k8s client doesn't honor Limit.
- No user-facing language SDK surface yet; schema metadata only. Awaiting language codegen upstream.

Builds on the runtime draft from @Frassle.

Closes #4332.