### PR TITLE
Drop SkipIfShort on five KinD-runnable tests

### DIFF
--- a/tests/sdk/dotnet/dotnet_test.go
+++ b/tests/sdk/dotnet/dotnet_test.go
@@ -84,7 +84,6 @@ func TestDotnet_Basic(t *testing.T) {
 }
 
 func TestDotnet_Guestbook(t *testing.T) {
-	tests.SkipIfShort(t, "test creates a load balancer and requires a Cloud cluster")
 	test := baseOptions.With(integration.ProgramTestOptions{
 		Dir:   "guestbook",
 		Quick: true,

--- a/tests/sdk/nodejs/examples/examples_test.go
+++ b/tests/sdk/nodejs/examples/examples_test.go
@@ -135,33 +135,22 @@ func TestAccGuestbook(t *testing.T) {
 }
 
 func TestAccIngress(t *testing.T) {
-	tests.SkipIfShort(t, "test provisions a load balancer and requires a cloud provider cluster to run")
-	testNetworkingV1 := getBaseOptions(t).
+	test := getBaseOptions(t).
 		With(integration.ProgramTestOptions{
-			Dir:           filepath.Join(getCwd(t), "ingress"),
-			Quick:         true,
-			NoParallel:    true, // We want to run this and the next test serially so nginx ingress isn't clobbered.
-			DebugLogLevel: 3,
-			SkipRefresh:   true, // ingress may have changes during refresh.
+			Dir:         filepath.Join(getCwd(t), "ingress"),
+			Quick:       true,
+			SkipRefresh: true,
 			ExtraRuntimeValidation: func(
 				t *testing.T, stackInfo integration.RuntimeValidationStackInfo,
 			) {
-				assert.NotNil(t, stackInfo.Deployment)
-				assert.Equal(t, 15, len(stackInfo.Deployment.Resources))
-
 				integration.AssertHTTPResultWithRetry(t,
-					fmt.Sprintf("%s/index.html", stackInfo.Outputs["ingressIp"]),
-					nil, 10*time.Minute, func(body string) bool {
-						return assert.NotEmpty(t, body, "Body should not be empty")
-					})
-
-				integration.AssertHTTPResultWithRetry(t, fmt.Sprintf("%s/hello", stackInfo.Outputs["ingressNginxIp"]),
-					map[string]string{"Host": "ingresshello.io"}, 10*time.Minute, func(body string) bool {
+					fmt.Sprintf("%s/hello", stackInfo.Outputs["ingressIp"]),
+					nil, 5*time.Minute, func(body string) bool {
 						return assert.NotEmpty(t, body, "Body should not be empty")
 					})
 			},
 		})
-	integration.ProgramTest(t, &testNetworkingV1)
+	integration.ProgramTest(t, &test)
 }
 
 func TestAccHelm(t *testing.T) {

--- a/tests/sdk/nodejs/examples/ingress/index.ts
+++ b/tests/sdk/nodejs/examples/ingress/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2016-2021, Pulumi Corporation.
+// Copyright 2016-2026, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,31 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as pulumi from "@pulumi/pulumi";
 import * as k8s from "@pulumi/kubernetes";
-import { output as outputs } from "@pulumi/kubernetes/types";
 
 const ns = new k8s.core.v1.Namespace("test");
 const namespace = ns.metadata.name;
 
-const config = new pulumi.Config();
-const useV1Beta1Ingress = config.get("use-v1beta1-ingress") != undefined;
+const helloLabels = { app: "hello", tier: "frontend" };
 
-// Install nginx ingress controller first
-const ingressNs = new k8s.core.v1.Namespace("ingress-nginx");
-const ingressController = new k8s.helm.v3.Release(
-    "nginx-ingress", {
-    name: "nginx-ingress",
-    namespace: ingressNs.metadata.name,
-    chart: "ingress-nginx",
-    version: "4.1.4",
-    repositoryOpts: {
-        repo: "https://kubernetes.github.io/ingress-nginx",
-    },
-});
-
-// nginx hello app
-let helloLabels = { app: "hello", tier: "frontend" };
 const helloService = new k8s.core.v1.Service("hello-svc", {
     metadata: {
         namespace: namespace,
@@ -44,310 +26,49 @@ const helloService = new k8s.core.v1.Service("hello-svc", {
         labels: helloLabels,
     },
     spec: {
-        // GKE ingress will only work with service type of NodePort or LoadBalancer.
-        // We only want one endpoint through the ingress so choosing NodePort.
         ports: [{ port: 8080, targetPort: 8080 }],
         selector: helloLabels,
     },
 });
 
-let helloDeployment = new k8s.apps.v1.Deployment("hello-app", {
+new k8s.apps.v1.Deployment("hello-app", {
     metadata: {
         namespace: namespace,
         name: "hello",
     },
     spec: {
-        selector: {
-            matchLabels: helloLabels,
-        },
-        replicas: 3,
+        selector: { matchLabels: helloLabels },
+        replicas: 1,
         template: {
-            metadata: {
-                labels: helloLabels,
-            },
+            metadata: { labels: helloLabels },
             spec: {
                 containers: [{
                     name: "hello",
                     image: "gcr.io/google-samples/hello-app:1.0",
-                    resources: {
-                        requests: {
-                            cpu: "100m",
-                            memory: "100Mi",
-                        },
-                    },
-                    ports: [{
-                        containerPort: 8080,
-                    }],
+                    ports: [{ containerPort: 8080 }],
                 }],
             },
         },
     },
 });
 
-let feIngressNginx = undefined;
-
-if (!useV1Beta1Ingress) {
-    // Note - this uses the nginx ingress controller which should work across k8s providers.
-    feIngressNginx = new k8s.networking.v1.Ingress("feIngressNginx", {
-        metadata: {
-            namespace: namespace,
-            name: "feingress-nginx",
-            annotations: {
-                "kubernetes.io/ingress.class": "nginx",
-                "nginx.ingress.kubernetes.io/ssl-redirect": "false"
-            },
-        },
-        spec: {
-            rules: [{
-                host: "ingresshello.io",
-                http: {
-                    paths: [{
-                        path: "/hello",
-                        pathType: "Prefix",
-                        backend: { service: { name: helloService.metadata.name, port: { number: 8080 } } }
-                    }]
-                }
-            }],
-        }
-    }, { dependsOn: [ingressController] });
-
-} else {
-    // Note - this uses the nginx ingress controller which should work across k8s providers.
-    feIngressNginx = new k8s.networking.v1beta1.Ingress("feIngressNginx", {
-        metadata: {
-            namespace: namespace,
-            name: "feingress-nginx",
-            annotations: {
-                "kubernetes.io/ingress.class": "nginx",
-                "nginx.ingress.kubernetes.io/ssl-redirect": "false"
-            },
-        },
-        spec: {
-            rules: [{
-                host: "ingresshello.io",
-                http: {
-                    paths: [{
-                        path: "/hello",
-                        pathType: "Prefix",
-                        backend: { serviceName: helloService.metadata.name, servicePort: 8080 }
-                    }]
-                }
-            }],
-        }
-    }, { dependsOn: [ingressController] });
-}
-export const ingressNginxIp = feIngressNginx.status.loadBalancer.ingress[0].ip;
-
-// REDIS MASTER
-
-let redisMasterLabels = { app: "redis", tier: "backend", role: "master" };
-let redisMasterService = new k8s.core.v1.Service("redis-master", {
+const feIngress = new k8s.networking.v1.Ingress("feIngress", {
     metadata: {
         namespace: namespace,
-        name: "redis-master",
-        labels: redisMasterLabels,
+        name: "feingress",
     },
     spec: {
-        ports: [{ port: 6379, targetPort: 6379 }],
-        selector: redisMasterLabels,
-    },
-});
-
-let redisMasterDeployment = new k8s.apps.v1.Deployment("redis-master", {
-    metadata: {
-        namespace: namespace,
-        name: "redis-master",
-    },
-    spec: {
-        selector: {
-            matchLabels: redisMasterLabels,
-        },
-        replicas: 1,
-        template: {
-            metadata: {
-                labels: redisMasterLabels,
-            },
-            spec: {
-                containers: [{
-                    name: "master",
-                    image: "docker.io/redis:6.0.5",
-                    resources: {
-                        requests: {
-                            cpu: "100m",
-                            memory: "100Mi",
-                        },
-                    },
-                    ports: [{
-                        containerPort: 6379,
-                    }],
+        ingressClassName: "traefik",
+        rules: [{
+            http: {
+                paths: [{
+                    path: "/hello",
+                    pathType: "Prefix",
+                    backend: { service: { name: helloService.metadata.name, port: { number: 8080 } } },
                 }],
             },
-        },
+        }],
     },
 });
 
-// REDIS SLAVE
-let redisSlaveLabels = { app: "redis", tier: "backend", role: "slave" };
-let redisSlaveService = new k8s.core.v1.Service("redis-slave", {
-    metadata: {
-        namespace: namespace,
-        name: "redis-slave",
-        labels: redisSlaveLabels,
-    },
-    spec: {
-        ports: [{ port: 6379, targetPort: 6379 }],
-        selector: redisSlaveLabels,
-    },
-});
-
-let redisSlaveDeployment = new k8s.apps.v1.Deployment("redis-slave", {
-    metadata: {
-        namespace: namespace,
-        name: "redis-slave",
-    },
-    spec: {
-        selector: {
-            matchLabels: redisSlaveLabels
-        },
-        replicas: 1,
-        template: {
-            metadata: {
-                labels: redisSlaveLabels,
-            },
-            spec: {
-                containers: [{
-                    name: "slave",
-                    image: "us-docker.pkg.dev/google-samples/containers/gke/gb-redis-follower:v2",
-                    resources: {
-                        requests: {
-                            cpu: "100m",
-                            memory: "100Mi",
-                        },
-                    },
-                    env: [{
-                        name: "GET_HOSTS_FROM",
-                        value: "dns",
-                        // If your cluster config does not include a dns service, then to instead access an environment
-                        // variable to find the master service's host, comment out the 'value: dns' line above, and
-                        // uncomment the line below:
-                        // value: "env"
-                    }],
-                    ports: [{
-                        containerPort: 6379,
-                    }],
-                }],
-            },
-        },
-    },
-});
-
-// FRONTEND
-let frontendLabels = { app: "guestbook", tier: "frontend" };
-const frontendService = new k8s.core.v1.Service("frontend", {
-    metadata: {
-        namespace: namespace,
-        name: "frontend",
-        labels: frontendLabels,
-    },
-    spec: {
-        // GKE ingress will only work with service type of NodePort or LoadBalancer.
-        // We only want one endpoint through the ingress so choosing NodePort.
-        type: "NodePort",
-        ports: [{ port: 80 }],
-        selector: frontendLabels,
-    },
-});
-
-
-
-let frontendDeployment = new k8s.apps.v1.Deployment("frontend", {
-    metadata: {
-        namespace: namespace,
-        name: "frontend",
-    },
-    spec: {
-        selector: {
-            matchLabels: frontendLabels,
-        },
-        replicas: 3,
-        template: {
-            metadata: {
-                labels: frontendLabels,
-            },
-            spec: {
-                containers: [{
-                    name: "php-redis",
-                    image: "us-docker.pkg.dev/google-samples/containers/gke/gb-frontend:v5",
-                    resources: {
-                        requests: {
-                            cpu: "100m",
-                            memory: "100Mi",
-                        },
-                    },
-                    env: [{
-                        name: "GET_HOSTS_FROM",
-                        value: "dns",
-                        // If your cluster config does not include a dns service, then to instead access an environment
-                        // variable to find the master service's host, comment out the 'value: dns' line above, and
-                        // uncomment the line below:
-                        // value: "env"
-                    }],
-                    ports: [{
-                        containerPort: 80,
-                    }],
-                }],
-            },
-        },
-    },
-});
-
-let feIngress = undefined;
-
-if (!useV1Beta1Ingress) {
-    // Note - this uses the built-in GKE ingress controller. This will not work across other Kubernetes providers.
-    feIngress = new k8s.networking.v1.Ingress("feIngress", {
-        metadata: {
-            namespace: namespace,
-            name: "feingress",
-            annotations: {
-                "kubernetes.io/ingress.class": "gce"
-            },
-        },
-        spec: {
-            rules: [{
-                http: {
-                    paths: [{
-                        path: "/*",
-                        pathType: "ImplementationSpecific",
-                        backend: { service: { name: frontendService.metadata.name, port: { number: 80 } } }
-                    }]
-                }
-            }],
-        }
-        // Don't want to race with the ingress controller admission webhook being fully available.
-    }, { dependsOn: [ingressController] });
-} else {
-    // Note - this uses the built-in GKE ingress controller. This will not work across other Kubernetes providers.
-    feIngress = new k8s.networking.v1beta1.Ingress("feIngress", {
-        metadata: {
-            namespace: namespace,
-            name: "feingress",
-            annotations: {
-                "kubernetes.io/ingress.class": "gce"
-            },
-        },
-        spec: {
-            rules: [{
-                http: {
-                    paths: [{
-                        path: "/*",
-                        pathType: "ImplementationSpecific",
-                        backend: { serviceName: frontendService.metadata.name, servicePort: 80 }
-                    }]
-                }
-            }],
-        }
-        // Don't want to race with the ingress controller admission controller being fully available.
-    }, { dependsOn: [ingressController] });
-}
 export const ingressIp = feIngress.status.loadBalancer.ingress[0].ip;

--- a/tests/sdk/nodejs/nodejs_test.go
+++ b/tests/sdk/nodejs/nodejs_test.go
@@ -850,7 +850,6 @@ func TestGet(t *testing.T) {
 }
 
 func TestIstio(t *testing.T) {
-	tests.SkipIfShort(t, "test provisions a load balancer and requires a cloud provider cluster to run")
 	test := baseOptions.With(integration.ProgramTestOptions{
 		Dir:         filepath.Join("istio", "step1"),
 		Quick:       true,
@@ -2383,7 +2382,6 @@ func ignoreChageTest(t *testing.T, testFolderName string) {
 // and has a controller backing it. We create 2 pods to test egress between them, rather than hitting
 // a live URL, to avoid flakiness.
 func TestEmptyItemNormalization(t *testing.T) {
-	tests.SkipIfShort(t, "test requires a cluster with NetworkPolicy support")
 	validateProgram := func(networkingEnabled bool) func(*testing.T, integration.RuntimeValidationStackInfo) {
 		return func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
 			ns, ok := stackInfo.Outputs["podANamespace"].(string)

--- a/tests/sdk/nodejs/preview_test.go
+++ b/tests/sdk/nodejs/preview_test.go
@@ -153,7 +153,6 @@ func createSAKubeconfig(t *testing.T, saName string) (string, error) {
 // subresoruces. This is to ensure we don't fail preview, since status fields are only populated after the resource is
 // created on cluster.
 func TestPreviewWithApply(t *testing.T) {
-	tests.SkipIfShort(t, "test requires a load balancer and won't work on kind clusters")
 	var externalIP, nsName, svcName string
 	test := baseOptions.With(integration.ProgramTestOptions{
 		Dir:                  "preview-apply",


### PR DESCRIPTION
## Summary
Drops `SkipIfShort` on the five tests that #4368 + pulumi/ci-mgmt#2249 now enable on `KinD` PR CI:

- `TestPreviewWithApply`, `TestIstio`, `TestDotnet_Guestbook` — need MetalLB
- `TestAccIngress` — needs Traefik; also trims bloated testdata (drops in-stack nginx-ingress install + Guestbook bits, swaps to `ingressClassName: traefik`)
- `TestEmptyItemNormalization` — needs Calico

Step 2 of #4356. Stacked on #4368.

## Test plan
- [ ] PR CI green across the language matrix
- [ ] All five tests run (not skipped) on this PR's nodejs + dotnet jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)