### PR TITLE
fix: prevent nil panic when creating service-account-token Secret with missing SA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- [#4396](https://github.com/pulumi/pulumi-kubernetes/issues/4396) Fix panic when creating a `kubernetes.io/service-account-token` Secret with a non-existent ServiceAccount.
+
 ### Changed
 
 - Align the documented minimum supported Kubernetes version and local SDK install instructions with current provider behavior.

--- a/provider/pkg/await/await_test.go
+++ b/provider/pkg/await/await_test.go
@@ -1405,10 +1405,10 @@ func TestAwaiterInterfaceTimeout(t *testing.T) {
 	assert.True(t, isPartialErr, "Timed out watcher should emit `await.PartialError`")
 }
 
-// TestCreation_ServiceAccountTokenSecret tests that Creation returns a non-nil
-// object even when the awaiter never observed the resource (i.e. returns nil).
-// Regression test for https://github.com/pulumi/pulumi-kubernetes/issues/4396.
-func TestCreation_ServiceAccountTokenSecret(t *testing.T) {
+// TestCreation_AwaiterReturnsNilObject is a regression test for
+// https://github.com/pulumi/pulumi-kubernetes/issues/4396: Creation must
+// return a non-nil object even when the awaiter never observed the resource.
+func TestCreation_AwaiterReturnsNilObject(t *testing.T) {
 	secretWithoutData := &unstructured.Unstructured{
 		Object: map[string]any{
 			"apiVersion": "v1",

--- a/provider/pkg/await/await_test.go
+++ b/provider/pkg/await/await_test.go
@@ -1405,15 +1405,9 @@ func TestAwaiterInterfaceTimeout(t *testing.T) {
 	assert.True(t, isPartialErr, "Timed out watcher should emit `await.PartialError`")
 }
 
-// TestCreation_ServiceAccountTokenSecret tests that creating a
-// kubernetes.io/service-account-token Secret whose referenced ServiceAccount
-// does not exist returns a PartialError rather than panicking. The bug
-// (https://github.com/pulumi/pulumi-kubernetes/issues/4396) was that when the
-// awaiter's internal poll returned (nil, err) the PartialError's Object() was
-// nil; provider.go then overrode the initialized variable with nil and
-// GetName() panicked. The fix ensures the last known non-nil object from the
-// watcher is preserved, and provider.go falls back to the API-created outputs
-// when PartialError.Object() is nil.
+// TestCreation_ServiceAccountTokenSecret tests that Creation returns a non-nil
+// object even when the awaiter never observed the resource (i.e. returns nil).
+// Regression test for https://github.com/pulumi/pulumi-kubernetes/issues/4396.
 func TestCreation_ServiceAccountTokenSecret(t *testing.T) {
 	secretWithoutData := &unstructured.Unstructured{
 		Object: map[string]any{
@@ -1424,7 +1418,6 @@ func TestCreation_ServiceAccountTokenSecret(t *testing.T) {
 				"namespace": "default",
 			},
 			"type": "kubernetes.io/service-account-token",
-			// data intentionally absent — SA doesn't exist, controller won't populate it
 		},
 	}
 
@@ -1441,10 +1434,7 @@ func TestCreation_ServiceAccountTokenSecret(t *testing.T) {
 		"testresource",
 	)
 
-	// Use a custom awaiter that simulates the failure mode: the awaiter's internal
-	// poll never produced a non-nil object, so it returns (nil, err). This is the
-	// exact condition that triggered the nil-pointer panic in provider.go before
-	// the fix.
+	// Simulate the awaiter never observing the object (poll returned nil).
 	awaitNilObject := func(_ awaitConfig) (*unstructured.Unstructured, error) {
 		return nil, fmt.Errorf("service account does not exist")
 	}
@@ -1470,16 +1460,11 @@ func TestCreation_ServiceAccountTokenSecret(t *testing.T) {
 
 	outputs, awaitErr := Creation(config)
 
-	// Creation must return the API-created outputs (non-nil) even when the
-	// awaiter itself could not observe any state.
 	assert.NotNil(t, outputs, "Creation should return the API-created object even when the awaiter returns nil")
 
-	// The error must be a PartialError so the provider can checkpoint state.
 	partialErr, isPartialErr := awaitErr.(PartialError)
 	assert.True(t, isPartialErr, "await error should be a PartialError")
 
-	// PartialError.Object() may be nil when the awaiter never observed the
-	// object. The provider.go fix guards against using this nil value directly.
 	if isPartialErr && partialErr.Object() != nil {
 		assert.Equal(t, "my-secret", partialErr.Object().GetName())
 	}

--- a/provider/pkg/await/await_test.go
+++ b/provider/pkg/await/await_test.go
@@ -1405,6 +1405,86 @@ func TestAwaiterInterfaceTimeout(t *testing.T) {
 	assert.True(t, isPartialErr, "Timed out watcher should emit `await.PartialError`")
 }
 
+// TestCreation_ServiceAccountTokenSecret tests that creating a
+// kubernetes.io/service-account-token Secret whose referenced ServiceAccount
+// does not exist returns a PartialError rather than panicking. The bug
+// (https://github.com/pulumi/pulumi-kubernetes/issues/4396) was that when the
+// awaiter's internal poll returned (nil, err) the PartialError's Object() was
+// nil; provider.go then overrode the initialized variable with nil and
+// GetName() panicked. The fix ensures the last known non-nil object from the
+// watcher is preserved, and provider.go falls back to the API-created outputs
+// when PartialError.Object() is nil.
+func TestCreation_ServiceAccountTokenSecret(t *testing.T) {
+	secretWithoutData := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Secret",
+			"metadata": map[string]any{
+				"name":      "my-secret",
+				"namespace": "default",
+			},
+			"type": "kubernetes.io/service-account-token",
+			// data intentionally absent — SA doesn't exist, controller won't populate it
+		},
+	}
+
+	host := &fakehost.HostClient{}
+	client, disco, _, _ := fake.NewSimpleDynamicClient()
+	resources, err := openapi.GetResourceSchemasForClient(disco)
+	require.NoError(t, err)
+
+	urn := resource.NewURN(
+		tokens.QName("teststack"),
+		tokens.PackageName("testproj"),
+		tokens.Type(""),
+		tokens.Type("kubernetes:core/v1:Secret"),
+		"testresource",
+	)
+
+	// Use a custom awaiter that simulates the failure mode: the awaiter's internal
+	// poll never produced a non-nil object, so it returns (nil, err). This is the
+	// exact condition that triggered the nil-pointer panic in provider.go before
+	// the fix.
+	awaitNilObject := func(_ awaitConfig) (*unstructured.Unstructured, error) {
+		return nil, fmt.Errorf("service account does not exist")
+	}
+
+	config := CreateConfig{
+		ProviderConfig: ProviderConfig{
+			Context:           context.Background(),
+			Host:              host,
+			URN:               urn,
+			InitialAPIVersion: corev1.SchemeGroupVersion.String(),
+			FieldManager:      "test",
+			ClusterVersion:    testServerVersion,
+			ClientSet:         client,
+			DedupLogger:       logging.NewLogger(context.Background(), host, urn),
+			Resources:         resources,
+			awaiters: map[string]awaitSpec{
+				"v1/Secret": {await: wrap(awaitNilObject)},
+			},
+			Factories: informers.NewFactories(t.Context()),
+		},
+		Inputs: secretWithoutData,
+	}
+
+	outputs, awaitErr := Creation(config)
+
+	// Creation must return the API-created outputs (non-nil) even when the
+	// awaiter itself could not observe any state.
+	assert.NotNil(t, outputs, "Creation should return the API-created object even when the awaiter returns nil")
+
+	// The error must be a PartialError so the provider can checkpoint state.
+	partialErr, isPartialErr := awaitErr.(PartialError)
+	assert.True(t, isPartialErr, "await error should be a PartialError")
+
+	// PartialError.Object() may be nil when the awaiter never observed the
+	// object. The provider.go fix guards against using this nil value directly.
+	if isPartialErr && partialErr.Object() != nil {
+		assert.Equal(t, "my-secret", partialErr.Object().GetName())
+	}
+}
+
 // --------------------------------------------------------------------------
 
 // Helpers

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -15,6 +15,7 @@
 package provider
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"errors"
@@ -1831,11 +1832,9 @@ func (k *kubeProvider) Create(
 
 		// Resource was created, but failed to become fully initialized.
 		// partialErr.Object() may be nil if the awaiter never observed the object
-		// (e.g., a transient poll error before any successful Get). Fall back to
-		// the outputs returned by the API server at creation time.
-		if obj := partialErr.Object(); obj != nil {
-			initialized = obj
-		}
+		// (e.g., a transient poll error before any successful Get), so fall back
+		// to the outputs returned by the API server at creation time.
+		initialized = cmp.Or(partialErr.Object(), initialized)
 	}
 	contract.Assertf(initialized.GetName() != "", "expected live object name to be nonempty: %v", initialized)
 

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -1830,10 +1830,8 @@ func (k *kubeProvider) Create(
 				"resource %q was not successfully created by the Kubernetes API server: %w", urn, awaitErr)
 		}
 
-		// Resource was created, but failed to become fully initialized.
-		// partialErr.Object() may be nil if the awaiter never observed the object
-		// (e.g., a transient poll error before any successful Get), so fall back
-		// to the outputs returned by the API server at creation time.
+		// Resource was created but failed to fully initialize. Fall back to
+		// the API-created outputs if the awaiter didn't observe any state.
 		initialized = cmp.Or(partialErr.Object(), initialized)
 	}
 	contract.Assertf(initialized.GetName() != "", "expected live object name to be nonempty: %v", initialized)

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -1830,7 +1830,12 @@ func (k *kubeProvider) Create(
 		}
 
 		// Resource was created, but failed to become fully initialized.
-		initialized = partialErr.Object()
+		// partialErr.Object() may be nil if the awaiter never observed the object
+		// (e.g., a transient poll error before any successful Get). Fall back to
+		// the outputs returned by the API server at creation time.
+		if obj := partialErr.Object(); obj != nil {
+			initialized = obj
+		}
 	}
 	contract.Assertf(initialized.GetName() != "", "expected live object name to be nonempty: %v", initialized)
 

--- a/provider/pkg/watcher/watcher.go
+++ b/provider/pkg/watcher/watcher.go
@@ -129,9 +129,15 @@ func (ow *ObjectWatcher) watch(
 		case <-ow.ctx.Done():
 			return obj, cancellationErr(ow.objName, obj)
 		case res := <-results:
-			obj = res.Obj
+			// Only update the tracked object when we receive a non-nil result so
+			// that a transient poll error doesn't clobber the last known state.
+			if res.Obj != nil {
+				obj = res.Obj
+			}
 			if stop, err := until(res.Obj, res.Err); err != nil {
-				return res.Obj, err
+				// Return the last known non-nil object alongside the error so
+				// callers can checkpoint partial state instead of panicking on nil.
+				return obj, err
 			} else if stop {
 				return res.Obj, nil
 			}

--- a/provider/pkg/watcher/watcher.go
+++ b/provider/pkg/watcher/watcher.go
@@ -129,14 +129,11 @@ func (ow *ObjectWatcher) watch(
 		case <-ow.ctx.Done():
 			return obj, cancellationErr(ow.objName, obj)
 		case res := <-results:
-			// Only update the tracked object when we receive a non-nil result so
-			// that a transient poll error doesn't clobber the last known state.
+			// Preserve the last non-nil object so a poll error doesn't lose state.
 			if res.Obj != nil {
 				obj = res.Obj
 			}
 			if stop, err := until(res.Obj, res.Err); err != nil {
-				// Return the last known non-nil object alongside the error so
-				// callers can checkpoint partial state instead of panicking on nil.
 				return obj, err
 			} else if stop {
 				return res.Obj, nil

--- a/provider/pkg/watcher/watcher_test.go
+++ b/provider/pkg/watcher/watcher_test.go
@@ -176,11 +176,8 @@ func Test_RetryUntil_Cancel(t *testing.T) {
 	}
 }
 
-// Test_WatchUntil_PollErrorAfterSuccess verifies that when a poll succeeds
-// initially but later fails (returning nil), WatchUntil returns the last
-// known non-nil object alongside the error rather than returning nil.
-// This prevents nil pointer panics in callers that assume a non-nil object
-// is returned whenever the resource was successfully created.
+// Test_WatchUntil_PollErrorAfterSuccess verifies that a poll error after an
+// initial success returns the last known non-nil object, not nil.
 func Test_WatchUntil_PollErrorAfterSuccess(t *testing.T) {
 	knownObj := &unstructured.Unstructured{Object: map[string]any{
 		"metadata": map[string]any{"name": "my-secret"},
@@ -192,14 +189,12 @@ func Test_WatchUntil_PollErrorAfterSuccess(t *testing.T) {
 		func() (*unstructured.Unstructured, error) {
 			calls++
 			if calls == 1 {
-				// First poll returns the object successfully.
 				return knownObj, nil
 			}
-			// Subsequent polls fail (e.g., transient API error).
 			return nil, fmt.Errorf("transient error")
 		}).
 		WatchUntil(
-			func(*unstructured.Unstructured) bool { return false }, // never satisfied
+			func(*unstructured.Unstructured) bool { return false },
 			1*time.Second,
 		)
 

--- a/provider/pkg/watcher/watcher_test.go
+++ b/provider/pkg/watcher/watcher_test.go
@@ -16,6 +16,7 @@ package watcher
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -173,4 +174,36 @@ func Test_RetryUntil_Cancel(t *testing.T) {
 	if err == nil {
 		t.Error("Expected watch to terminate with an initialization error")
 	}
+}
+
+// Test_WatchUntil_PollErrorAfterSuccess verifies that when a poll succeeds
+// initially but later fails (returning nil), WatchUntil returns the last
+// known non-nil object alongside the error rather than returning nil.
+// This prevents nil pointer panics in callers that assume a non-nil object
+// is returned whenever the resource was successfully created.
+func Test_WatchUntil_PollErrorAfterSuccess(t *testing.T) {
+	knownObj := &unstructured.Unstructured{Object: map[string]any{
+		"metadata": map[string]any{"name": "my-secret"},
+	}}
+
+	calls := 0
+	obj, err := testObjWatcher(
+		context.Background(),
+		func() (*unstructured.Unstructured, error) {
+			calls++
+			if calls == 1 {
+				// First poll returns the object successfully.
+				return knownObj, nil
+			}
+			// Subsequent polls fail (e.g., transient API error).
+			return nil, fmt.Errorf("transient error")
+		}).
+		WatchUntil(
+			func(*unstructured.Unstructured) bool { return false }, // never satisfied
+			1*time.Second,
+		)
+
+	assert.NotNil(t, obj, "WatchUntil should return the last known non-nil object on poll failure")
+	assert.Equal(t, "my-secret", obj.GetName())
+	assert.Error(t, err)
 }


### PR DESCRIPTION
Fixes #4396.

## Summary

- When a `kubernetes.io/service-account-token` Secret is created with an annotation referencing a non-existent ServiceAccount, the token controller never populates `data`. The 5-second await in `untilCoreV1SecretInitialized` times out. If any poll during that window returned `(nil, err)` (transient API error, context cancellation, or the Secret being briefly unavailable), the `obj` tracking variable in `watcher.watch` was overwritten with `nil`. This nil propagated through `legacyReadyCondition.Object()` → `errObject.Object()` → `provider.go`, where `initialized = partialErr.Object()` replaced the valid API-created object with `nil`, causing `initialized.GetName()` to panic with a nil pointer dereference.
- **Root cause fix (`watcher.go`)**: only update the tracked `obj` when a poll returns a non-nil result; return the last known non-nil object on poll error rather than `res.Obj` (nil).
- **Safety net (`provider.go`)**: only override `initialized` with `partialErr.Object()` when it is non-nil; fall back to the API-created `outputs` otherwise.

## Test plan

- [ ] `Test_WatchUntil_PollErrorAfterSuccess` (new): verifies that when a poll succeeds initially then fails, `WatchUntil` returns the last known non-nil object rather than nil.
- [ ] `TestCreation_ServiceAccountTokenSecret` (new): verifies that `Creation` returns the API-created object even when the awaiter's internal poll returns `(nil, err)`.
- [ ] `make test_provider` passes.