### PR TITLE
Add `scripts/setup-kind-cluster.sh` for `KinD`-on-default work

### DIFF
--- a/scripts/kind-config.yaml
+++ b/scripts/kind-config.yaml
@@ -1,0 +1,4 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  disableDefaultCNI: true

--- a/scripts/setup-kind-cluster.sh
+++ b/scripts/setup-kind-cluster.sh
@@ -5,12 +5,14 @@ CALICO_VERSION="v3.28.2"
 METALLB_VERSION="v0.14.8"
 
 echo "Installing Calico..."
-kubectl apply -f "https://raw.githubusercontent.com/projectcalico/calico/${CALICO_VERSION}/manifests/calico.yaml"
+gh api -H "Accept: application/vnd.github.raw" "/repos/projectcalico/calico/contents/manifests/calico.yaml?ref=${CALICO_VERSION}" > /tmp/calico.yaml
+kubectl apply -f /tmp/calico.yaml
 kubectl -n kube-system rollout status daemonset/calico-node --timeout=5m
 kubectl -n kube-system rollout status deployment/calico-kube-controllers --timeout=5m
 
 echo "Installing MetalLB..."
-kubectl apply -f "https://raw.githubusercontent.com/metallb/metallb/${METALLB_VERSION}/config/manifests/metallb-native.yaml"
+gh api -H "Accept: application/vnd.github.raw" "/repos/metallb/metallb/contents/config/manifests/metallb-native.yaml?ref=${METALLB_VERSION}" > /tmp/metallb-native.yaml
+kubectl apply -f /tmp/metallb-native.yaml
 kubectl wait --namespace metallb-system --for=condition=available deploy/controller --timeout=120s
 kubectl wait --namespace metallb-system --for=condition=ready pod -l component=speaker --timeout=120s
 

--- a/scripts/setup-kind-cluster.sh
+++ b/scripts/setup-kind-cluster.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -o nounset -o errexit -o pipefail
+
+CALICO_VERSION="v3.28.2"
+METALLB_VERSION="v0.14.8"
+
+echo "Installing Calico..."
+kubectl apply -f "https://raw.githubusercontent.com/projectcalico/calico/${CALICO_VERSION}/manifests/calico.yaml"
+kubectl -n kube-system rollout status daemonset/calico-node --timeout=5m
+kubectl -n kube-system rollout status deployment/calico-kube-controllers --timeout=5m
+
+echo "Installing MetalLB..."
+kubectl apply -f "https://raw.githubusercontent.com/metallb/metallb/${METALLB_VERSION}/config/manifests/metallb-native.yaml"
+kubectl wait --namespace metallb-system --for=condition=available deploy/controller --timeout=120s
+kubectl wait --namespace metallb-system --for=condition=ready pod -l component=speaker --timeout=120s
+
+# Address range is taken from the high end of kind's default docker network (172.18.0.0/16).
+kubectl apply -f - <<EOF
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: default
+  namespace: metallb-system
+spec:
+  addresses:
+  - 172.18.255.200-172.18.255.250
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: default
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+  - default
+EOF
+
+echo "Installing Traefik..."
+helm repo add traefik https://traefik.github.io/charts
+helm repo update
+helm upgrade --install traefik traefik/traefik --namespace traefik --create-namespace --wait


### PR DESCRIPTION
Setup for #4356.

- `scripts/setup-kind-cluster.sh` — installs Calico → MetalLB → Traefik on a freshly-created `KinD` cluster. Idempotent (uses `helm upgrade --install`).
- `scripts/kind-config.yaml` — `disableDefaultCNI: true` so Calico can replace kindnet.

[Companion ci-mgmt PR](https://github.com/pulumi/ci-mgmt/pull/2249) wires this into the `run-acceptance-tests.yml` template. 

Once ci-mgmt changes land in this repo, follow-up PRs will unskip the five `SkipIfShort` tests (proofs of concept: #4335, #4342, #4344).

🤖 Generated with [Claude Code](https://claude.com/claude-code)