### PR TITLE
PoC: run TestEmptyItemNormalization on PR CI's kind cluster via Calico

### DIFF
--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -489,26 +489,9 @@ jobs:
         config: /tmp/kind-calico-config.yaml
     - name: Install Calico (NetworkPolicy-enforcing CNI)
       run: |
-        kubectl create -f https://raw.githubusercontent.com/projectcalico/calico/v3.28.2/manifests/tigera-operator.yaml
-        kubectl create -f - <<EOF
-        apiVersion: operator.tigera.io/v1
-        kind: Installation
-        metadata:
-          name: default
-        spec:
-          calicoNetwork:
-            ipPools:
-              - cidr: 10.244.0.0/16
-                encapsulation: VXLAN
-        ---
-        apiVersion: operator.tigera.io/v1
-        kind: APIServer
-        metadata:
-          name: default
-        spec: {}
-        EOF
-        kubectl wait --for=condition=Ready tigerastatus/calico --timeout=5m
-        kubectl wait --for=condition=Ready tigerastatus/apiserver --timeout=5m
+        kubectl apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.28.2/manifests/calico.yaml
+        kubectl -n kube-system rollout status daemonset/calico-node --timeout=5m
+        kubectl -n kube-system rollout status deployment/calico-kube-controllers --timeout=5m
     - name: Run tests
       run: cd tests/sdk/${{ matrix.language }} && go test -v -count=1 -cover -timeout
         2h -parallel 4 -short ./...

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -473,11 +473,42 @@ jobs:
       with:
         version: v2.5.0
         token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Write Kind config (disable default CNI for Calico)
+      run: |
+        cat > /tmp/kind-calico-config.yaml <<EOF
+        kind: Cluster
+        apiVersion: kind.x-k8s.io/v1alpha4
+        networking:
+          disableDefaultCNI: true
+        EOF
     - name: Setup KinD cluster
       uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
       with:
         cluster_name: kind-integration-tests-${{ matrix.language }}
         node_image: kindest/node:v1.29.2
+        config: /tmp/kind-calico-config.yaml
+    - name: Install Calico (NetworkPolicy-enforcing CNI)
+      run: |
+        kubectl create -f https://raw.githubusercontent.com/projectcalico/calico/v3.28.2/manifests/tigera-operator.yaml
+        kubectl create -f - <<EOF
+        apiVersion: operator.tigera.io/v1
+        kind: Installation
+        metadata:
+          name: default
+        spec:
+          calicoNetwork:
+            ipPools:
+              - cidr: 10.244.0.0/16
+                encapsulation: VXLAN
+        ---
+        apiVersion: operator.tigera.io/v1
+        kind: APIServer
+        metadata:
+          name: default
+        spec: {}
+        EOF
+        kubectl wait --for=condition=Ready tigerastatus/calico --timeout=5m
+        kubectl wait --for=condition=Ready tigerastatus/apiserver --timeout=5m
     - name: Run tests
       run: cd tests/sdk/${{ matrix.language }} && go test -v -count=1 -cover -timeout
         2h -parallel 4 -short ./...

--- a/tests/sdk/nodejs/nodejs_test.go
+++ b/tests/sdk/nodejs/nodejs_test.go
@@ -2383,7 +2383,6 @@ func ignoreChageTest(t *testing.T, testFolderName string) {
 // and has a controller backing it. We create 2 pods to test egress between them, rather than hitting
 // a live URL, to avoid flakiness.
 func TestEmptyItemNormalization(t *testing.T) {
-	tests.SkipIfShort(t, "test requires a cluster with NetworkPolicy support")
 	validateProgram := func(networkingEnabled bool) func(*testing.T, integration.RuntimeValidationStackInfo) {
 		return func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
 			ns, ok := stackInfo.Outputs["podANamespace"].(string)


### PR DESCRIPTION
This pull request drops `SkipIfShort` on `TestEmptyItemNormalization` (the last NetworkPolicy-dependent test gated to master), allowing it to run on a `KinD` cluster on pull requests.

To do so, we disable kindnet and install Calico (manifest install, no operator) so NetworkPolicy resources are actually enforced — kindnet creates NP resources but doesn't filter traffic.

## Notes
- Workflow change in `run-acceptance-tests.yml` is a local PoC override; if this looks good, we'll port to ci-mgmt.
- Sibling to #4335 (MetalLB) and #4342 (MetalLB + Traefik). Merge order is independent; small workflow-section conflicts possible.

## Test plan
- [ ] PR CI green on all 5 language matrix entries
- [ ] TestEmptyItemNormalization runs in CI on the nodejs job

🤖 Generated with [Claude Code](https://claude.com/claude-code)