### PR TITLE
Prepare for v4.34.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ## Unreleased
 
+## 4.34.0 (August 27, 2026)
+
 ### Added
 
 - Support adding CustomResourceDefinitions as an extension of the base `kubernetes` provider via `pulumi package add <provider> --extension`. Extension-served resources alias their `kubernetes:`-namespaced token, so state written by a crd2pulumi-generated SDK is adopted rather than replaced.


### PR DESCRIPTION
Adds the `4.34.0 (August 26, 2026)` heading under `## Unreleased`, covering the extension-parameterization support, the Kubernetes v1.36.3/v1.36.4 upgrades, and the `waitFor` JSONPath filter fix.

Also records the four security-flagged dependency updates that landed since v4.33.0, which had no changelog entries of their own.

## Test plan

- Changelog-only change; CI on master must be green before the release is cut.
