### PR TITLE
Don't fail YAML render when namespace scope is unknown offline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Fixed
 
 - [#4396](https://github.com/pulumi/pulumi-kubernetes/issues/4396) Fix panic when creating a `kubernetes.io/service-account-token` Secret with a non-existent ServiceAccount.
+- [#4394](https://github.com/pulumi/pulumi-kubernetes/issues/4394) Don't fail YAML render when a custom resource's namespace scope can't be determined offline. The resource is rendered without a namespace and a warning is logged, rather than erroring.
 
 ### Changed
 

--- a/provider/pkg/provider/helm/v4/chart.go
+++ b/provider/pkg/provider/helm/v4/chart.go
@@ -261,10 +261,11 @@ func (r *ChartProvider) Construct(
 	if ns == "" {
 		ns = r.opts.DefaultNamespace
 	}
-	objs, err = provideryamlv2.Normalize(objs, ns, r.opts.ClientSet)
+	objs, unresolvedScope, err := provideryamlv2.Normalize(objs, ns, r.opts.ClientSet)
 	if err != nil {
 		return nil, err
 	}
+	provideryamlv2.WarnUnresolvedNamespaceScope(ctx, unresolvedScope)
 
 	// Register the objects as Pulumi resources.
 	registerOpts := provideryamlv2.RegisterOptions{

--- a/provider/pkg/provider/kustomize/v2/directory.go
+++ b/provider/pkg/provider/kustomize/v2/directory.go
@@ -155,10 +155,11 @@ func (r *DirectoryProvider) Construct(
 	if directoryArgs.Namespace != "" {
 		ns = directoryArgs.Namespace
 	}
-	objs, err = provideryamlv2.Normalize(objs, ns, r.opts.ClientSet)
+	objs, unresolvedScope, err := provideryamlv2.Normalize(objs, ns, r.opts.ClientSet)
 	if err != nil {
 		return nil, err
 	}
+	provideryamlv2.WarnUnresolvedNamespaceScope(ctx, unresolvedScope)
 
 	// Register the objects as Pulumi resources.
 	registerOpts := provideryamlv2.RegisterOptions{

--- a/provider/pkg/provider/yaml/v2/configfile.go
+++ b/provider/pkg/provider/yaml/v2/configfile.go
@@ -109,10 +109,11 @@ func (k *ConfigFileProvider) Construct(
 			}
 
 			// Normalize the objects (apply a default namespace, etc.)
-			objs, err = Normalize(objs, k.defaultNamespace, k.clientSet)
+			objs, unresolvedScope, err := Normalize(objs, k.defaultNamespace, k.clientSet)
 			if err != nil {
 				return pulumi.ArrayOutput{}, err
 			}
+			WarnUnresolvedNamespaceScope(ctx, unresolvedScope)
 
 			// Register the objects as Pulumi resources.
 			registerOpts := RegisterOptions{

--- a/provider/pkg/provider/yaml/v2/configgroup.go
+++ b/provider/pkg/provider/yaml/v2/configgroup.go
@@ -120,10 +120,11 @@ func (k *ConfigGroupProvider) Construct(
 			}
 
 			// Normalize the objects (apply a default namespace, etc.)
-			objs, err = Normalize(objs, k.defaultNamespace, k.clientSet)
+			objs, unresolvedScope, err := Normalize(objs, k.defaultNamespace, k.clientSet)
 			if err != nil {
 				return pulumi.ArrayOutput{}, err
 			}
+			WarnUnresolvedNamespaceScope(ctx, unresolvedScope)
 
 			// Register the objects as Pulumi resources.
 			registerOpts := RegisterOptions{

--- a/provider/pkg/provider/yaml/v2/yaml.go
+++ b/provider/pkg/provider/yaml/v2/yaml.go
@@ -35,6 +35,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	cliutilsobject "sigs.k8s.io/cli-utils/pkg/object"
 	cliutilsgraph "sigs.k8s.io/cli-utils/pkg/object/graph"
@@ -138,30 +139,36 @@ func yamlDecode(text string) ([]unstructured.Unstructured, error) {
 // - canonicalize the kind (core/v1 -> v1)
 // - expands any list types into their individual resources
 // - applies the default namespace to namespaced resources that do not have a namespace
+//
+// The second return value lists the GroupVersionKinds whose namespace scope could not be
+// determined (no reachable cluster and no matching CustomResourceDefinition). Those objects are
+// left without a namespace rather than failing; callers should surface them with
+// WarnUnresolvedNamespaceScope.
 func Normalize(
 	objs []unstructured.Unstructured,
 	defaultNamespace string,
 	clientSet *clients.DynamicClientSet,
-) ([]unstructured.Unstructured, error) {
+) ([]unstructured.Unstructured, []schema.GroupVersionKind, error) {
 	contract.Requiref(clientSet != nil, "clientSet", "expected != nil")
 
 	var err error
 	objs, err = expand(objs)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
+	var unresolved []schema.GroupVersionKind
 	for _, obj := range objs {
 		gvk := obj.GroupVersionKind()
 
 		// Ensure there is a kind and API version.
 		if gvk.Kind == "" || gvk.GroupVersion().Empty() {
-			return nil, fmt.Errorf("Kubernetes resources require a kind and apiVersion: `%s`", printUnstructured(&obj))
+			return nil, nil, fmt.Errorf("Kubernetes resources require a kind and apiVersion: `%s`", printUnstructured(&obj))
 		}
 
 		// Validate that it has the requisite metadata and name properties.
 		if obj.GetName() == "" {
-			return nil, fmt.Errorf("Kubernetes resources require a .metadata.name: `%s`", printUnstructured(&obj))
+			return nil, nil, fmt.Errorf("Kubernetes resources require a .metadata.name: `%s`", printUnstructured(&obj))
 		}
 
 		// canonicalize the "core" group for the sake of a depends-on annotation that might reference this object.
@@ -170,17 +177,51 @@ func Normalize(
 			obj.SetGroupVersionKind(gvk)
 		}
 
-		// determine whether the kind is namespaced, which may involve a call to the API server.
-		// note that the object list is searched for a matching CRD before resorting to a discovery call.
-		isNamespaced, err := clients.IsNamespacedKind(gvk, clientSet, objs...)
-		if err != nil {
-			return nil, err
+		// The kind's scope only matters when we might apply a default namespace.
+		if obj.GetNamespace() != "" {
+			continue
 		}
-		if isNamespaced && obj.GetNamespace() == "" {
+
+		// Determine whether the kind is namespaced, which may involve a call to the API server.
+		// The object list is searched for a matching CRD before resorting to a discovery call.
+		isNamespaced, err := clients.IsNamespacedKind(gvk, clientSet, objs...)
+		switch {
+		case clients.IsNoNamespaceInfoErr(err):
+			// Scope can't be determined offline (no reachable cluster, and no matching CRD bundled or
+			// declared in the program). Leave the namespace unset rather than failing the operation;
+			// apply-time resolves it. Cluster-scoped kinds are correct as-is, and namespaced kinds fall
+			// back to the apply-time namespace.
+			unresolved = append(unresolved, gvk)
+		case err != nil:
+			return nil, nil, err
+		case isNamespaced:
 			obj.SetNamespace(defaultNamespace)
 		}
 	}
-	return objs, nil
+	return objs, unresolved, nil
+}
+
+// WarnUnresolvedNamespaceScope logs a warning for kinds whose namespace scope Normalize could not
+// determine, so their rendered manifests omit a namespace. It is a no-op when gvks is empty.
+func WarnUnresolvedNamespaceScope(ctx *pulumi.Context, gvks []schema.GroupVersionKind) {
+	if len(gvks) == 0 {
+		return
+	}
+	seen := map[string]bool{}
+	kinds := make([]string, 0, len(gvks))
+	for _, gvk := range gvks {
+		s := gvk.String()
+		if seen[s] {
+			continue
+		}
+		seen[s] = true
+		kinds = append(kinds, s)
+	}
+	msg := fmt.Sprintf("Unable to determine whether the following kinds are namespaced without a reachable "+
+		"cluster or a matching CustomResourceDefinition, so they are rendered without a namespace: %s. Set "+
+		".metadata.namespace explicitly, or include the CustomResourceDefinition, to control the namespace.",
+		strings.Join(kinds, ", "))
+	_ = ctx.Log.Warn(msg, nil)
 }
 
 func expand(objs []unstructured.Unstructured) ([]unstructured.Unstructured, error) {

--- a/provider/pkg/provider/yaml/v2/yaml_test.go
+++ b/provider/pkg/provider/yaml/v2/yaml_test.go
@@ -553,7 +553,7 @@ var _ = gk.Describe("Normalize", func() {
 				}}
 			})
 			gk.It("should fail", func(_ /* ctx */ context.Context) {
-				_, err := Normalize(objs, defaultNamespace, clientSet)
+				_, _, err := Normalize(objs, defaultNamespace, clientSet)
 				gm.Expect(err).Should(gm.MatchError(gm.ContainSubstring("Kubernetes resources require a kind and apiVersion")))
 			})
 		})
@@ -569,7 +569,7 @@ var _ = gk.Describe("Normalize", func() {
 				}}
 			})
 			gk.It("should fail", func(_ /* ctx */ context.Context) {
-				_, err := Normalize(objs, defaultNamespace, clientSet)
+				_, _, err := Normalize(objs, defaultNamespace, clientSet)
 				gm.Expect(err).Should(gm.MatchError(gm.ContainSubstring("Kubernetes resources require a .metadata.name")))
 			})
 		})
@@ -590,7 +590,7 @@ var _ = gk.Describe("Normalize", func() {
 			})
 
 			gk.It("should apply the default namespace", func(_ /* ctx */ context.Context) {
-				objs, err := Normalize(objs, defaultNamespace, clientSet)
+				objs, _, err := Normalize(objs, defaultNamespace, clientSet)
 				gm.Expect(err).ShouldNot(gm.HaveOccurred())
 				gm.Expect(objs).To(gm.HaveExactElements(
 					matchUnstructured(gs.Keys{"metadata": gs.MatchKeys(gs.IgnoreExtras, gs.Keys{"namespace": gm.Equal("default")})}),
@@ -612,7 +612,7 @@ var _ = gk.Describe("Normalize", func() {
 			})
 
 			gk.It("should not apply the default namespace", func(_ /* ctx */ context.Context) {
-				objs, err := Normalize(objs, defaultNamespace, clientSet)
+				objs, _, err := Normalize(objs, defaultNamespace, clientSet)
 				gm.Expect(err).ShouldNot(gm.HaveOccurred())
 				gm.Expect(objs).To(gm.HaveExactElements(
 					matchUnstructured(gs.Keys{"metadata": gm.Not(gm.HaveKey("namespace"))}),
@@ -629,7 +629,7 @@ var _ = gk.Describe("Normalize", func() {
 				objs = resources
 			})
 			gk.It("should flatten the list", func(_ /* ctx */ context.Context) {
-				objs, err := Normalize(objs, defaultNamespace, clientSet)
+				objs, _, err := Normalize(objs, defaultNamespace, clientSet)
 				gm.Expect(err).ShouldNot(gm.HaveOccurred())
 				gm.Expect(objs).To(gm.HaveExactElements(
 					matchUnstructured(gs.Keys{"metadata": gs.MatchKeys(gs.IgnoreExtras, gs.Keys{"name": gm.Equal("map-1")})}),
@@ -653,7 +653,7 @@ var _ = gk.Describe("Normalize", func() {
 			})
 
 			gk.It("should replace with 'v1", func(_ /* ctx */ context.Context) {
-				objs, err := Normalize(objs, defaultNamespace, clientSet)
+				objs, _, err := Normalize(objs, defaultNamespace, clientSet)
 				gm.Expect(err).ShouldNot(gm.HaveOccurred())
 				gm.Expect(objs).To(gm.HaveExactElements(
 					matchUnstructured(gs.Keys{"apiVersion": gm.Equal("v1"), "kind": gm.Equal("Secret")}),
@@ -662,6 +662,32 @@ var _ = gk.Describe("Normalize", func() {
 		})
 	})
 })
+
+func TestNormalizeLeavesNamespaceUnsetWhenClusterOffline(t *testing.T) {
+	t.Parallel()
+
+	clientSet, err := clients.NewDynamicClientSet(nil)
+	assert.NoError(t, err)
+
+	objs := []unstructured.Unstructured{{
+		Object: map[string]any{
+			"apiVersion": "pulumi.com/v1",
+			"kind":       "Stack",
+			"metadata": map[string]any{
+				"name": "test-stack",
+			},
+		},
+	}}
+
+	got, unresolved, err := Normalize(objs, "default", clientSet)
+	assert.NoError(t, err)
+	if assert.Len(t, got, 1) {
+		assert.Empty(t, got[0].GetNamespace())
+	}
+	if assert.Len(t, unresolved, 1) {
+		assert.Equal(t, "pulumi.com/v1, Kind=Stack", unresolved[0].String())
+	}
+}
 
 func TestIsGlobPattern(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
In YAML render mode the provider can't always tell whether a Kubernetes custom resource is namespaced or cluster-scoped. The check for this is in live mode is to connect to the cluster and query the API server.

This PR introduces a default fallback: when namespace scope is unknown, render manifests without a `scope` field. The result is valid YAML that responds to `kubectl apply`, and will use the current-configured namespace, which is already default `kubectl` behavior.

When scope can't be determined offline, Normalize leaves the resource un-namespaced and logs one warning naming the kind. 

Fixes #4394.
    
  🤖 Generated with Claude Code (https://claude.com/claude-code)
