### PR TITLE
Security: Potential environment variable leakage to GITHUB_OUTPUT

### DIFF
--- a/.github/actions/esc-action/index.js
+++ b/.github/actions/esc-action/index.js
@@ -3,7 +3,19 @@ const fs = require("fs");
 const file = process.env["GITHUB_OUTPUT"];
 var stream = fs.createWriteStream(file, { flags: "a" });
 
-for (const [name, value] of Object.entries(process.env)) {
+const allowed = [
+  "PULUMI_CONFIG",
+  "PULUMI_KUBERNETES_PROVIDER",
+  "PULUMI_KUBERNETES_PROVIDER_VERSION",
+  "PULUMI_KUBERNETES_PROVIDER_DOWNLOAD_URL",
+  "PULUMI_KUBERNETES_PROVIDER_CHECKSUM",
+];
+
+for (const name of allowed) {
+  const value = process.env[name];
+  if (value === undefined) {
+    continue;
+  }
   try {
     stream.write(`${name}<<EEEOOOFFF\n${value}\nEEEOOOFFF\n`); // << syntax accommodates multiline strings.
   } catch (err) {


### PR DESCRIPTION
## Summary

Security: Potential environment variable leakage to GITHUB_OUTPUT

## Problem

**Severity**: `High` | **File**: `.github/actions/esc-action/index.js:L7`

The `esc-action/index.js` script iterates over all available environment variables (`process.env`) and writes them to the `GITHUB_OUTPUT` file. In a CI/CD environment, `process.env` often contains sensitive secrets (tokens, passwords, cloud credentials). By dumping all environment variables to an output file, these secrets could be inadvertently exposed in subsequent steps, logs, or to untrusted actions that read the output file.

## Solution

Explicitly whitelist the specific environment variables that need to be exported to `GITHUB_OUTPUT` instead of iterating over and dumping the entirety of `process.env`.

## Changes

- `.github/actions/esc-action/index.js` (modified)