### PR TITLE
feat: use OpenAPI v3 for schema loading with v2 fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- [#4434](https://github.com/pulumi/pulumi-kubernetes/pull/4434) Fix slow provider registration caused by repeatedly downloading the full Kubernetes API schema. Schemas are now fetched and cached incrementally. Older clusters (pre-v1.24) fall back to the previous behaviour automatically.
+
 ## 4.32.0 (June 5, 2026)
 
 ### Fixed

--- a/provider/pkg/clients/fake/clients.go
+++ b/provider/pkg/clients/fake/clients.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubeversion "k8s.io/apimachinery/pkg/version"
+	clientopenapi "k8s.io/client-go/openapi"
 	"k8s.io/client-go/restmapper"
 	kubetesting "k8s.io/client-go/testing"
 	"k8s.io/kubectl/pkg/scheme"
@@ -49,10 +50,35 @@ func WithServerVersion(version kubeversion.Info) NewDynamicClientOption {
 	}
 }
 
+// WithOpenAPIV3Error configures the fake discovery client to return an error from its OpenAPI v3
+// endpoint, so that the v3→v2 fallback path in getResources() can be exercised in tests.
+func WithOpenAPIV3Error(err error) NewDynamicClientOption {
+	return func(options *newDynamicClientOptions) {
+		options.v3Err = err
+	}
+}
+
+// WithOpenAPIV2Error configures the fake discovery client to return an error from its OpenAPI v2
+// endpoint, so that the double-failure path in getResources() can be exercised in tests.
+func WithOpenAPIV2Error(err error) NewDynamicClientOption {
+	return func(options *newDynamicClientOptions) {
+		options.v2Err = err
+	}
+}
+
 type newDynamicClientOptions struct {
 	ServerVersion kubeversion.Info
 	Scheme        *runtime.Scheme
 	Objects       []runtime.Object
+	v3Err         error
+	v2Err         error
+}
+
+// errorV3Client is an openapi.Client whose Paths() always returns the given error.
+type errorV3Client struct{ err error }
+
+func (e *errorV3Client) Paths() (map[string]clientopenapi.GroupVersion, error) {
+	return nil, e.err
 }
 
 // NewSimpleDynamicClient creates a simple dynamic client for testing purposes,
