### PR TITLE
fix: use %w for error wrapping, drop duplicate helm status fields

### DIFF
--- a/provider/pkg/clients/clients.go
+++ b/provider/pkg/clients/clients.go
@@ -46,7 +46,7 @@ func ResourceClient(kind kinds.Kind, namespace string, client *DynamicClientSet)
 
 	c, err := client.ResourceClient(*gvk, namespace)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get client: %v", err)
+		return nil, fmt.Errorf("failed to get client: %w", err)
 	}
 
 	return c, nil
@@ -71,7 +71,7 @@ func NewDynamicClientSet(clientConfig *rest.Config) (*DynamicClientSet, error) {
 
 	disco, err := discovery.NewDiscoveryClientForConfig(clientConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to initialize discovery client: %v", err)
+		return nil, fmt.Errorf("failed to initialize discovery client: %w", err)
 	}
 
 	// Cache the discovery information (OpenAPI schema, etc.) so we don't have to retrieve it for
@@ -82,7 +82,7 @@ func NewDynamicClientSet(clientConfig *rest.Config) (*DynamicClientSet, error) {
 	// Create dynamic resource client
 	client, err := dynamic.NewForConfig(clientConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to initialize dynamic client: %v", err)
+		return nil, fmt.Errorf("failed to initialize dynamic client: %w", err)
 	}
 
 	return &DynamicClientSet{

--- a/provider/pkg/clients/memcache.go
+++ b/provider/pkg/clients/memcache.go
@@ -167,7 +167,7 @@ func (d *memCacheClient) GroupsAndMaybeResources() (
 		for gv, cacheEntry := range d.groupToServerResources {
 			groupVersion, err := schema.ParseGroupVersion(gv)
 			if err != nil {
-				return nil, nil, nil, fmt.Errorf("failed to parse group version (%v): %v", gv, err)
+				return nil, nil, nil, fmt.Errorf("failed to parse group version (%v): %w", gv, err)
 			}
 			if cacheEntry.err != nil {
 				failedGVs[groupVersion] = cacheEntry.err

--- a/provider/pkg/provider/helm_release.go
+++ b/provider/pkg/provider/helm_release.go
@@ -1254,11 +1254,7 @@ func setReleaseAttributes(release *Release, r *release.Release, isPreview bool) 
 		release.Status = &ReleaseStatus{}
 	}
 
-	release.Status.Version = r.Chart.Metadata.Version
-	release.Status.Namespace = r.Namespace
-	release.Status.Name = r.Name
 	release.Status.Status = r.Info.Status.String()
-
 	release.Status.Name = r.Name
 	release.Status.Namespace = r.Namespace
 	release.Status.Revision = &r.Version

--- a/provider/pkg/provider/util.go
+++ b/provider/pkg/provider/util.go
@@ -183,7 +183,7 @@ func parseKubeconfigPropertyValue(kubeconfig resource.PropertyValue) (*clientapi
 		raw := kubeconfig.ObjectValue().Mappable()
 		jsonBytes, err := json.Marshal(raw)
 		if err != nil {
-			return nil, fmt.Errorf("failed to unmarshal kubeconfig: %v", err)
+			return nil, fmt.Errorf("failed to unmarshal kubeconfig: %w", err)
 		}
 		cfg = string(jsonBytes)
 	} else {
@@ -191,7 +191,7 @@ func parseKubeconfigPropertyValue(kubeconfig resource.PropertyValue) (*clientapi
 	}
 	config, err := parseKubeconfigString(cfg)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse kubeconfig: %v", err)
+		return nil, fmt.Errorf("failed to parse kubeconfig: %w", err)
 	}
 	return config, nil
 }


### PR DESCRIPTION
### Proposed changes

Two small fixes bundled together:

1. `%v` -> `%w` in `fmt.Errorf` calls

`clients.go`, `util.go` and `memcache.go` were using `%v` to format errors, which breaks `errors.Is`/`errors.As` unwrapping. Rest of the codebase already uses `%w` consistently (138 spots), these 6 were stragglers.

To reproduce:

```go
_, err := clients.NewDynamicClientSet(badConfig)
var target *url.Error
fmt.Println(errors.As(err, &target)) // prints false with %v, true with %w
```

2. Duplicate field assignments in `setReleaseAttributes` (helm_release.go)

`Status.Name`, `Status.Namespace` and `Status.Version` were each assigned twice in a row with identical values - first block is dead code. Introduced in a single commit back in 2021, looks like copy/paste that never got cleaned up.

### Related issues (optional)

n/a