### PR TITLE
Add HCL examples to provider docs

### DIFF
--- a/provider/pkg/gen/examples/upstream/deployment.md
+++ b/provider/pkg/gen/examples/upstream/deployment.md
@@ -271,6 +271,47 @@ resources:
         type: kubernetes:apps/v1:Deployment
 runtime: yaml
 ```
+```hcl
+pulumi {
+  required_providers {
+    kubernetes = {
+      source = "pulumi/kubernetes"
+    }
+  }
+}
+
+resource "kubernetes_apps_v1_deployment" "deployment" {
+  metadata = {
+    labels = {
+      app = "nginx"
+    }
+  }
+  spec = {
+    replicas = 3
+    selector = {
+      match_labels = {
+        app = "nginx"
+      }
+    }
+    template = {
+      metadata = {
+        labels = {
+          app = "nginx"
+        }
+      }
+      spec = {
+        containers = [{
+          image = "nginx:1.14.2"
+          name  = "nginx"
+          ports = [{
+            container_port = 80
+          }]
+        }]
+      }
+    }
+  }
+}
+```
 {{% /example %}}
 {{% example %}}
 ### Create a Deployment with a user-specified name
@@ -548,6 +589,48 @@ resources:
                                 - containerPort: 80
         type: kubernetes:apps/v1:Deployment
 runtime: yaml
+```
+```hcl
+pulumi {
+  required_providers {
+    kubernetes = {
+      source = "pulumi/kubernetes"
+    }
+  }
+}
+
+resource "kubernetes_apps_v1_deployment" "deployment" {
+  metadata = {
+    labels = {
+      app = "nginx"
+    }
+    name = "nginx-deployment"
+  }
+  spec = {
+    replicas = 3
+    selector = {
+      match_labels = {
+        app = "nginx"
+      }
+    }
+    template = {
+      metadata = {
+        labels = {
+          app = "nginx"
+        }
+      }
+      spec = {
+        containers = [{
+          image = "nginx:1.14.2"
+          name  = "nginx"
+          ports = [{
+            container_port = 80
+          }]
+        }]
+      }
+    }
+  }
+}
 ```
 {{% /example %}}
 {{% /examples %}}

--- a/provider/pkg/gen/examples/upstream/ingress.md
+++ b/provider/pkg/gen/examples/upstream/ingress.md
@@ -235,6 +235,41 @@ resources:
         type: kubernetes:networking.k8s.io/v1:Ingress
 runtime: yaml
 ```
+```hcl
+pulumi {
+  required_providers {
+    kubernetes = {
+      source = "pulumi/kubernetes"
+    }
+  }
+}
+
+resource "kubernetes_networking.k8s.io_v1_ingress" "ingress" {
+  metadata = {
+    annotations = {
+      "nginx.ingress.kubernetes.io/rewrite-target" = "/"
+    }
+  }
+  spec = {
+    rules = [{
+      http = {
+        paths = [{
+          backend = {
+            service = {
+              name = "test"
+              port = {
+                number = 80
+              }
+            }
+          }
+          path      = "/testpath"
+          path_type = "Prefix"
+        }]
+      }
+    }]
+  }
+}
+```
 {{% /example %}}
 {{% example %}}
 ### Create an Ingress with a user-specified name
@@ -476,6 +511,42 @@ resources:
                               pathType: Prefix
         type: kubernetes:networking.k8s.io/v1:Ingress
 runtime: yaml
+```
+```hcl
+pulumi {
+  required_providers {
+    kubernetes = {
+      source = "pulumi/kubernetes"
+    }
+  }
+}
+
+resource "kubernetes_networking.k8s.io_v1_ingress" "ingress" {
+  metadata = {
+    annotations = {
+      "nginx.ingress.kubernetes.io/rewrite-target" = "/"
+    }
+    name = "minimal-ingress"
+  }
+  spec = {
+    rules = [{
+      http = {
+        paths = [{
+          backend = {
+            service = {
+              name = "test"
+              port = {
+                number = 80
+              }
+            }
+          }
+          path      = "/testpath"
+          path_type = "Prefix"
+        }]
+      }
+    }]
+  }
+}
 ```
 {{% /example %}}
 {{% /examples %}}

