### PR TITLE
hotfix: e2e test failure on master

### DIFF
--- a/tests/sdk/yaml/helm_release_crd_scope_test.go
+++ b/tests/sdk/yaml/helm_release_crd_scope_test.go
@@ -20,7 +20,7 @@ func TestHelmReleaseCRDScopeWritesToCache(t *testing.T) {
 
 	preview := test.Preview(t)
 	assert.Contains(t, preview.StdOut, "default/my-crontab",
-		"CronTab should resolve as namespaced at preview")
+		"ScopedCronTab should resolve as namespaced at preview")
 
 	test.Up(t)
 
@@ -28,12 +28,12 @@ func TestHelmReleaseCRDScopeWritesToCache(t *testing.T) {
 	require.NoError(t, json.Unmarshal(test.ExportStack(t).Deployment, &deployment))
 	var found bool
 	for _, r := range deployment.Resources {
-		if r.Type != "kubernetes:stable.example.com/v1:CronTab" {
+		if r.Type != "kubernetes:crd-scope.example.com/v1:ScopedCronTab" {
 			continue
 		}
 		found = true
 		assert.Contains(t, string(r.URN), "default/my-crontab",
-			"CronTab should be namespaced in state")
+			"ScopedCronTab should be namespaced in state")
 	}
-	assert.True(t, found, "expected a CronTab custom resource in the stack")
+	assert.True(t, found, "expected a ScopedCronTab custom resource in the stack")
 }

--- a/tests/sdk/yaml/testdata/helm-release-crd-scope/Pulumi.yaml
+++ b/tests/sdk/yaml/testdata/helm-release-crd-scope/Pulumi.yaml
@@ -14,8 +14,8 @@ resources:
         - ${operator}
     properties:
       objs:
-        - apiVersion: stable.example.com/v1
-          kind: CronTab
+        - apiVersion: crd-scope.example.com/v1
+          kind: ScopedCronTab
           metadata:
             name: my-crontab
           spec:

--- a/tests/sdk/yaml/testdata/helm-release-crd-scope/crontab-operator/crds/crontab.yaml
+++ b/tests/sdk/yaml/testdata/helm-release-crd-scope/crontab-operator/crds/crontab.yaml
@@ -1,14 +1,15 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: crontabs.stable.example.com
+  name: scopedcrontabs.crd-scope.example.com
 spec:
-  group: stable.example.com
+  group: crd-scope.example.com
   scope: Namespaced
   names:
-    plural: crontabs
-    singular: crontab
-    kind: CronTab
+    plural: scopedcrontabs
+    singular: scopedcrontab
+    kind: ScopedCronTab
+    listKind: ScopedCronTabList
     shortNames:
     - ct
   versions:


### PR DESCRIPTION
This PR uses a different CRD shape to avoid collision in CI on the prod CI cluster.

Fixes https://github.com/pulumi/pulumi-kubernetes/issues/4421.