### PR TITLE
Prepare for v4.32.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ## Unreleased
 
+## 4.32.0 (June 5, 2026)
+
 ### Fixed
 - [#3176](https://github.com/pulumi/pulumi-kubernetes/issues/3176) ensure Helm-installed CRDs can be resolved during preview
 - [#4396](https://github.com/pulumi/pulumi-kubernetes/issues/4396) Fix panic when creating a `kubernetes.io/service-account-token` Secret with a non-existent ServiceAccount.


### PR DESCRIPTION
Cut v4.32.0 — moves the Unreleased CHANGELOG entries under the `## 4.32.0 (June 5, 2026)` heading: three fixes (#3176 Helm-installed CRD resolution during preview, #4396, #4394) plus a docs note. After merge, run `@release-bot release pulumi-kubernetes minor` in #release-ops.