### PR TITLE
Prepare for v4.30.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ## Unreleased
 
+## 4.31.0 (May 14, 2026)
+
 ### Added
 
 - [#2744](https://github.com/pulumi/pulumi-kubernetes/issues/2744) Advertise a `helm` mapping for `terraform` conversion so `pulumi import --from terraform` and `pulumi convert --from terraform` recognize `helm_release` and emit `kubernetes:helm.sh/v3:Release`.
@@ -10,19 +12,24 @@
 
 ### Fixed
 
+- [#4261](https://github.com/pulumi/pulumi-kubernetes/pull/4261) Fix CRD parameterization: implement `Parameterize(Value)` so subsequent runs can reconstruct the CRD schema from saved state, and flatten array-of-objects in OpenAPI specs so nested fields like `spec.listeners` generate typed args.
+
+### Changed
+
+- Upgrade Kubernetes schema and libraries to v1.36.1.
+
+## 4.30.0 (April 24, 2026)
+
+### Fixed
+
 - [#4295](https://github.com/pulumi/pulumi-kubernetes/pull/4295)Fix kustomize.v2.Directory resource output type in the schema to properly support array outputs.
 Previously, the resources field was incorrectly typed as a `string` in the schema. This fix updates the type to an array of `Any`, aligning the schema with the provider's Go implementation (`pulumi.ArrayOutput`). This resolves a regression that caused the Kustomize v2 resource to fail in the Python SDK.
 - [#2997](https://github.com/pulumi/pulumi-kubernetes/issues/2997) Stop stripping null values when unmarshaling, fixing Helm chart default deletion and `valueYamlFiles` null handling. Deprecate `allowNullValues` (no longer needed).
-- [#4261](https://github.com/pulumi/pulumi-kubernetes/pull/4261) Fix CRD parameterization: implement `Parameterize(Value)` so subsequent runs can reconstruct the CRD schema from saved state, and flatten array-of-objects in OpenAPI specs so nested fields like `spec.listeners` generate typed args.
 
 ### Changed
 
 - Upgrade Kubernetes schema and libraries to v1.35.4.
 - Upgrade Kubernetes schema and libraries to v1.36.0.
-
-### Changed
-
-- Upgrade Kubernetes schema and libraries to v1.36.1.
 
 ## 4.29.0 (April 15, 2026)
 


### PR DESCRIPTION
Adds the `## 4.30.0 (May 14, 2026)` heading and folds the duplicate `### Changed` block (left over from #4341) into a single block.

**Hold for #4340** (`pulumi/pulumi` → 3.239.0) to merge before this lands, so the release picks up that bump.

After merge, kick the release in `#release-ops`: `@release-bot release pulumi-kubernetes minor`.