### PR TITLE
Prepare for v4.31.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 
 ## Unreleased
 
+## 4.31.1 (May 19, 2026)
+
+### Changed
+
+- [#4364](https://github.com/pulumi/pulumi-kubernetes/pull/4364) Update `github.com/go-git/go-git/v5` to v5.19.1 (SECURITY).
+- Update first-party Pulumi dependencies to v3.242.0.
+
 ## 4.31.0 (May 14, 2026)
 
 ### Added


### PR DESCRIPTION
Adds the `## 4.31.1 (May 19, 2026)` heading with entries since v4.31.0:

- [#4364](https://github.com/pulumi/pulumi-kubernetes/pull/4364) go-git v5.19.1 (SECURITY)
- First-party Pulumi dependencies → v3.242.0

After merge, kick the release in `#release-ops`: `@release-bot release pulumi-kubernetes patch`.