### PR TITLE
Document that skipAwait defaults to false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Changed
 
 - Upgrade Kubernetes schema and libraries to v1.36.2.
+- [#4454](https://github.com/pulumi/pulumi-kubernetes/issues/4454) Document that `skipAwait` defaults to `false` on `yaml/v2.ConfigFile`, `yaml/v2.ConfigGroup`, and `kustomize/v2.Directory`.
 
 ## 4.32.0 (June 5, 2026)
 

--- a/provider/pkg/gen/overlays.go
+++ b/provider/pkg/gen/overlays.go
@@ -1323,7 +1323,7 @@ var kustomizeDirectoryV2Resource = pschema.ResourceSpec{
 			TypeSpec: pschema.TypeSpec{
 				Type: "boolean",
 			},
-			Description: "Indicates that child resources should skip the await logic.",
+			Description: "Indicates that child resources should skip the await logic. Defaults to `false`.",
 		},
 	},
 	RequiredInputs: []string{
@@ -1418,7 +1418,7 @@ var yamlConfigFileV2Resource = pschema.ResourceSpec{
 			TypeSpec: pschema.TypeSpec{
 				Type: "boolean",
 			},
-			Description: "Indicates that child resources should skip the await logic.",
+			Description: "Indicates that child resources should skip the await logic. Defaults to `false`.",
 		},
 	},
 	RequiredInputs: []string{
@@ -1564,7 +1564,7 @@ var yamlConfigGroupV2Resource = pschema.ResourceSpec{
 			TypeSpec: pschema.TypeSpec{
 				Type: "boolean",
 			},
-			Description: "Indicates that child resources should skip the await logic.",
+			Description: "Indicates that child resources should skip the await logic. Defaults to `false`.",
 		},
 		"yaml": {
 			TypeSpec: pschema.TypeSpec{

--- a/sdk/dotnet/Kustomize/V2/Directory.cs
+++ b/sdk/dotnet/Kustomize/V2/Directory.cs
@@ -110,7 +110,7 @@ namespace Pulumi.Kubernetes.Types.Inputs.Kustomize.V2
         public Input<string>? ResourcePrefix { get; set; }
 
         /// <summary>
-        /// Indicates that child resources should skip the await logic.
+        /// Indicates that child resources should skip the await logic. Defaults to `false`.
         /// </summary>
         [Input("skipAwait")]
         public Input<bool>? SkipAwait { get; set; }

--- a/sdk/dotnet/Yaml/V2/ConfigFile.cs
+++ b/sdk/dotnet/Yaml/V2/ConfigFile.cs
@@ -118,7 +118,7 @@ namespace Pulumi.Kubernetes.Types.Inputs.Yaml.V2
         public Input<string>? ResourcePrefix { get; set; }
 
         /// <summary>
-        /// Indicates that child resources should skip the await logic.
+        /// Indicates that child resources should skip the await logic. Defaults to `false`.
         /// </summary>
         [Input("skipAwait")]
         public Input<bool>? SkipAwait { get; set; }

--- a/sdk/dotnet/Yaml/V2/ConfigGroup.cs
+++ b/sdk/dotnet/Yaml/V2/ConfigGroup.cs
@@ -203,7 +203,7 @@ namespace Pulumi.Kubernetes.Types.Inputs.Yaml.V2
         public Input<string>? ResourcePrefix { get; set; }
 
         /// <summary>
-        /// Indicates that child resources should skip the await logic.
+        /// Indicates that child resources should skip the await logic. Defaults to `false`.
         /// </summary>
         [Input("skipAwait")]
         public Input<bool>? SkipAwait { get; set; }

--- a/sdk/go/kubernetes/kustomize/v2/directory.go
+++ b/sdk/go/kubernetes/kustomize/v2/directory.go
@@ -105,7 +105,7 @@ type directoryArgs struct {
 	Namespace *string `pulumi:"namespace"`
 	// A prefix for the auto-generated resource names. Defaults to the name of the Directory resource. Example: A resource created with resourcePrefix="foo" would produce a resource named "foo:resourceName".
 	ResourcePrefix *string `pulumi:"resourcePrefix"`
-	// Indicates that child resources should skip the await logic.
+	// Indicates that child resources should skip the await logic. Defaults to `false`.
 	SkipAwait *bool `pulumi:"skipAwait"`
 }
 
@@ -120,7 +120,7 @@ type DirectoryArgs struct {
 	Namespace pulumi.StringPtrInput
 	// A prefix for the auto-generated resource names. Defaults to the name of the Directory resource. Example: A resource created with resourcePrefix="foo" would produce a resource named "foo:resourceName".
 	ResourcePrefix pulumi.StringPtrInput
-	// Indicates that child resources should skip the await logic.
+	// Indicates that child resources should skip the await logic. Defaults to `false`.
 	SkipAwait pulumi.BoolPtrInput
 }
 

--- a/sdk/go/kubernetes/yaml/v2/configFile.go
+++ b/sdk/go/kubernetes/yaml/v2/configFile.go
@@ -106,7 +106,7 @@ type configFileArgs struct {
 	File string `pulumi:"file"`
 	// A prefix for the auto-generated resource names. Defaults to the name of the ConfigFile. Example: A resource created with resourcePrefix="foo" would produce a resource named "foo-resourceName".
 	ResourcePrefix *string `pulumi:"resourcePrefix"`
-	// Indicates that child resources should skip the await logic.
+	// Indicates that child resources should skip the await logic. Defaults to `false`.
 	SkipAwait *bool `pulumi:"skipAwait"`
 }
 
@@ -116,7 +116,7 @@ type ConfigFileArgs struct {
 	File pulumi.StringInput
 	// A prefix for the auto-generated resource names. Defaults to the name of the ConfigFile. Example: A resource created with resourcePrefix="foo" would produce a resource named "foo-resourceName".
 	ResourcePrefix pulumi.StringPtrInput
-	// Indicates that child resources should skip the await logic.
+	// Indicates that child resources should skip the await logic. Defaults to `false`.
 	SkipAwait pulumi.BoolPtrInput
 }
 

--- a/sdk/go/kubernetes/yaml/v2/configGroup.go
+++ b/sdk/go/kubernetes/yaml/v2/configGroup.go
@@ -199,7 +199,7 @@ type configGroupArgs struct {
 	Objs []interface{} `pulumi:"objs"`
 	// A prefix for the auto-generated resource names. Defaults to the name of the ConfigGroup. Example: A resource created with resourcePrefix="foo" would produce a resource named "foo-resourceName".
 	ResourcePrefix *string `pulumi:"resourcePrefix"`
-	// Indicates that child resources should skip the await logic.
+	// Indicates that child resources should skip the await logic. Defaults to `false`.
 	SkipAwait *bool `pulumi:"skipAwait"`
 	// A Kubernetes YAML manifest containing Kubernetes resource configuration(s).
 	Yaml *string `pulumi:"yaml"`
@@ -213,7 +213,7 @@ type ConfigGroupArgs struct {
 	Objs pulumi.ArrayInput
 	// A prefix for the auto-generated resource names. Defaults to the name of the ConfigGroup. Example: A resource created with resourcePrefix="foo" would produce a resource named "foo-resourceName".
 	ResourcePrefix pulumi.StringPtrInput
-	// Indicates that child resources should skip the await logic.
+	// Indicates that child resources should skip the await logic. Defaults to `false`.
 	SkipAwait pulumi.BoolPtrInput
 	// A Kubernetes YAML manifest containing Kubernetes resource configuration(s).
 	Yaml pulumi.StringPtrInput

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/kustomize/v2/DirectoryArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/kustomize/v2/DirectoryArgs.java
@@ -69,14 +69,14 @@ public final class DirectoryArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * Indicates that child resources should skip the await logic.
+     * Indicates that child resources should skip the await logic. Defaults to `false`.
      * 
      */
     @Import(name="skipAwait")
     private @Nullable Output<Boolean> skipAwait;
 
     /**
-     * @return Indicates that child resources should skip the await logic.
+     * @return Indicates that child resources should skip the await logic. Defaults to `false`.
      * 
      */
     public Optional<Output<Boolean>> skipAwait() {
@@ -180,7 +180,7 @@ public final class DirectoryArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param skipAwait Indicates that child resources should skip the await logic.
+         * @param skipAwait Indicates that child resources should skip the await logic. Defaults to `false`.
          * 
          * @return builder
          * 
@@ -191,7 +191,7 @@ public final class DirectoryArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param skipAwait Indicates that child resources should skip the await logic.
+         * @param skipAwait Indicates that child resources should skip the await logic. Defaults to `false`.
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/yaml/v2/ConfigFileArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/yaml/v2/ConfigFileArgs.java
@@ -48,14 +48,14 @@ public final class ConfigFileArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * Indicates that child resources should skip the await logic.
+     * Indicates that child resources should skip the await logic. Defaults to `false`.
      * 
      */
     @Import(name="skipAwait")
     private @Nullable Output<Boolean> skipAwait;
 
     /**
-     * @return Indicates that child resources should skip the await logic.
+     * @return Indicates that child resources should skip the await logic. Defaults to `false`.
      * 
      */
     public Optional<Output<Boolean>> skipAwait() {
@@ -131,7 +131,7 @@ public final class ConfigFileArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param skipAwait Indicates that child resources should skip the await logic.
+         * @param skipAwait Indicates that child resources should skip the await logic. Defaults to `false`.
          * 
          * @return builder
          * 
@@ -142,7 +142,7 @@ public final class ConfigFileArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param skipAwait Indicates that child resources should skip the await logic.
+         * @param skipAwait Indicates that child resources should skip the await logic. Defaults to `false`.
          * 
          * @return builder
          * 

--- a/sdk/java/src/main/java/com/pulumi/kubernetes/yaml/v2/ConfigGroupArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetes/yaml/v2/ConfigGroupArgs.java
@@ -64,14 +64,14 @@ public final class ConfigGroupArgs extends com.pulumi.resources.ResourceArgs {
     }
 
     /**
-     * Indicates that child resources should skip the await logic.
+     * Indicates that child resources should skip the await logic. Defaults to `false`.
      * 
      */
     @Import(name="skipAwait")
     private @Nullable Output<Boolean> skipAwait;
 
     /**
-     * @return Indicates that child resources should skip the await logic.
+     * @return Indicates that child resources should skip the await logic. Defaults to `false`.
      * 
      */
     public Optional<Output<Boolean>> skipAwait() {
@@ -205,7 +205,7 @@ public final class ConfigGroupArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param skipAwait Indicates that child resources should skip the await logic.
+         * @param skipAwait Indicates that child resources should skip the await logic. Defaults to `false`.
          * 
          * @return builder
          * 
@@ -216,7 +216,7 @@ public final class ConfigGroupArgs extends com.pulumi.resources.ResourceArgs {
         }
 
         /**
-         * @param skipAwait Indicates that child resources should skip the await logic.
+         * @param skipAwait Indicates that child resources should skip the await logic. Defaults to `false`.
          * 
          * @return builder
          * 

--- a/sdk/nodejs/kustomize/v2/directory.ts
+++ b/sdk/nodejs/kustomize/v2/directory.ts
@@ -92,7 +92,7 @@ export interface DirectoryArgs {
      */
     resourcePrefix?: pulumi.Input<string | undefined>;
     /**
-     * Indicates that child resources should skip the await logic.
+     * Indicates that child resources should skip the await logic. Defaults to `false`.
      */
     skipAwait?: pulumi.Input<boolean | undefined>;
 }

--- a/sdk/nodejs/yaml/v2/configFile.ts
+++ b/sdk/nodejs/yaml/v2/configFile.ts
@@ -113,7 +113,7 @@ export interface ConfigFileArgs {
      */
     resourcePrefix?: pulumi.Input<string | undefined>;
     /**
-     * Indicates that child resources should skip the await logic.
+     * Indicates that child resources should skip the await logic. Defaults to `false`.
      */
     skipAwait?: pulumi.Input<boolean | undefined>;
 }

--- a/sdk/nodejs/yaml/v2/configGroup.ts
+++ b/sdk/nodejs/yaml/v2/configGroup.ts
@@ -162,7 +162,7 @@ export interface ConfigGroupArgs {
      */
     resourcePrefix?: pulumi.Input<string | undefined>;
     /**
-     * Indicates that child resources should skip the await logic.
+     * Indicates that child resources should skip the await logic. Defaults to `false`.
      */
     skipAwait?: pulumi.Input<boolean | undefined>;
     /**

--- a/sdk/python/pulumi_kubernetes/kustomize/v2/Directory.py
+++ b/sdk/python/pulumi_kubernetes/kustomize/v2/Directory.py
@@ -32,7 +32,7 @@ class DirectoryArgs:
                Example: https://github.com/kubernetes-sigs/kustomize/tree/master/examples/helloWorld
         :param pulumi.Input[_builtins.str] namespace: The default namespace to apply to the resources. Defaults to the provider's namespace.
         :param pulumi.Input[_builtins.str] resource_prefix: A prefix for the auto-generated resource names. Defaults to the name of the Directory resource. Example: A resource created with resourcePrefix="foo" would produce a resource named "foo:resourceName".
-        :param pulumi.Input[_builtins.bool] skip_await: Indicates that child resources should skip the await logic.
+        :param pulumi.Input[_builtins.bool] skip_await: Indicates that child resources should skip the await logic. Defaults to `false`.
         """
         pulumi.set(__self__, "directory", directory)
         if namespace is not None:
@@ -85,7 +85,7 @@ class DirectoryArgs:
     @pulumi.getter(name="skipAwait")
     def skip_await(self) -> pulumi.Input[Optional[_builtins.bool]]:
         """
-        Indicates that child resources should skip the await logic.
+        Indicates that child resources should skip the await logic. Defaults to `false`.
         """
         return pulumi.get(self, "skip_await")
 
@@ -137,7 +137,7 @@ class Directory(pulumi.ComponentResource):
                Example: https://github.com/kubernetes-sigs/kustomize/tree/master/examples/helloWorld
         :param pulumi.Input[_builtins.str] namespace: The default namespace to apply to the resources. Defaults to the provider's namespace.
         :param pulumi.Input[_builtins.str] resource_prefix: A prefix for the auto-generated resource names. Defaults to the name of the Directory resource. Example: A resource created with resourcePrefix="foo" would produce a resource named "foo:resourceName".
-        :param pulumi.Input[_builtins.bool] skip_await: Indicates that child resources should skip the await logic.
+        :param pulumi.Input[_builtins.bool] skip_await: Indicates that child resources should skip the await logic. Defaults to `false`.
         """
         ...
     @overload

--- a/sdk/python/pulumi_kubernetes/yaml/v2/ConfigFile.py
+++ b/sdk/python/pulumi_kubernetes/yaml/v2/ConfigFile.py
@@ -27,7 +27,7 @@ class ConfigFileArgs:
 
         :param pulumi.Input[_builtins.str] file: Path or URL to a Kubernetes manifest file. File must exist.
         :param pulumi.Input[_builtins.str] resource_prefix: A prefix for the auto-generated resource names. Defaults to the name of the ConfigFile. Example: A resource created with resourcePrefix="foo" would produce a resource named "foo-resourceName".
-        :param pulumi.Input[_builtins.bool] skip_await: Indicates that child resources should skip the await logic.
+        :param pulumi.Input[_builtins.bool] skip_await: Indicates that child resources should skip the await logic. Defaults to `false`.
         """
         pulumi.set(__self__, "file", file)
         if resource_prefix is not None:
@@ -63,7 +63,7 @@ class ConfigFileArgs:
     @pulumi.getter(name="skipAwait")
     def skip_await(self) -> pulumi.Input[Optional[_builtins.bool]]:
         """
-        Indicates that child resources should skip the await logic.
+        Indicates that child resources should skip the await logic. Defaults to `false`.
         """
         return pulumi.get(self, "skip_await")
 
@@ -138,7 +138,7 @@ class ConfigFile(pulumi.ComponentResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[_builtins.str] file: Path or URL to a Kubernetes manifest file. File must exist.
         :param pulumi.Input[_builtins.str] resource_prefix: A prefix for the auto-generated resource names. Defaults to the name of the ConfigFile. Example: A resource created with resourcePrefix="foo" would produce a resource named "foo-resourceName".
-        :param pulumi.Input[_builtins.bool] skip_await: Indicates that child resources should skip the await logic.
+        :param pulumi.Input[_builtins.bool] skip_await: Indicates that child resources should skip the await logic. Defaults to `false`.
         """
         ...
     @overload

--- a/sdk/python/pulumi_kubernetes/yaml/v2/ConfigGroup.py
+++ b/sdk/python/pulumi_kubernetes/yaml/v2/ConfigGroup.py
@@ -30,7 +30,7 @@ class ConfigGroupArgs:
         :param pulumi.Input[Sequence[pulumi.Input[_builtins.str]]] files: Set of paths and/or URLs to Kubernetes manifest files. Supports glob patterns.
         :param pulumi.Input[Sequence[Any]] objs: Objects representing Kubernetes resource configurations.
         :param pulumi.Input[_builtins.str] resource_prefix: A prefix for the auto-generated resource names. Defaults to the name of the ConfigGroup. Example: A resource created with resourcePrefix="foo" would produce a resource named "foo-resourceName".
-        :param pulumi.Input[_builtins.bool] skip_await: Indicates that child resources should skip the await logic.
+        :param pulumi.Input[_builtins.bool] skip_await: Indicates that child resources should skip the await logic. Defaults to `false`.
         :param pulumi.Input[_builtins.str] yaml: A Kubernetes YAML manifest containing Kubernetes resource configuration(s).
         """
         if files is not None:
@@ -84,7 +84,7 @@ class ConfigGroupArgs:
     @pulumi.getter(name="skipAwait")
     def skip_await(self) -> pulumi.Input[Optional[_builtins.bool]]:
         """
-        Indicates that child resources should skip the await logic.
+        Indicates that child resources should skip the await logic. Defaults to `false`.
         """
         return pulumi.get(self, "skip_await")
 
@@ -223,7 +223,7 @@ class ConfigGroup(pulumi.ComponentResource):
         :param pulumi.Input[Sequence[pulumi.Input[_builtins.str]]] files: Set of paths and/or URLs to Kubernetes manifest files. Supports glob patterns.
         :param pulumi.Input[Sequence[Any]] objs: Objects representing Kubernetes resource configurations.
         :param pulumi.Input[_builtins.str] resource_prefix: A prefix for the auto-generated resource names. Defaults to the name of the ConfigGroup. Example: A resource created with resourcePrefix="foo" would produce a resource named "foo-resourceName".
-        :param pulumi.Input[_builtins.bool] skip_await: Indicates that child resources should skip the await logic.
+        :param pulumi.Input[_builtins.bool] skip_await: Indicates that child resources should skip the await logic. Defaults to `false`.
         :param pulumi.Input[_builtins.str] yaml: A Kubernetes YAML manifest containing Kubernetes resource configuration(s).
         """
         ...


### PR DESCRIPTION
## Proposed changes

The `skipAwait` input on `yaml/v2.ConfigFile`, `yaml/v2.ConfigGroup`, and `kustomize/v2.Directory` did not document its default value. Their descriptions now read:

> Indicates that child resources should skip the await logic. Defaults to `false`.

The description is authored in the overlay source (`provider/pkg/gen/overlays.go`); the schema and all SDKs are regenerated artifacts.

The Helm `skipAwait` descriptions were left unchanged — they already convey the default ("By default, the provider waits until all resources are in a ready state… Setting this to true will skip such await logic").

Note: the Python SDK docs render the literal as `false` rather than `False`, since schema property descriptions are a single shared string and the codegen docs parser only strips `examples`/`example`/`ref` shortcodes (a `{{% choosable %}}` block would leak raw text into SDK doc comments).

Fixes #4454

## Related issues

Fixes #4454

🤖 Generated with [Claude Code](https://claude.com/claude-code)