### PR TITLE
Trim TestAccIngress and run on kind via Traefik (PoC)

### DIFF
--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -478,6 +478,35 @@ jobs:
       with:
         cluster_name: kind-integration-tests-${{ matrix.language }}
         node_image: kindest/node:v1.29.2
+    - name: Setup MetalLB for LoadBalancer support
+      run: |
+        kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.14.8/config/manifests/metallb-native.yaml
+        kubectl wait --namespace metallb-system --for=condition=available deploy/controller --timeout=120s
+        kubectl wait --namespace metallb-system --for=condition=ready pod -l component=speaker --timeout=120s
+        kubectl apply -f - <<EOF
+        apiVersion: metallb.io/v1beta1
+        kind: IPAddressPool
+        metadata:
+          name: default
+          namespace: metallb-system
+        spec:
+          addresses:
+          - 172.18.255.200-172.18.255.250
+        ---
+        apiVersion: metallb.io/v1beta1
+        kind: L2Advertisement
+        metadata:
+          name: default
+          namespace: metallb-system
+        spec:
+          ipAddressPools:
+          - default
+        EOF
+    - name: Setup Traefik (Ingress controller)
+      run: |
+        helm repo add traefik https://traefik.github.io/charts
+        helm repo update
+        helm install traefik traefik/traefik --namespace traefik --create-namespace --wait
     - name: Run tests
       run: cd tests/sdk/${{ matrix.language }} && go test -v -count=1 -cover -timeout
         2h -parallel 4 -short ./...

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
 kubectl = "1.28.15"
-helm = "3.8.0"
+helm = "3.21.0"
 kind = "0.29.0"
 golangci-lint = "2.11.4"

