### PR TITLE
PoC: run LoadBalancer-dependent tests on PR CI's kind cluster via MetalLB

### DIFF
--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -478,6 +478,30 @@ jobs:
       with:
         cluster_name: kind-integration-tests-${{ matrix.language }}
         node_image: kindest/node:v1.29.2
+    - name: Setup MetalLB for LoadBalancer support
+      run: |
+        kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.14.8/config/manifests/metallb-native.yaml
+        kubectl wait --namespace metallb-system --for=condition=available deploy/controller --timeout=120s
+        kubectl wait --namespace metallb-system --for=condition=ready pod -l component=speaker --timeout=120s
+        kubectl apply -f - <<EOF
+        apiVersion: metallb.io/v1beta1
+        kind: IPAddressPool
+        metadata:
+          name: default
+          namespace: metallb-system
+        spec:
+          addresses:
+          - 172.18.255.200-172.18.255.250
+        ---
+        apiVersion: metallb.io/v1beta1
+        kind: L2Advertisement
+        metadata:
+          name: default
+          namespace: metallb-system
+        spec:
+          ipAddressPools:
+          - default
+        EOF
     - name: Run tests
       run: cd tests/sdk/${{ matrix.language }} && go test -v -count=1 -cover -timeout
         2h -parallel 4 -short ./...

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-kubectl = "1.28.15"
+kubectl = "1.36.1"
 helm = "3.8.0"
 kind = "0.29.0"
 golangci-lint = "2.11.4"

--- a/tests/sdk/dotnet/dotnet_test.go
+++ b/tests/sdk/dotnet/dotnet_test.go
@@ -84,7 +84,6 @@ func TestDotnet_Basic(t *testing.T) {
 }
 
 func TestDotnet_Guestbook(t *testing.T) {
-	tests.SkipIfShort(t, "test creates a load balancer and requires a Cloud cluster")
 	test := baseOptions.With(integration.ProgramTestOptions{
 		Dir:   "guestbook",
 		Quick: true,

--- a/tests/sdk/nodejs/examples/examples_test.go
+++ b/tests/sdk/nodejs/examples/examples_test.go
@@ -135,6 +135,7 @@ func TestAccGuestbook(t *testing.T) {
 }
 
 func TestAccIngress(t *testing.T) {
+	tests.SkipIfShort(t, "test requires an Ingress controller, which kind does not ship with by default")
 	testNetworkingV1 := getBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			Dir:           filepath.Join(getCwd(t), "ingress"),

--- a/tests/sdk/nodejs/examples/examples_test.go
+++ b/tests/sdk/nodejs/examples/examples_test.go
@@ -135,7 +135,6 @@ func TestAccGuestbook(t *testing.T) {
 }
 
 func TestAccIngress(t *testing.T) {
-	tests.SkipIfShort(t, "test provisions a load balancer and requires a cloud provider cluster to run")
 	testNetworkingV1 := getBaseOptions(t).
 		With(integration.ProgramTestOptions{
 			Dir:           filepath.Join(getCwd(t), "ingress"),

--- a/tests/sdk/nodejs/nodejs_test.go
+++ b/tests/sdk/nodejs/nodejs_test.go
@@ -850,7 +850,6 @@ func TestGet(t *testing.T) {
 }
 
 func TestIstio(t *testing.T) {
-	tests.SkipIfShort(t, "test provisions a load balancer and requires a cloud provider cluster to run")
 	test := baseOptions.With(integration.ProgramTestOptions{
 		Dir:         filepath.Join("istio", "step1"),
 		Quick:       true,

--- a/tests/sdk/nodejs/preview_test.go
+++ b/tests/sdk/nodejs/preview_test.go
@@ -153,7 +153,6 @@ func createSAKubeconfig(t *testing.T, saName string) (string, error) {
 // subresoruces. This is to ensure we don't fail preview, since status fields are only populated after the resource is
 // created on cluster.
 func TestPreviewWithApply(t *testing.T) {
-	tests.SkipIfShort(t, "test requires a load balancer and won't work on kind clusters")
 	var externalIP, nsName, svcName string
 	test := baseOptions.With(integration.ProgramTestOptions{
 		Dir:                  "preview-apply",


### PR DESCRIPTION
This pull request drops `SkipIfShort` on three LoadBalancer-dependent tests (`TestPreviewWithApply`, `TestIstio`, `TestDotnet_Guestbook`), allowing them to run on a `KinD` cluster on pull requests.

To do so, we add a MetalLB install + IP pool step to the PR CI kind setup so those tests can get an external IP.
We've also bumped `mise.toml` kubectl from 1.28.15 → 1.36.1 to match the provider's 1.36 schema.

## Notes
- Workflow change in `run-acceptance-tests.yml` is a local PoC override; if this looks good, we'll port to ci-mgmt

## Test plan
- [x] PR CI green on all 5 language matrix entries
- [x] The three newly-enabled tests run in CI
     - [x] https://github.com/pulumi/pulumi-kubernetes/actions/runs/25877643170/job/76049675044?pr=4335#step:24:7906
     - [x] https://github.com/pulumi/pulumi-kubernetes/actions/runs/25877643170/job/76049675044?pr=4335#step:24:14059
     - [x] https://github.com/pulumi/pulumi-kubernetes/actions/runs/25877643170/job/76049675038?pr=4335#step:24:3536

🤖 Generated with [Claude Code](https://claude.com/claude-code)