@@ -70,6 +96,10 @@ func NewSimpleDynamicClient(opts ...NewDynamicClientOption) (*clients.DynamicCli
 
 	// make a fake discovery client that produces the core/v1 schema, and a mapper based on that.
 	disco := NewSimpleDiscovery(options.ServerVersion)
+	if options.v3Err != nil {
+		disco.v3Client = &errorV3Client{err: options.v3Err}
+	}
+	disco.v2Err = options.v2Err
 	resources, err := restmapper.GetAPIGroupResources(disco)
 	if err != nil {
 		panic(err)

--- a/provider/pkg/clients/fake/clients.go
+++ b/provider/pkg/clients/fake/clients.go
@@ -66,12 +66,21 @@ func WithOpenAPIV2Error(err error) NewDynamicClientOption {
 	}
 }
 
+// WithV3EmptySchemaPath injects a GV path into the fake v3 client that returns empty schema
+// bytes, simulating an API server returning an empty response for that path.
+func WithV3EmptySchemaPath(path string) NewDynamicClientOption {
+	return func(options *newDynamicClientOptions) {
+		options.v3EmptyPath = path
+	}
+}
+
 type newDynamicClientOptions struct {
 	ServerVersion kubeversion.Info
 	Scheme        *runtime.Scheme
 	Objects       []runtime.Object
 	v3Err         error
 	v2Err         error
+	v3EmptyPath   string
 }
 
 // errorV3Client is an openapi.Client whose Paths() always returns the given error.
@@ -96,8 +105,14 @@ func NewSimpleDynamicClient(opts ...NewDynamicClientOption) (*clients.DynamicCli
 
 	// make a fake discovery client that produces the core/v1 schema, and a mapper based on that.
 	disco := NewSimpleDiscovery(options.ServerVersion)
-	if options.v3Err != nil {
+	switch {
+	case options.v3Err != nil:
 		disco.v3Client = &errorV3Client{err: options.v3Err}
+	case options.v3EmptyPath != "":
+		disco.v3Client = &emptyPathV3Client{
+			inner: loadFakeV3Client(),
+			path:  options.v3EmptyPath,
+		}
 	}
 	disco.v2Err = options.v2Err
 	resources, err := restmapper.GetAPIGroupResources(disco)

--- a/provider/pkg/clients/fake/discovery.go
+++ b/provider/pkg/clients/fake/discovery.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"io"
 	"io/fs"
+	"strings"
 	"sync"
 
 	openapi_v2 "github.com/google/gnostic-models/openapiv2"
@@ -28,12 +29,16 @@ import (
 	kubeversion "k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/discovery"
 	discoveryfake "k8s.io/client-go/discovery/fake"
+	clientopenapi "k8s.io/client-go/openapi"
 	"k8s.io/client-go/restmapper"
 	kubetesting "k8s.io/client-go/testing"
 )
 
 //go:embed swagger.json
 var swagger []byte
+
+//go:embed testdata/openapi_v3
+var openapiV3FS embed.FS
 
 // _schema caches our OpenAPI schema since it is moderately slow to re-parse
 // during tests.
@@ -95,6 +100,65 @@ func (*SimpleDiscovery) Invalidate() {}
 
 func (*SimpleDiscovery) OpenAPISchema() (*openapi_v2.Document, error) {
 	return LoadOpenAPISchema()
+}
+
+// OpenAPIV3 returns a fake OpenAPI v3 client backed by the test fixtures in testdata/openapi_v3/.
+// Each JSON file in that directory is served as a separate GV path (filename without .json becomes
+// the path, with underscores converted to slashes).
+func (*SimpleDiscovery) OpenAPIV3() clientopenapi.Client {
+	return loadFakeV3Client()
+}
+
+// loadFakeV3Client reads all *.json fixtures from the embedded testdata/openapi_v3 directory
+// and returns a fake Client whose Paths() returns one entry per file.
+func loadFakeV3Client() clientopenapi.Client {
+	paths := map[string][]byte{}
+	err := fs.WalkDir(openapiV3FS, "testdata/openapi_v3", func(path string, d fs.DirEntry, _ error) error {
+		if d.IsDir() || !strings.HasSuffix(d.Name(), ".json") {
+			return nil
+		}
+		data, err := openapiV3FS.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		// Convert filename (e.g. "apis_apps_v1.json") to a GV path ("apis/apps/v1").
+		gvPath := strings.TrimSuffix(d.Name(), ".json")
+		gvPath = strings.ReplaceAll(gvPath, "_", "/")
+		// Preserve "api/v1" — the single underscore maps correctly.
+		// "apis/apps/v1" also maps correctly since we replace all underscores.
+		paths[gvPath] = data
+		return nil
+	})
+	if err != nil {
+		panic(err)
+	}
+	return &fakeV3Client{paths: paths}
+}
+
+// fakeV3Client implements clientopenapi.Client using a map of GV path → raw JSON bytes.
+type fakeV3Client struct {
+	paths map[string][]byte
+}
+
+func (f *fakeV3Client) Paths() (map[string]clientopenapi.GroupVersion, error) {
+	out := make(map[string]clientopenapi.GroupVersion, len(f.paths))
+	for path, data := range f.paths {
+		out[path] = &fakeGroupVersion{data: data}
+	}
+	return out, nil
+}
+
+// fakeGroupVersion implements clientopenapi.GroupVersion returning fixed JSON bytes.
+type fakeGroupVersion struct {
+	data []byte
+}
+
+func (g *fakeGroupVersion) Schema(_ string) ([]byte, error) {
+	return g.data, nil
+}
+
+func (g *fakeGroupVersion) ServerRelativeURL() string {
+	return ""
 }
 
 func NewSimpleDiscovery(serverVersion kubeversion.Info) *SimpleDiscovery {

--- a/provider/pkg/clients/fake/discovery.go
+++ b/provider/pkg/clients/fake/discovery.go
@@ -162,6 +162,22 @@ type fakeGroupVersion struct {
 	data []byte
 }
 
+// emptyPathV3Client wraps an existing Client and adds a single extra path that returns empty
+// schema bytes, simulating an API server that returns an empty body for that path.
+type emptyPathV3Client struct {
+	inner clientopenapi.Client
+	path  string
+}
+
+func (e *emptyPathV3Client) Paths() (map[string]clientopenapi.GroupVersion, error) {
+	paths, err := e.inner.Paths()
+	if err != nil {
+		return nil, err
+	}
+	paths[e.path] = &fakeGroupVersion{data: []byte{}}
+	return paths, nil
+}
+
 func (g *fakeGroupVersion) Schema(_ string) ([]byte, error) {
 	return g.data, nil
 }

--- a/provider/pkg/clients/fake/discovery.go
+++ b/provider/pkg/clients/fake/discovery.go
@@ -88,6 +88,10 @@ func loadServerResources() ([]*metav1.APIResourceList, error) {
 // SimpleDiscovery provides a fake discovery client with core Kubernetes types.
 type SimpleDiscovery struct {
 	*discoveryfake.FakeDiscovery
+	// v3Client overrides OpenAPIV3(); if nil the embedded testdata fixtures are used.
+	v3Client clientopenapi.Client
+	// v2Err, if non-nil, is returned by OpenAPISchema() to simulate a v2 failure.
+	v2Err error
 }
 
 var _ discovery.CachedDiscoveryInterface = &SimpleDiscovery{}
@@ -98,14 +102,19 @@ func (*SimpleDiscovery) Fresh() bool {
 
 func (*SimpleDiscovery) Invalidate() {}
 
-func (*SimpleDiscovery) OpenAPISchema() (*openapi_v2.Document, error) {
+func (d *SimpleDiscovery) OpenAPISchema() (*openapi_v2.Document, error) {
+	if d.v2Err != nil {
+		return nil, d.v2Err
+	}
 	return LoadOpenAPISchema()
 }
 
-// OpenAPIV3 returns a fake OpenAPI v3 client backed by the test fixtures in testdata/openapi_v3/.
-// Each JSON file in that directory is served as a separate GV path (filename without .json becomes
-// the path, with underscores converted to slashes).
-func (*SimpleDiscovery) OpenAPIV3() clientopenapi.Client {
+// OpenAPIV3 returns a fake OpenAPI v3 client. If a v3Client override has been set (e.g. to
+// simulate a failure) it is returned; otherwise the embedded testdata/openapi_v3 fixtures are used.
+func (d *SimpleDiscovery) OpenAPIV3() clientopenapi.Client {
+	if d.v3Client != nil {
+		return d.v3Client
+	}
 	return loadFakeV3Client()
 }
 

--- a/provider/pkg/clients/fake/testdata/openapi_v3/api_v1.json
+++ b/provider/pkg/clients/fake/testdata/openapi_v3/api_v1.json
@@ -1,0 +1,35 @@
+{
+  "openapi": "3.0.0",
+  "info": {"title": "Kubernetes", "version": "unversioned"},
+  "paths": {},
+  "components": {
+    "schemas": {
+      "io.k8s.api.core.v1.ConfigMap": {
+        "type": "object",
+        "x-kubernetes-group-version-kind": [
+          {"group": "", "version": "v1", "kind": "ConfigMap"}
+        ],
+        "properties": {
+          "apiVersion": {"type": "string"},
+          "binaryData": {"type": "object"},
+          "data": {"type": "object"},
+          "kind": {"type": "string"},
+          "metadata": {"type": "object"}
+        }
+      },
+      "io.k8s.api.core.v1.Pod": {
+        "type": "object",
+        "x-kubernetes-group-version-kind": [
+          {"group": "", "version": "v1", "kind": "Pod"}
+        ],
+        "properties": {
+          "apiVersion": {"type": "string"},
+          "kind": {"type": "string"},
+          "metadata": {"type": "object"},
+          "spec": {"type": "object"},
+          "status": {"type": "object"}
+        }
+      }
+    }
+  }
+}

--- a/provider/pkg/clients/fake/testdata/openapi_v3/apis_apps_v1.json
+++ b/provider/pkg/clients/fake/testdata/openapi_v3/apis_apps_v1.json
@@ -1,0 +1,34 @@
+{
+  "openapi": "3.0.0",
+  "info": {"title": "Kubernetes", "version": "unversioned"},
+  "paths": {},
+  "components": {
+    "schemas": {
+      "io.k8s.api.apps.v1.Deployment": {
+        "type": "object",
+        "x-kubernetes-group-version-kind": [
+          {"group": "apps", "version": "v1", "kind": "Deployment"}
+        ],
+        "properties": {
+          "apiVersion": {"type": "string", "description": "APIVersion defines the versioned schema."},
+          "kind": {"type": "string", "description": "Kind is a string value representing the REST resource."},
+          "metadata": {"type": "object"},
+          "spec": {"type": "object"},
+          "status": {"type": "object"}
+        }
+      },
+      "io.k8s.api.apps.v1.DeploymentList": {
+        "type": "object",
+        "x-kubernetes-group-version-kind": [
+          {"group": "apps", "version": "v1", "kind": "DeploymentList"}
+        ],
+        "properties": {
+          "apiVersion": {"type": "string"},
+          "items": {"type": "array", "items": {"type": "object"}},
+          "kind": {"type": "string"},
+          "metadata": {"type": "object"}
+        }
+      }
+    }
+  }
+}

--- a/provider/pkg/openapi/openapi_v3.go
+++ b/provider/pkg/openapi/openapi_v3.go
@@ -15,6 +15,8 @@
 package openapi
 
 import (
+	"fmt"
+
 	openapi_v3 "github.com/google/gnostic-models/openapiv3"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -46,7 +48,12 @@ func GetResourceSchemasForClientV3(client clientopenapi.Client) (k8sopenapi.Reso
 			continue
 		}
 
-		doc, err := openapi_v3.ParseDocument(schemaBytes)
+		if len(schemaBytes) == 0 {
+			logger.V(9).Infof("skipping OpenAPI v3 path %q: empty schema bytes", path)
+			continue
+		}
+
+		doc, err := safeParseDocument(schemaBytes)
 		if err != nil {
 			logger.V(9).Infof("skipping OpenAPI v3 path %q: failed to parse document: %v", path, err)
 			continue
@@ -153,6 +160,17 @@ func gvksFromSchema(s proto.Schema) []schema.GroupVersionKind {
 		})
 	}
 	return result
+}
+
+// safeParseDocument wraps openapi_v3.ParseDocument to convert panics (which the
+// gnostic-models library can emit on malformed input) into errors.
+func safeParseDocument(data []byte) (doc *openapi_v3.Document, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("ParseDocument panicked: %v", r)
+		}
+	}()
+	return openapi_v3.ParseDocument(data)
 }
 
 // extractGVK extracts group/version/kind strings from a YAML-unmarshaled map,

--- a/provider/pkg/openapi/openapi_v3.go
+++ b/provider/pkg/openapi/openapi_v3.go
@@ -15,13 +15,13 @@
 package openapi
 
 import (
+	openapi_v3 "github.com/google/gnostic-models/openapiv3"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	clientopenapi "k8s.io/client-go/openapi"
 	"k8s.io/kube-openapi/pkg/util/proto"
 	k8sopenapi "k8s.io/kubectl/pkg/util/openapi"
 
-	openapi_v3 "github.com/google/gnostic-models/openapiv3"
 	logger "github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 )
 

--- a/provider/pkg/openapi/openapi_v3.go
+++ b/provider/pkg/openapi/openapi_v3.go
@@ -1,0 +1,172 @@
+// Copyright 2016-2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openapi
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	clientopenapi "k8s.io/client-go/openapi"
+	"k8s.io/kube-openapi/pkg/util/proto"
+	k8sopenapi "k8s.io/kubectl/pkg/util/openapi"
+
+	openapi_v3 "github.com/google/gnostic-models/openapiv3"
+	logger "github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
+)
+
+// GetResourceSchemasForClientV3 fetches resource schemas using the OpenAPI v3 per-GV
+// endpoint. Unlike GetResourceSchemasForClient (v2), schemas are fetched per
+// group-version and benefit from the per-GV caching in cachedopenapi.NewClient, so
+// repeated calls for the same GV avoid re-downloading the schema.
+func GetResourceSchemasForClientV3(client clientopenapi.Client) (k8sopenapi.Resources, error) {
+	paths, err := client.Paths()
+	if err != nil {
+		return nil, err
+	}
+
+	gvkToModel := map[schema.GroupVersionKind]string{}
+	var allModels []proto.Models
+
+	for path, gv := range paths {
+		schemaBytes, err := gv.Schema(runtime.ContentTypeJSON)
+		if err != nil {
+			// Some paths (e.g. metrics endpoints) don't serve OpenAPI schemas; skip them.
+			logger.V(9).Infof("skipping OpenAPI v3 path %q: %v", path, err)
+			continue
+		}
+
+		doc, err := openapi_v3.ParseDocument(schemaBytes)
+		if err != nil {
+			logger.V(9).Infof("skipping OpenAPI v3 path %q: failed to parse document: %v", path, err)
+			continue
+		}
+
+		models, err := proto.NewOpenAPIV3Data(doc)
+		if err != nil {
+			logger.V(9).Infof("skipping OpenAPI v3 path %q: failed to build models: %v", path, err)
+			continue
+		}
+
+		for _, name := range models.ListModels() {
+			s := models.LookupModel(name)
+			if s == nil {
+				continue
+			}
+			for _, gvk := range gvksFromSchema(s) {
+				gvkToModel[gvk] = name
+			}
+		}
+
+		allModels = append(allModels, models)
+	}
+
+	return &v3document{
+		resources: gvkToModel,
+		models:    &mergedModels{models: allModels},
+	}, nil
+}
+
+// v3document implements k8sopenapi.Resources backed by merged per-GV proto.Models.
+type v3document struct {
+	resources map[schema.GroupVersionKind]string
+	models    proto.Models
+}
+
+func (d *v3document) LookupResource(gvk schema.GroupVersionKind) proto.Schema {
+	name, ok := d.resources[gvk]
+	if !ok {
+		return nil
+	}
+	return d.models.LookupModel(name)
+}
+
+// GetConsumes returns the accepted content types for the given GVK and operation.
+// The v3 schema does not encode consumes; returning nil matches the behaviour of
+// LookupResource for an unknown GVK in the v2 implementation.
+func (d *v3document) GetConsumes(_ schema.GroupVersionKind, _ string) []string {
+	return nil
+}
+
+// mergedModels implements proto.Models by searching across multiple per-GV Models.
+type mergedModels struct {
+	models []proto.Models
+}
+
+func (m *mergedModels) LookupModel(name string) proto.Schema {
+	for _, mm := range m.models {
+		if s := mm.LookupModel(name); s != nil {
+			return s
+		}
+	}
+	return nil
+}
+
+func (m *mergedModels) ListModels() []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, mm := range m.models {
+		for _, name := range mm.ListModels() {
+			if !seen[name] {
+				seen[name] = true
+				out = append(out, name)
+			}
+		}
+	}
+	return out
+}
+
+// gvksFromSchema extracts Kubernetes GroupVersionKinds from a proto.Schema by
+// reading the x-kubernetes-group-version-kind extension.
+func gvksFromSchema(s proto.Schema) []schema.GroupVersionKind {
+	exts := s.GetExtensions()
+	val, ok := exts["x-kubernetes-group-version-kind"]
+	if !ok {
+		return nil
+	}
+
+	list, ok := val.([]interface{})
+	if !ok {
+		return nil
+	}
+
+	var result []schema.GroupVersionKind
+	for _, item := range list {
+		group, version, kind := extractGVK(item)
+		if version == "" || kind == "" {
+			continue
+		}
+		result = append(result, schema.GroupVersionKind{
+			Group:   group,
+			Version: version,
+			Kind:    kind,
+		})
+	}
+	return result
+}
+
+// extractGVK extracts group/version/kind strings from a YAML-unmarshaled map,
+// handling both yaml.v2 (map[interface{}]interface{}) and yaml.v3 (map[string]interface{}) formats.
+func extractGVK(item interface{}) (group, version, kind string) {
+	switch m := item.(type) {
+	case map[string]interface{}:
+		group, _ = m["group"].(string)
+		version, _ = m["version"].(string)
+		kind, _ = m["kind"].(string)
+	case map[interface{}]interface{}:
+		group, _ = m["group"].(string)
+		version, _ = m["version"].(string)
+		kind, _ = m["kind"].(string)
+	}
+	return
+}

--- a/provider/pkg/openapi/openapi_v3_test.go
+++ b/provider/pkg/openapi/openapi_v3_test.go
@@ -1,0 +1,210 @@
+// Copyright 2016-2026, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openapi
+
+import (
+	"fmt"
+	"testing"
+
+	openapi_v2 "github.com/google/gnostic-models/openapiv2"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	clientopenapi "k8s.io/client-go/openapi"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/pulumi-kubernetes/provider/v4/pkg/clients/fake"
+)
+
+// fakeV2Disco wraps an openapi_v2.Document to satisfy discovery.OpenAPISchemaInterface.
+type fakeV2Disco struct {
+	doc *openapi_v2.Document
+}
+
+func (f *fakeV2Disco) OpenAPISchema() (*openapi_v2.Document, error) {
+	return f.doc, nil
+}
+
+// appsV1Schema is a minimal OpenAPI v3 document for the apps/v1 group version.
+const appsV1Schema = `{
+  "openapi": "3.0.0",
+  "info": {"title": "Kubernetes", "version": "unversioned"},
+  "paths": {},
+  "components": {
+    "schemas": {
+      "io.k8s.api.apps.v1.Deployment": {
+        "type": "object",
+        "x-kubernetes-group-version-kind": [
+          {"group": "apps", "version": "v1", "kind": "Deployment"}
+        ],
+        "properties": {
+          "apiVersion": {"type": "string"},
+          "kind": {"type": "string"},
+          "metadata": {"type": "object"},
+          "spec": {"type": "object"}
+        }
+      }
+    }
+  }
+}`
+
+// coreV1Schema is a minimal OpenAPI v3 document for the core v1 group version.
+const coreV1Schema = `{
+  "openapi": "3.0.0",
+  "info": {"title": "Kubernetes", "version": "unversioned"},
+  "paths": {},
+  "components": {
+    "schemas": {
+      "io.k8s.api.core.v1.ConfigMap": {
+        "type": "object",
+        "x-kubernetes-group-version-kind": [
+          {"group": "", "version": "v1", "kind": "ConfigMap"}
+        ],
+        "properties": {
+          "apiVersion": {"type": "string"},
+          "kind": {"type": "string"},
+          "metadata": {"type": "object"},
+          "data": {"type": "object"}
+        }
+      }
+    }
+  }
+}`
+
+// fakeV3Client is a test-only openapi.Client backed by a map of path → JSON bytes.
+type fakeV3Client struct {
+	paths map[string][]byte
+}
+
+func (f *fakeV3Client) Paths() (map[string]clientopenapi.GroupVersion, error) {
+	out := make(map[string]clientopenapi.GroupVersion, len(f.paths))
+	for path, data := range f.paths {
+		out[path] = &fakeV3GV{data: data}
+	}
+	return out, nil
+}
+
+type fakeV3GV struct{ data []byte }
+
+func (g *fakeV3GV) Schema(_ string) ([]byte, error) { return g.data, nil }
+func (g *fakeV3GV) ServerRelativeURL() string        { return "" }
+
+type errorV3GV struct{ err error }
+
+func (g *errorV3GV) Schema(_ string) ([]byte, error) { return nil, g.err }
+func (g *errorV3GV) ServerRelativeURL() string        { return "" }
+
+// partialErrorV3Client wraps fakeV3Client and injects an additional error GV.
+type partialErrorV3Client struct {
+	delegate  *fakeV3Client
+	errorPath string
+	err       error
+}
+
+func (p *partialErrorV3Client) Paths() (map[string]clientopenapi.GroupVersion, error) {
+	paths, err := p.delegate.Paths()
+	if err != nil {
+		return nil, err
+	}
+	paths[p.errorPath] = &errorV3GV{err: p.err}
+	return paths, nil
+}
+
+func TestGetResourceSchemasForClientV3_LookupKnownGVK(t *testing.T) {
+	client := &fakeV3Client{paths: map[string][]byte{
+		"apis/apps/v1": []byte(appsV1Schema),
+	}}
+
+	resources, err := GetResourceSchemasForClientV3(client)
+	require.NoError(t, err)
+
+	deploymentGVK := schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}
+	s := resources.LookupResource(deploymentGVK)
+	assert.NotNil(t, s, "LookupResource should return a non-nil schema for apps/v1/Deployment")
+}
+
+func TestGetResourceSchemasForClientV3_NilForUnknownGVK(t *testing.T) {
+	client := &fakeV3Client{paths: map[string][]byte{
+		"apis/apps/v1": []byte(appsV1Schema),
+	}}
+
+	resources, err := GetResourceSchemasForClientV3(client)
+	require.NoError(t, err)
+
+	unknownGVK := schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "StatefulSet"}
+	s := resources.LookupResource(unknownGVK)
+	assert.Nil(t, s, "LookupResource should return nil for a GVK not in the schema")
+}
+
+func TestGetResourceSchemasForClientV3_MultipleGVs(t *testing.T) {
+	client := &fakeV3Client{paths: map[string][]byte{
+		"apis/apps/v1": []byte(appsV1Schema),
+		"api/v1":       []byte(coreV1Schema),
+	}}
+
+	resources, err := GetResourceSchemasForClientV3(client)
+	require.NoError(t, err)
+
+	assert.NotNil(t, resources.LookupResource(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}))
+	assert.NotNil(t, resources.LookupResource(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}))
+}
+
+func TestGetResourceSchemasForClientV3_PartialFailure(t *testing.T) {
+	// An error on one path (e.g. a metrics endpoint) must not prevent schemas from
+	// other paths being returned.
+	client := &partialErrorV3Client{
+		delegate: &fakeV3Client{paths: map[string][]byte{
+			"apis/apps/v1": []byte(appsV1Schema),
+		}},
+		errorPath: "metrics",
+		err:       fmt.Errorf("metrics endpoint unavailable"),
+	}
+
+	resources, err := GetResourceSchemasForClientV3(client)
+	require.NoError(t, err)
+
+	deploymentGVK := schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}
+	assert.NotNil(t, resources.LookupResource(deploymentGVK),
+		"Deployment should be found despite error on the metrics path")
+}
+
+// TestGetResourceSchemasV2V3Parity verifies that GVKs available via the v3 fixture
+// are also present in the v2 embedded swagger.json, confirming the two code paths
+// produce consistent results for the same underlying data.
+func TestGetResourceSchemasV2V3Parity(t *testing.T) {
+	// v3 resources: load from inline fixtures.
+	v3Client := &fakeV3Client{paths: map[string][]byte{
+		"apis/apps/v1": []byte(appsV1Schema),
+		"api/v1":       []byte(coreV1Schema),
+	}}
+	v3Resources, err := GetResourceSchemasForClientV3(v3Client)
+	require.NoError(t, err)
+
+	// v2 resources: load from the embedded swagger.json in the fake package.
+	v2Doc, err := fake.LoadOpenAPISchema()
+	require.NoError(t, err)
+	v2Resources, err := GetResourceSchemasForClient(&fakeV2Disco{doc: v2Doc})
+	require.NoError(t, err)
+
+	// Both paths should return non-nil for GVKs covered by the fixtures.
+	gvks := []schema.GroupVersionKind{
+		{Group: "apps", Version: "v1", Kind: "Deployment"},
+		{Group: "", Version: "v1", Kind: "ConfigMap"},
+	}
+	for _, gvk := range gvks {
+		assert.NotNilf(t, v3Resources.LookupResource(gvk), "v3: LookupResource(%v)", gvk)
+		assert.NotNilf(t, v2Resources.LookupResource(gvk), "v2: LookupResource(%v)", gvk)
+	}
+}