--- a/tests/sdk/nodejs/examples/examples_test.go
+++ b/tests/sdk/nodejs/examples/examples_test.go
@@ -135,33 +135,22 @@ func TestAccGuestbook(t *testing.T) {
 }
 
 func TestAccIngress(t *testing.T) {
-	tests.SkipIfShort(t, "test provisions a load balancer and requires a cloud provider cluster to run")
-	testNetworkingV1 := getBaseOptions(t).
+	test := getBaseOptions(t).
 		With(integration.ProgramTestOptions{
-			Dir:           filepath.Join(getCwd(t), "ingress"),
-			Quick:         true,
-			NoParallel:    true, // We want to run this and the next test serially so nginx ingress isn't clobbered.
-			DebugLogLevel: 3,
-			SkipRefresh:   true, // ingress may have changes during refresh.
+			Dir:         filepath.Join(getCwd(t), "ingress"),
+			Quick:       true,
+			SkipRefresh: true,
 			ExtraRuntimeValidation: func(
 				t *testing.T, stackInfo integration.RuntimeValidationStackInfo,
 			) {
-				assert.NotNil(t, stackInfo.Deployment)
-				assert.Equal(t, 15, len(stackInfo.Deployment.Resources))
-
 				integration.AssertHTTPResultWithRetry(t,
-					fmt.Sprintf("%s/index.html", stackInfo.Outputs["ingressIp"]),
-					nil, 10*time.Minute, func(body string) bool {
-						return assert.NotEmpty(t, body, "Body should not be empty")
-					})
-
-				integration.AssertHTTPResultWithRetry(t, fmt.Sprintf("%s/hello", stackInfo.Outputs["ingressNginxIp"]),
-					map[string]string{"Host": "ingresshello.io"}, 10*time.Minute, func(body string) bool {
+					fmt.Sprintf("%s/hello", stackInfo.Outputs["ingressIp"]),
+					nil, 5*time.Minute, func(body string) bool {
 						return assert.NotEmpty(t, body, "Body should not be empty")
 					})
 			},
 		})
-	integration.ProgramTest(t, &testNetworkingV1)
+	integration.ProgramTest(t, &test)
 }
 
 func TestAccHelm(t *testing.T) {

--- a/tests/sdk/nodejs/examples/ingress/index.ts
+++ b/tests/sdk/nodejs/examples/ingress/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2016-2021, Pulumi Corporation.
+// Copyright 2016-2026, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,31 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as pulumi from "@pulumi/pulumi";
 import * as k8s from "@pulumi/kubernetes";
-import { output as outputs } from "@pulumi/kubernetes/types";
 
 const ns = new k8s.core.v1.Namespace("test");
 const namespace = ns.metadata.name;
 
-const config = new pulumi.Config();
-const useV1Beta1Ingress = config.get("use-v1beta1-ingress") != undefined;
+const helloLabels = { app: "hello", tier: "frontend" };
 
-// Install nginx ingress controller first
-const ingressNs = new k8s.core.v1.Namespace("ingress-nginx");
-const ingressController = new k8s.helm.v3.Release(
-    "nginx-ingress", {
-    name: "nginx-ingress",
-    namespace: ingressNs.metadata.name,
-    chart: "ingress-nginx",
-    version: "4.1.4",
-    repositoryOpts: {
-        repo: "https://kubernetes.github.io/ingress-nginx",
-    },
-});
-
-// nginx hello app
-let helloLabels = { app: "hello", tier: "frontend" };
 const helloService = new k8s.core.v1.Service("hello-svc", {
     metadata: {
         namespace: namespace,
@@ -44,310 +26,49 @@ const helloService = new k8s.core.v1.Service("hello-svc", {
         labels: helloLabels,
     },
     spec: {
-        // GKE ingress will only work with service type of NodePort or LoadBalancer.
-        // We only want one endpoint through the ingress so choosing NodePort.
         ports: [{ port: 8080, targetPort: 8080 }],
         selector: helloLabels,
     },
 });
 
-let helloDeployment = new k8s.apps.v1.Deployment("hello-app", {
+new k8s.apps.v1.Deployment("hello-app", {
     metadata: {
         namespace: namespace,
         name: "hello",
     },
     spec: {
-        selector: {
-            matchLabels: helloLabels,
-        },
-        replicas: 3,
+        selector: { matchLabels: helloLabels },
+        replicas: 1,
         template: {
-            metadata: {
-                labels: helloLabels,
-            },
+            metadata: { labels: helloLabels },
             spec: {
                 containers: [{
                     name: "hello",
                     image: "gcr.io/google-samples/hello-app:1.0",
-                    resources: {
-                        requests: {
-                            cpu: "100m",
-                            memory: "100Mi",
-                        },
-                    },
-                    ports: [{
-                        containerPort: 8080,
-                    }],
+                    ports: [{ containerPort: 8080 }],
                 }],
             },
         },
     },
 });
 
-let feIngressNginx = undefined;
-
-if (!useV1Beta1Ingress) {
-    // Note - this uses the nginx ingress controller which should work across k8s providers.
-    feIngressNginx = new k8s.networking.v1.Ingress("feIngressNginx", {
-        metadata: {
-            namespace: namespace,
-            name: "feingress-nginx",
-            annotations: {
-                "kubernetes.io/ingress.class": "nginx",
-                "nginx.ingress.kubernetes.io/ssl-redirect": "false"
-            },
-        },
-        spec: {
-            rules: [{
-                host: "ingresshello.io",
-                http: {
-                    paths: [{
-                        path: "/hello",
-                        pathType: "Prefix",
-                        backend: { service: { name: helloService.metadata.name, port: { number: 8080 } } }
-                    }]
-                }
-            }],
-        }
-    }, { dependsOn: [ingressController] });
-
-} else {
-    // Note - this uses the nginx ingress controller which should work across k8s providers.
-    feIngressNginx = new k8s.networking.v1beta1.Ingress("feIngressNginx", {
-        metadata: {
-            namespace: namespace,
-            name: "feingress-nginx",
-            annotations: {
-                "kubernetes.io/ingress.class": "nginx",
-                "nginx.ingress.kubernetes.io/ssl-redirect": "false"
-            },
-        },
-        spec: {
-            rules: [{
-                host: "ingresshello.io",
-                http: {
-                    paths: [{
-                        path: "/hello",
-                        pathType: "Prefix",
-                        backend: { serviceName: helloService.metadata.name, servicePort: 8080 }
-                    }]
-                }
-            }],
-        }
-    }, { dependsOn: [ingressController] });
-}
-export const ingressNginxIp = feIngressNginx.status.loadBalancer.ingress[0].ip;
-
-// REDIS MASTER
-
-let redisMasterLabels = { app: "redis", tier: "backend", role: "master" };
-let redisMasterService = new k8s.core.v1.Service("redis-master", {
+const feIngress = new k8s.networking.v1.Ingress("feIngress", {
     metadata: {
         namespace: namespace,
-        name: "redis-master",
-        labels: redisMasterLabels,
+        name: "feingress",
     },
     spec: {
-        ports: [{ port: 6379, targetPort: 6379 }],
-        selector: redisMasterLabels,
-    },
-});
-
-let redisMasterDeployment = new k8s.apps.v1.Deployment("redis-master", {
-    metadata: {
-        namespace: namespace,
-        name: "redis-master",
-    },
-    spec: {
-        selector: {
-            matchLabels: redisMasterLabels,
-        },
-        replicas: 1,
-        template: {
-            metadata: {
-                labels: redisMasterLabels,
-            },
-            spec: {
-                containers: [{
-                    name: "master",
-                    image: "docker.io/redis:6.0.5",
-                    resources: {
-                        requests: {
-                            cpu: "100m",
-                            memory: "100Mi",
-                        },
-                    },
-                    ports: [{
-                        containerPort: 6379,
-                    }],
+        ingressClassName: "traefik",
+        rules: [{
+            http: {
+                paths: [{
+                    path: "/hello",
+                    pathType: "Prefix",
+                    backend: { service: { name: helloService.metadata.name, port: { number: 8080 } } },
                 }],
             },
-        },
+        }],
     },
 });
 
-// REDIS SLAVE
-let redisSlaveLabels = { app: "redis", tier: "backend", role: "slave" };
-let redisSlaveService = new k8s.core.v1.Service("redis-slave", {
-    metadata: {
-        namespace: namespace,
-        name: "redis-slave",
-        labels: redisSlaveLabels,
-    },
-    spec: {
-        ports: [{ port: 6379, targetPort: 6379 }],
-        selector: redisSlaveLabels,
-    },
-});
-
-let redisSlaveDeployment = new k8s.apps.v1.Deployment("redis-slave", {
-    metadata: {
-        namespace: namespace,
-        name: "redis-slave",
-    },
-    spec: {
-        selector: {
-            matchLabels: redisSlaveLabels
-        },
-        replicas: 1,
-        template: {
-            metadata: {
-                labels: redisSlaveLabels,
-            },
-            spec: {
-                containers: [{
-                    name: "slave",
-                    image: "us-docker.pkg.dev/google-samples/containers/gke/gb-redis-follower:v2",
-                    resources: {
-                        requests: {
-                            cpu: "100m",
-                            memory: "100Mi",
-                        },
-                    },
-                    env: [{
-                        name: "GET_HOSTS_FROM",
-                        value: "dns",
-                        // If your cluster config does not include a dns service, then to instead access an environment
-                        // variable to find the master service's host, comment out the 'value: dns' line above, and
-                        // uncomment the line below:
-                        // value: "env"
-                    }],
-                    ports: [{
-                        containerPort: 6379,
-                    }],
-                }],
-            },
-        },
-    },
-});
-
-// FRONTEND
-let frontendLabels = { app: "guestbook", tier: "frontend" };
-const frontendService = new k8s.core.v1.Service("frontend", {
-    metadata: {
-        namespace: namespace,
-        name: "frontend",
-        labels: frontendLabels,
-    },
-    spec: {
-        // GKE ingress will only work with service type of NodePort or LoadBalancer.
-        // We only want one endpoint through the ingress so choosing NodePort.
-        type: "NodePort",
-        ports: [{ port: 80 }],
-        selector: frontendLabels,
-    },
-});
-
-
-
-let frontendDeployment = new k8s.apps.v1.Deployment("frontend", {
-    metadata: {
-        namespace: namespace,
-        name: "frontend",
-    },
-    spec: {
-        selector: {
-            matchLabels: frontendLabels,
-        },
-        replicas: 3,
-        template: {
-            metadata: {
-                labels: frontendLabels,
-            },
-            spec: {
-                containers: [{
-                    name: "php-redis",
-                    image: "us-docker.pkg.dev/google-samples/containers/gke/gb-frontend:v5",
-                    resources: {
-                        requests: {
-                            cpu: "100m",
-                            memory: "100Mi",
-                        },
-                    },
-                    env: [{
-                        name: "GET_HOSTS_FROM",
-                        value: "dns",
-                        // If your cluster config does not include a dns service, then to instead access an environment
-                        // variable to find the master service's host, comment out the 'value: dns' line above, and
-                        // uncomment the line below:
-                        // value: "env"
-                    }],
-                    ports: [{
-                        containerPort: 80,
-                    }],
-                }],
-            },
-        },
-    },
-});
-
-let feIngress = undefined;
-
-if (!useV1Beta1Ingress) {
-    // Note - this uses the built-in GKE ingress controller. This will not work across other Kubernetes providers.
-    feIngress = new k8s.networking.v1.Ingress("feIngress", {
-        metadata: {
-            namespace: namespace,
-            name: "feingress",
-            annotations: {
-                "kubernetes.io/ingress.class": "gce"
-            },
-        },
-        spec: {
-            rules: [{
-                http: {
-                    paths: [{
-                        path: "/*",
-                        pathType: "ImplementationSpecific",
-                        backend: { service: { name: frontendService.metadata.name, port: { number: 80 } } }
-                    }]
-                }
-            }],
-        }
-        // Don't want to race with the ingress controller admission webhook being fully available.
-    }, { dependsOn: [ingressController] });
-} else {
-    // Note - this uses the built-in GKE ingress controller. This will not work across other Kubernetes providers.
-    feIngress = new k8s.networking.v1beta1.Ingress("feIngress", {
-        metadata: {
-            namespace: namespace,
-            name: "feingress",
-            annotations: {
-                "kubernetes.io/ingress.class": "gce"
-            },
-        },
-        spec: {
-            rules: [{
-                http: {
-                    paths: [{
-                        path: "/*",
-                        pathType: "ImplementationSpecific",
-                        backend: { serviceName: frontendService.metadata.name, servicePort: 80 }
-                    }]
-                }
-            }],
-        }
-        // Don't want to race with the ingress controller admission controller being fully available.
-    }, { dependsOn: [ingressController] });
-}
 export const ingressIp = feIngress.status.loadBalancer.ingress[0].ip;


### PR DESCRIPTION
## Summary
- Trim `TestAccIngress` testdata: drop Guestbook, drop in-stack nginx-ingress Helm install, drop the gce-annotated `feIngress` (kind has no GCE controller).
- Keep a single hello-app + Ingress, routed via `spec.ingressClassName: traefik`.
- Workflow adds MetalLB + Traefik install steps before the test run.
- Drop `SkipIfShort` so the test runs under PR CI's `-short`.
- Addresses #1838 — by removing the cloud-LoadBalancer dependency entirely, the original flake mode (waiting for cloud LB) no longer applies.

## Notes
- Workflow change is a local PoC override — overwritten on next ci-mgmt regen. Real fix lives in `pulumi/ci-mgmt`.
- MetalLB step is a verbatim copy from #4335; small merge conflict expected if both land.

## Test plan
- [ ] PR CI green; nodejs job runs TestAccIngress to completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