--- a/provider/pkg/gen/examples/upstream/job.md
+++ b/provider/pkg/gen/examples/upstream/job.md
@@ -209,6 +209,36 @@ resources:
         type: kubernetes:batch/v1:Job
 runtime: yaml
 ```
+```hcl
+pulumi {
+  required_providers {
+    kubernetes = {
+      source = "pulumi/kubernetes"
+    }
+  }
+}
+
+resource "kubernetes_batch_v1_job" "job" {
+  spec = {
+    backoff_limit = 4
+    template = {
+      spec = {
+        containers = [{
+          command = [
+            "perl",
+            "-Mbignum=bpi",
+            "-wle",
+            "print bpi(2000)",
+          ]
+          image = "perl"
+          name  = "pi"
+        }]
+        restart_policy = "Never"
+      }
+    }
+  }
+}
+```
 {{% /example %}}
 {{% example %}}
 ### Create a Job with a user-specified name
@@ -431,6 +461,39 @@ resources:
                         restartPolicy: Never
         type: kubernetes:batch/v1:Job
 runtime: yaml
+```
+```hcl
+pulumi {
+  required_providers {
+    kubernetes = {
+      source = "pulumi/kubernetes"
+    }
+  }
+}
+
+resource "kubernetes_batch_v1_job" "job" {
+  metadata = {
+    name = "pi"
+  }
+  spec = {
+    backoff_limit = 4
+    template = {
+      spec = {
+        containers = [{
+          command = [
+            "perl",
+            "-Mbignum=bpi",
+            "-wle",
+            "print bpi(2000)",
+          ]
+          image = "perl"
+          name  = "pi"
+        }]
+        restart_policy = "Never"
+      }
+    }
+  }
+}
 ```
 {{% /example %}}
 {{% /examples %}}

--- a/provider/pkg/gen/examples/upstream/pod.md
+++ b/provider/pkg/gen/examples/upstream/pod.md
@@ -148,6 +148,27 @@ resources:
         type: kubernetes:core/v1:Pod
 runtime: yaml
 ```
+```hcl
+pulumi {
+  required_providers {
+    kubernetes = {
+      source = "pulumi/kubernetes"
+    }
+  }
+}
+
+resource "kubernetes_core_v1_pod" "pod" {
+  spec = {
+    containers = [{
+      image = "nginx:1.14.2"
+      name  = "nginx"
+      ports = [{
+        container_port = 80
+      }]
+    }]
+  }
+}
+```
 {{% /example %}}
 {{% example %}}
 ### Create a Pod with a user-specified name
@@ -319,6 +340,30 @@ resources:
                         - containerPort: 80
         type: kubernetes:core/v1:Pod
 runtime: yaml
+```
+```hcl
+pulumi {
+  required_providers {
+    kubernetes = {
+      source = "pulumi/kubernetes"
+    }
+  }
+}
+
+resource "kubernetes_core_v1_pod" "pod" {
+  metadata = {
+    name = "nginx"
+  }
+  spec = {
+    containers = [{
+      image = "nginx:1.14.2"
+      name  = "nginx"
+      ports = [{
+        container_port = 80
+      }]
+    }]
+  }
+}
 ```
 {{% /example %}}
 {{% /examples %}}

--- a/provider/pkg/gen/examples/upstream/service.md
+++ b/provider/pkg/gen/examples/upstream/service.md
@@ -147,6 +147,28 @@ resources:
         type: kubernetes:core/v1:Service
 runtime: yaml
 ```
+```hcl
+pulumi {
+  required_providers {
+    kubernetes = {
+      source = "pulumi/kubernetes"
+    }
+  }
+}
+
+resource "kubernetes_core_v1_service" "service" {
+  spec = {
+    ports = [{
+      port        = 80
+      protocol    = "TCP"
+      target_port = 9376
+    }]
+    selector = {
+      app = "MyApp"
+    }
+  }
+}
+```
 {{% /example %}}
 {{% example %}}
 ### Create a Service with a user-specified name
@@ -317,6 +339,31 @@ resources:
                     app: MyApp
         type: kubernetes:core/v1:Service
 runtime: yaml
+```
+```hcl
+pulumi {
+  required_providers {
+    kubernetes = {
+      source = "pulumi/kubernetes"
+    }
+  }
+}
+
+resource "kubernetes_core_v1_service" "service" {
+  metadata = {
+    name = "my-service"
+  }
+  spec = {
+    ports = [{
+      port        = 80
+      protocol    = "TCP"
+      target_port = 9376
+    }]
+    selector = {
+      app = "MyApp"
+    }
+  }
+}
 ```
 {{% /example %}}
 {{% /examples %}}

