### PR TITLE
Alias base-provider tokens on extension-served resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Added
 
-- Support adding CustomResourceDefinitions as an extension of the base `kubernetes` provider via `pulumi package add <provider> --extension`.
+- Support adding CustomResourceDefinitions as an extension of the base `kubernetes` provider via `pulumi package add <provider> --extension`. Extension-served resources alias their `kubernetes:`-namespaced token, so state written by a crd2pulumi-generated SDK is adopted rather than replaced.
 
 ### Changed
 

--- a/provider/pkg/gen/schema.go
+++ b/provider/pkg/gen/schema.go
@@ -589,6 +589,12 @@ func PulumiSchema(swagger map[string]any, opts ...schemaGeneratorOption) pschema
 				for _, t := range kind.Aliases() {
 					resourceSpec.Aliases = append(resourceSpec.Aliases, pschema.AliasSpec{Type: t})
 				}
+				// Extension resources live under the extension's namespace; alias the base
+				// provider token (what crd2pulumi emits) so migrating doesn't replace them.
+				if gen.extensionName != "" {
+					baseTok := fmt.Sprintf("kubernetes:%s:%s", kind.apiVersion, kind.kind)
+					resourceSpec.Aliases = append(resourceSpec.Aliases, pschema.AliasSpec{Type: baseTok})
+				}
 
 				// Check if the current resource exists in the overlays and overwrite types accordingly.
 				if overlaySpec, hasResource := gen.resourceOverlays[tok]; hasResource {

--- a/provider/pkg/gen/schema_test.go
+++ b/provider/pkg/gen/schema_test.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	pschema "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 )
 
 func TestListInputsSpec(t *testing.T) {
@@ -49,4 +51,65 @@ func TestListInputsSpec(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestExtensionResourcesAliasBaseProviderToken(t *testing.T) {
+	swagger := map[string]any{
+		"definitions": map[string]any{
+			"io.k8s.api.gateway.v1.Gateway": map[string]any{
+				"properties": map[string]any{
+					"apiVersion": map[string]any{"type": "string"},
+					"kind":       map[string]any{"type": "string"},
+					"metadata":   map[string]any{"$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"},
+					"spec":       map[string]any{"type": "object"},
+				},
+				"x-kubernetes-group-version-kind": []any{
+					map[string]any{"group": "gateway", "version": "v1", "kind": "Gateway"},
+				},
+			},
+		},
+	}
+
+	pkg := PulumiSchema(swagger,
+		WithExtensionName("crdfoo"),
+		WithParameterization(&pschema.ExtensionParameterizationSpec{
+			BaseProvider: pschema.BaseProviderRefSpec{Name: "kubernetes", Version: "4.33.0"},
+		}),
+	)
+
+	require.Equal(t, "crdfoo", pkg.Name)
+
+	res, ok := pkg.Resources["crdfoo:gateway/v1:Gateway"]
+	require.True(t, ok, "extension resource must be tokened under the extension package")
+	assert.NotContains(t, pkg.Resources, "kubernetes:gateway/v1:Gateway",
+		"the base-namespaced token must not be emitted as a resource of its own")
+
+	assert.Contains(t, res.Aliases, pschema.AliasSpec{Type: "kubernetes:gateway/v1:Gateway"},
+		"extension resource must alias the base token so crd2pulumi state is adopted rather than replaced")
+}
+
+func TestBaseProviderResourcesHaveNoExtensionAlias(t *testing.T) {
+	swagger := map[string]any{
+		"definitions": map[string]any{
+			"io.k8s.api.gateway.v1.Gateway": map[string]any{
+				"properties": map[string]any{
+					"apiVersion": map[string]any{"type": "string"},
+					"kind":       map[string]any{"type": "string"},
+					"metadata":   map[string]any{"$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"},
+					"spec":       map[string]any{"type": "object"},
+				},
+				"x-kubernetes-group-version-kind": []any{
+					map[string]any{"group": "gateway", "version": "v1", "kind": "Gateway"},
+				},
+			},
+		},
+	}
+
+	pkg := PulumiSchema(swagger)
+
+	res, ok := pkg.Resources["kubernetes:gateway/v1:Gateway"]
+	require.True(t, ok, "base schema must keep kubernetes-namespaced tokens")
+
+	assert.NotContains(t, res.Aliases, pschema.AliasSpec{Type: "kubernetes:gateway/v1:Gateway"},
+		"a resource must not alias its own token when generating the base provider schema")
 }

--- a/provider/pkg/gen/typegen_test.go
+++ b/provider/pkg/gen/typegen_test.go
@@ -664,6 +664,49 @@ func TestMakeSchemaTypeSpec(t *testing.T) {
 	}
 }
 
+func TestMakeSchemaTypeSpecExtensionRefs(t *testing.T) {
+	extension := &extensionInfo{baseVersion: "v4.33.0", name: "crdfoo"}
+
+	tests := []struct {
+		name             string
+		prop             map[string]any
+		canonicalGroups  map[string]string
+		expectedTypeSpec pschema.TypeSpec
+	}{
+		{
+			name: "extension-owned type refs the extension package",
+			prop: map[string]any{
+				"$ref": "#/definitions/io.k8s.api.gateway.v1.Gateway",
+			},
+			canonicalGroups: map[string]string{
+				"io.k8s.api.gateway": "gateway",
+			},
+			expectedTypeSpec: pschema.TypeSpec{
+				Ref: "#/types/crdfoo:gateway/v1:Gateway",
+			},
+		},
+		{
+			name: "base-provider type refs the base schema externally",
+			prop: map[string]any{
+				"$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+			},
+			canonicalGroups: map[string]string{
+				"io.k8s.apimachinery.pkg.apis.meta": "meta",
+			},
+			expectedTypeSpec: pschema.TypeSpec{
+				Ref: "/kubernetes/v4.33.0/schema.json#/types/kubernetes:meta%2Fv1:ObjectMeta",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := makeSchemaTypeSpec(tt.prop, tt.canonicalGroups, extension)
+			assert.Equal(t, tt.expectedTypeSpec, actual)
+		})
+	}
+}
+
 func TestIsTopLevel(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/tests/sdk/yaml/extension_alias_test.go
+++ b/tests/sdk/yaml/extension_alias_test.go
@@ -1,0 +1,75 @@
+package test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/providertest/pulumitest"
+	"github.com/pulumi/providertest/pulumitest/opttest"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+)
+
+const (
+	extensionGatewayClassType = "gateway-networking:gateway.networking.k8s.io/v1:GatewayClass"
+	baseGatewayClassType      = "kubernetes:gateway.networking.k8s.io/v1:GatewayClass"
+)
+
+// Reproduces the state a crd2pulumi-generated SDK would have written, without generating one.
+func rewriteToBaseNamespace(t *testing.T, exported apitype.UntypedDeployment) apitype.UntypedDeployment {
+	t.Helper()
+
+	var deployment apitype.DeploymentV3
+	require.NoError(t, json.Unmarshal(exported.Deployment, &deployment))
+
+	rewritten := 0
+	for i := range deployment.Resources {
+		r := &deployment.Resources[i]
+		if string(r.Type) != extensionGatewayClassType {
+			continue
+		}
+		r.Type = tokens.Type(baseGatewayClassType)
+		r.URN = resource.URN(strings.Replace(string(r.URN),
+			extensionGatewayClassType, baseGatewayClassType, 1))
+		rewritten++
+	}
+	require.Equal(t, 1, rewritten, "expected exactly one extension-served GatewayClass in state")
+
+	raw, err := json.Marshal(deployment)
+	require.NoError(t, err)
+	return apitype.UntypedDeployment{Version: exported.Version, Deployment: raw}
+}
+
+func TestExtensionAliasAdoptsBaseNamespacedState(t *testing.T) {
+	test := pulumitest.NewPulumiTest(t, "testdata/extension-alias-migration", opttest.SkipInstall())
+	t.Cleanup(func() {
+		test.Destroy(t)
+	})
+
+	packageAdd := packageAddCmd(t, test)
+	packageAdd()
+	packageAdd("--extension", "name=gateway-networking crd-manifest=gateway-api-crds.yaml")
+
+	created := test.Up(t)
+	require.NotNil(t, created.Summary.ResourceChanges)
+	require.NotZero(t, (*created.Summary.ResourceChanges)["create"],
+		"the extension-served GatewayClass should be created first")
+
+	test.ImportStack(t, rewriteToBaseNamespace(t, test.ExportStack(t)))
+
+	migrated := test.Up(t)
+
+	require.NotNil(t, migrated.Summary.ResourceChanges)
+	changes := *migrated.Summary.ResourceChanges
+	assert.Zero(t, changes["replace"],
+		"the base-namespaced GatewayClass must be adopted via its alias, not replaced")
+	assert.Zero(t, changes["delete"],
+		"the base-namespaced GatewayClass must be adopted via its alias, not deleted")
+	assert.Zero(t, changes["create"],
+		"the base-namespaced GatewayClass must be adopted via its alias, not recreated")
+}

--- a/tests/sdk/yaml/extension_test.go
+++ b/tests/sdk/yaml/extension_test.go
@@ -11,23 +11,29 @@ import (
 	"github.com/pulumi/providertest/pulumitest/opttest"
 )
 
-func TestExtensionGatewayAPI(t *testing.T) {
-	test := pulumitest.NewPulumiTest(t, "testdata/extension-gateway-api", opttest.SkipInstall())
-	t.Cleanup(func() {
-		test.Destroy(t)
-	})
+func packageAddCmd(t *testing.T, test *pulumitest.PulumiTest) func(args ...string) {
+	t.Helper()
 
 	cwd, err := os.Getwd()
 	require.NoError(t, err)
 	providerBin := filepath.Join(cwd, "..", "..", "..", "bin", "pulumi-resource-kubernetes")
 
 	pulumi := test.CurrentStack().Workspace().PulumiCommand()
-	packageAdd := func(args ...string) {
+	return func(args ...string) {
 		t.Helper()
 		_, stderr, _, err := pulumi.Run(test.Context(), test.WorkingDir(),
 			nil, nil, nil, nil, append([]string{"package", "add", providerBin}, args...)...)
 		require.NoErrorf(t, err, "pulumi package add %v failed: %s", args, stderr)
 	}
+}
+
+func TestExtensionGatewayAPI(t *testing.T) {
+	test := pulumitest.NewPulumiTest(t, "testdata/extension-gateway-api", opttest.SkipInstall())
+	t.Cleanup(func() {
+		test.Destroy(t)
+	})
+
+	packageAdd := packageAddCmd(t, test)
 
 	packageAdd("--extension", "name=gateway-networking crd-manifest=gateway-api-crds.yaml")
 

--- a/tests/sdk/yaml/testdata/extension-alias-migration/Pulumi.yaml
+++ b/tests/sdk/yaml/testdata/extension-alias-migration/Pulumi.yaml
@@ -1,0 +1,14 @@
+name: extension-alias-migration
+runtime: yaml
+description: Verifies that base-namespaced CRD state is adopted by extension-served types.
+resources:
+  test-gateway-class:
+    type: gateway-networking:gateway.networking.k8s.io/v1:GatewayClass
+    properties:
+      metadata:
+        name: alias-migration-class
+      spec:
+        controllerName: example.com/gateway-controller
+
+outputs:
+  gatewayClassUID: ${test-gateway-class.metadata.uid}

--- a/tests/sdk/yaml/testdata/extension-alias-migration/gateway-api-crds.yaml
+++ b/tests/sdk/yaml/testdata/extension-alias-migration/gateway-api-crds.yaml
@@ -1,0 +1,481 @@
+#
+# config/crd/standard/gateway.networking.k8s.io_gatewayclasses.yaml
+#
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
+    gateway.networking.k8s.io/bundle-version: v1.2.1
+    gateway.networking.k8s.io/channel: standard
+  creationTimestamp: null
+  name: gatewayclasses.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+    - gateway-api
+    kind: GatewayClass
+    listKind: GatewayClassList
+    plural: gatewayclasses
+    shortNames:
+    - gc
+    singular: gatewayclass
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.controllerName
+      name: Controller
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .spec.description
+      name: Description
+      priority: 1
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          GatewayClass describes a class of Gateways available to the user for creating
+          Gateway resources.
+
+          It is recommended that this resource be used as a template for Gateways. This
+          means that a Gateway is based on the state of the GatewayClass at the time it
+          was created and changes to the GatewayClass or associated parameters are not
+          propagated down to existing Gateways. This recommendation is intended to
+          limit the blast radius of changes to GatewayClass or associated parameters.
+          If implementations choose to propagate GatewayClass changes to existing
+          Gateways, that MUST be clearly documented by the implementation.
+
+          Whenever one or more Gateways are using a GatewayClass, implementations SHOULD
+          add the `gateway-exists-finalizer.gateway.networking.k8s.io` finalizer on the
+          associated GatewayClass. This ensures that a GatewayClass associated with a
+          Gateway is not deleted while in use.
+
+          GatewayClass is a Cluster level resource.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of GatewayClass.
+            properties:
+              controllerName:
+                description: |-
+                  ControllerName is the name of the controller that is managing Gateways of
+                  this class. The value of this field MUST be a domain prefixed path.
+
+                  Example: "example.net/gateway-controller".
+
+                  This field is not mutable and cannot be empty.
+
+                  Support: Core
+                maxLength: 253
+                minLength: 1
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                type: string
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
+              description:
+                description: Description helps describe a GatewayClass with more details.
+                maxLength: 64
+                type: string
+              parametersRef:
+                description: |-
+                  ParametersRef is a reference to a resource that contains the configuration
+                  parameters corresponding to the GatewayClass. This is optional if the
+                  controller does not require any additional configuration.
+
+                  ParametersRef can reference a standard Kubernetes resource, i.e. ConfigMap,
+                  or an implementation-specific custom resource. The resource can be
+                  cluster-scoped or namespace-scoped.
+
+                  If the referent cannot be found, refers to an unsupported kind, or when
+                  the data within that resource is malformed, the GatewayClass SHOULD be
+                  rejected with the "Accepted" status condition set to "False" and an
+                  "InvalidParameters" reason.
+
+                  A Gateway for this GatewayClass may provide its own `parametersRef`. When both are specified,
+                  the merging behavior is implementation specific.
+                  It is generally recommended that GatewayClass provides defaults that can be overridden by a Gateway.
+
+                  Support: Implementation-specific
+                properties:
+                  group:
+                    description: Group is the group of the referent.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the referent.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the referent.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace is the namespace of the referent.
+                      This field is required when referring to a Namespace-scoped resource and
+                      MUST be unset when referring to a Cluster-scoped resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+            required:
+            - controllerName
+            type: object
+          status:
+            default:
+              conditions:
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for controller
+                reason: Pending
+                status: Unknown
+                type: Accepted
+            description: |-
+              Status defines the current state of GatewayClass.
+
+              Implementations MUST populate status on all GatewayClass resources which
+              specify their controller name.
+            properties:
+              conditions:
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Accepted
+                description: |-
+                  Conditions is the current status from the controller for
+                  this GatewayClass.
+
+                  Controllers should prefer to publish conditions using values
+                  of GatewayClassConditionType for the type of each Condition.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .spec.controllerName
+      name: Controller
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .spec.description
+      name: Description
+      priority: 1
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          GatewayClass describes a class of Gateways available to the user for creating
+          Gateway resources.
+
+          It is recommended that this resource be used as a template for Gateways. This
+          means that a Gateway is based on the state of the GatewayClass at the time it
+          was created and changes to the GatewayClass or associated parameters are not
+          propagated down to existing Gateways. This recommendation is intended to
+          limit the blast radius of changes to GatewayClass or associated parameters.
+          If implementations choose to propagate GatewayClass changes to existing
+          Gateways, that MUST be clearly documented by the implementation.
+
+          Whenever one or more Gateways are using a GatewayClass, implementations SHOULD
+          add the `gateway-exists-finalizer.gateway.networking.k8s.io` finalizer on the
+          associated GatewayClass. This ensures that a GatewayClass associated with a
+          Gateway is not deleted while in use.
+
+          GatewayClass is a Cluster level resource.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of GatewayClass.
+            properties:
+              controllerName:
+                description: |-
+                  ControllerName is the name of the controller that is managing Gateways of
+                  this class. The value of this field MUST be a domain prefixed path.
+
+                  Example: "example.net/gateway-controller".
+
+                  This field is not mutable and cannot be empty.
+
+                  Support: Core
+                maxLength: 253
+                minLength: 1
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                type: string
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
+              description:
+                description: Description helps describe a GatewayClass with more details.
+                maxLength: 64
+                type: string
+              parametersRef:
+                description: |-
+                  ParametersRef is a reference to a resource that contains the configuration
+                  parameters corresponding to the GatewayClass. This is optional if the
+                  controller does not require any additional configuration.
+
+                  ParametersRef can reference a standard Kubernetes resource, i.e. ConfigMap,
+                  or an implementation-specific custom resource. The resource can be
+                  cluster-scoped or namespace-scoped.
+
+                  If the referent cannot be found, refers to an unsupported kind, or when
+                  the data within that resource is malformed, the GatewayClass SHOULD be
+                  rejected with the "Accepted" status condition set to "False" and an
+                  "InvalidParameters" reason.
+
+                  A Gateway for this GatewayClass may provide its own `parametersRef`. When both are specified,
+                  the merging behavior is implementation specific.
+                  It is generally recommended that GatewayClass provides defaults that can be overridden by a Gateway.
+
+                  Support: Implementation-specific
+                properties:
+                  group:
+                    description: Group is the group of the referent.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the referent.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the referent.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace is the namespace of the referent.
+                      This field is required when referring to a Namespace-scoped resource and
+                      MUST be unset when referring to a Cluster-scoped resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+            required:
+            - controllerName
+            type: object
+          status:
+            default:
+              conditions:
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for controller
+                reason: Pending
+                status: Unknown
+                type: Accepted
+            description: |-
+              Status defines the current state of GatewayClass.
+
+              Implementations MUST populate status on all GatewayClass resources which
+              specify their controller name.
+            properties:
+              conditions:
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Accepted
+                description: |-
+                  Conditions is the current status from the controller for
+                  this GatewayClass.
+
+                  Controllers should prefer to publish conditions using values
+                  of GatewayClassConditionType for the type of each Condition.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null


### PR DESCRIPTION
CRD extensions are token-namespaced in the extension name as the package name.

In order to support seamless migration from `crd2pulumi`- based programs, which use `kubernetes:` as the package token,  this PR declares an alias for this token, so that state is adopted instead.

This also adds the unit test coverage for the extension token namespacing itself.

Fixes https://github.com/pulumi/pulumi-kubernetes/issues/4532.
