### PR TITLE
Fix docs for Kubernetes version support and local SDK install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## Unreleased
 
+### Changed
+
+- Align the documented minimum supported Kubernetes version and local SDK install instructions with current provider behavior.
+
 ## 4.31.1 (May 19, 2026)
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,14 +21,12 @@ $ make ensure
 
 Run the following command to build and install the source.
 
-The output will be stored in `/opt/pulumi/node_modules/@pulumi/kubernetes`.
-
 ```bash
 $ make ensure build install
 ```
 
-`cd` into your Pulumi program directory.  After `make` has completed,
-link the recent `@pulumi/kubernetes` build from `/opt/` by running the following command:
+`make install` links the local Node.js SDK build from `sdk/nodejs/bin`.
+`cd` into your Pulumi program directory and link `@pulumi/kubernetes` by running:
 
 ```
 $ yarn link @pulumi/kubernetes
@@ -38,7 +36,7 @@ $ yarn link @pulumi/kubernetes
 
 The examples and integration tests in this repository will create and destroy
 real Kubernetes objects while running. Before running these tests, make sure that you have
-[configured Pulumi with your Kubernetes cluster](https://pulumi.io/install/kubernetes.html)
+[configured Pulumi with your Kubernetes cluster](https://www.pulumi.com/registry/packages/kubernetes/installation-configuration/)
 successfully at least once before.
 
 You can run Kubernetes tests against `minikube` or against real Kubernetes

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ to the full API surface, including deprecated endpoints.
 The SDK API is 100% compatible with the Kubernetes API, and is
 schematically identical to what Kubernetes users expect.
 
-We support Kubernetes clusters with version >=1.9.0.
+We support Kubernetes clusters with version >=1.13.0.
 
 #### How does API support for Kubernetes work?
 
@@ -68,7 +68,7 @@ for more details.
 
 * [Reference Documentation](https://www.pulumi.com/registry/packages/kubernetes/)
 * API Documentation
-    * [Node.js API](https://pulumi.io/reference/pkg/nodejs/@pulumi/kubernetes)
+    * [Node.js API](https://www.pulumi.com/registry/packages/kubernetes/api-docs/)
     * [Python API](https://www.pulumi.com/docs/reference/pkg/python/pulumi_kubernetes/)
 * [All Examples](./examples)
 * [How-to Guides](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/)
@@ -76,7 +76,7 @@ for more details.
 ## Prerequisites
 
 1. [Install Pulumi](https://www.pulumi.com/docs/get-started/kubernetes/install-pulumi/).
-1. Install a language runtime such as [Node.js](https://nodejs.org/en/download), [Python](https://www.python.org/downloads/) or [.NET](https://dotnet.microsoft.com/download/dotnet-core/3.1).
+1. Install a language runtime such as [Node.js](https://nodejs.org/en/download), [Python](https://www.python.org/downloads/) or [.NET](https://dotnet.microsoft.com/download).
 1. Install a package manager
     * For Node.js, use [NPM](https://www.npmjs.com/get-npm) or [Yarn](https://yarnpkg.com/lang/en/docs/install).
     * For Python, use [pip](https://pip.pypa.io/en/stable/installing/).

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -48,7 +48,7 @@ to the full API surface, including deprecated endpoints.
 The SDK API is 100% compatible with the Kubernetes API, and is
 schematically identical to what Kubernetes users expect.
 
-We support Kubernetes clusters with version >=1.9.0.
+We support Kubernetes clusters with version >=1.13.0.
 
 #### How does API support for Kubernetes work?
 
@@ -68,7 +68,7 @@ for more details.
 
 * [Reference Documentation](https://www.pulumi.com/registry/packages/kubernetes/)
 * API Documentation
-    * [Node.js API](https://pulumi.io/reference/pkg/nodejs/@pulumi/kubernetes)
+    * [Node.js API](https://www.pulumi.com/registry/packages/kubernetes/api-docs/)
     * [Python API](https://www.pulumi.com/docs/reference/pkg/python/pulumi_kubernetes/)
 * [All Examples](./examples)
 * [How-to Guides](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/)
@@ -76,7 +76,7 @@ for more details.
 ## Prerequisites
 
 1. [Install Pulumi](https://www.pulumi.com/docs/get-started/kubernetes/install-pulumi/).
-1. Install a language runtime such as [Node.js](https://nodejs.org/en/download), [Python](https://www.python.org/downloads/) or [.NET](https://dotnet.microsoft.com/download/dotnet-core/3.1).
+1. Install a language runtime such as [Node.js](https://nodejs.org/en/download), [Python](https://www.python.org/downloads/) or [.NET](https://dotnet.microsoft.com/download).
 1. Install a package manager
     * For Node.js, use [NPM](https://www.npmjs.com/get-npm) or [Yarn](https://yarnpkg.com/lang/en/docs/install).
     * For Python, use [pip](https://pip.pypa.io/en/stable/installing/).


### PR DESCRIPTION
### Proposed changes

Small docs fix, but its a real footgun.

- align the documented minimum Kubernetes version with the provider check of `v1.13`
- refresh stale docs links
- fix the local `yarn link` flow in `CONTRIBUTING.md` so it matches `make install`

### Repro

1. Open `README.md`. It says clusters `>=1.9.0` are supported.
2. The provider rejects anything below `v1.13` in `provider/pkg/provider/provider.go`.
3. The existing provider suite covers that path too:
   `go test ./pkg/provider -run TestSuite -count=1 -args -ginkgo.focus='server version is < 1.13'`

So yeah, docs were a bit off. This makes them line up again.

### Related issues (optional)

None found.
