### PR TITLE
tests: upgrade GKE test cluster to v1.36

### DIFF
--- a/tests/ci-cluster/gke.ts
+++ b/tests/ci-cluster/gke.ts
@@ -26,8 +26,8 @@ export class GkeCluster extends pulumi.ComponentResource {
                 opts: pulumi.ComponentResourceOptions = {}) {
         super("pulumi-kubernetes:ci:GkeCluster", name, {}, opts);
 
-        // Use the latest 1.33.x engine version.
-        const engineVersion = "1.33";
+        // Use the latest 1.36.x engine version.
+        const engineVersion = "1.36";
 
         // Create the GKE cluster.
         const k8sCluster = new gcp.container.Cluster("ephemeral-ci-cluster", {


### PR DESCRIPTION
GKE has dropped 1.33 in `us-west1-a`, so `build-test-cluster` on master fails while creating the ephemeral cluster:

```
gcp:container:Cluster (ephemeral-ci-cluster):
  error: sdk-v2/provider2.go:571: sdk.helper_schema: googleapi: Error 400: No valid versions with the prefix "1.33" found.
```

Bump the pinned engine version in `tests/ci-cluster/gke.ts` from `1.33` to `1.36`, which also matches the upstream Kubernetes version this repo now builds against. Mirrors #4327 (1.32 to 1.33) and #3504 (1.28 to 1.32).

Note for later: no-channel GKE clusters are deprecated with removal scheduled for 2027-06-14, so this pin will need replacing with a release channel at some point.

## Test plan

- `build-test-cluster` provisions successfully and the downstream test jobs run.
