### PR TITLE
fix: correct broken Helm dependency examples

### DIFF
--- a/provider/pkg/gen/examples/overlays/chartV3.md
+++ b/provider/pkg/gen/examples/overlays/chartV3.md
@@ -365,7 +365,7 @@ const nginxIngress = new k8s.helm.v3.Chart("nginx-ingress", {
 // Create a ConfigMap depending on the Chart. The ConfigMap will not be created until after all of the Chart
 // resources are ready. Note the use of the `ready` attribute; depending on the Chart resource directly will not work.
 new k8s.core.v1.ConfigMap("foo", {
-    metadata: { namespace: namespaceName },
+    metadata: { namespace: "test-namespace" },
     data: {foo: "bar"}
 }, {dependsOn: nginxIngress.ready})
 ```
@@ -440,7 +440,7 @@ import (
 
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
-		_, err := helm.NewChart(ctx, "nginx-ingress", helm.ChartArgs{
+		nginxIngress, err := helm.NewChart(ctx, "nginx-ingress", helm.ChartArgs{
 			Chart:     pulumi.String("nginx-ingress"),
 			Version:   pulumi.String("1.24.4"),
 			Namespace: pulumi.String("test-namespace"),
@@ -459,7 +459,7 @@ func main() {
 			Data: pulumi.StringMap{
 				"foo": pulumi.String("bar"),
 			},
-		}, pulumi.DependsOnInputs(chart.Ready))
+		}, pulumi.DependsOnInputs(nginxIngress.Ready))
 		if err != nil {
 			return err
 		}

--- a/provider/pkg/gen/examples/overlays/helmRelease.md
+++ b/provider/pkg/gen/examples/overlays/helmRelease.md
@@ -336,7 +336,7 @@ func main() {
 {{% /example %}}
  {{% example %}}
 
-### Depend on a Chart resource
+### Depend on a Release resource
 
 ```typescript
 import * as k8s from "@pulumi/kubernetes";
@@ -351,11 +351,11 @@ const nginxIngress = new k8s.helm.v3.Release("nginx-ingress", {
     skipAwait: false,
 });
 
-// Create a ConfigMap depending on the Chart. The ConfigMap will not be created until after all of the Chart
+// Create a ConfigMap depending on the Release. The ConfigMap will not be created until after all of the Release
 // resources are ready. Notice skipAwait is set to false above. This is the default and will cause Helm
 // to await the underlying resources to be available. Setting it to true will make the ConfigMap available right away.
 new k8s.core.v1.ConfigMap("foo", {
-    metadata: {namespace: namespaceName},
+    metadata: {namespace: "test-namespace"},
     data: {foo: "bar"}
 }, {dependsOn: nginxIngress})
 ```
@@ -377,7 +377,7 @@ nginx_ingress = Release(
     ),
 )
 
-# Create a ConfigMap depending on the Chart. The ConfigMap will not be created until after all of the Chart
+# Create a ConfigMap depending on the Release. The ConfigMap will not be created until after all of the Release
 # resources are ready. Notice skip_await is set to false above. This is the default and will cause Helm
 # to await the underlying resources to be available. Setting it to true will make the ConfigMap available right away.
 ConfigMap("foo", ConfigMapInitArgs(data={"foo": "bar"}), opts=pulumi.ResourceOptions(depends_on=nginx_ingress))
@@ -405,7 +405,7 @@ class HelmStack : Stack
             SkipAwait = false,
         });
 
-        // Create a ConfigMap depending on the Chart. The ConfigMap will not be created until after all of the Chart
+        // Create a ConfigMap depending on the Release. The ConfigMap will not be created until after all of the Release
         // resources are ready. Notice SkipAwait is set to false above. This is the default and will cause Helm
         // to await the underlying resources to be available. Setting it to true will make the ConfigMap available right away.
         new ConfigMap("foo", new Pulumi.Kubernetes.Types.Inputs.Core.V1.ConfigMapArgs
@@ -446,7 +446,7 @@ func main() {
 			return err
 		}
 
-		// Create a ConfigMap depending on the Chart. The ConfigMap will not be created until after all of the Chart
+		// Create a ConfigMap depending on the Release. The ConfigMap will not be created until after all of the Release
 		// resources are ready. Notice SkipAwait is set to false above. This is the default and will cause Helm
 		// to await the underlying resources to be available. Setting it to true will make the ConfigMap available right away.
 		_, err = corev1.NewConfigMap(ctx, "cm", &corev1.ConfigMapArgs{

--- a/provider/pkg/gen/overlay_examples_test.go
+++ b/provider/pkg/gen/overlay_examples_test.go
@@ -1,0 +1,28 @@
+package gen
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestHelmV3ChartOverlayExamplesDoNotReferenceUndefinedIdentifiers(t *testing.T) {
+	t.Helper()
+
+	if strings.Contains(helmV3ChartMD, "namespaceName") {
+		t.Fatal("helm v3 chart overlay contains an undefined namespaceName identifier")
+	}
+	if strings.Contains(helmV3ChartMD, "DependsOnInputs(chart.Ready)") {
+		t.Fatal("helm v3 chart overlay contains an undefined chart identifier")
+	}
+}
+
+func TestHelmV3ReleaseOverlayExamplesUseReleaseTerminology(t *testing.T) {
+	t.Helper()
+
+	if strings.Contains(helmV3ReleaseMD, "### Depend on a Chart resource") {
+		t.Fatal("helm v3 release overlay still labels the example as a chart dependency")
+	}
+	if strings.Contains(helmV3ReleaseMD, "metadata: {namespace: namespaceName}") {
+		t.Fatal("helm v3 release overlay contains an undefined namespaceName identifier")
+	}
+}

--- a/sdk/nodejs/helm/v3/release.ts
+++ b/sdk/nodejs/helm/v3/release.ts
@@ -75,7 +75,7 @@ import * as utilities from "../../utilities";
  * });
  * ```
  *
- * ### Depend on a Chart resource
+ * ### Depend on a Release resource
  *
  * ```typescript
  * import * as k8s from "@pulumi/kubernetes";
@@ -90,11 +90,11 @@ import * as utilities from "../../utilities";
  *     skipAwait: false,
  * });
  *
- * // Create a ConfigMap depending on the Chart. The ConfigMap will not be created until after all of the Chart
+ * // Create a ConfigMap depending on the Release. The ConfigMap will not be created until after all of the Release
  * // resources are ready. Notice skipAwait is set to false above. This is the default and will cause Helm
  * // to await the underlying resources to be available. Setting it to true will make the ConfigMap available right away.
  * new k8s.core.v1.ConfigMap("foo", {
- *     metadata: {namespace: namespaceName},
+ *     metadata: {namespace: "test-namespace"},
  *     data: {foo: "bar"}
  * }, {dependsOn: nginxIngress})
  * ```


### PR DESCRIPTION
### Proposed changes

Small follow-up to #4423.
A couple Helm docs snippets were still busted.

Repro:
1. Open `provider/pkg/gen/examples/overlays/chartV3.md` on `master`.
2. Copy the `Depend on a Chart resource` snippets.
3. TS uses `namespaceName`, and Go uses `chart.Ready`, both are undefined so the snippets fall over fast.
4. Open `provider/pkg/gen/examples/overlays/helmRelease.md`.
5. The release example is labeled as Chart, and the TS snippet uses `namespaceName` again.

This swaps in real identifiers, fixes the Release wording, syncs the checked-in Node.js doc comment too, and adds a tiny test so it doesnt drift back. Pretty small, but saves a copy paste faceplant.

### Related issues (optional)

Related: #4423
