### PR TITLE
Bump kind 0.29.0 → 0.31.0

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
 kubectl = "1.28.15"
 helm = "3.8.0"
-kind = "0.29.0"
+kind = "0.31.0"
 golangci-lint = "2.11.4"


### PR DESCRIPTION
What it says on the box.

Prereq for #4356 (kind integration tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)