--- a/provider/pkg/gen/examples/upstream/statefulset.md
+++ b/provider/pkg/gen/examples/upstream/statefulset.md
@@ -488,6 +488,80 @@ resources:
         type: kubernetes:apps/v1:StatefulSet
 runtime: yaml
 ```
+```hcl
+pulumi {
+  required_providers {
+    kubernetes = {
+      source = "pulumi/kubernetes"
+    }
+  }
+}
+
+resource "kubernetes_core_v1_service" "service" {
+  metadata = {
+    labels = {
+      app = "nginx"
+    }
+  }
+  spec = {
+    cluster_ip = "None"
+    ports = [{
+      name = "web"
+      port = 80
+    }]
+    selector = {
+      app = "nginx"
+    }
+  }
+}
+
+resource "kubernetes_apps_v1_stateful_set" "statefulset" {
+  spec = {
+    replicas = 3
+    selector = {
+      match_labels = {
+        app = "nginx"
+      }
+    }
+    service_name = kubernetes_core_v1_service.service.metadata.name
+    template = {
+      metadata = {
+        labels = {
+          app = "nginx"
+        }
+      }
+      spec = {
+        containers = [{
+          image = "nginx:stable-alpine3.17-slim"
+          name  = "nginx"
+          ports = [{
+            container_port = 80
+            name           = "web"
+          }]
+          volume_mounts = [{
+            mount_path = "/usr/share/nginx/html"
+            name       = "www"
+          }]
+        }]
+        termination_grace_period_seconds = 10
+      }
+    }
+    volume_claim_templates = [{
+      metadata = {
+        name = "www"
+      }
+      spec = {
+        access_modes = ["ReadWriteOnce"]
+        resources = {
+          requests = {
+            storage = "1Gi"
+          }
+        }
+      }
+    }]
+  }
+}
+```
 {{% /example %}}
 {{% example %}}
 ### Create a StatefulSet with a user-specified name
@@ -1003,6 +1077,84 @@ resources:
                                 storage: 1Gi
         type: kubernetes:apps/v1:StatefulSet
 runtime: yaml
+```
+```hcl
+pulumi {
+  required_providers {
+    kubernetes = {
+      source = "pulumi/kubernetes"
+    }
+  }
+}
+
+resource "kubernetes_core_v1_service" "service" {
+  metadata = {
+    labels = {
+      app = "nginx"
+    }
+    name = "nginx"
+  }
+  spec = {
+    cluster_ip = "None"
+    ports = [{
+      name = "web"
+      port = 80
+    }]
+    selector = {
+      app = "nginx"
+    }
+  }
+}
+
+resource "kubernetes_apps_v1_stateful_set" "statefulset" {
+  metadata = {
+    name = "web"
+  }
+  spec = {
+    replicas = 3
+    selector = {
+      match_labels = {
+        app = "nginx"
+      }
+    }
+    service_name = kubernetes_core_v1_service.service.metadata.name
+    template = {
+      metadata = {
+        labels = {
+          app = "nginx"
+        }
+      }
+      spec = {
+        containers = [{
+          image = "nginx:stable-alpine3.17-slim"
+          name  = "nginx"
+          ports = [{
+            container_port = 80
+            name           = "web"
+          }]
+          volume_mounts = [{
+            mount_path = "/usr/share/nginx/html"
+            name       = "www"
+          }]
+        }]
+        termination_grace_period_seconds = 10
+      }
+    }
+    volume_claim_templates = [{
+      metadata = {
+        name = "www"
+      }
+      spec = {
+        access_modes = ["ReadWriteOnce"]
+        resources = {
+          requests = {
+            storage = "1Gi"
+          }
+        }
+      }
+    }]
+  }
+}
 ```
 {{% /example %}}
 {{% /examples %}}


### PR DESCRIPTION
## Summary

- Adds an `hcl` fence to each `{{% example %}}` block in `provider/pkg/gen/examples/upstream/*.md` (pod, service, deployment, statefulset, job, ingress — 12 examples total) so the registry can render HCL alongside the other languages.
- Each fence shows a complete `main.hcl` for the Pulumi HCL runtime (`runtime: hcl`), matching the structure of the existing yaml fence.
- Verified by running `pulumi up` against a kind cluster for each example; the projects used to verify are committed under `example-proof/<example-name>/`.

Fixes #4323.

## HCL runtime requirements

These examples assume the pulumi-hcl runtime has the following pulumi-labs/pulumi-hcl fixes:

- [pulumi-labs/pulumi-hcl#126](https://github.com/pulumi-labs/pulumi-hcl/issues/126) — heterogeneous output panic (fixed in v0.3.1)
- [pulumi-labs/pulumi-hcl#135](https://github.com/pulumi-labs/pulumi-hcl/issues/135) — `WithoutOptionalAttributesDeep` panic on convert (fixed by #136)
- [pulumi-labs/pulumi-hcl#137](https://github.com/pulumi-labs/pulumi-hcl/issues/137) — schema `const` values not applied (fixed by #139)
- [pulumi-labs/pulumi-hcl#140](https://github.com/pulumi-labs/pulumi-hcl/issues/140) — resource name corrupted for dotted-module tokens (fix in flight on the `iwahbe/no-dots-in-names` branch)

The fences are written to work after these fixes ship; the examples used to verify them were run against a local build that includes all four.

## Test plan

- [x] `pulumi up` succeeds for each of the 12 example-proof projects against a kind cluster
- [x] `pulumi destroy` succeeds for each
- [x] Regenerated `provider/cmd/pulumi-resource-kubernetes/schema.json` contains 12 \`\`\`hcl fences
- [ ] Reviewer eyeballs the schema diff to confirm fences land in the right resource descriptions
- [ ] CI passes