### PR TITLE
Make TestAccIngress portable: self-install nginx ingress controller

### DIFF
--- a/tests/sdk/nodejs/examples/ingress/index.ts
+++ b/tests/sdk/nodejs/examples/ingress/index.ts
@@ -17,6 +17,20 @@ import * as k8s from "@pulumi/kubernetes";
 const ns = new k8s.core.v1.Namespace("test");
 const namespace = ns.metadata.name;
 
+// Self-install an nginx ingress controller so the test is portable: the GKE
+// cluster used by master CI has no ingress controller of its own. nginx uses a
+// distinct ingress class, so it coexists with the KinD cluster's Traefik.
+const ingressNs = new k8s.core.v1.Namespace("ingress-nginx");
+const ingressController = new k8s.helm.v3.Release("nginx-ingress", {
+    name: "nginx-ingress",
+    namespace: ingressNs.metadata.name,
+    chart: "ingress-nginx",
+    version: "4.13.9",
+    repositoryOpts: {
+        repo: "https://kubernetes.github.io/ingress-nginx",
+    },
+});
+
 const helloLabels = { app: "hello", tier: "frontend" };
 
 const helloService = new k8s.core.v1.Service("hello-svc", {
@@ -56,9 +70,12 @@ const feIngress = new k8s.networking.v1.Ingress("feIngress", {
     metadata: {
         namespace: namespace,
         name: "feingress",
+        annotations: {
+            "nginx.ingress.kubernetes.io/ssl-redirect": "false",
+        },
     },
     spec: {
-        ingressClassName: "traefik",
+        ingressClassName: "nginx",
         rules: [{
             http: {
                 paths: [{
@@ -69,6 +86,6 @@ const feIngress = new k8s.networking.v1.Ingress("feIngress", {
             },
         }],
     },
-});
+}, { dependsOn: [ingressController] });
 
 export const ingressIp = feIngress.status.loadBalancer.ingress[0].ip;


### PR DESCRIPTION
`TestAccIngress` started failing on every master build after #4369 trimmed `ingress/index.ts` to use `ingressClassName: traefik`. That works on PR CI (the KinD cluster installs Traefik) but not on master CI, which runs on a GKE cluster with no ingress controller of its own.

This makes the test self-contained: it installs its own nginx ingress controller (chart 4.13.9 / controller v1.13 — supports both the KinD 1.29 and GKE 1.33 clusters) and points the Ingress at the `nginx` class. nginx coexists with the KinD cluster's Traefik since the two own different ingress classes.

Fixes the failures tracked in #4375. Once master also runs on KinD (#4380), the self-install can be dropped in favor of the cluster's Traefik.