### PR TITLE
fix: allow ambient KUBECONFIG in render mode

### DIFF
--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -415,7 +415,9 @@ func (k *kubeProvider) CheckConfig(
 				Reason:   fmt.Sprintf(errTemplate, "context"),
 			})
 		}
-		if truthyValue("kubeconfig", news) {
+		// SDKs default kubeconfig from $KUBECONFIG. In render mode we still want ambient
+		// kubeconfig loading to work, so don't reject that specific defaulted value.
+		if truthyValue("kubeconfig", news) && !matchesAmbientKubeconfigEnv(news["kubeconfig"]) {
 			failures = append(failures, &pulumirpc.CheckFailure{
 				Property: "kubeconfig",
 				Reason:   fmt.Sprintf(errTemplate, "kubeconfig"),
@@ -438,6 +440,14 @@ func (k *kubeProvider) CheckConfig(
 		}
 	}
 	return &pulumirpc.CheckResponse{Inputs: req.GetNews()}, nil
+}
+
+func matchesAmbientKubeconfigEnv(v resource.PropertyValue) bool {
+	if !v.IsString() {
+		return false
+	}
+	kubeconfig, ok := os.LookupEnv("KUBECONFIG")
+	return ok && kubeconfig != "" && v.StringValue() == kubeconfig
 }
 
 // DiffConfig diffs the configuration for this provider.

--- a/provider/pkg/provider/provider_checkconfig_test.go
+++ b/provider/pkg/provider/provider_checkconfig_test.go
@@ -151,6 +151,27 @@ var _ = gk.Describe("RPC:CheckConfig", func() {
 			})
 		})
 
+		gk.Context("when kubeconfig does not match ambient KUBECONFIG", func() {
+			gk.BeforeEach(func() {
+				path := WriteKubeconfigToFile(config)
+				gm.Expect(os.Setenv("KUBECONFIG", path)).To(gm.Succeed())
+				gk.DeferCleanup(func() {
+					os.Unsetenv("KUBECONFIG")
+				})
+				news["kubeconfig"] = resource.NewStringProperty(WriteKubeconfigToString(config))
+			})
+			gk.It("should fail because an explicit kubeconfig is disallowed", func() {
+				resp, err := k.CheckConfig(context.Background(), req)
+				gm.Expect(err).ToNot(gm.HaveOccurred())
+				gm.Expect(resp.Failures).To(gm.HaveExactElements(
+					CheckFailure(
+						"kubeconfig",
+						gm.Equal(`"kubeconfig" arg is not compatible with "renderYamlToDirectory" arg`),
+					),
+				))
+			})
+		})
+
 		gk.Context("when context is specified", func() {
 			gk.BeforeEach(func() {
 				news["context"] = resource.NewStringProperty(config.CurrentContext)

--- a/provider/pkg/provider/provider_checkconfig_test.go
+++ b/provider/pkg/provider/provider_checkconfig_test.go
@@ -16,6 +16,7 @@ package provider
 
 import (
 	"context"
+	"os"
 
 	_ "embed"
 
@@ -131,6 +132,22 @@ var _ = gk.Describe("RPC:CheckConfig", func() {
 						gm.Equal(`"kubeconfig" arg is not compatible with "renderYamlToDirectory" arg`),
 					),
 				))
+			})
+		})
+
+		gk.Context("when kubeconfig matches ambient KUBECONFIG", func() {
+			gk.BeforeEach(func() {
+				path := WriteKubeconfigToFile(config)
+				gm.Expect(os.Setenv("KUBECONFIG", path)).To(gm.Succeed())
+				gk.DeferCleanup(func() {
+					os.Unsetenv("KUBECONFIG")
+				})
+				news["kubeconfig"] = resource.NewStringProperty(path)
+			})
+			gk.It("should succeed", func() {
+				resp, err := k.CheckConfig(context.Background(), req)
+				gm.Expect(err).ToNot(gm.HaveOccurred())
+				gm.Expect(resp.Failures).To(gm.BeEmpty())
 			})
 		})
 


### PR DESCRIPTION
### Proposed changes

Allow render mode to accept `kubeconfig` when it is only the ambient `KUBECONFIG` value injected by the SDK.

This path is pretty normal in CI. `google-github-actions/get-gke-credentials` exports `KUBECONFIG` out of the box. Before this PR, render mode tripped on that and failed with `"kubeconfig" arg is not compatible with "renderYamlToDirectory" arg`. After this PR, that ambient path is allowed, while explicit `kubeconfig` is still blocked. Added a regression test too.

Repro:
1. Set `KUBECONFIG` to a valid kubeconfig file.
2. Create a provider with `renderYamlToDirectory` and do not pass `kubeconfig` yourself.
3. The SDK fills `kubeconfig` from `KUBECONFIG`, then `CheckConfig` fails.
4. With this PR, render mode works as expected.

### Related issues (optional)

Fixes #4399
Related #3498