--- a/provider/pkg/openapi/openapi_v3_test.go
+++ b/provider/pkg/openapi/openapi_v3_test.go
@@ -19,11 +19,10 @@ import (
 	"testing"
 
 	openapi_v2 "github.com/google/gnostic-models/openapiv2"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	clientopenapi "k8s.io/client-go/openapi"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	clientopenapi "k8s.io/client-go/openapi"
 
 	"github.com/pulumi/pulumi-kubernetes/provider/v4/pkg/clients/fake"
 )
@@ -99,12 +98,12 @@ func (f *fakeV3Client) Paths() (map[string]clientopenapi.GroupVersion, error) {
 type fakeV3GV struct{ data []byte }
 
 func (g *fakeV3GV) Schema(_ string) ([]byte, error) { return g.data, nil }
-func (g *fakeV3GV) ServerRelativeURL() string        { return "" }
+func (g *fakeV3GV) ServerRelativeURL() string       { return "" }
 
 type errorV3GV struct{ err error }
 
 func (g *errorV3GV) Schema(_ string) ([]byte, error) { return nil, g.err }
-func (g *errorV3GV) ServerRelativeURL() string        { return "" }
+func (g *errorV3GV) ServerRelativeURL() string       { return "" }
 
 // partialErrorV3Client wraps fakeV3Client and injects an additional error GV.
 type partialErrorV3Client struct {

--- a/provider/pkg/provider/provider.go
+++ b/provider/pkg/provider/provider.go
@@ -234,9 +234,16 @@ func (k *kubeProvider) getResources() (k8sopenapi.Resources, error) {
 	k.resourcesMutex.Lock()
 	defer k.resourcesMutex.Unlock()
 
-	rs, err := openapi.GetResourceSchemasForClient(k.clientSet.DiscoveryClientCached)
+	// Try v3 first: schemas are fetched per-GV and benefit from the per-GV cache
+	// in cachedopenapi.NewClient, avoiding the full schema download on every Configure().
+	rs, err := openapi.GetResourceSchemasForClientV3(k.clientSet.DiscoveryClientCached.OpenAPIV3())
 	if err != nil {
-		return nil, err
+		// Fall back to v2 for older clusters (< v1.24) or transient v3 failures.
+		logger.V(9).Infof("OpenAPI v3 schema unavailable (%v), falling back to v2", err)
+		rs, err = openapi.GetResourceSchemasForClient(k.clientSet.DiscoveryClientCached)
+		if err != nil {
+			return nil, err
+		}
 	}
 	k.resources = rs
 	return k.resources, nil

--- a/provider/pkg/provider/provider_configure_test.go
+++ b/provider/pkg/provider/provider_configure_test.go
@@ -343,6 +343,19 @@ var _ = gk.Describe("RPC:Configure", func() {
 			})
 		})
 
+		gk.Context("when an OpenAPI v3 path returns empty schema bytes", func() {
+			gk.BeforeEach(func() {
+				opts = append(opts, WithV3EmptySchemaPath("apis/fake.io/v1"))
+			})
+			gk.It("should skip the bad path and return a non-nil resource cache", func() {
+				_, err := k.Configure(context.Background(), req)
+				gm.Expect(err).ShouldNot(gm.HaveOccurred())
+				rs, err := k.getResources()
+				gm.Expect(err).ShouldNot(gm.HaveOccurred())
+				gm.Expect(rs).ToNot(gm.BeNil())
+			})
+		})
+
 		gk.Context("when both OpenAPI v3 and v2 are unavailable", func() {
 			gk.BeforeEach(func() {
 				opts = append(opts, WithV3SchemaError(fmt.Errorf("v3 unavailable")))

--- a/provider/pkg/provider/provider_configure_test.go
+++ b/provider/pkg/provider/provider_configure_test.go
@@ -17,6 +17,7 @@ package provider
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 
 	_ "embed"
@@ -327,6 +328,32 @@ var _ = gk.Describe("RPC:Configure", func() {
 			k.invalidateResources()
 			gm.Expect(k.resources).To(gm.BeNil())
 			gm.Expect(k.getResources()).ToNot(gm.BeNil())
+		})
+
+		gk.Context("when OpenAPI v3 is unavailable", func() {
+			gk.BeforeEach(func() {
+				opts = append(opts, WithV3SchemaError(fmt.Errorf("v3 unavailable")))
+			})
+			gk.It("should fall back to v2 and return a non-nil resource cache", func() {
+				_, err := k.Configure(context.Background(), req)
+				gm.Expect(err).ShouldNot(gm.HaveOccurred())
+				rs, err := k.getResources()
+				gm.Expect(err).ShouldNot(gm.HaveOccurred())
+				gm.Expect(rs).ToNot(gm.BeNil())
+			})
+		})
+
+		gk.Context("when both OpenAPI v3 and v2 are unavailable", func() {
+			gk.BeforeEach(func() {
+				opts = append(opts, WithV3SchemaError(fmt.Errorf("v3 unavailable")))
+				opts = append(opts, WithV2SchemaError(fmt.Errorf("v2 unavailable")))
+			})
+			gk.It("should return an error from getResources", func() {
+				_, err := k.Configure(context.Background(), req)
+				gm.Expect(err).ShouldNot(gm.HaveOccurred())
+				_, err = k.getResources()
+				gm.Expect(err).Should(gm.HaveOccurred())
+			})
 		})
 
 		gk.Context("when the server version is < 1.13", func() {

--- a/provider/pkg/provider/suite_test.go
+++ b/provider/pkg/provider/suite_test.go
@@ -226,6 +226,18 @@ func WithResourceProvider(typ string, provider providerresource.ResourceProvider
 	}
 }
 
+func WithV3SchemaError(err error) NewProviderOption {
+	return func(options *newProviderOptions) {
+		options.copts = append(options.copts, fakeclients.WithOpenAPIV3Error(err))
+	}
+}
+
+func WithV2SchemaError(err error) NewProviderOption {
+	return func(options *newProviderOptions) {
+		options.copts = append(options.copts, fakeclients.WithOpenAPIV2Error(err))
+	}
+}
+
 func (c *providerTestContext) NewProvider(opts ...NewProviderOption) *kubeProvider {
 	options := newProviderOptions{}
 	for _, opt := range opts {

--- a/provider/pkg/provider/suite_test.go
+++ b/provider/pkg/provider/suite_test.go
@@ -238,6 +238,12 @@ func WithV2SchemaError(err error) NewProviderOption {
 	}
 }
 
+func WithV3EmptySchemaPath(path string) NewProviderOption {
+	return func(options *newProviderOptions) {
+		options.copts = append(options.copts, fakeclients.WithV3EmptySchemaPath(path))
+	}
+}
+
 func (c *providerTestContext) NewProvider(opts ...NewProviderOption) *kubeProvider {
 	options := newProviderOptions{}
 	for _, opt := range opts {

--- a/tests/pulumirpc/log.go
+++ b/tests/pulumirpc/log.go
@@ -174,12 +174,13 @@ func ParseRegisterResource(entry DebugInterceptorLogEntry) (*RegisterResource, b
 		return nil, false
 	}
 	request := &pulumirpc.RegisterResourceRequest{}
-	err := protojson.Unmarshal(entry.Request, request)
+	unmarshalOpts := protojson.UnmarshalOptions{DiscardUnknown: true}
+	err := unmarshalOpts.Unmarshal(entry.Request, request)
 	if err != nil {
 		return nil, false
 	}
 	response := &pulumirpc.RegisterResourceResponse{}
-	err = protojson.Unmarshal(entry.Response, response)
+	err = unmarshalOpts.Unmarshal(entry.Response, response)
 	if err != nil {
 		return nil, false
 	}
@@ -241,12 +242,13 @@ func ParseInvoke(entry DebugInterceptorLogEntry) (*Invoke, bool) {
 		return nil, false
 	}
 	request := &pulumirpc.ResourceInvokeRequest{}
-	err := protojson.Unmarshal(entry.Request, request)
+	unmarshalOpts := protojson.UnmarshalOptions{DiscardUnknown: true}
+	err := unmarshalOpts.Unmarshal(entry.Request, request)
 	if err != nil {
 		return nil, false
 	}
 	response := &pulumirpc.InvokeResponse{}
-	err = protojson.Unmarshal(entry.Response, response)
+	err = unmarshalOpts.Unmarshal(entry.Response, response)
 	if err != nil {
 		return nil, false
 	}


### PR DESCRIPTION
## Summary

- Switches `getResources()` to fetch schemas via the OpenAPI v3 per-GV endpoint (`/openapi/v3/{group}/{version}`) instead of the monolithic v2 endpoint (`/openapi/v2`)
- The v3 path benefits from the per-GV caching already wired up in `cachedopenapi.NewClient` inside `memCacheClient.OpenAPIV3()`; the v2 path had no caching at all and re-downloaded the full schema on every `Configure()` call
- Falls back to v2 automatically for clusters older than k8s v1.24 (where v3 is unavailable)

## Test plan

- [x] `go test ./pkg/openapi/...` — 5 new tests covering v3 lookup, unknown GVK, multiple GVs, partial error resilience, and v2/v3 parity
- [x] `go test ./pkg/clients/...` — existing fake client tests pass with new `OpenAPIV3()` override
- [x] `go test ./pkg/provider/...` — existing provider/await tests pass unmodified

Fixes: #4433 