### PR TITLE
Fix waitFor JSONPath filters using !=, >= and <=

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 
 - Upgrade Kubernetes schema and libraries to v1.36.3.
 
+### Fixed
+
+- [#4524](https://github.com/pulumi/pulumi-kubernetes/pull/4524) Fix `pulumi.com/waitFor` rejecting JSONPath filters that use `!=`, `>=` or `<=`. The expression was split on every `=` that was not part of `==`, so `jsonpath={.status.conditions[?(@.type!="Failed")].status}=True` failed to parse. The path and value are now separated structurally, which also allows braces inside string literals. Comparing one path against another (`jsonpath={.status.readyReplicas}={.spec.replicas}`) is still unsupported, but now reports an error instead of silently never matching.
+
 ## 4.33.0 (July 7, 2026)
 
 ### Added

--- a/provider/pkg/jsonpath/jsonpath.go
+++ b/provider/pkg/jsonpath/jsonpath.go
@@ -2,7 +2,6 @@ package jsonpath
 
 import (
 	"fmt"
-	"regexp"
 	"slices"
 	"strings"
 
@@ -58,8 +57,6 @@ type MatchResult struct {
 	Message string
 }
 
-var _bracketExpr = regexp.MustCompile(`\{\s*(.*?)\s*\}`)
-
 // Parse parses a single JSONPath expression. Only the strict syntax of
 // `kubectl get -o jsonpath={...}` is accepted, because the "relaxed" syntax
 // used by `wait` is somewhat buggy.
@@ -72,18 +69,15 @@ func Parse(raw string) (*Parsed, error) {
 	}
 	raw = strings.TrimPrefix(raw, "jsonpath=")
 
-	// Split only on "=" and preserve "==".
-	placeholder := "�"
-	normalized := strings.ReplaceAll(raw, "==", placeholder)
-	parts := strings.Split(normalized, "=")
+	parts := splitOnValue(raw)
 
 	var value string
-	path := strings.ReplaceAll(parts[0], placeholder, "==")
+	path := parts[0]
 	if len(parts) > 2 {
 		return nil, fmt.Errorf("format should be {.path}=value or {.path}, got %q", raw)
 	}
 	if len(parts) == 2 {
-		value = strings.ReplaceAll(parts[1], placeholder, "==")
+		value = parts[1]
 		if value == "" {
 			return nil, fmt.Errorf("%s= requires a value", path)
 		}
@@ -93,11 +87,15 @@ func Parse(raw string) (*Parsed, error) {
 		return nil, fmt.Errorf("%s should omit shell quotes", path)
 	}
 
-	matches := _bracketExpr.FindStringSubmatch(path)
-	if len(matches) != 2 {
+	// Comparing one path against another isn't supported; without this the value is treated as a literal and never matches.
+	if strings.HasPrefix(value, "{") {
+		return nil, fmt.Errorf("%s=%s compares against another JSONPath, which is not supported; the value must be a literal", path, value)
+	}
+
+	pathWithoutBrackets, ok := unbracket(path)
+	if !ok {
 		return nil, fmt.Errorf("%s should be wrapped in brackets { ... }", path)
 	}
-	pathWithoutBrackets := matches[1]
 	if !strings.HasPrefix(pathWithoutBrackets, "$") {
 		pathWithoutBrackets = "$" + pathWithoutBrackets
 	}
@@ -109,4 +107,80 @@ func Parse(raw string) (*Parsed, error) {
 	}
 
 	return &Parsed{expr: expr, Path: path, Value: value}, nil
+}
+
+// splitOnValue splits raw into the bracketed JSONPath expression and an optional value, breaking only on "=" found
+// outside the brackets. Comparison operators inside the expression ("==", "!=", "<=", ">=") are left intact, while a
+// value containing a bare "=" still yields more than two elements so it can be rejected as ambiguous.
+func splitOnValue(raw string) []string {
+	var parts []string
+	var element strings.Builder
+	depth := 0
+	var quote byte // The active string-literal delimiter, when inside the brackets.
+
+	for i := 0; i < len(raw); i++ {
+		c := raw[i]
+		switch {
+		case quote != 0:
+			// Inside a string literal, where only the closing delimiter is structural.
+			if c == '\\' && i < len(raw)-1 {
+				element.WriteByte(c)
+				i++
+				c = raw[i]
+				break
+			}
+			if c == quote {
+				quote = 0
+			}
+		case depth > 0 && (c == '\'' || c == '"'):
+			quote = c
+		case c == '{':
+			depth++
+		case c == '}':
+			if depth > 0 {
+				depth--
+			}
+		case c == '=' && depth == 0:
+			parts = append(parts, element.String())
+			element.Reset()
+			continue
+		}
+		element.WriteByte(c)
+	}
+
+	return append(parts, element.String())
+}
+
+// unbracket returns the contents of the first balanced { ... } group in path, ignoring braces inside string literals.
+func unbracket(path string) (string, bool) {
+	start := strings.IndexByte(path, '{')
+	if start < 0 {
+		return "", false
+	}
+
+	depth := 0
+	var quote byte
+
+	for i := start; i < len(path); i++ {
+		c := path[i]
+		switch {
+		case quote != 0:
+			if c == '\\' && i < len(path)-1 {
+				i++
+			} else if c == quote {
+				quote = 0
+			}
+		case c == '\'' || c == '"':
+			quote = c
+		case c == '{':
+			depth++
+		case c == '}':
+			depth--
+			if depth == 0 {
+				return strings.TrimSpace(path[start+1 : i]), true
+			}
+		}
+	}
+
+	return "", false
 }

--- a/provider/pkg/jsonpath/jsonpath.go
+++ b/provider/pkg/jsonpath/jsonpath.go
@@ -87,9 +87,11 @@ func Parse(raw string) (*Parsed, error) {
 		return nil, fmt.Errorf("%s should omit shell quotes", path)
 	}
 
-	// Comparing one path against another isn't supported; without this the value is treated as a literal and never matches.
+	// Comparing one path against another isn't supported; without this the value is treated as a literal and never
+	// matches.
 	if strings.HasPrefix(value, "{") {
-		return nil, fmt.Errorf("%s=%s compares against another JSONPath, which is not supported; the value must be a literal", path, value)
+		return nil, fmt.Errorf(
+			"%s=%s compares against another JSONPath, which is not supported; the value must be a literal", path, value)
 	}
 
 	pathWithoutBrackets, ok := unbracket(path)

--- a/provider/pkg/jsonpath/jsonpath_test.go
+++ b/provider/pkg/jsonpath/jsonpath_test.go
@@ -76,6 +76,22 @@ func TestParse(t *testing.T) {
 			wantValue: "c",
 		},
 		{
+			name:      "escaped quote inside a string literal",
+			expr:      `jsonpath={.metadata.labels['a\'}b']}=c`,
+			wantPath:  `{.metadata.labels['a\'}b']}`,
+			wantValue: "c",
+		},
+		{
+			name:     "escaped quote hiding a value separator",
+			expr:     `jsonpath={.metadata.labels['a\'}=b']}`,
+			wantPath: `{.metadata.labels['a\'}=b']}`,
+		},
+		{
+			name:     "escaped backslash inside a string literal",
+			expr:     `jsonpath={.metadata.labels['a\\']}`,
+			wantPath: `{.metadata.labels['a\\']}`,
+		},
+		{
 			name:    "comparing two paths is rejected",
 			expr:    "jsonpath={.status.readyReplicas}={.spec.replicas}",
 			wantErr: "compares against another JSONPath, which is not supported",
@@ -305,6 +321,18 @@ func TestMatches(t *testing.T) {
 				Matched: false,
 				Message: `{.conditions[?(@.type!="Failed")].status} selected nothing`,
 			},
+		},
+		{
+			name: "escaped quote inside a string literal",
+			expr: `jsonpath={.metadata.labels['a\'b']}=c`,
+			uns: &unstructured.Unstructured{Object: map[string]any{
+				"metadata": map[string]any{
+					"labels": map[string]any{
+						`a'b`: "c",
+					},
+				},
+			}},
+			want: MatchResult{Matched: true, Found: "c"},
 		},
 		{
 			name: "complex OR match",

--- a/provider/pkg/jsonpath/jsonpath_test.go
+++ b/provider/pkg/jsonpath/jsonpath_test.go
@@ -48,6 +48,39 @@ func TestParse(t *testing.T) {
 			wantValue: "True",
 		},
 		{
+			name:      "preserve != with a value",
+			expr:      `jsonpath={.status.conditions[?(@.type!="Failed")].status}=True`,
+			wantPath:  `{.status.conditions[?(@.type!="Failed")].status}`,
+			wantValue: "True",
+		},
+		{
+			name:     "preserve != without a value",
+			expr:     `jsonpath={.status.conditions[?(@.type!="Failed")].status}`,
+			wantPath: `{.status.conditions[?(@.type!="Failed")].status}`,
+		},
+		{
+			name:      "preserve >=",
+			expr:      `jsonpath={.status.conditions[?(@.observedGeneration>=2)].status}=True`,
+			wantPath:  `{.status.conditions[?(@.observedGeneration>=2)].status}`,
+			wantValue: "True",
+		},
+		{
+			name:     "preserve <=",
+			expr:     `jsonpath={.status.conditions[?(@.observedGeneration<=2)].status}`,
+			wantPath: `{.status.conditions[?(@.observedGeneration<=2)].status}`,
+		},
+		{
+			name:      "brace inside a string literal",
+			expr:      `jsonpath={.metadata.labels['a}b']}=c`,
+			wantPath:  `{.metadata.labels['a}b']}`,
+			wantValue: "c",
+		},
+		{
+			name:    "comparing two paths is rejected",
+			expr:    "jsonpath={.status.readyReplicas}={.spec.replicas}",
+			wantErr: "compares against another JSONPath, which is not supported",
+		},
+		{
 			name:     "key with any value",
 			expr:     "jsonpath={.foo}",
 			wantPath: "{.foo}",
@@ -243,6 +276,35 @@ func TestMatches(t *testing.T) {
 				},
 			}},
 			want: MatchResult{Matched: false, Found: "False"},
+		},
+		{
+			name: "negated selector match",
+			expr: `jsonpath={.conditions[?(@.type!="Failed")].status}=True`,
+			uns: &unstructured.Unstructured{Object: map[string]any{
+				"conditions": []any{
+					map[string]any{
+						"type":   "Complete",
+						"status": "True",
+					},
+				},
+			}},
+			want: MatchResult{Matched: true, Found: "True"},
+		},
+		{
+			name: "negated selector non-match",
+			expr: `jsonpath={.conditions[?(@.type!="Failed")].status}=True`,
+			uns: &unstructured.Unstructured{Object: map[string]any{
+				"conditions": []any{
+					map[string]any{
+						"type":   "Failed",
+						"status": "True",
+					},
+				},
+			}},
+			want: MatchResult{
+				Matched: false,
+				Message: `{.conditions[?(@.type!="Failed")].status} selected nothing`,
+			},
 		},
 		{
 			name: "complex OR match",


### PR DESCRIPTION
`pulumi.com/waitFor` rejects any JSONPath filter that uses `!=`, `>=` or `<=`. The expression is split on every `=` that is not part of `==`, so the operator gets torn in half.

With a value:

```
jsonpath={.status.conditions[?(@.type!="Failed")].status}=True
-> format should be {.path}=value or {.path}, got "..."
```

Without a value the error is more confusing, because the split truncates the path mid-operator and the brackets no longer balance:

```
jsonpath={.status.conditions[?(@.type!="Failed")].status}
-> {.status.conditions[?(@.type! should be wrapped in brackets { ... }
```

`theory/jsonpath` evaluates all of these operators correctly, so the split was the only thing blocking them.

### What changed

1. The path and the optional value are separated structurally, breaking only on `=` found outside the brackets. Comparison operators inside the expression survive.
2. Braces inside string literals now parse, so `{.metadata.labels['a}b']}` works. The old `_bracketExpr` regex was non greedy and stopped at the first `}`.
3. Comparing one path against another errors at parse time instead of silently never matching.

Point 3 is a behaviour change rather than a pure fix, so calling it out separately. Today `jsonpath={.status.readyReplicas}={.spec.replicas}` parses, compares the found value against the literal string `{.spec.replicas}`, and never matches, so the await runs to the deadline with nothing explaining why. After this it fails immediately with a clear message. Anyone relying on such an annotation currently has one that never fires, but it will now be a hard error instead of a timeout.

A value containing a bare `=` is still rejected, matching kubectl, and the existing `{.metadata.name}='test=wrong'` test still passes unchanged.

### Tests

`go test ./pkg/jsonpath/...` plus `./pkg/await/...` and `./pkg/metadata/...` all pass. New cases cover `!=` with and without a value, `>=`, `<=`, a brace inside a string literal, the rejected path-to-path comparison, and `!=` end to end through `Matches`.
