### PR TITLE
Resolve custom resource namespace scope from Helm release CRDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ## Unreleased
 
 ### Fixed
-
+- [#3176](https://github.com/pulumi/pulumi-kubernetes/issues/3176) ensure Helm-installed CRDs can be resolved during preview
 - [#4396](https://github.com/pulumi/pulumi-kubernetes/issues/4396) Fix panic when creating a `kubernetes.io/service-account-token` Secret with a non-existent ServiceAccount.
 - [#4394](https://github.com/pulumi/pulumi-kubernetes/issues/4394) Don't fail YAML render when a custom resource's namespace scope can't be determined offline. The resource is rendered without a namespace and a warning is logged, rather than erroring.
 

--- a/provider/pkg/provider/helm_release.go
+++ b/provider/pkg/provider/helm_release.go
@@ -15,7 +15,6 @@
 package provider
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -498,28 +497,19 @@ func (r *helmReleaseProvider) cacheReleaseCRDs(ctx context.Context, chart *helmc
 	if r.clientSet == nil || chart == nil {
 		return
 	}
-	cache := &r.clientSet.CRDCache
-
-	// CRDs in the chart's crds/ directory.
-	if err := cacheChartCRDs(ctx, chart, cache); err != nil {
-		logger.V(9).Infof("caching crds/ CRDs for release %q: %v", rel.Name, err)
-	}
-
-	// CRDs templated into the chart's manifest.
-	if !chartTemplatesMentionCRD(chart) {
-		return
-	}
 	manifest, err := r.renderChartManifest(chart, rel)
 	if err != nil {
 		logger.V(9).Infof("rendering chart to find CRDs for release %q: %v", rel.Name, err)
 		return
 	}
-	if err := cacheCRDsFromManifest(ctx, manifest, cache); err != nil {
-		logger.V(9).Infof("caching templated CRDs for release %q: %v", rel.Name, err)
+	if err := cacheCRDsFromManifest(ctx, manifest, &r.clientSet.CRDCache); err != nil {
+		logger.V(9).Infof("caching CRDs for release %q: %v", rel.Name, err)
 	}
 }
 
-// renderChartManifest runs a client-side helm template (no cluster) and returns the rendered manifest.
+// renderChartManifest runs a client-side helm template (no cluster) and returns the rendered
+// manifest. IncludeCRDs (honoring skipCrds) makes Helm emit the crds/ CRDs across the chart and its
+// subcharts; templated CRDs render regardless.
 func (r *helmReleaseProvider) renderChartManifest(chart *helmchart.Chart, rel *Release) (string, error) {
 	conf, err := r.getActionConfig(rel.Namespace)
 	if err != nil {
@@ -528,6 +518,7 @@ func (r *helmReleaseProvider) renderChartManifest(chart *helmchart.Chart, rel *R
 	install := action.NewInstall(conf)
 	install.ClientOnly = true
 	install.DryRun = true
+	install.IncludeCRDs = !rel.SkipCrds
 	install.ReleaseName = rel.Name
 	if install.ReleaseName == "" {
 		install.ReleaseName = "release-name"
@@ -545,18 +536,6 @@ func (r *helmReleaseProvider) renderChartManifest(chart *helmchart.Chart, rel *R
 		return "", nil
 	}
 	return rendered.Manifest, nil
-}
-
-func cacheChartCRDs(ctx context.Context, chart *helmchart.Chart, cache *clients.CRDCache) error {
-	if chart == nil || cache == nil {
-		return nil
-	}
-	for _, crd := range chart.CRDObjects() {
-		if err := cacheCRDsFromManifest(ctx, string(crd.File.Data), cache); err != nil {
-			return fmt.Errorf("parsing CRD file %q: %w", crd.Name, err)
-		}
-	}
-	return nil
 }
 
 func cacheCRDsFromManifest(ctx context.Context, manifest string, cache *clients.CRDCache) error {
@@ -577,24 +556,6 @@ func cacheCRDsFromManifest(ctx context.Context, manifest string, cache *clients.
 		}
 	}
 	return nil
-}
-
-// chartTemplatesMentionCRD reports whether the chart or its subcharts template a CRD.
-func chartTemplatesMentionCRD(chart *helmchart.Chart) bool {
-	if chart == nil {
-		return false
-	}
-	for _, t := range chart.Templates {
-		if bytes.Contains(t.Data, []byte("CustomResourceDefinition")) {
-			return true
-		}
-	}
-	for _, dep := range chart.Dependencies() {
-		if chartTemplatesMentionCRD(dep) {
-			return true
-		}
-	}
-	return false
 }
 
 func (r *helmReleaseProvider) helmCreate(ctx context.Context, urn resource.URN, newRelease *Release) error {

--- a/provider/pkg/provider/helm_release.go
+++ b/provider/pkg/provider/helm_release.go
@@ -15,6 +15,7 @@
 package provider
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -57,6 +58,7 @@ import (
 	"github.com/pulumi/pulumi-kubernetes/provider/v4/pkg/clients"
 	"github.com/pulumi/pulumi-kubernetes/provider/v4/pkg/helm"
 	"github.com/pulumi/pulumi-kubernetes/provider/v4/pkg/host"
+	provideryamlv2 "github.com/pulumi/pulumi-kubernetes/provider/v4/pkg/provider/yaml/v2"
 )
 
 // Default timeout for awaited install and uninstall operations
@@ -386,6 +388,8 @@ func (r *helmReleaseProvider) Check(
 			// as opposed to the program input (which is a constraint such as ">= 1.2.3").
 			// with this we may determine whether the Helm release needs to be upgraded.
 			newRelease.Version = chart.Metadata.Version
+
+			r.cacheReleaseCRDs(ctx, chart, newRelease)
 		}
 	}
 
@@ -485,6 +489,112 @@ func (r *helmReleaseProvider) helmLoad(
 	}
 
 	return c, nil
+}
+
+// cacheReleaseCRDs records the CRDs a release's chart ships in the shared cache so custom resources
+// elsewhere in the program can resolve their namespace scope at preview, before the CRD is installed
+// on the cluster.
+func (r *helmReleaseProvider) cacheReleaseCRDs(ctx context.Context, chart *helmchart.Chart, rel *Release) {
+	if r.clientSet == nil || chart == nil {
+		return
+	}
+	cache := &r.clientSet.CRDCache
+
+	// CRDs in the chart's crds/ directory.
+	if err := cacheChartCRDs(ctx, chart, cache); err != nil {
+		logger.V(9).Infof("caching crds/ CRDs for release %q: %v", rel.Name, err)
+	}
+
+	// CRDs templated into the chart's manifest.
+	if !chartTemplatesMentionCRD(chart) {
+		return
+	}
+	manifest, err := r.renderChartManifest(chart, rel)
+	if err != nil {
+		logger.V(9).Infof("rendering chart to find CRDs for release %q: %v", rel.Name, err)
+		return
+	}
+	if err := cacheCRDsFromManifest(ctx, manifest, cache); err != nil {
+		logger.V(9).Infof("caching templated CRDs for release %q: %v", rel.Name, err)
+	}
+}
+
+// renderChartManifest runs a client-side helm template (no cluster) and returns the rendered manifest.
+func (r *helmReleaseProvider) renderChartManifest(chart *helmchart.Chart, rel *Release) (string, error) {
+	conf, err := r.getActionConfig(rel.Namespace)
+	if err != nil {
+		return "", err
+	}
+	install := action.NewInstall(conf)
+	install.ClientOnly = true
+	install.DryRun = true
+	install.ReleaseName = rel.Name
+	if install.ReleaseName == "" {
+		install.ReleaseName = "release-name"
+	}
+	install.Namespace = rel.Namespace
+	values, err := getValues(rel)
+	if err != nil {
+		return "", err
+	}
+	rendered, err := install.Run(chart, values)
+	if err != nil {
+		return "", err
+	}
+	if rendered == nil {
+		return "", nil
+	}
+	return rendered.Manifest, nil
+}
+
+func cacheChartCRDs(ctx context.Context, chart *helmchart.Chart, cache *clients.CRDCache) error {
+	if chart == nil || cache == nil {
+		return nil
+	}
+	for _, crd := range chart.CRDObjects() {
+		if err := cacheCRDsFromManifest(ctx, string(crd.File.Data), cache); err != nil {
+			return fmt.Errorf("parsing CRD file %q: %w", crd.Name, err)
+		}
+	}
+	return nil
+}
+
+func cacheCRDsFromManifest(ctx context.Context, manifest string, cache *clients.CRDCache) error {
+	if cache == nil {
+		return nil
+	}
+	objects, err := provideryamlv2.Parse(ctx, provideryamlv2.ParseOptions{YAML: manifest})
+	if err != nil {
+		return err
+	}
+	for i := range objects {
+		object := &objects[i]
+		if !clients.IsCRD(object) {
+			continue
+		}
+		if err := cache.AddCRD(object); err != nil {
+			return fmt.Errorf("caching CRD %q: %w", object.GetName(), err)
+		}
+	}
+	return nil
+}
+
+// chartTemplatesMentionCRD reports whether the chart or its subcharts template a CRD.
+func chartTemplatesMentionCRD(chart *helmchart.Chart) bool {
+	if chart == nil {
+		return false
+	}
+	for _, t := range chart.Templates {
+		if bytes.Contains(t.Data, []byte("CustomResourceDefinition")) {
+			return true
+		}
+	}
+	for _, dep := range chart.Dependencies() {
+		if chartTemplatesMentionCRD(dep) {
+			return true
+		}
+	}
+	return false
 }
 
 func (r *helmReleaseProvider) helmCreate(ctx context.Context, urn resource.URN, newRelease *Release) error {

--- a/provider/pkg/provider/helm_release_test.go
+++ b/provider/pkg/provider/helm_release_test.go
@@ -15,14 +15,20 @@
 package provider
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	helmchart "helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/chart/loader"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/asset"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+
+	"github.com/pulumi/pulumi-kubernetes/provider/v4/pkg/clients"
 )
 
 func TestDecodeRelease(t *testing.T) {
@@ -238,4 +244,56 @@ func TestDecodeRelease_NullPreservedThroughWire(t *testing.T) {
 	tag, hasTag := image["tag"]
 	assert.True(t, hasTag, "tag key should be present in image values (got %v)", image)
 	assert.Nil(t, tag, "tag value should be nil (the user's explicit null)")
+}
+
+func TestCacheChartCRDsResolvesScope(t *testing.T) {
+	chart, err := loader.Load("./helm/v4/testdata/reference")
+	require.NoError(t, err)
+
+	clientSet := &clients.DynamicClientSet{}
+	gvk := schema.GroupVersionKind{Group: "stable.example.com", Version: "v1", Kind: "CronTab"}
+
+	_, err = clients.IsNamespacedKind(gvk, clientSet)
+	require.True(t, clients.IsNoNamespaceInfoErr(err))
+
+	require.NoError(t, cacheChartCRDs(context.Background(), chart, &clientSet.CRDCache))
+
+	namespaced, err := clients.IsNamespacedKind(gvk, clientSet)
+	require.NoError(t, err)
+	require.True(t, namespaced)
+}
+
+func TestCacheCRDsFromManifest(t *testing.T) {
+	manifest := `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: not-a-crd
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: widgets.example.com
+spec:
+  group: example.com
+  names:
+    kind: Widget
+  scope: Cluster
+`
+	cache := &clients.CRDCache{}
+	require.NoError(t, cacheCRDsFromManifest(context.Background(), manifest, cache))
+	require.NotNil(t, cache.GetCRD(schema.GroupKind{Group: "example.com", Kind: "Widget"}))
+	require.Nil(t, cache.GetCRD(schema.GroupKind{Group: "", Kind: "ConfigMap"}))
+}
+
+func TestChartTemplatesMentionCRD(t *testing.T) {
+	withCRD := &helmchart.Chart{Templates: []*helmchart.File{
+		{Name: "templates/crd.yaml", Data: []byte("kind: CustomResourceDefinition\n")},
+	}}
+	require.True(t, chartTemplatesMentionCRD(withCRD))
+
+	withoutCRD := &helmchart.Chart{Templates: []*helmchart.File{
+		{Name: "templates/deployment.yaml", Data: []byte("kind: Deployment\n")},
+	}}
+	require.False(t, chartTemplatesMentionCRD(withoutCRD))
 }

--- a/provider/pkg/provider/helm_release_test.go
+++ b/provider/pkg/provider/helm_release_test.go
@@ -20,8 +20,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	helmchart "helm.sh/helm/v3/pkg/chart"
-	"helm.sh/helm/v3/pkg/chart/loader"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
@@ -246,23 +244,6 @@ func TestDecodeRelease_NullPreservedThroughWire(t *testing.T) {
 	assert.Nil(t, tag, "tag value should be nil (the user's explicit null)")
 }
 
-func TestCacheChartCRDsResolvesScope(t *testing.T) {
-	chart, err := loader.Load("./helm/v4/testdata/reference")
-	require.NoError(t, err)
-
-	clientSet := &clients.DynamicClientSet{}
-	gvk := schema.GroupVersionKind{Group: "stable.example.com", Version: "v1", Kind: "CronTab"}
-
-	_, err = clients.IsNamespacedKind(gvk, clientSet)
-	require.True(t, clients.IsNoNamespaceInfoErr(err))
-
-	require.NoError(t, cacheChartCRDs(context.Background(), chart, &clientSet.CRDCache))
-
-	namespaced, err := clients.IsNamespacedKind(gvk, clientSet)
-	require.NoError(t, err)
-	require.True(t, namespaced)
-}
-
 func TestCacheCRDsFromManifest(t *testing.T) {
 	manifest := `
 apiVersion: v1
@@ -284,16 +265,4 @@ spec:
 	require.NoError(t, cacheCRDsFromManifest(context.Background(), manifest, cache))
 	require.NotNil(t, cache.GetCRD(schema.GroupKind{Group: "example.com", Kind: "Widget"}))
 	require.Nil(t, cache.GetCRD(schema.GroupKind{Group: "", Kind: "ConfigMap"}))
-}
-
-func TestChartTemplatesMentionCRD(t *testing.T) {
-	withCRD := &helmchart.Chart{Templates: []*helmchart.File{
-		{Name: "templates/crd.yaml", Data: []byte("kind: CustomResourceDefinition\n")},
-	}}
-	require.True(t, chartTemplatesMentionCRD(withCRD))
-
-	withoutCRD := &helmchart.Chart{Templates: []*helmchart.File{
-		{Name: "templates/deployment.yaml", Data: []byte("kind: Deployment\n")},
-	}}
-	require.False(t, chartTemplatesMentionCRD(withoutCRD))
 }

--- a/tests/sdk/yaml/helm_release_crd_scope_test.go
+++ b/tests/sdk/yaml/helm_release_crd_scope_test.go
@@ -17,12 +17,15 @@ func TestHelmReleaseCRDScopeWritesToCache(t *testing.T) {
 	t.Cleanup(func() {
 		test.Destroy(t)
 	})
-	test.Preview(t)
+
+	preview := test.Preview(t)
+	assert.Contains(t, preview.StdOut, "default/my-crontab",
+		"CronTab should resolve as namespaced at preview")
+
 	test.Up(t)
 
 	var deployment apitype.DeploymentV3
 	require.NoError(t, json.Unmarshal(test.ExportStack(t).Deployment, &deployment))
-
 	var found bool
 	for _, r := range deployment.Resources {
 		if r.Type != "kubernetes:stable.example.com/v1:CronTab" {
@@ -30,7 +33,7 @@ func TestHelmReleaseCRDScopeWritesToCache(t *testing.T) {
 		}
 		found = true
 		assert.Contains(t, string(r.URN), "default/my-crontab",
-			"CronTab should resolve as namespaced via the cached CRD")
+			"CronTab should be namespaced in state")
 	}
 	assert.True(t, found, "expected a CronTab custom resource in the stack")
 }

--- a/tests/sdk/yaml/helm_release_crd_scope_test.go
+++ b/tests/sdk/yaml/helm_release_crd_scope_test.go
@@ -1,0 +1,36 @@
+package test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/providertest/pulumitest"
+	"github.com/pulumi/providertest/pulumitest/opttest"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+)
+
+func TestHelmReleaseCRDScopeWritesToCache(t *testing.T) {
+	test := pulumitest.NewPulumiTest(t, "testdata/helm-release-crd-scope", opttest.SkipInstall())
+	t.Cleanup(func() {
+		test.Destroy(t)
+	})
+	test.Preview(t)
+	test.Up(t)
+
+	var deployment apitype.DeploymentV3
+	require.NoError(t, json.Unmarshal(test.ExportStack(t).Deployment, &deployment))
+
+	var found bool
+	for _, r := range deployment.Resources {
+		if r.Type != "kubernetes:stable.example.com/v1:CronTab" {
+			continue
+		}
+		found = true
+		assert.Contains(t, string(r.URN), "default/my-crontab",
+			"CronTab should resolve as namespaced via the cached CRD")
+	}
+	assert.True(t, found, "expected a CronTab custom resource in the stack")
+}

--- a/tests/sdk/yaml/testdata/helm-release-crd-scope/Pulumi.yaml
+++ b/tests/sdk/yaml/testdata/helm-release-crd-scope/Pulumi.yaml
@@ -1,0 +1,23 @@
+name: helm-release-crd-scope
+runtime: yaml
+description: A v3 Release ships a CRD; a dependent custom resource resolves its scope from the cache.
+resources:
+  operator:
+    type: kubernetes:helm.sh/v3:Release
+    properties:
+      name: crontab-operator
+      chart: ./crontab-operator
+  crontab:
+    type: kubernetes:yaml/v2:ConfigGroup
+    options:
+      dependsOn:
+        - ${operator}
+    properties:
+      objs:
+        - apiVersion: stable.example.com/v1
+          kind: CronTab
+          metadata:
+            name: my-crontab
+          spec:
+            cronSpec: "* * * * *"
+            image: busybox

--- a/tests/sdk/yaml/testdata/helm-release-crd-scope/crontab-operator/Chart.yaml
+++ b/tests/sdk/yaml/testdata/helm-release-crd-scope/crontab-operator/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: crontab-operator
+description: Test chart that installs the CronTab CRD from its crds/ directory.
+type: application
+version: 0.1.0

--- a/tests/sdk/yaml/testdata/helm-release-crd-scope/crontab-operator/crds/crontab.yaml
+++ b/tests/sdk/yaml/testdata/helm-release-crd-scope/crontab-operator/crds/crontab.yaml
@@ -1,0 +1,30 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: crontabs.stable.example.com
+spec:
+  group: stable.example.com
+  scope: Namespaced
+  names:
+    plural: crontabs
+    singular: crontab
+    kind: CronTab
+    shortNames:
+    - ct
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              cronSpec:
+                type: string
+              image:
+                type: string
+              replicas:
+                type: integer


### PR DESCRIPTION
When a custom resource's CRD is installed by a Helm Release in the same program, the provider can't tell at preview whether the resource is namespaced or cluster-scoped: a Release installs its CRDs server-side, so they never land in the provider's CRD cache the way a CustomResourceDefinition resource or a helm.sh/v4:Chart child does. 

This reads a release's CRDs into the shared cache during Check, from both the chart's crds/ directory and its rendered templates, so a custom resource elsewhere in the program resolves the real scope on the first preview. Rendering is gated by a cheap text scan, so only charts that actually template a CustomResourceDefinition are rendered, and it's best-effort. 
  
Fixes #3176.
Fixes https://github.com/pulumi/pulumi-kubernetes/issues/3299.
Also fixes https://github.com/pulumi-labs/pulumi-nvidia-aicr/issues/6.


