### PR TITLE
Render Helm hooks in helm.v4.Chart when using renderYamlToDirectory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Added
 
-- [#3284](https://github.com/pulumi/pulumi-kubernetes/issues/3284) Add `includeHooks` to `kubernetes.helm.sh/v4:Chart`. When set together with the provider's `renderYamlToDirectory`, Helm hook resources (annotated `helm.sh/hook`) are included in the rendered output instead of being dropped, so that another tool (e.g. Argo CD) can apply them. Test hooks (`helm.sh/hook: test`) are excluded. The flag has no effect outside of render mode.
+- [#3284](https://github.com/pulumi/pulumi-kubernetes/issues/3284) Add `includeHooks` to `kubernetes.helm.sh/v4:Chart`. When set together with the provider's `renderYamlToDirectory`, Helm hook resources (annotated `helm.sh/hook`) are included in the rendered output instead of being dropped, so that another tool (e.g. Argo CD) can apply them. Test hooks (`helm.sh/hook: test`) are excluded, and the flag has no effect outside of render mode. This only brings render mode up to par with `helm template`; it does not implement full Helm hook lifecycle support (ordering, weights, delete policies, execution), so #3284 remains open.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## Unreleased
 
+### Added
+
+- [#3284](https://github.com/pulumi/pulumi-kubernetes/issues/3284) Add `includeHooks` to `kubernetes.helm.sh/v4:Chart`. When set together with the provider's `renderYamlToDirectory`, Helm hook resources (annotated `helm.sh/hook`) are included in the rendered output instead of being dropped, so that another tool (e.g. Argo CD) can apply them. Test hooks (`helm.sh/hook: test`) are excluded. The flag has no effect outside of render mode.
+
 ### Changed
 
 - Upgrade Kubernetes schema and libraries to v1.36.2.

--- a/provider/pkg/gen/overlays.go
+++ b/provider/pkg/gen/overlays.go
@@ -240,6 +240,16 @@ var helmV4ChartResource = pschema.ResourceSpec{
 			},
 			Description: "If set, no CRDs will be installed. By default, CRDs are installed if not already present.",
 		},
+		"includeHooks": {
+			TypeSpec: pschema.TypeSpec{
+				Type: "boolean",
+			},
+			Description: "By default, Helm hook resources (those annotated with `helm.sh/hook`) are omitted " +
+				"from the rendered output. When the provider is configured with `renderYamlToDirectory`, set " +
+				"this to true to include hook resources in the rendered manifests so that another tool " +
+				"(e.g. Argo CD) can apply them. Test hooks (`helm.sh/hook: test`) are always excluded. This " +
+				"setting has no effect outside of render mode, where hooks are not supported.",
+		},
 		"postRenderer": {
 			TypeSpec: pschema.TypeSpec{
 				Ref: "#/types/kubernetes:helm.sh/v4:PostRenderer",

--- a/provider/pkg/provider/helm/v4/chart.go
+++ b/provider/pkg/provider/helm/v4/chart.go
@@ -17,11 +17,14 @@ package v4
 import (
 	"context"
 	"fmt"
+	"regexp"
+	"strings"
 
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chartutil"
 	helmkube "helm.sh/helm/v3/pkg/kube"
 	"helm.sh/helm/v3/pkg/postrender"
+	"helm.sh/helm/v3/pkg/release"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/discovery"
 
@@ -248,8 +251,21 @@ func (r *ChartProvider) Construct(
 	}
 
 	// Parse the YAML file into an array of Kubernetes objects.
+	//
+	// Helm hook resources (those annotated with `helm.sh/hook`) are separated
+	// from the regular manifest by the Helm SDK and are not applied by Pulumi.
+	// In render-only mode (`renderYamlToDirectory`) Pulumi is not in charge of
+	// the resource lifecycle; it merely emits YAML for another tool (e.g. ArgoCD)
+	// to apply. In that case, include the hook resources in the output as-is so
+	// they are not silently dropped, mirroring `helm template`. Test hooks
+	// (`helm.sh/hook: test`) are excluded since they are not part of a normal
+	// deployment.
+	manifest := release.Manifest
+	if r.opts.RenderYAMLToDirectory {
+		manifest = manifestWithHooks(release)
+	}
 	parseOpts := provideryamlv2.ParseOptions{
-		YAML: release.Manifest,
+		YAML: manifest,
 	}
 	objs, err := provideryamlv2.Parse(ctx.Context(), parseOpts)
 	if err != nil {
@@ -314,6 +330,25 @@ func preregister(ctx *pulumi.Context, comp *ChartState, obj *unstructured.Unstru
 	}
 
 	return obj, resourceOpts
+}
+
+// testHookAnnotation matches test-related Helm hook annotations (test, test-success, test-failure).
+var testHookAnnotation = regexp.MustCompile(`"?helm.sh/hook"?:.*test`)
+
+// manifestWithHooks returns the release manifest with hook resources appended,
+// mirroring the output of `helm template`. Test hooks are skipped because they
+// are only meant to run during `helm test` and are not part of a deployment.
+func manifestWithHooks(rel *release.Release) string {
+	var b strings.Builder
+	b.WriteString(rel.Manifest)
+	for _, hook := range rel.Hooks {
+		if testHookAnnotation.MatchString(hook.Manifest) {
+			continue
+		}
+		b.WriteString("\n---\n")
+		b.WriteString(hook.Manifest)
+	}
+	return b.String()
 }
 
 func setKubeVersionAndAPIVersions(clientSet *clients.DynamicClientSet, cmd *kubehelm.TemplateCommand) error {

--- a/provider/pkg/provider/helm/v4/chart.go
+++ b/provider/pkg/provider/helm/v4/chart.go
@@ -17,7 +17,6 @@ package v4
 import (
 	"context"
 	"fmt"
-	"regexp"
 	"strings"
 
 	"helm.sh/helm/v3/pkg/action"
@@ -60,6 +59,7 @@ type ChartArgs struct {
 	Values       pulumi.MapInput          `pulumi:"values,optional"`
 	ValuesFiles  pulumi.AssetArrayInput   `pulumi:"valueYamlFiles,optional"`
 	SkipCrds     pulumi.BoolInput         `pulumi:"skipCrds,optional"`
+	IncludeHooks pulumi.BoolInput         `pulumi:"includeHooks,optional"`
 	PostRenderer helmv4.PostRendererInput `pulumi:"postRenderer,optional"`
 
 	ResourcePrefix pulumi.StringInput `pulumi:"resourcePrefix,optional"`
@@ -81,6 +81,7 @@ type chartArgs struct {
 	Values       map[string]any
 	ValuesFiles  []pulumi.Asset
 	SkipCrds     bool
+	IncludeHooks bool
 	PostRenderer *helmv4.PostRenderer
 
 	ResourcePrefix *string
@@ -92,7 +93,7 @@ func unwrapChartArgs(ctx context.Context, args *ChartArgs) (*chartArgs, internal
 	result, err := internals.UnsafeAwaitOutput(ctx, pulumi.All(
 		args.Name, args.Namespace,
 		args.Chart, args.Version, args.Devel, args.RepositoryOpts, args.DependencyUpdate, args.Verify, args.Keyring,
-		args.Values, args.ValuesFiles, args.SkipCrds, args.PostRenderer,
+		args.Values, args.ValuesFiles, args.SkipCrds, args.IncludeHooks, args.PostRenderer,
 		args.ResourcePrefix, args.SkipAwait, args.PlainHTTP))
 	if err != nil || !result.Known {
 		return nil, result, err
@@ -117,6 +118,7 @@ func unwrapChartArgs(ctx context.Context, args *ChartArgs) (*chartArgs, internal
 	r.Values, _ = pop().(map[string]any)
 	r.ValuesFiles, _ = pop().([]pulumi.Asset)
 	r.SkipCrds, _ = pop().(bool)
+	r.IncludeHooks, _ = pop().(bool)
 	if v, ok := pop().(helmv4.PostRenderer); ok {
 		r.PostRenderer = &v
 	}
@@ -254,15 +256,24 @@ func (r *ChartProvider) Construct(
 	//
 	// Helm hook resources (those annotated with `helm.sh/hook`) are separated
 	// from the regular manifest by the Helm SDK and are not applied by Pulumi.
-	// In render-only mode (`renderYamlToDirectory`) Pulumi is not in charge of
-	// the resource lifecycle; it merely emits YAML for another tool (e.g. ArgoCD)
-	// to apply. In that case, include the hook resources in the output as-is so
-	// they are not silently dropped, mirroring `helm template`. Test hooks
-	// (`helm.sh/hook: test`) are excluded since they are not part of a normal
-	// deployment.
+	// When the user opts in via `includeHooks` AND the provider is in render-only
+	// mode (`renderYamlToDirectory`), include the hook resources in the output
+	// as-is so they are not silently dropped, mirroring `helm template`. This is
+	// useful when another tool (e.g. Argo CD) is responsible for applying the
+	// rendered manifests. Test hooks (`helm.sh/hook: test`) are always excluded
+	// since they are not part of a normal deployment.
+	//
+	// Outside of render mode hooks are not supported (they would be registered as
+	// ordinary Pulumi-managed resources with no hook semantics), so `includeHooks`
+	// is ignored there and a warning is emitted.
 	manifest := release.Manifest
-	if r.opts.RenderYAMLToDirectory {
-		manifest = manifestWithHooks(release)
+	if chartArgs.IncludeHooks {
+		if r.opts.RenderYAMLToDirectory {
+			manifest = manifestWithHooks(release)
+		} else {
+			_ = ctx.Log.Warn("includeHooks is only supported when the provider is configured with "+
+				"renderYamlToDirectory; Helm hooks will be ignored.", &pulumi.LogArgs{Resource: comp})
+		}
 	}
 	parseOpts := provideryamlv2.ParseOptions{
 		YAML: manifest,
@@ -332,8 +343,15 @@ func preregister(ctx *pulumi.Context, comp *ChartState, obj *unstructured.Unstru
 	return obj, resourceOpts
 }
 
-// testHookAnnotation matches test-related Helm hook annotations (test, test-success, test-failure).
-var testHookAnnotation = regexp.MustCompile(`"?helm.sh/hook"?:.*test`)
+// isTestHook reports whether the given Helm hook fires on the test event.
+func isTestHook(h *release.Hook) bool {
+	for _, e := range h.Events {
+		if e == release.HookTest {
+			return true
+		}
+	}
+	return false
+}
 
 // manifestWithHooks returns the release manifest with hook resources appended,
 // mirroring the output of `helm template`. Test hooks are skipped because they
@@ -342,7 +360,7 @@ func manifestWithHooks(rel *release.Release) string {
 	var b strings.Builder
 	b.WriteString(rel.Manifest)
 	for _, hook := range rel.Hooks {
-		if testHookAnnotation.MatchString(hook.Manifest) {
+		if isTestHook(hook) {
 			continue
 		}
 		b.WriteString("\n---\n")

--- a/provider/pkg/provider/helm/v4/chart_test.go
+++ b/provider/pkg/provider/helm/v4/chart_test.go
@@ -424,6 +424,13 @@ var _ = gk.Describe("Construct", func() {
 					"test:default/test-reference-test-connection",
 				"test:default/test-reference-test-connection",
 			)
+			// A normal (non-hook) resource from the chart, used to confirm the chart
+			// still renders its regular resources regardless of hook handling.
+			normalService := pgm.MatchResourceReferenceValue(
+				"urn:pulumi:stack::project::kubernetes:helm/v4:Chart$kubernetes:core/v1:Service::"+
+					"test:default/test-reference",
+				"test:default/test-reference",
+			)
 
 			gk.Context("by default (includeHooks unset)", func() {
 				gk.It("should drop all hook resources", func(ctx context.Context) {
@@ -462,22 +469,27 @@ var _ = gk.Describe("Construct", func() {
 					opts.RenderYAMLToDirectory = false
 					inputs["includeHooks"] = resource.NewBoolProperty(true)
 				})
-				gk.It("should ignore hooks and emit a warning", func(ctx context.Context) {
-					resp, err := pulumiprovider.Construct(ctx, req, tc.EngineConn(), k.Construct)
-					gm.Expect(err).ShouldNot(gm.HaveOccurred())
-					outputs := unmarshalProperties(gk.GinkgoTB(), resp.State)
-					gm.Expect(outputs).To(pgm.MatchProps(gs.IgnoreExtras, pgm.Props{
-						"resources": pgm.MatchArrayValue(gm.And(
-							gm.Not(gm.ContainElement(preInstallHook)),
-							gm.Not(gm.ContainElement(testHook)),
-						)),
-					}))
-					var msgs []string
-					for _, l := range tc.engine.Logs() {
-						msgs = append(msgs, l.GetMessage())
-					}
-					gm.Expect(msgs).To(gm.ContainElement(gm.ContainSubstring("includeHooks")))
-				})
+				gk.It("should ignore hooks, still render normal resources, and emit a warning",
+					func(ctx context.Context) {
+						resp, err := pulumiprovider.Construct(ctx, req, tc.EngineConn(), k.Construct)
+						gm.Expect(err).ShouldNot(gm.HaveOccurred())
+						outputs := unmarshalProperties(gk.GinkgoTB(), resp.State)
+						// includeHooks has no effect outside render mode: all hooks are
+						// dropped, but the chart's normal resources are still rendered.
+						gm.Expect(outputs).To(pgm.MatchProps(gs.IgnoreExtras, pgm.Props{
+							"resources": pgm.MatchArrayValue(gm.And(
+								gm.ContainElement(normalService),
+								gm.Not(gm.ContainElement(preInstallHook)),
+								gm.Not(gm.ContainElement(testHook)),
+							)),
+						}))
+						// A warning is logged so the user understands why hooks were ignored.
+						var msgs []string
+						for _, l := range tc.engine.Logs() {
+							msgs = append(msgs, l.GetMessage())
+						}
+						gm.Expect(msgs).To(gm.ContainElement(gm.ContainSubstring("includeHooks")))
+					})
 			})
 		})
 

--- a/provider/pkg/provider/helm/v4/chart_test.go
+++ b/provider/pkg/provider/helm/v4/chart_test.go
@@ -410,6 +410,53 @@ var _ = gk.Describe("Construct", func() {
 			})
 		})
 
+		gk.Describe("Helm hooks", func() {
+			// The reference chart contains a non-test hook (a ConfigMap annotated
+			// "helm.sh/hook": pre-install) and a test hook (a Pod annotated
+			// "helm.sh/hook": test).
+			preInstallHook := pgm.MatchResourceReferenceValue(
+				"urn:pulumi:stack::project::kubernetes:helm/v4:Chart$kubernetes:core/v1:ConfigMap::"+
+					"test:default/test-reference-pre-install",
+				"test:default/test-reference-pre-install",
+			)
+			testHook := pgm.MatchResourceReferenceValue(
+				"urn:pulumi:stack::project::kubernetes:helm/v4:Chart$kubernetes:core/v1:Pod::"+
+					"test:default/test-reference-test-connection",
+				"test:default/test-reference-test-connection",
+			)
+
+			gk.Context("by default (not in render mode)", func() {
+				gk.It("should drop all hook resources", func(ctx context.Context) {
+					resp, err := pulumiprovider.Construct(ctx, req, tc.EngineConn(), k.Construct)
+					gm.Expect(err).ShouldNot(gm.HaveOccurred())
+					outputs := unmarshalProperties(gk.GinkgoTB(), resp.State)
+					gm.Expect(outputs).To(pgm.MatchProps(gs.IgnoreExtras, pgm.Props{
+						"resources": pgm.MatchArrayValue(gm.And(
+							gm.Not(gm.ContainElement(preInstallHook)),
+							gm.Not(gm.ContainElement(testHook)),
+						)),
+					}))
+				})
+			})
+
+			gk.Context("in renderYamlToDirectory mode", func() {
+				gk.BeforeEach(func() {
+					opts.RenderYAMLToDirectory = true
+				})
+				gk.It("should include non-test hooks but exclude test hooks", func(ctx context.Context) {
+					resp, err := pulumiprovider.Construct(ctx, req, tc.EngineConn(), k.Construct)
+					gm.Expect(err).ShouldNot(gm.HaveOccurred())
+					outputs := unmarshalProperties(gk.GinkgoTB(), resp.State)
+					gm.Expect(outputs).To(pgm.MatchProps(gs.IgnoreExtras, pgm.Props{
+						"resources": pgm.MatchArrayValue(gm.And(
+							gm.ContainElement(preInstallHook),
+							gm.Not(gm.ContainElement(testHook)),
+						)),
+					}))
+				})
+			})
+		})
+
 		gk.Describe("Post Renderer", func() {
 			gk.Context("given a postRenderer", func() {
 				var tempdir string

--- a/provider/pkg/provider/helm/v4/chart_test.go
+++ b/provider/pkg/provider/helm/v4/chart_test.go
@@ -425,7 +425,7 @@ var _ = gk.Describe("Construct", func() {
 				"test:default/test-reference-test-connection",
 			)
 
-			gk.Context("by default (not in render mode)", func() {
+			gk.Context("by default (includeHooks unset)", func() {
 				gk.It("should drop all hook resources", func(ctx context.Context) {
 					resp, err := pulumiprovider.Construct(ctx, req, tc.EngineConn(), k.Construct)
 					gm.Expect(err).ShouldNot(gm.HaveOccurred())
@@ -439,9 +439,10 @@ var _ = gk.Describe("Construct", func() {
 				})
 			})
 
-			gk.Context("in renderYamlToDirectory mode", func() {
+			gk.Context("given includeHooks in renderYamlToDirectory mode", func() {
 				gk.BeforeEach(func() {
 					opts.RenderYAMLToDirectory = true
+					inputs["includeHooks"] = resource.NewBoolProperty(true)
 				})
 				gk.It("should include non-test hooks but exclude test hooks", func(ctx context.Context) {
 					resp, err := pulumiprovider.Construct(ctx, req, tc.EngineConn(), k.Construct)
@@ -453,6 +454,29 @@ var _ = gk.Describe("Construct", func() {
 							gm.Not(gm.ContainElement(testHook)),
 						)),
 					}))
+				})
+			})
+
+			gk.Context("given includeHooks but NOT in render mode", func() {
+				gk.BeforeEach(func() {
+					opts.RenderYAMLToDirectory = false
+					inputs["includeHooks"] = resource.NewBoolProperty(true)
+				})
+				gk.It("should ignore hooks and emit a warning", func(ctx context.Context) {
+					resp, err := pulumiprovider.Construct(ctx, req, tc.EngineConn(), k.Construct)
+					gm.Expect(err).ShouldNot(gm.HaveOccurred())
+					outputs := unmarshalProperties(gk.GinkgoTB(), resp.State)
+					gm.Expect(outputs).To(pgm.MatchProps(gs.IgnoreExtras, pgm.Props{
+						"resources": pgm.MatchArrayValue(gm.And(
+							gm.Not(gm.ContainElement(preInstallHook)),
+							gm.Not(gm.ContainElement(testHook)),
+						)),
+					}))
+					var msgs []string
+					for _, l := range tc.engine.Logs() {
+						msgs = append(msgs, l.GetMessage())
+					}
+					gm.Expect(msgs).To(gm.ContainElement(gm.ContainSubstring("includeHooks")))
 				})
 			})
 		})

--- a/provider/pkg/provider/helm/v4/testdata/reference/templates/pre-install-hook.yaml
+++ b/provider/pkg/provider/helm/v4/testdata/reference/templates/pre-install-hook.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "reference.fullname" . }}-pre-install
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "reference.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install
+data:
+  hello: world

--- a/provider/pkg/provider/provider_construct.go
+++ b/provider/pkg/provider/provider_construct.go
@@ -51,8 +51,9 @@ func (k *kubeProvider) getResourceProvider(typ string) (providerresource.Resourc
 	}
 
 	options := &providerresource.ResourceProviderOptions{
-		ClientSet:        k.clientSet,
-		DefaultNamespace: defaultNamespace,
+		ClientSet:             k.clientSet,
+		DefaultNamespace:      defaultNamespace,
+		RenderYAMLToDirectory: k.yamlRenderMode,
 		HelmOptions: &providerresource.HelmOptions{
 			SuppressHelmHookWarnings: k.suppressHelmHookWarnings,
 			HelmDriver:               k.helmDriver,

--- a/provider/pkg/provider/resource/provider.go
+++ b/provider/pkg/provider/resource/provider.go
@@ -32,6 +32,11 @@ type ResourceProviderOptions struct { // nolint:revive // stutters
 	ClientSet        *clients.DynamicClientSet
 	DefaultNamespace string
 	HelmOptions      *HelmOptions
+
+	// RenderYAMLToDirectory indicates that the provider is in render-only mode
+	// (the `renderYamlToDirectory` provider config is set). In this mode the
+	// provider emits YAML rather than applying resources to a cluster.
+	RenderYAMLToDirectory bool
 }
 
 type HelmOptions struct {

--- a/sdk/dotnet/Helm/V4/Chart.cs
+++ b/sdk/dotnet/Helm/V4/Chart.cs
@@ -273,6 +273,12 @@ namespace Pulumi.Kubernetes.Types.Inputs.Helm.V4
         public Input<bool>? Devel { get; set; }
 
         /// <summary>
+        /// By default, Helm hook resources (those annotated with `helm.sh/hook`) are omitted from the rendered output. When the provider is configured with `renderYamlToDirectory`, set this to true to include hook resources in the rendered manifests so that another tool (e.g. Argo CD) can apply them. Test hooks (`helm.sh/hook: test`) are always excluded. This setting has no effect outside of render mode, where hooks are not supported.
+        /// </summary>
+        [Input("includeHooks")]
+        public Input<bool>? IncludeHooks { get; set; }
+
+        /// <summary>
         /// Location of public keys used for verification. Used only if `verify` is true
         /// </summary>
         [Input("keyring")]

--- a/sdk/go/kubernetes/helm/v4/chart.go
+++ b/sdk/go/kubernetes/helm/v4/chart.go
@@ -285,6 +285,8 @@ type chartArgs struct {
 	DependencyUpdate *bool `pulumi:"dependencyUpdate"`
 	// Use chart development versions, too. Equivalent to version '>0.0.0-0'. If `version` is set, this is ignored.
 	Devel *bool `pulumi:"devel"`
+	// By default, Helm hook resources (those annotated with `helm.sh/hook`) are omitted from the rendered output. When the provider is configured with `renderYamlToDirectory`, set this to true to include hook resources in the rendered manifests so that another tool (e.g. Argo CD) can apply them. Test hooks (`helm.sh/hook: test`) are always excluded. This setting has no effect outside of render mode, where hooks are not supported.
+	IncludeHooks *bool `pulumi:"includeHooks"`
 	// Location of public keys used for verification. Used only if `verify` is true
 	Keyring pulumi.AssetOrArchive `pulumi:"keyring"`
 	// Release name.
@@ -321,6 +323,8 @@ type ChartArgs struct {
 	DependencyUpdate pulumi.BoolPtrInput
 	// Use chart development versions, too. Equivalent to version '>0.0.0-0'. If `version` is set, this is ignored.
 	Devel pulumi.BoolPtrInput
+	// By default, Helm hook resources (those annotated with `helm.sh/hook`) are omitted from the rendered output. When the provider is configured with `renderYamlToDirectory`, set this to true to include hook resources in the rendered manifests so that another tool (e.g. Argo CD) can apply them. Test hooks (`helm.sh/hook: test`) are always excluded. This setting has no effect outside of render mode, where hooks are not supported.
+	IncludeHooks pulumi.BoolPtrInput
 	// Location of public keys used for verification. Used only if `verify` is true
 	Keyring pulumi.AssetOrArchiveInput
 	// Release name.

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/helm/v4/ChartArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/helm/v4/ChartArgs.java
@@ -69,6 +69,21 @@ public final class ChartArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
+     * By default, Helm hook resources (those annotated with `helm.sh/hook`) are omitted from the rendered output. When the provider is configured with `renderYamlToDirectory`, set this to true to include hook resources in the rendered manifests so that another tool (e.g. Argo CD) can apply them. Test hooks (`helm.sh/hook: test`) are always excluded. This setting has no effect outside of render mode, where hooks are not supported.
+     * 
+     */
+    @Import(name="includeHooks")
+    private @Nullable Output<Boolean> includeHooks;
+
+    /**
+     * @return By default, Helm hook resources (those annotated with `helm.sh/hook`) are omitted from the rendered output. When the provider is configured with `renderYamlToDirectory`, set this to true to include hook resources in the rendered manifests so that another tool (e.g. Argo CD) can apply them. Test hooks (`helm.sh/hook: test`) are always excluded. This setting has no effect outside of render mode, where hooks are not supported.
+     * 
+     */
+    public Optional<Output<Boolean>> includeHooks() {
+        return Optional.ofNullable(this.includeHooks);
+    }
+
+    /**
      * Location of public keys used for verification. Used only if `verify` is true
      * 
      */
@@ -269,6 +284,7 @@ public final class ChartArgs extends com.pulumi.resources.ResourceArgs {
         this.chart = $.chart;
         this.dependencyUpdate = $.dependencyUpdate;
         this.devel = $.devel;
+        this.includeHooks = $.includeHooks;
         this.keyring = $.keyring;
         this.name = $.name;
         this.namespace = $.namespace;
@@ -363,6 +379,27 @@ public final class ChartArgs extends com.pulumi.resources.ResourceArgs {
          */
         public Builder devel(Boolean devel) {
             return devel(Output.of(devel));
+        }
+
+        /**
+         * @param includeHooks By default, Helm hook resources (those annotated with `helm.sh/hook`) are omitted from the rendered output. When the provider is configured with `renderYamlToDirectory`, set this to true to include hook resources in the rendered manifests so that another tool (e.g. Argo CD) can apply them. Test hooks (`helm.sh/hook: test`) are always excluded. This setting has no effect outside of render mode, where hooks are not supported.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder includeHooks(@Nullable Output<Boolean> includeHooks) {
+            $.includeHooks = includeHooks;
+            return this;
+        }
+
+        /**
+         * @param includeHooks By default, Helm hook resources (those annotated with `helm.sh/hook`) are omitted from the rendered output. When the provider is configured with `renderYamlToDirectory`, set this to true to include hook resources in the rendered manifests so that another tool (e.g. Argo CD) can apply them. Test hooks (`helm.sh/hook: test`) are always excluded. This setting has no effect outside of render mode, where hooks are not supported.
+         * 
+         * @return builder
+         * 
+         */
+        public Builder includeHooks(Boolean includeHooks) {
+            return includeHooks(Output.of(includeHooks));
         }
 
         /**

--- a/sdk/nodejs/helm/v4/chart.ts
+++ b/sdk/nodejs/helm/v4/chart.ts
@@ -208,6 +208,7 @@ export class Chart extends pulumi.ComponentResource {
             resourceInputs["chart"] = args?.chart;
             resourceInputs["dependencyUpdate"] = args?.dependencyUpdate;
             resourceInputs["devel"] = args?.devel;
+            resourceInputs["includeHooks"] = args?.includeHooks;
             resourceInputs["keyring"] = args?.keyring;
             resourceInputs["name"] = args?.name;
             resourceInputs["namespace"] = args?.namespace;
@@ -246,6 +247,10 @@ export interface ChartArgs {
      * Use chart development versions, too. Equivalent to version '>0.0.0-0'. If `version` is set, this is ignored.
      */
     devel?: pulumi.Input<boolean | undefined>;
+    /**
+     * By default, Helm hook resources (those annotated with `helm.sh/hook`) are omitted from the rendered output. When the provider is configured with `renderYamlToDirectory`, set this to true to include hook resources in the rendered manifests so that another tool (e.g. Argo CD) can apply them. Test hooks (`helm.sh/hook: test`) are always excluded. This setting has no effect outside of render mode, where hooks are not supported.
+     */
+    includeHooks?: pulumi.Input<boolean | undefined>;
     /**
      * Location of public keys used for verification. Used only if `verify` is true
      */

--- a/sdk/python/pulumi_kubernetes/helm/v4/Chart.py
+++ b/sdk/python/pulumi_kubernetes/helm/v4/Chart.py
@@ -23,6 +23,7 @@ class ChartArgs:
                  chart: pulumi.Input[_builtins.str],
                  dependency_update: pulumi.Input[Optional[_builtins.bool]] = None,
                  devel: pulumi.Input[Optional[_builtins.bool]] = None,
+                 include_hooks: pulumi.Input[Optional[_builtins.bool]] = None,
                  keyring: pulumi.Input[Optional[Union[pulumi.Asset, pulumi.Archive]]] = None,
                  name: pulumi.Input[Optional[_builtins.str]] = None,
                  namespace: pulumi.Input[Optional[_builtins.str]] = None,
@@ -42,6 +43,7 @@ class ChartArgs:
         :param pulumi.Input[_builtins.str] chart: Chart name to be installed. A path may be used.
         :param pulumi.Input[_builtins.bool] dependency_update: Run helm dependency update before installing the chart.
         :param pulumi.Input[_builtins.bool] devel: Use chart development versions, too. Equivalent to version '>0.0.0-0'. If `version` is set, this is ignored.
+        :param pulumi.Input[_builtins.bool] include_hooks: By default, Helm hook resources (those annotated with `helm.sh/hook`) are omitted from the rendered output. When the provider is configured with `renderYamlToDirectory`, set this to true to include hook resources in the rendered manifests so that another tool (e.g. Argo CD) can apply them. Test hooks (`helm.sh/hook: test`) are always excluded. This setting has no effect outside of render mode, where hooks are not supported.
         :param pulumi.Input[Union[pulumi.Asset, pulumi.Archive]] keyring: Location of public keys used for verification. Used only if `verify` is true
         :param pulumi.Input[_builtins.str] name: Release name.
         :param pulumi.Input[_builtins.str] namespace: Namespace for the release.
@@ -61,6 +63,8 @@ class ChartArgs:
             pulumi.set(__self__, "dependency_update", dependency_update)
         if devel is not None:
             pulumi.set(__self__, "devel", devel)
+        if include_hooks is not None:
+            pulumi.set(__self__, "include_hooks", include_hooks)
         if keyring is not None:
             pulumi.set(__self__, "keyring", keyring)
         if name is not None:
@@ -123,6 +127,18 @@ class ChartArgs:
     @devel.setter
     def devel(self, value: pulumi.Input[Optional[_builtins.bool]]):
         pulumi.set(self, "devel", value)
+
+    @_builtins.property
+    @pulumi.getter(name="includeHooks")
+    def include_hooks(self) -> pulumi.Input[Optional[_builtins.bool]]:
+        """
+        By default, Helm hook resources (those annotated with `helm.sh/hook`) are omitted from the rendered output. When the provider is configured with `renderYamlToDirectory`, set this to true to include hook resources in the rendered manifests so that another tool (e.g. Argo CD) can apply them. Test hooks (`helm.sh/hook: test`) are always excluded. This setting has no effect outside of render mode, where hooks are not supported.
+        """
+        return pulumi.get(self, "include_hooks")
+
+    @include_hooks.setter
+    def include_hooks(self, value: pulumi.Input[Optional[_builtins.bool]]):
+        pulumi.set(self, "include_hooks", value)
 
     @_builtins.property
     @pulumi.getter
@@ -290,6 +306,7 @@ class Chart(pulumi.ComponentResource):
                  chart: pulumi.Input[Optional[_builtins.str]] = None,
                  dependency_update: pulumi.Input[Optional[_builtins.bool]] = None,
                  devel: pulumi.Input[Optional[_builtins.bool]] = None,
+                 include_hooks: pulumi.Input[Optional[_builtins.bool]] = None,
                  keyring: pulumi.Input[Optional[Union[pulumi.Asset, pulumi.Archive]]] = None,
                  name: pulumi.Input[Optional[_builtins.str]] = None,
                  namespace: pulumi.Input[Optional[_builtins.str]] = None,
@@ -478,6 +495,7 @@ class Chart(pulumi.ComponentResource):
         :param pulumi.Input[_builtins.str] chart: Chart name to be installed. A path may be used.
         :param pulumi.Input[_builtins.bool] dependency_update: Run helm dependency update before installing the chart.
         :param pulumi.Input[_builtins.bool] devel: Use chart development versions, too. Equivalent to version '>0.0.0-0'. If `version` is set, this is ignored.
+        :param pulumi.Input[_builtins.bool] include_hooks: By default, Helm hook resources (those annotated with `helm.sh/hook`) are omitted from the rendered output. When the provider is configured with `renderYamlToDirectory`, set this to true to include hook resources in the rendered manifests so that another tool (e.g. Argo CD) can apply them. Test hooks (`helm.sh/hook: test`) are always excluded. This setting has no effect outside of render mode, where hooks are not supported.
         :param pulumi.Input[Union[pulumi.Asset, pulumi.Archive]] keyring: Location of public keys used for verification. Used only if `verify` is true
         :param pulumi.Input[_builtins.str] name: Release name.
         :param pulumi.Input[_builtins.str] namespace: Namespace for the release.
@@ -685,6 +703,7 @@ class Chart(pulumi.ComponentResource):
                  chart: pulumi.Input[Optional[_builtins.str]] = None,
                  dependency_update: pulumi.Input[Optional[_builtins.bool]] = None,
                  devel: pulumi.Input[Optional[_builtins.bool]] = None,
+                 include_hooks: pulumi.Input[Optional[_builtins.bool]] = None,
                  keyring: pulumi.Input[Optional[Union[pulumi.Asset, pulumi.Archive]]] = None,
                  name: pulumi.Input[Optional[_builtins.str]] = None,
                  namespace: pulumi.Input[Optional[_builtins.str]] = None,
@@ -714,6 +733,7 @@ class Chart(pulumi.ComponentResource):
             __props__.__dict__["chart"] = chart
             __props__.__dict__["dependency_update"] = dependency_update
             __props__.__dict__["devel"] = devel
+            __props__.__dict__["include_hooks"] = include_hooks
             __props__.__dict__["keyring"] = keyring
             __props__.__dict__["name"] = name
             __props__.__dict__["namespace"] = namespace

--- a/tests/sdk/nodejs/helm-chart-v4-render-yaml-hooks/Pulumi.yaml
+++ b/tests/sdk/nodejs/helm-chart-v4-render-yaml-hooks/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: helm-chart-v4-render-yaml-hooks
+description: Test Helm Chart v4 hook rendering with includeHooks + renderYamlToDirectory
+runtime: nodejs

--- a/tests/sdk/nodejs/helm-chart-v4-render-yaml-hooks/index.ts
+++ b/tests/sdk/nodejs/helm-chart-v4-render-yaml-hooks/index.ts
@@ -1,0 +1,20 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as k8s from "@pulumi/kubernetes";
+
+let config = new pulumi.Config();
+let renderDir: string = config.require("renderDir");
+
+const manifestProvider = new k8s.Provider("k8s_manifest_renderer", {
+    renderYamlToDirectory: renderDir,
+});
+
+// The local chart contains a normal ConfigMap, a pre-install hook ConfigMap
+// (helm.sh/hook: pre-install) and a test hook Pod (helm.sh/hook: test). With
+// includeHooks set, the pre-install hook should be rendered while the test hook
+// is excluded.
+const chart = new k8s.helm.v4.Chart("hooks", {
+    chart: "./testchart",
+    includeHooks: true,
+}, {
+    provider: manifestProvider,
+});

--- a/tests/sdk/nodejs/helm-chart-v4-render-yaml-hooks/package.json
+++ b/tests/sdk/nodejs/helm-chart-v4-render-yaml-hooks/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "helm-chart-v4-render-yaml-hooks",
+    "version": "0.1.0",
+    "dependencies": {
+        "@pulumi/pulumi": "latest"
+    },
+    "devDependencies": {
+    },
+    "peerDependencies": {
+        "@pulumi/kubernetes": "latest"
+    }
+}

--- a/tests/sdk/nodejs/helm-chart-v4-render-yaml-hooks/testchart/Chart.yaml
+++ b/tests/sdk/nodejs/helm-chart-v4-render-yaml-hooks/testchart/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: testchart
+description: Minimal chart exercising Helm hook rendering
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/tests/sdk/nodejs/helm-chart-v4-render-yaml-hooks/testchart/templates/configmap.yaml
+++ b/tests/sdk/nodejs/helm-chart-v4-render-yaml-hooks/testchart/templates/configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-config
+  namespace: {{ .Release.Namespace }}
+data:
+  hello: world

--- a/tests/sdk/nodejs/helm-chart-v4-render-yaml-hooks/testchart/templates/pre-install-hook.yaml
+++ b/tests/sdk/nodejs/helm-chart-v4-render-yaml-hooks/testchart/templates/pre-install-hook.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-pre-install
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-install
+data:
+  hello: hook

--- a/tests/sdk/nodejs/helm-chart-v4-render-yaml-hooks/testchart/templates/test-hook.yaml
+++ b/tests/sdk/nodejs/helm-chart-v4-render-yaml-hooks/testchart/templates/test-hook.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ .Release.Name }}-test
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  restartPolicy: Never
+  containers:
+    - name: test
+      image: busybox
+      command: ["true"]

--- a/tests/sdk/nodejs/helm-chart-v4-render-yaml-hooks/tsconfig.json
+++ b/tests/sdk/nodejs/helm-chart-v4-render-yaml-hooks/tsconfig.json
@@ -1,0 +1,21 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": true,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/tests/sdk/nodejs/helm_test.go
+++ b/tests/sdk/nodejs/helm_test.go
@@ -304,3 +304,47 @@ func TestHelmChartV4WithYamlRenderModeRendersWithoutClusterConnection(t *testing
 			To(gm.BeNumerically(">", 0), "Manifest directory should contain rendered Helm chart resources")
 	}
 }
+
+// TestHelmChartV4RenderYamlIncludesHooks verifies that, in renderYamlToDirectory mode with
+// includeHooks set, the Helm v4 Chart renders non-test hook resources (mirroring `helm template`)
+// while excluding test hooks. See https://github.com/pulumi/pulumi-kubernetes/issues/3284.
+func TestHelmChartV4RenderYamlIncludesHooks(t *testing.T) {
+	t.Parallel()
+	g := gm.NewWithT(t)
+
+	// Create a temporary directory to hold rendered YAML manifests.
+	dir, err := os.MkdirTemp("", "helm-chart-v4-render-yaml-hooks-test")
+	g.Expect(err).ToNot(gm.HaveOccurred())
+	defer os.RemoveAll(dir)
+
+	test := pulumitest.NewPulumiTest(t, "helm-chart-v4-render-yaml-hooks")
+	t.Cleanup(func() {
+		test.Destroy(t)
+	})
+
+	// Set the config value for renderDir
+	err = test.CurrentStack().SetConfig(context.Background(), "renderDir", auto.ConfigValue{
+		Value:  dir,
+		Secret: false,
+	})
+	g.Expect(err).ToNot(gm.HaveOccurred())
+
+	preview := test.Preview(t)
+	t.Log(preview.StdOut)
+
+	up := test.Up(t)
+	t.Log(up.StdOut)
+
+	manifestDir := filepath.Join(dir, "1-manifest")
+	files, err := os.ReadDir(manifestDir)
+	g.Expect(err).ToNot(gm.HaveOccurred())
+
+	// The normal ConfigMap and the pre-install hook ConfigMap should both be rendered.
+	g.Expect(checkFileNamePrefix(files, "v1-configmap-default-hooks-config")).
+		To(gm.BeTrue(), "normal ConfigMap should be rendered")
+	g.Expect(checkFileNamePrefix(files, "v1-configmap-default-hooks-pre-install")).
+		To(gm.BeTrue(), "pre-install hook ConfigMap should be rendered when includeHooks is set")
+	// The test hook Pod should be excluded.
+	g.Expect(checkFileNamePrefix(files, "v1-pod-default-hooks-test")).
+		To(gm.BeFalse(), "test hook Pod should be excluded from rendered output")
+}

--- a/tests/sdk/nodejs/helm_test.go
+++ b/tests/sdk/nodejs/helm_test.go
@@ -308,43 +308,37 @@ func TestHelmChartV4WithYamlRenderModeRendersWithoutClusterConnection(t *testing
 // TestHelmChartV4RenderYamlIncludesHooks verifies that, in renderYamlToDirectory mode with
 // includeHooks set, the Helm v4 Chart renders non-test hook resources (mirroring `helm template`)
 // while excluding test hooks. See https://github.com/pulumi/pulumi-kubernetes/issues/3284.
+//
+// This uses the integration.ProgramTest framework (via baseOptions) rather than pulumitest because
+// the program references the new `includeHooks` input, which only exists in the locally built SDK;
+// baseOptions links `@pulumi/kubernetes` so the program compiles against it.
 func TestHelmChartV4RenderYamlIncludesHooks(t *testing.T) {
-	t.Parallel()
-	g := gm.NewWithT(t)
-
 	// Create a temporary directory to hold rendered YAML manifests.
 	dir, err := os.MkdirTemp("", "helm-chart-v4-render-yaml-hooks-test")
-	g.Expect(err).ToNot(gm.HaveOccurred())
+	assert.NoError(t, err)
 	defer os.RemoveAll(dir)
 
-	test := pulumitest.NewPulumiTest(t, "helm-chart-v4-render-yaml-hooks")
-	t.Cleanup(func() {
-		test.Destroy(t)
+	test := baseOptions.With(integration.ProgramTestOptions{
+		Config: map[string]string{
+			"renderDir": dir,
+		},
+		Dir:         "helm-chart-v4-render-yaml-hooks",
+		Quick:       true,
+		SkipRefresh: true,
+		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			manifestDir := filepath.Join(dir, "1-manifest")
+			files, err := os.ReadDir(manifestDir)
+			assert.NoError(t, err)
+
+			// The normal ConfigMap and the pre-install hook ConfigMap should both be rendered.
+			assert.True(t, checkFileNamePrefix(files, "v1-configmap-default-hooks-config"),
+				"normal ConfigMap should be rendered")
+			assert.True(t, checkFileNamePrefix(files, "v1-configmap-default-hooks-pre-install"),
+				"pre-install hook ConfigMap should be rendered when includeHooks is set")
+			// The test hook Pod should be excluded.
+			assert.False(t, checkFileNamePrefix(files, "v1-pod-default-hooks-test"),
+				"test hook Pod should be excluded from rendered output")
+		},
 	})
-
-	// Set the config value for renderDir
-	err = test.CurrentStack().SetConfig(context.Background(), "renderDir", auto.ConfigValue{
-		Value:  dir,
-		Secret: false,
-	})
-	g.Expect(err).ToNot(gm.HaveOccurred())
-
-	preview := test.Preview(t)
-	t.Log(preview.StdOut)
-
-	up := test.Up(t)
-	t.Log(up.StdOut)
-
-	manifestDir := filepath.Join(dir, "1-manifest")
-	files, err := os.ReadDir(manifestDir)
-	g.Expect(err).ToNot(gm.HaveOccurred())
-
-	// The normal ConfigMap and the pre-install hook ConfigMap should both be rendered.
-	g.Expect(checkFileNamePrefix(files, "v1-configmap-default-hooks-config")).
-		To(gm.BeTrue(), "normal ConfigMap should be rendered")
-	g.Expect(checkFileNamePrefix(files, "v1-configmap-default-hooks-pre-install")).
-		To(gm.BeTrue(), "pre-install hook ConfigMap should be rendered when includeHooks is set")
-	// The test hook Pod should be excluded.
-	g.Expect(checkFileNamePrefix(files, "v1-pod-default-hooks-test")).
-		To(gm.BeFalse(), "test hook Pod should be excluded from rendered output")
+	integration.ProgramTest(t, &test)
 }

--- a/tests/sdk/nodejs/helm_test.go
+++ b/tests/sdk/nodejs/helm_test.go
@@ -325,7 +325,7 @@ func TestHelmChartV4RenderYamlIncludesHooks(t *testing.T) {
 		Dir:         "helm-chart-v4-render-yaml-hooks",
 		Quick:       true,
 		SkipRefresh: true,
-		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+		ExtraRuntimeValidation: func(t *testing.T, _ integration.RuntimeValidationStackInfo) {
 			manifestDir := filepath.Join(dir, "1-manifest")
 			files, err := os.ReadDir(manifestDir)
 			assert.NoError(t, err)


### PR DESCRIPTION
## Scope

> **This does not fully resolve #3284.** It does not implement Helm hook *lifecycle* support (ordering, weights, delete policies, execution) — that remains open in #3284 (and #555 for live apply). This PR only brings `helm.v4.Chart` **render mode** up to par with `helm template` by letting hook resources be emitted instead of silently dropped. Relates to #3284.

## Problem

`kubernetes.helm.sh/v4:Chart` renders a chart with the Helm SDK but discards all Helm hook resources (anything annotated `helm.sh/hook`): only `release.Manifest` is parsed and `release.Hooks` is ignored.

For a normal apply this is intentional (Pulumi can't currently honor hook semantics). **But** in `renderYamlToDirectory` mode Pulumi is *not* applying anything — it only emits YAML for another tool (e.g. Argo CD) to apply. There, the output should mirror `helm template`, which includes hook resources so the downstream tool can act on them. Today they vanish, which breaks GitOps-style workflows that pack the rendered YAML into an OCI artifact for Argo CD.

## Change

Add an explicit, opt-in `includeHooks` boolean to `helm.v4.Chart` (default `false`).

- When `includeHooks: true` **and** the provider is in `renderYamlToDirectory` mode, hook resources are appended to the rendered output as-is, with their `helm.sh/hook` annotations preserved.
- If `includeHooks` is set **without** render mode, it is ignored and a warning is logged — hooks are never silently registered as live Pulumi-managed resources.
- Default behavior is unchanged: with `includeHooks` unset, hooks are dropped exactly as before.
- Test hooks (`helm.sh/hook: test`) are always excluded (detected via `hook.Events` / `release.HookTest`, not a regexp).

The flag lives on the Chart (mirroring the existing chart-level `skipCrds`, and v3's `includeTestHookResources`). Render mode is plumbed to the component via a `RenderYAMLToDirectory` field on `ResourceProviderOptions`, wired from the provider's existing `yamlRenderMode`.

## Tests

- Unit (`chart_test.go`): `includeHooks` unset → all hooks dropped; `includeHooks: true` + render mode → non-test hook included, test hook excluded; `includeHooks: true` without render mode → hooks ignored + warning logged.
- Full render integration (`TestHelmChartV4RenderYamlIncludesHooks`, modeled on `TestHelmChartV4WithYamlRenderModeRendersWithoutClusterConnection`) with a new local chart fixture containing a normal resource, a `pre-install` hook, and a `test` hook; asserts the pre-install hook is rendered under `1-manifest/` and the test hook is not.

Schema and all language SDKs were regenerated for the new `includeHooks` input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)